### PR TITLE
 fix(vm): set default for modelName in comparators

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vmchange/comparators.go
+++ b/images/virtualization-artifact/pkg/controller/vmchange/comparators.go
@@ -6,6 +6,7 @@ import (
 
 const (
 	DefaultCPUCoreFraction               = "100%"
+	DefaultCPUModelName                  = "generic-v1"
 	DefaultDisruptionsApprovalMode       = v1alpha2.Manual
 	DefaultOSType                        = v1alpha2.GenericOs
 	DefaultBootloader                    = v1alpha2.BIOS
@@ -122,7 +123,7 @@ func compareCPU(current, desired *v1alpha2.VirtualMachineSpec) []FieldChange {
 		return fractionChanges
 	}
 
-	modelChanges := compareStrings("cpu.model", current.CPU.ModelName, desired.CPU.ModelName, "", ActionRestart)
+	modelChanges := compareStrings("cpu.model", current.CPU.ModelName, desired.CPU.ModelName, DefaultCPUModelName, ActionRestart)
 	if HasChanges(modelChanges) {
 		return modelChanges
 	}


### PR DESCRIPTION
## Description

Set proper default for modelName comparator.

## Why do we need it, and what problem does it solve?

Wrong default (empty string) leads to excess change in restartAwaitingChanges.



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
