### PR TITLE
fix(client): rename pkg kubecli to kubeclient

### DIFF
--- a/api/client/kubeclient/async.go
+++ b/api/client/kubeclient/async.go
@@ -17,7 +17,7 @@ limitations under the License.
 Initially copied from https://github.com/kubevirt/kubevirt/blob/main/staging/src/kubevirt.io/client-go/kubecli/async.go
 */
 
-package kubecli
+package kubeclient
 
 import (
 	"encoding/json"

--- a/api/client/kubeclient/client.go
+++ b/api/client/kubeclient/client.go
@@ -1,4 +1,4 @@
-package kubecli
+package kubeclient
 
 import (
 	"io"

--- a/api/client/kubeclient/config.go
+++ b/api/client/kubeclient/config.go
@@ -17,7 +17,7 @@ limitations under the License.
 Initially copied from https://github.com/kubevirt/kubevirt/blob/main/staging/src/kubevirt.io/client-go/kubecli/kubecli.go
 */
 
-package kubecli
+package kubeclient
 
 import (
 	"os"

--- a/api/client/kubeclient/request.go
+++ b/api/client/kubeclient/request.go
@@ -17,7 +17,7 @@ limitations under the License.
 Initially copied from https://github.com/kubevirt/kubevirt/blob/main/staging/src/kubevirt.io/client-go/kubecli/vmi.go
 */
 
-package kubecli
+package kubeclient
 
 import (
 	"fmt"

--- a/api/client/kubeclient/streamer.go
+++ b/api/client/kubeclient/streamer.go
@@ -17,7 +17,7 @@ limitations under the License.
 Initially copied from https://github.com/kubevirt/kubevirt/blob/main/staging/src/kubevirt.io/client-go/kubecli/streamer.go
 */
 
-package kubecli
+package kubeclient
 
 import (
 	"net"

--- a/api/client/kubeclient/vm.go
+++ b/api/client/kubeclient/vm.go
@@ -17,7 +17,7 @@ limitations under the License.
 Initially copied from https://github.com/kubevirt/kubevirt/blob/main/staging/src/kubevirt.io/client-go/kubecli/vmi.go
 */
 
-package kubecli
+package kubeclient
 
 import (
 	"errors"

--- a/api/client/kubeclient/websocket.go
+++ b/api/client/kubeclient/websocket.go
@@ -17,7 +17,7 @@ limitations under the License.
 Initially copied from https://github.com/kubevirt/kubevirt/blob/main/staging/src/kubevirt.io/client-go/kubecli/websocket.go
 */
 
-package kubecli
+package kubeclient
 
 import (
 	"crypto/tls"


### PR DESCRIPTION
## Description
rename pkg kubecli to kubeclient

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
