### PR TITLE
fix(vmi,cvmi): normalize size format

### DIFF
--- a/images/virtualization-artifact/pkg/controller/monitoring/final_report.go
+++ b/images/virtualization-artifact/pkg/controller/monitoring/final_report.go
@@ -5,8 +5,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/dustin/go-humanize"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/deckhouse/virtualization-controller/pkg/util"
 )
 
 // FinalReport example: { "source-image-size": "1111", "source-image-virtual-size": "8888", "source-image-format": "qcow2"}
@@ -19,15 +20,15 @@ type FinalReport struct {
 }
 
 func (r *FinalReport) StoredSize() string {
-	return humanize.Bytes(r.StoredSizeBytes)
+	return util.HumanizeIBytes(r.StoredSizeBytes)
 }
 
 func (r *FinalReport) UnpackedSize() string {
-	return humanize.Bytes(r.UnpackedSizeBytes)
+	return util.HumanizeIBytes(r.UnpackedSizeBytes)
 }
 
 func (r *FinalReport) GetAverageSpeed() string {
-	return humanize.Bytes(r.AverageSpeed) + "/s"
+	return util.HumanizeIBytes(r.AverageSpeed) + "/s"
 }
 
 func (r *FinalReport) GetAverageSpeedRaw() uint64 {

--- a/images/virtualization-artifact/pkg/controller/monitoring/progress.go
+++ b/images/virtualization-artifact/pkg/controller/monitoring/progress.go
@@ -10,9 +10,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dustin/go-humanize"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/net"
+
+	"github.com/deckhouse/virtualization-controller/pkg/util"
 )
 
 var httpClient *http.Client
@@ -99,7 +100,7 @@ func (p *ImportProgress) ProgressRaw() float64 {
 
 // CurSpeed is a current speed in human-readable format with SI size.
 func (p *ImportProgress) CurSpeed() string {
-	return humanize.Bytes(p.curSpeed) + "/s"
+	return util.HumanizeIBytes(p.curSpeed) + "/s"
 }
 
 // CurSpeedRaw is a current in bytes per second.
@@ -109,7 +110,7 @@ func (p *ImportProgress) CurSpeedRaw() uint64 {
 
 // AvgSpeed is an average speed in human-readable format with SI size.
 func (p *ImportProgress) AvgSpeed() string {
-	return humanize.Bytes(p.avgSpeed) + "/s"
+	return util.HumanizeIBytes(p.avgSpeed) + "/s"
 }
 
 // AvgSpeedRaw is an average speed in bytes per second.

--- a/images/virtualization-artifact/pkg/controller/monitoring/progress_test.go
+++ b/images/virtualization-artifact/pkg/controller/monitoring/progress_test.go
@@ -1,6 +1,8 @@
 package monitoring
 
-import "testing"
+import (
+	"testing"
+)
 
 func Test_Humanize(t *testing.T) {
 	p, _ := extractProgress(`
@@ -8,12 +10,11 @@ registry_progress{ownerUID="11"} 12.34
 registry_average_speed{ownerUID="11"} 1.234532345432e+6
 registry_current_speed{ownerUID="11"} 2.345632345432e+6
 `, `11`)
-
-	if p.AvgSpeed() != `1.2 MB/s` {
+	if p.AvgSpeed() != `1.2Mi/s` {
 		t.Fatalf("%s is not expected human readable value for raw value %v", p.AvgSpeed(), p.AvgSpeedRaw())
 	}
 
-	if p.CurSpeed() != `2.3 MB/s` {
+	if p.CurSpeed() != `2.2Mi/s` {
 		t.Fatalf("%s is not expected human readable value for raw value %v", p.CurSpeed(), p.CurSpeedRaw())
 	}
 }

--- a/images/virtualization-artifact/pkg/util/util.go
+++ b/images/virtualization-artifact/pkg/util/util.go
@@ -1,5 +1,10 @@
 package util
 
+import (
+	"fmt"
+	"math"
+)
+
 func CopyByPointer[T any](objP *T) *T {
 	copyObj := *objP
 	return &copyObj
@@ -47,4 +52,31 @@ func BoolFloat64(b bool) float64 {
 		return 1
 	}
 	return 0
+}
+
+func HumanizeIBytes(s uint64) string {
+	sizes := []string{"B", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei"}
+	return humanateBytes(s, 1024, sizes)
+}
+
+func humanateBytes(s uint64, base float64, sizes []string) string {
+	if s < 10 {
+		return fmt.Sprintf("%dB", s)
+	}
+	e := math.Floor(logn(float64(s), base))
+
+	suffix := sizes[int(e)]
+	val := math.Floor(float64(s)/math.Pow(base, e)*10+0.5) / 10
+	_, frac := math.Modf(val)
+	f := "%.0f%s"
+
+	if frac > 0 {
+		f = "%.1f%s"
+	}
+
+	return fmt.Sprintf(f, val, suffix)
+}
+
+func logn(n, b float64) float64 {
+	return math.Log(n) / math.Log(b)
 }


### PR DESCRIPTION
## Description
The size format in our status does not correspond to the standard one in Kubernetes
```
status:
  downloadSpeed:
    avg: 38 MB/s
  size:
    stored: 406 MB
    unpacked: 2.4 GB
```

It must be like this
```
status:
  downloadSpeed:
    avg: 38Mi/s
  size:
    stored: 406Mi
    unpacked: 2.4Gi
```

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [X] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
