### PR TITLE
fix(crd): restore the original value of the terminationGracePeriodSeconds parameter

### DIFF
--- a/crds/virtualmachine.yaml
+++ b/crds/virtualmachine.yaml
@@ -794,7 +794,7 @@ spec:
                 terminationGracePeriodSeconds:
                   format: int64
                   type: integer
-                  default: 3600
+                  default: 60
                   description: |
                     Grace period observed after signalling a VM to stop after which the VM is force terminated.
 

--- a/tests/e2e/Taskfile.yaml
+++ b/tests/e2e/Taskfile.yaml
@@ -69,7 +69,7 @@ tasks:
           linux*)       RIGHTS_SSH=$(stat -c "%a" $ID_ED) ;;
           *)            echo "unknown: {{OS}}"; exit 1       ;;
         esac
-        
+
         if [ $RIGHTS_SSH -ne 600 ]; then
           echo "Fix permissions for file $ID_ED"
           chmod 600 $ID_ED


### PR DESCRIPTION
This reverts commit ba34ffd05ed19f7e62966138d3bb6636718cf4b6.

## Description
Restore the original value of the terminationGracePeriodSeconds parameter

## Why do we need it, and what problem does it solve?
The problematic requires a different approach to solving restart problems

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
