### PR TITLE
fix: free some space on Github-hosted runners

### DIFF
--- a/.github/actions/remove-unwanted-software/action.yml
+++ b/.github/actions/remove-unwanted-software/action.yml
@@ -1,0 +1,134 @@
+# Usage:
+#
+# jobs:
+#   build_job:
+#   - steps:
+#       - name: Remove unwanted software
+#         uses: ./.github/actions/remove-unwanted-software
+#
+# Inspired by:
+# https://github.com/AdityaGarg8/remove-unwanted-software
+
+name: Remove unwanted software
+description: Remove huge unwanted software packages from the Github-hosted runner.
+branding:
+  icon: "scissors"
+  color: "blue"
+inputs:
+  show-sizes:
+    description: "Calculate and show space usage for some notable directories (increase execution time heavily)"
+    required: false
+    default: "false"
+  keep-docker-images:
+    description: "Keep preinstalled Docker images, e.g. alpine, debian, ubuntu, node"
+    required: false
+    default: "false"
+  deeper-cleanup:
+    description: "Deeper cleanup by removing some packages less then 1Gb: Azure and AWS tools, Julia, MS Edge, powershell, chromium"
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Calculate space usage
+      shell: bash
+      if: ${{ inputs.show-sizes == 'true' }}
+      run: |
+        echo Usage for /opt
+        sudo du -shc /opt/* || true
+
+        echo Usage for /opt/hostedtoolcache
+        du -shc /opt/hostedtoolcache/* || true
+        echo
+
+        echo Usage for /opt/microsoft
+        du -shc /opt/microsoft/* || true
+        echo
+
+        echo Usage for /opt/az
+        du -shc /opt/az/* || true
+        echo
+
+        echo Usage for /usr/lib
+        sudo du -shc /usr/lib/* || true
+        echo
+
+        echo Usage for /usr/local/lib
+        sudo du -shc /usr/local/lib/* || true
+        echo
+
+        echo Usage for /usr/local/share
+        sudo du -shc /usr/local/share/* || true
+        echo
+
+        echo Usage for /usr/share
+        sudo du -shc /usr/share/* || true
+        echo
+
+        echo Docker images:
+        docker images -a
+        echo
+        echo Usage for /var/lib/docker
+        sudo bash -c 'du -shc /var/lib/docker/*' || true
+        echo
+
+    - name: Remove unwanted software
+      shell: bash
+      run: |
+        echo "Space available before cleanup"
+        df -h /
+
+        function cleanup_dir() {
+          dir=$1
+          TIMEFORMAT="Cleanup ${dir} took %R seconds"
+          time {
+            sudo rm -rf $dir || true
+          }
+        }
+
+        echo "Remove Android ... (~8.9G)"
+        cleanup_dir /usr/local/lib/android
+
+        echo "Remove CodeQL ... (~5.0G)" 
+        cleanup_dir /opt/hostedtoolcache/CodeQL
+
+        echo "Remove Swift ... (~1.9G)"
+        cleanup_dir /usr/share/swift
+
+        echo "Remove DotNet ... (~1.6G)"
+        cleanup_dir /usr/share/dotnet
+
+        if [[ ${{ inputs.keep-docker-images }} != 'true' ]] ; then
+          echo "Remove preinstalled Docker images ..."
+          TIMEFORMAT="Cleanup preinstalled Docker images took %R seconds"
+          time {
+            sudo docker image prune --all --force > /dev/null
+          }
+        fi
+
+        if [[ ${{ inputs.deeper-cleanup }} == 'true' ]] ; then
+          echo "Remove Azure tools ... (~747M)"
+          cleanup_dir /opt/az
+
+          echo "Remove chromium ... (~510M)"
+          cleanup_dir /usr/local/share/chromium
+
+          echo "Remove Julia ... (~579M)"
+          cleanup_dir /usr/local/julia1.10.2
+
+          echo "Remove MS Tools: MS Edge ... (~559M)"
+          cleanup_dir /opt/microsoft/msedge
+
+          echo "Remove MS Tools: powershell ... (~175M)"
+          cleanup_dir /usr/local/share/powershell
+
+          echo "Remove AWS tools ... (~403M)"
+          cleanup_dir /usr/local/aws-cli
+          cleanup_dir /usr/local/aws-sam-cli
+        fi
+
+        echo "Space available after cleanup"
+        df -h /
+        rootSize=$(df -h / | tail -n 1 )
+        echo "::notice title=Space available after cleanup::${rootSize}"

--- a/.github/workflows/build_dev.yml
+++ b/.github/workflows/build_dev.yml
@@ -90,7 +90,7 @@ jobs:
           go-version: "1.21"
       
       - name: Install Task
-        uses: arduino/setup-task@v1
+        uses: arduino/setup-task@v2
         
       - uses: actions/checkout@v4
         
@@ -104,7 +104,7 @@ jobs:
     name: Run yaml linter
     steps:
       - name: Install Task
-        uses: arduino/setup-task@v1
+        uses: arduino/setup-task@v2
         
       - uses: actions/checkout@v4
         with:
@@ -123,7 +123,7 @@ jobs:
           go-version: "1.21"
       
       - name: Install Task
-        uses: arduino/setup-task@v1
+        uses: arduino/setup-task@v2
       
       - uses: actions/checkout@v4
       
@@ -163,10 +163,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Remove unwanted software
+        uses: ./.github/actions/remove-unwanted-software
+
       - uses: deckhouse/modules-actions/setup@v1
       - uses: deckhouse/modules-actions/build@v1
 
-      - name: Register the module 
+      - name: Register the module
         run: |
           echo "✨ Register the module ${MODULES_MODULE_NAME}"
           crane append \

--- a/.github/workflows/build_prod.yml
+++ b/.github/workflows/build_prod.yml
@@ -33,6 +33,9 @@ jobs:
         shell: bash
         name: Show vars
 
+      - name: Remove unwanted software
+        uses: ./.github/actions/remove-unwanted-software
+
       - uses: actions/checkout@v4
       - uses: deckhouse/modules-actions/setup@v1
       - uses: deckhouse/modules-actions/build@v1
@@ -61,6 +64,9 @@ jobs:
         shell: bash
         name: Show vars
 
+      - name: Remove unwanted software
+        uses: ./.github/actions/remove-unwanted-software
+
       - uses: actions/checkout@v4
       - uses: deckhouse/modules-actions/setup@v1
       - uses: deckhouse/modules-actions/build@v1
@@ -88,6 +94,9 @@ jobs:
           echo $MODULES_MODULE_TAG
         shell: bash
         name: Show vars
+
+      - name: Remove unwanted software
+        uses: ./.github/actions/remove-unwanted-software
 
       - uses: actions/checkout@v4
       - uses: deckhouse/modules-actions/setup@v1


### PR DESCRIPTION

## Description

- Initial 20Gb of free space is not enough for building kubevirt and cdi.
- Remove preinstalled Docker images and some huge packages: android, codeql, swift, etc. to get extra ~20Gb of free space.
- Update arduino/setup-task to v2 to use Node 20.


## Why do we need it, and what problem does it solve?

Initial 20Gb of free space is not enough for building kubevirt and cdi.

## What is the expected result?

Kubevirt and CDI components are successfully built after changing patches.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
