### PR TITLE
fix(vmcpur): fixed reconciliation bugs and rbac

### DIFF
--- a/api/core/v1alpha2/virtual_machine.go
+++ b/api/core/v1alpha2/virtual_machine.go
@@ -96,7 +96,7 @@ const (
 )
 
 type CPUSpec struct {
-	Model        string `json:"model"`
+	ModelName    string `json:"modelName"`
 	Cores        int    `json:"cores"`
 	CoreFraction string `json:"coreFraction"`
 }

--- a/api/pkg/apiserver/api/generated/openapi/zz_generated.openapi.go
+++ b/api/pkg/apiserver/api/generated/openapi/zz_generated.openapi.go
@@ -776,7 +776,7 @@ func schema_virtualization_api_core_v1alpha2_CPUSpec(ref common.ReferenceCallbac
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
-					"model": {
+					"modelName": {
 						SchemaProps: spec.SchemaProps{
 							Default: "",
 							Type:    []string{"string"},
@@ -798,7 +798,7 @@ func schema_virtualization_api_core_v1alpha2_CPUSpec(ref common.ReferenceCallbac
 						},
 					},
 				},
-				Required: []string{"model", "cores", "coreFraction"},
+				Required: []string{"modelName", "cores", "coreFraction"},
 			},
 		},
 	}

