### PR TITLE
feat: add mirrord tasks

### DIFF
--- a/images/virtualization-controller/Taskfile.dist.yaml
+++ b/images/virtualization-controller/Taskfile.dist.yaml
@@ -617,6 +617,17 @@ tasks:
       - |
         golangci-lint run --sort-results
 
+  mirrord:run:
+    desc: "Run local virtualization-controller in cluster using a mirrord"
+    deps:
+      - _ensure:mirrord
+    cmd: ./hack/mirrord.sh run
+  mirrord:wipe:
+    desc: "wipe up Mirrord's trash"
+    deps:
+      - _ensure:mirrord
+    cmd: ./hack/mirrord.sh wipe
+
   _copy_d8_registry_secret:
     internal: true
     vars:
@@ -752,3 +763,12 @@ tasks:
       - exit 1
     status:
       - which virtctl >/dev/null
+  _ensure:mirrord:
+    desc: "Ensure mirrord tool is installed"
+    internal: true
+    cmds:
+      - echo -e >&2 "Please install mirrord https://mirrord.dev/docs/overview/quick-start/#cli-tool"
+      - exit 1
+    status:
+      - which mirrord >/dev/null
+

--- a/images/virtualization-controller/hack/mirrord-config.json
+++ b/images/virtualization-controller/hack/mirrord-config.json
@@ -1,0 +1,12 @@
+{
+  "feature": {
+    "fs": {
+      "mode": "write",
+      "read_write": ".*"
+    },
+    "network": {
+      "incoming": "steal"
+    }
+  }
+}
+

--- a/images/virtualization-controller/hack/mirrord.sh
+++ b/images/virtualization-controller/hack/mirrord.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -eo pipefail
+
+function usage { echo "Usage: $0 [run/wipe]" ; exit 1; }
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+BIN_DIR="${SCRIPT_DIR}/../bin"
+APP="${SCRIPT_DIR}/../cmd/virtualization-controller/main.go"
+CONFIG_MIRRORD="${SCRIPT_DIR}/mirrord-config.json"
+BINARY="virtualization-controller"
+NAMESPACE="d8-virtualization"
+DEPLOYMENT="virtualization-controller"
+NEW_NAME="mirrord-copy-${DEPLOYMENT}"
+export NEW_NAME
+
+if [[ -z $1 ]]; then
+  usage
+elif [[ $1 == "wipe" ]]; then
+  echo "Stopping mirror..."
+  echo "Delete deployment ${NAMESPACE}/${NEW_NAME}"
+  kubectl -n "${NAMESPACE}" delete deployment/"${NEW_NAME}"
+  kubectl -n "${NAMESPACE}" scale deployment "${DEPLOYMENT}" --replicas 1
+  exit 0
+elif [[ $1 == "run" ]]; then
+  echo "Starting mirror..."
+else
+  usage
+fi
+
+
+if [ ! -d "${BIN_DIR}" ]; then
+  mkdir "${BIN_DIR}"
+fi
+
+go build -ldflags='-linkmode external' -o "${BIN_DIR}/${BINARY}" "${APP}"
+chmod +x "${BIN_DIR}/${BINARY}"
+
+if ! kubectl -n "${NAMESPACE}" get deployment/"${NEW_NAME}" &>/dev/null; then
+  kubectl -n "${NAMESPACE}" get deployment/"${DEPLOYMENT}" -ojson | \
+  jq '.metadata.name = env.NEW_NAME |
+      .spec.template.spec.containers[0].command = [ "/bin/bash", "-c", "--" ] |
+      .spec.template.spec.containers[0].args = [ "while true; do sleep 60; done;" ] |
+      .spec.replicas = 1 |
+      .spec.template.metadata.labels.mirror = "true"' | \
+  kubectl create -f -
+fi
+
+kubectl wait pod --for=jsonpath='{.status.phase}'=Running -l mirror=true,app="${DEPLOYMENT}" --timeout 60s
+kubectl -n "${NAMESPACE}" scale deployment "${DEPLOYMENT}" --replicas 0
+mirrord exec --config-file "${CONFIG_MIRRORD}"  --target "deployment/${NEW_NAME}" --target-namespace "${NAMESPACE}" "${BIN_DIR}/${BINARY}"

--- a/images/virtualization-controller/hack/mirrord.sh
+++ b/images/virtualization-controller/hack/mirrord.sh
@@ -45,6 +45,6 @@ if ! kubectl -n "${NAMESPACE}" get deployment/"${NEW_NAME}" &>/dev/null; then
   kubectl create -f -
 fi
 
-kubectl wait pod --for=jsonpath='{.status.phase}'=Running -l mirror=true,app="${DEPLOYMENT}" --timeout 60s
+kubectl -n "${NAMESPACE}" wait pod --for=jsonpath='{.status.phase}'=Running -l mirror=true,app="${DEPLOYMENT}" --timeout 60s
 kubectl -n "${NAMESPACE}" scale deployment "${DEPLOYMENT}" --replicas 0
 mirrord exec --config-file "${CONFIG_MIRRORD}"  --target "deployment/${NEW_NAME}" --target-namespace "${NAMESPACE}" "${BIN_DIR}/${BINARY}"


### PR DESCRIPTION
## Description
Add two task for local development. 
1. mirrord:run 
2. mirrord:wipe

## Why do we need it, and what problem does it solve?
Run your local code in the real-time context of your kubernetes cluster.
Testing controllers and webhooks.

