### PR TITLE
feat(apiserver): implement table-converter

### DIFF
--- a/images/virtualization-artifact/pkg/apiserver/api/install.go
+++ b/images/virtualization-artifact/pkg/apiserver/api/install.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -9,7 +10,7 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/client-go/tools/cache"
 
-	rest2 "github.com/deckhouse/virtualization-controller/pkg/apiserver/registry/vm/rest"
+	vmrest "github.com/deckhouse/virtualization-controller/pkg/apiserver/registry/vm/rest"
 	"github.com/deckhouse/virtualization-controller/pkg/apiserver/registry/vm/storage"
 	"github.com/deckhouse/virtualization-controller/pkg/tls/certmanager"
 	"github.com/deckhouse/virtualization/api/subresources"
@@ -52,10 +53,11 @@ func Build(store *storage.VirtualMachineStorage) genericapiserver.APIGroupInfo {
 func Install(
 	vmLister cache.GenericLister,
 	server *genericapiserver.GenericAPIServer,
-	kubevirt rest2.KubevirtApiServerConfig,
+	kubevirt vmrest.KubevirtApiServerConfig,
 	proxyCertManager certmanager.CertificateManager,
+	crd *apiextensionsv1.CustomResourceDefinition,
 ) error {
-	vmStorage := storage.NewStorage(subresources.Resource("virtualmachines"), vmLister, kubevirt, proxyCertManager)
+	vmStorage := storage.NewStorage(subresources.Resource("virtualmachines"), vmLister, kubevirt, proxyCertManager, crd)
 	info := Build(vmStorage)
 	return server.InstallAPIGroup(&info)
 }


### PR DESCRIPTION
## Description
adding the same table-converter as "virtualmachines.virtualization.deckhouse.io" to "virtualmachines.subresources.virtualization.deck house.io".
```bash                                                                                                                                                                                                                                
❯ kubectl get virtualmachines.virtualization.deckhouse.io 
NAME   PHASE     NODENAME   IPADDRESS    AGE
test   Pending              10.66.10.1   6s

❯ kubectl get virtualmachines.subresources.virtualization.deckhouse.io 
NAME   PHASE     NODENAME   IPADDRESS    AGE
test   Pending              10.66.10.1   10s

```
## Why do we need it, and what problem does it solve?
The resource "virtualmachines.subresources.virtualization.deckhouse.io" has a higher priority than "virtualmachines.virtualization.deckhouse.io", that's why the execution of "kubectl get virtualmachine" fails with an error. 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