--- a/images/virtualization-artifact/pkg/controller/cpu/cpu_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/cpu/cpu_reconciler.go
@@ -95,7 +95,7 @@ func (r *VMCPUReconciler) UpdateStatus(_ context.Context, _ reconcile.Request, s
 	case virtv2.Host:
 	case virtv2.Model:
 		state.VMCPU.Changed().Status.Nodes = &modelNodes
-		isReady = containAll(modelNodes, state.VMCPU.Current().Spec.Model)
+		isReady = len(modelNodes) > 0
 	case virtv2.Features:
 		state.VMCPU.Changed().Status.Nodes = &modelNodes
 		state.VMCPU.Changed().Status.Features = &features
@@ -116,13 +116,13 @@ func (r *VMCPUReconciler) UpdateStatus(_ context.Context, _ reconcile.Request, s
 }
 
 func (r *VMCPUReconciler) FilterAttachedVM(vm *virtv2.VirtualMachine) bool {
-	return vm.Spec.CPU.Model != ""
+	return vm.Spec.CPU.ModelName != ""
 }
 
 func (r *VMCPUReconciler) EnqueueFromAttachedVM(vm *virtv2.VirtualMachine) []reconcile.Request {
 	return []reconcile.Request{{
 		NamespacedName: types.NamespacedName{
-			Name: vm.Spec.CPU.Model,
+			Name: vm.Spec.CPU.ModelName,
 		},
 	}}
 }
@@ -132,7 +132,7 @@ func (r *VMCPUReconciler) getModelNodes(model string, nodes []corev1.Node) []str
 
 	for _, node := range nodes {
 		for label, enabled := range node.Labels {
-			if !strings.HasPrefix(label, v1.CPUModelLabel+model) || enabled != "true" {
+			if label != v1.CPUModelLabel+model || enabled != "true" {
 				continue
 			}
 

--- a/images/virtualization-artifact/pkg/controller/cpu/cpu_reconciler_state.go
+++ b/images/virtualization-artifact/pkg/controller/cpu/cpu_reconciler_state.go
@@ -95,7 +95,11 @@ func (state *VMCPUReconcilerState) ShouldReconcile(log logr.Logger) bool {
 		return false
 	}
 
-	return state.AttacheeState.ShouldReconcile(log)
+	if state.AttacheeState.ShouldReconcile(log) {
+		return true
+	}
+
+	return true
 }
 
 func (state *VMCPUReconcilerState) IsAttachedToVM(vm virtv2.VirtualMachine) bool {
@@ -103,7 +107,7 @@ func (state *VMCPUReconcilerState) IsAttachedToVM(vm virtv2.VirtualMachine) bool
 		return false
 	}
 
-	return state.VMCPU.Name().Name == vm.Spec.CPU.Model
+	return state.VMCPU.Name().Name == vm.Spec.CPU.ModelName
 }
 
 func (state *VMCPUReconcilerState) isDeletion() bool {

--- a/images/virtualization-artifact/pkg/controller/vm_reconciler_state.go
+++ b/images/virtualization-artifact/pkg/controller/vm_reconciler_state.go
@@ -99,7 +99,7 @@ func (state *VMReconcilerState) Reload(ctx context.Context, req reconcile.Reques
 		return fmt.Errorf("unable to get Claim %s: %w", claimKey, err)
 	}
 
-	vmcpuKey := types.NamespacedName{Name: state.VM.Current().Spec.CPU.Model}
+	vmcpuKey := types.NamespacedName{Name: state.VM.Current().Spec.CPU.ModelName}
 	state.CPUModel, err = helper.FetchObject(ctx, vmcpuKey, state.Client, &virtv2.VirtualMachineCPUModel{})
 	if err != nil {
 		return fmt.Errorf("unable to get cpu model %s: %w", claimKey, err)

--- a/images/virtualization-artifact/pkg/controller/vm_reconciler_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm_reconciler_test.go
@@ -68,8 +68,8 @@ var _ = Describe("VM", func() {
 					EnableParavirtualization:         true,
 					OsType:                           virtv2.GenericOs,
 					CPU: virtv2.CPUSpec{
-						Model: "test-vmcpu",
-						Cores: 2,
+						ModelName: "test-vmcpu",
+						Cores:     2,
 					},
 					Memory: virtv2.MemorySpec{
 						Size: "2Gi",
@@ -408,8 +408,8 @@ var _ = Describe("Apply VM changes", func() {
 					EnableParavirtualization:         true,
 					OsType:                           virtv2.GenericOs,
 					CPU: virtv2.CPUSpec{
-						Model: vmcpuName,
-						Cores: 2,
+						ModelName: vmcpuName,
+						Cores:     2,
 					},
 					Memory: virtv2.MemorySpec{
 						Size: "2Gi",
@@ -560,7 +560,7 @@ var _ = Describe("Apply VM changes with manual approval", func() {
 					EnableParavirtualization:         true,
 					OsType:                           virtv2.GenericOs,
 					CPU: virtv2.CPUSpec{
-						Model:        vmcpuName,
+						ModelName:    vmcpuName,
 						Cores:        cpuStartingCores,
 						CoreFraction: cpuStartingCoreFraction,
 					},
@@ -697,12 +697,12 @@ var _ = Describe("Apply VM changes with manual approval", func() {
 					"path":      Equal("cpu"),
 					"operation": Equal(string(vmchange.ChangeReplace)),
 					"currentValue": MatchAllKeys(Keys{
-						"model":        BeEquivalentTo(vmcpuName),
+						"modelName":    BeEquivalentTo(vmcpuName),
 						"cores":        BeEquivalentTo(cpuStartingCores),
 						"coreFraction": Equal(cpuStartingCoreFraction),
 					}),
 					"desiredValue": MatchAllKeys(Keys{
-						"model":        BeEquivalentTo(vmcpuName),
+						"modelName":    BeEquivalentTo(vmcpuName),
 						"cores":        BeEquivalentTo(cpuNewCores),
 						"coreFraction": Equal(cpuNewCoreFraction),
 					}),

--- a/images/virtualization-artifact/pkg/controller/vmchange/comparators.go
+++ b/images/virtualization-artifact/pkg/controller/vmchange/comparators.go
@@ -122,7 +122,7 @@ func compareCPU(current, desired *v1alpha2.VirtualMachineSpec) []FieldChange {
 		return fractionChanges
 	}
 
-	modelChanges := compareStrings("cpu.model", current.CPU.Model, desired.CPU.Model, "", ActionRestart)
+	modelChanges := compareStrings("cpu.model", current.CPU.ModelName, desired.CPU.ModelName, "", ActionRestart)
 	if HasChanges(modelChanges) {
 		return modelChanges
 	}

--- a/templates/virtualization-controller/rbac-for-us.yaml
+++ b/templates/virtualization-controller/rbac-for-us.yaml
@@ -75,6 +75,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - events
   verbs:
   - create

--- a/templates/virtualization-controller/rbac-for-us.yaml
+++ b/templates/virtualization-controller/rbac-for-us.yaml
@@ -77,6 +77,7 @@ rules:
   resources:
   - nodes
   verbs:
+  - list
   - watch
 - apiGroups:
   - ""


### PR DESCRIPTION
## Description
Fixed bugs

## Why do we need it, and what problem does it solve?
- Fix non-compliance with the specification and the go-structure for VMCPU
- Fixed vmcpu reconciliation (ShouldReconcile method)
- Added Node resource to rbac
- Fixed vmcpu phase update for type: model 

## What is the expected result?
Bugs are fixed

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
