### PR TITLE
fix: mute noisy log messages by default

### DIFF
--- a/images/virtualization-controller/pkg/sdk/framework/helper/resource.go
+++ b/images/virtualization-controller/pkg/sdk/framework/helper/resource.go
@@ -96,20 +96,19 @@ func (r *Resource[T, ST]) UpdateMeta(ctx context.Context) error {
 		return nil
 	}
 
-	r.log.Info("UpdateMeta obj before update", "currentObj", r.currentObj.GetObjectMeta(), "changedObj", r.changedObj.GetObjectMeta())
+	r.log.V(4).Info("UpdateMeta obj meta before update", "currentObj", r.currentObj.GetObjectMeta(), "changedObj", r.changedObj.GetObjectMeta())
 	if !reflect.DeepEqual(r.getObjStatus(r.currentObj), r.getObjStatus(r.changedObj)) {
 		return fmt.Errorf("status update is not allowed in the meta updater: %#v changed to %#v", r.getObjStatus(r.currentObj), r.getObjStatus(r.changedObj))
 	}
-	r.log.V(4).Info("UpdateMeta obj meta before update", "currentObj.ObjectMeta", r.currentObj.GetObjectMeta(), "changedObj.ObjectMeta", r.changedObj.GetObjectMeta())
 	if !reflect.DeepEqual(r.currentObj.GetObjectMeta(), r.changedObj.GetObjectMeta()) {
 		if err := r.client.Update(ctx, r.changedObj); err != nil {
 			return fmt.Errorf("error updating: %w", err)
 		}
 		r.currentObj = r.changedObj.DeepCopy()
-		r.log.V(1).Info("UpdateStatus applied", "obj", r.currentObj.GetObjectKind().GroupVersionKind().Kind+"/"+r.currentObj.GetName())
+		r.log.V(1).Info("UpdateMeta applied", "obj", r.currentObj.GetObjectKind().GroupVersionKind().Kind+"/"+r.currentObj.GetName())
 		r.log.V(4).Info("UpdateMeta obj meta after update", "changedObj.ObjectMeta", r.changedObj.GetObjectMeta())
 	} else {
-		r.log.V(4).Info("UpdateMeta skipped: no changes", "currentObj.ObjectMeta", r.currentObj.GetObjectMeta())
+		r.log.V(2).Info("UpdateMeta skipped: no changes", "currentObj.ObjectMeta", r.currentObj.GetObjectMeta())
 	}
 	return nil
 }


### PR DESCRIPTION

## Description

- Use level 4 for trace messages like UpdateMetadata and UpdateStatus.
- Add messages to distinguish reconcile steps.
- Add message with reconcile result to see if requeue was requested.


## Why do we need it, and what problem does it solve?

UpdateMetadata and UpdateStatus are too noisy for default debug log level.

## What is the expected result?

Developer should change VERBOSITY to 4 to see more detailed huge logs.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
