### PR TITLE
chore(vi/vd): remove tag importDuration from image status and similar resources

### DIFF
--- a/api/core/v1alpha2/image_status.go
+++ b/api/core/v1alpha2/image_status.go
@@ -13,7 +13,6 @@ const (
 )
 
 type ImageStatus struct {
-	//ImportDuration string           `json:"importDuration,omitempty"`
 	DownloadSpeed ImageStatusSpeed `json:"downloadSpeed"`
 	Size          ImageStatusSize  `json:"size"`
 	Format        string           `json:"format"`

--- a/api/core/v1alpha2/image_status.go
+++ b/api/core/v1alpha2/image_status.go
@@ -13,10 +13,10 @@ const (
 )
 
 type ImageStatus struct {
-	ImportDuration string           `json:"importDuration,omitempty"`
-	DownloadSpeed  ImageStatusSpeed `json:"downloadSpeed"`
-	Size           ImageStatusSize  `json:"size"`
-	Format         string           `json:"format"`
+	//ImportDuration string           `json:"importDuration,omitempty"`
+	DownloadSpeed ImageStatusSpeed `json:"downloadSpeed"`
+	Size          ImageStatusSize  `json:"size"`
+	Format        string           `json:"format"`
 	// FIXME: create ClusterImageStatus without Capacity and PersistentVolumeClaim
 	Capacity       string            `json:"capacity,omitempty"`
 	CDROM          bool              `json:"cdrom"`

--- a/api/core/v1alpha2/virtual_disk.go
+++ b/api/core/v1alpha2/virtual_disk.go
@@ -27,7 +27,6 @@ type VirtualDiskSpec struct {
 }
 
 type VirtualDiskStatus struct {
-	//ImportDuration string                   `json:"importDuration,omitempty"`
 	DownloadSpeed  VirtualDiskDownloadSpeed `json:"downloadSpeed"`
 	Capacity       string                   `json:"capacity,omitempty"`
 	Target         DiskTarget               `json:"target"`

--- a/api/core/v1alpha2/virtual_disk.go
+++ b/api/core/v1alpha2/virtual_disk.go
@@ -27,7 +27,7 @@ type VirtualDiskSpec struct {
 }
 
 type VirtualDiskStatus struct {
-	ImportDuration string                   `json:"importDuration,omitempty"`
+	//ImportDuration string                   `json:"importDuration,omitempty"`
 	DownloadSpeed  VirtualDiskDownloadSpeed `json:"downloadSpeed"`
 	Capacity       string                   `json:"capacity,omitempty"`
 	Target         DiskTarget               `json:"target"`

--- a/api/pkg/apiserver/api/generated/openapi/zz_generated.openapi.go
+++ b/api/pkg/apiserver/api/generated/openapi/zz_generated.openapi.go
@@ -949,12 +949,6 @@ func schema_virtualization_api_core_v1alpha2_ClusterVirtualImageStatus(ref commo
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
-					//"importDuration": {
-					//	SchemaProps: spec.SchemaProps{
-					//		Type:   []string{"string"},
-					//		Format: "",
-					//	},
-					//},
 					"downloadSpeed": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
@@ -1177,12 +1171,6 @@ func schema_virtualization_api_core_v1alpha2_ImageStatus(ref common.ReferenceCal
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
-					//"importDuration": {
-					//	SchemaProps: spec.SchemaProps{
-					//		Type:   []string{"string"},
-					//		Format: "",
-					//	},
-					//},
 					"downloadSpeed": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
@@ -1782,12 +1770,6 @@ func schema_virtualization_api_core_v1alpha2_VirtualDiskStatus(ref common.Refere
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
-					//"importDuration": {
-					//	SchemaProps: spec.SchemaProps{
-					//		Type:   []string{"string"},
-					//		Format: "",
-					//	},
-					//},
 					"downloadSpeed": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
@@ -2063,12 +2045,6 @@ func schema_virtualization_api_core_v1alpha2_VirtualImageStatus(ref common.Refer
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
-					//"importDuration": {
-					//	SchemaProps: spec.SchemaProps{
-					//		Type:   []string{"string"},
-					//		Format: "",
-					//	},
-					//},
 					"downloadSpeed": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},

--- a/api/pkg/apiserver/api/generated/openapi/zz_generated.openapi.go
+++ b/api/pkg/apiserver/api/generated/openapi/zz_generated.openapi.go
@@ -949,12 +949,12 @@ func schema_virtualization_api_core_v1alpha2_ClusterVirtualImageStatus(ref commo
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
-					"importDuration": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
+					//"importDuration": {
+					//	SchemaProps: spec.SchemaProps{
+					//		Type:   []string{"string"},
+					//		Format: "",
+					//	},
+					//},
 					"downloadSpeed": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
@@ -1177,12 +1177,12 @@ func schema_virtualization_api_core_v1alpha2_ImageStatus(ref common.ReferenceCal
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
-					"importDuration": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
+					//"importDuration": {
+					//	SchemaProps: spec.SchemaProps{
+					//		Type:   []string{"string"},
+					//		Format: "",
+					//	},
+					//},
 					"downloadSpeed": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
@@ -1782,12 +1782,12 @@ func schema_virtualization_api_core_v1alpha2_VirtualDiskStatus(ref common.Refere
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
-					"importDuration": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
+					//"importDuration": {
+					//	SchemaProps: spec.SchemaProps{
+					//		Type:   []string{"string"},
+					//		Format: "",
+					//	},
+					//},
 					"downloadSpeed": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
@@ -2063,12 +2063,12 @@ func schema_virtualization_api_core_v1alpha2_VirtualImageStatus(ref common.Refer
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
-					"importDuration": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
+					//"importDuration": {
+					//	SchemaProps: spec.SchemaProps{
+					//		Type:   []string{"string"},
+					//		Format: "",
+					//	},
+					//},
 					"downloadSpeed": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},

--- a/crds/clustervirtualimage.yaml
+++ b/crds/clustervirtualimage.yaml
@@ -190,11 +190,6 @@ spec:
             status:
               type: object
               properties:
-                #importDuration:
-                  #type: string
-                  #example: 1m44s
-                  #description: |
-                    #The duration of the image import (from the moment of creation resource, to the moment of going to the Ready phase).
                 downloadSpeed:
                   type: object
                   description: |

--- a/crds/clustervirtualimage.yaml
+++ b/crds/clustervirtualimage.yaml
@@ -190,11 +190,11 @@ spec:
             status:
               type: object
               properties:
-                importDuration:
-                  type: string
-                  example: 1m44s
-                  description: |
-                    The duration of the image import (from the moment of creation resource, to the moment of going to the Ready phase).
+                #importDuration:
+                  #type: string
+                  #example: 1m44s
+                  #description: |
+                    #The duration of the image import (from the moment of creation resource, to the moment of going to the Ready phase).
                 downloadSpeed:
                   type: object
                   description: |

--- a/crds/doc-ru-clustervirtualmachineimage.yaml
+++ b/crds/doc-ru-clustervirtualmachineimage.yaml
@@ -101,9 +101,6 @@ spec:
                             Имя существующего `ClusterVirtualImage`.
             status:
               properties:
-                #importDuration:
-                  #description: |
-                    #Продолжительность импорта образа (от момента создания ресурса до перехода в фазу `Ready`).
                 downloadSpeed:
                   description: |
                     Скорость загрузки образа из внешнего источника. Появляется только на этапе `Provisioning`.

--- a/crds/doc-ru-clustervirtualmachineimage.yaml
+++ b/crds/doc-ru-clustervirtualmachineimage.yaml
@@ -101,9 +101,9 @@ spec:
                             Имя существующего `ClusterVirtualImage`.
             status:
               properties:
-                importDuration:
-                  description: |
-                    Продолжительность импорта образа (от момента создания ресурса до перехода в фазу `Ready`).
+                #importDuration:
+                  #description: |
+                    #Продолжительность импорта образа (от момента создания ресурса до перехода в фазу `Ready`).
                 downloadSpeed:
                   description: |
                     Скорость загрузки образа из внешнего источника. Появляется только на этапе `Provisioning`.

--- a/crds/doc-ru-virtualmachinedisk.yaml
+++ b/crds/doc-ru-virtualmachinedisk.yaml
@@ -100,9 +100,6 @@ spec:
                             Имя существующего `ClusterVirtualImage`.
             status:
               properties:
-                #importDuration:
-                  #description: |
-                    #Продолжительность создания диска (от момента создания ресурса до перехода в фазу `Ready`).
                 downloadSpeed:
                   description: |
                     Скорость загрузки образа из внешнего источника. Появляется только на этапе `Provisioning`.

--- a/crds/doc-ru-virtualmachinedisk.yaml
+++ b/crds/doc-ru-virtualmachinedisk.yaml
@@ -100,9 +100,9 @@ spec:
                             Имя существующего `ClusterVirtualImage`.
             status:
               properties:
-                importDuration:
-                  description: |
-                    Продолжительность создания диска (от момента создания ресурса до перехода в фазу `Ready`).
+                #importDuration:
+                  #description: |
+                    #Продолжительность создания диска (от момента создания ресурса до перехода в фазу `Ready`).
                 downloadSpeed:
                   description: |
                     Скорость загрузки образа из внешнего источника. Появляется только на этапе `Provisioning`.

--- a/crds/doc-ru-virtualmachineimage.yaml
+++ b/crds/doc-ru-virtualmachineimage.yaml
@@ -105,9 +105,9 @@ spec:
             status:
               type: object
               properties:
-                importDuration:
-                  description: |
-                    Продолжительность импорта образа (от момента создания ресурса до перехода в фазу `Ready`).
+                #importDuration:
+                  #description: |
+                    #Продолжительность импорта образа (от момента создания ресурса до перехода в фазу `Ready`).
                 downloadSpeed:
                   description: |
                     Скорость загрузки образа из внешнего источника. Появляется только на этапе `Provisioning`.

--- a/crds/doc-ru-virtualmachineimage.yaml
+++ b/crds/doc-ru-virtualmachineimage.yaml
@@ -105,9 +105,6 @@ spec:
             status:
               type: object
               properties:
-                #importDuration:
-                  #description: |
-                    #Продолжительность импорта образа (от момента создания ресурса до перехода в фазу `Ready`).
                 downloadSpeed:
                   description: |
                     Скорость загрузки образа из внешнего источника. Появляется только на этапе `Provisioning`.

--- a/crds/virtualdisk.yaml
+++ b/crds/virtualdisk.yaml
@@ -197,11 +197,11 @@ spec:
             status:
               type: object
               properties:
-                importDuration:
-                  type: string
-                  example: 1m44s
-                  description: |
-                    The duration of the image import (from the moment of creation resource, to the moment of going to the Ready phase).
+                #importDuration:
+                  #type: string
+                  #example: 1m44s
+                  #description: |
+                    #The duration of the image import (from the moment of creation resource, to the moment of going to the Ready phase).
                 downloadSpeed:
                   type: object
                   description: |

--- a/crds/virtualdisk.yaml
+++ b/crds/virtualdisk.yaml
@@ -197,11 +197,6 @@ spec:
             status:
               type: object
               properties:
-                #importDuration:
-                  #type: string
-                  #example: 1m44s
-                  #description: |
-                    #The duration of the image import (from the moment of creation resource, to the moment of going to the Ready phase).
                 downloadSpeed:
                   type: object
                   description: |

--- a/crds/virtualimage.yaml
+++ b/crds/virtualimage.yaml
@@ -197,11 +197,11 @@ spec:
             status:
               type: object
               properties:
-                importDuration:
-                  type: string
-                  example: 1m44s
-                  description: |
-                    The duration of the image import (from the moment of creation resource, to the moment of going to the Ready phase).
+                #importDuration:
+                  #type: string
+                  #example: 1m44s
+                  #description: |
+                    #The duration of the image import (from the moment of creation resource, to the moment of going to the Ready phase).
                 downloadSpeed:
                   type: object
                   description: |

--- a/crds/virtualimage.yaml
+++ b/crds/virtualimage.yaml
@@ -197,11 +197,6 @@ spec:
             status:
               type: object
               properties:
-                #importDuration:
-                  #type: string
-                  #example: 1m44s
-                  #description: |
-                    #The duration of the image import (from the moment of creation resource, to the moment of going to the Ready phase).
                 downloadSpeed:
                   type: object
                   description: |

--- a/images/virtualization-artifact/pkg/apiserver/api/generated/openapi/zz_generated.openapi.go
+++ b/images/virtualization-artifact/pkg/apiserver/api/generated/openapi/zz_generated.openapi.go
@@ -1014,12 +1014,12 @@ func schema_virtualization_controller_api_core_v1alpha2_ClusterVirtualImageStatu
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
-					"importDuration": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
+					//"importDuration": {
+					//	SchemaProps: spec.SchemaProps{
+					//		Type:   []string{"string"},
+					//		Format: "",
+					//	},
+					//},
 					"downloadSpeed": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
@@ -1349,12 +1349,12 @@ func schema_virtualization_controller_api_core_v1alpha2_ImageStatus(ref common.R
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
-					"importDuration": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
+					//"importDuration": {
+					//	SchemaProps: spec.SchemaProps{
+					//		Type:   []string{"string"},
+					//		Format: "",
+					//	},
+					//},
 					"downloadSpeed": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
@@ -2495,12 +2495,12 @@ func schema_virtualization_controller_api_core_v1alpha2_VirtualDiskStatus(ref co
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
-					"importDuration": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
+					//"importDuration": {
+					//	SchemaProps: spec.SchemaProps{
+					//		Type:   []string{"string"},
+					//		Format: "",
+					//	},
+					//},
 					"downloadSpeed": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
@@ -3053,12 +3053,12 @@ func schema_virtualization_controller_api_core_v1alpha2_VirtualImageStatus(ref c
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
-					"importDuration": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
+					//"importDuration": {
+					//	SchemaProps: spec.SchemaProps{
+					//		Type:   []string{"string"},
+					//		Format: "",
+					//	},
+					//},
 					"downloadSpeed": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},

--- a/images/virtualization-artifact/pkg/apiserver/api/generated/openapi/zz_generated.openapi.go
+++ b/images/virtualization-artifact/pkg/apiserver/api/generated/openapi/zz_generated.openapi.go
@@ -1014,12 +1014,6 @@ func schema_virtualization_controller_api_core_v1alpha2_ClusterVirtualImageStatu
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
-					//"importDuration": {
-					//	SchemaProps: spec.SchemaProps{
-					//		Type:   []string{"string"},
-					//		Format: "",
-					//	},
-					//},
 					"downloadSpeed": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
@@ -1349,12 +1343,6 @@ func schema_virtualization_controller_api_core_v1alpha2_ImageStatus(ref common.R
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
-					//"importDuration": {
-					//	SchemaProps: spec.SchemaProps{
-					//		Type:   []string{"string"},
-					//		Format: "",
-					//	},
-					//},
 					"downloadSpeed": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
@@ -2495,12 +2483,6 @@ func schema_virtualization_controller_api_core_v1alpha2_VirtualDiskStatus(ref co
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
-					//"importDuration": {
-					//	SchemaProps: spec.SchemaProps{
-					//		Type:   []string{"string"},
-					//		Format: "",
-					//	},
-					//},
 					"downloadSpeed": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
@@ -3053,12 +3035,6 @@ func schema_virtualization_controller_api_core_v1alpha2_VirtualImageStatus(ref c
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
-					//"importDuration": {
-					//	SchemaProps: spec.SchemaProps{
-					//		Type:   []string{"string"},
-					//		Format: "",
-					//	},
-					//},
 					"downloadSpeed": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},

--- a/images/virtualization-artifact/pkg/controller/cvmi_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/cvmi_reconciler.go
@@ -163,10 +163,6 @@ func (r *CVMIReconciler) UpdateStatus(ctx context.Context, _ reconcile.Request, 
 	dvcrDestImageName := r.dvcrSettings.RegistryImageForCVMI(state.CVMI.Current().Name)
 	cvmiStatus.Target.RegistryURL = dvcrDestImageName
 
-	//if cvmiStatus.Phase != virtv2.ImageReady {
-	//	cvmiStatus.ImportDuration = helper.GetAge(state.CVMI.Current()).String()
-	//}
-
 	switch {
 	case state.CVMI.Current().Status.Phase == "":
 		cvmiStatus.Phase = virtv2.ImagePending

--- a/images/virtualization-artifact/pkg/controller/cvmi_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/cvmi_reconciler.go
@@ -163,9 +163,9 @@ func (r *CVMIReconciler) UpdateStatus(ctx context.Context, _ reconcile.Request, 
 	dvcrDestImageName := r.dvcrSettings.RegistryImageForCVMI(state.CVMI.Current().Name)
 	cvmiStatus.Target.RegistryURL = dvcrDestImageName
 
-	if cvmiStatus.Phase != virtv2.ImageReady {
-		cvmiStatus.ImportDuration = helper.GetAge(state.CVMI.Current()).String()
-	}
+	//if cvmiStatus.Phase != virtv2.ImageReady {
+	//	cvmiStatus.ImportDuration = helper.GetAge(state.CVMI.Current()).String()
+	//}
 
 	switch {
 	case state.CVMI.Current().Status.Phase == "":

--- a/images/virtualization-artifact/pkg/controller/vmd_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/vmd_reconciler.go
@@ -290,11 +290,6 @@ func (r *VMDReconciler) UpdateStatus(_ context.Context, _ reconcile.Request, sta
 	}
 
 	vmdStatus := state.VMD.Current().Status.DeepCopy()
-
-	//if vmdStatus.Phase != virtv2.DiskReady {
-	//	vmdStatus.ImportDuration = helper.GetAge(state.VMD.Current()).String()
-	//}
-
 	if vmdStatus.Progress == "" {
 		vmdStatus.Progress = "0%"
 	}

--- a/images/virtualization-artifact/pkg/controller/vmd_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/vmd_reconciler.go
@@ -291,9 +291,9 @@ func (r *VMDReconciler) UpdateStatus(_ context.Context, _ reconcile.Request, sta
 
 	vmdStatus := state.VMD.Current().Status.DeepCopy()
 
-	if vmdStatus.Phase != virtv2.DiskReady {
-		vmdStatus.ImportDuration = helper.GetAge(state.VMD.Current()).String()
-	}
+	//if vmdStatus.Phase != virtv2.DiskReady {
+	//	vmdStatus.ImportDuration = helper.GetAge(state.VMD.Current()).String()
+	//}
 
 	if vmdStatus.Progress == "" {
 		vmdStatus.Progress = "0%"

--- a/images/virtualization-artifact/pkg/controller/vmi_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/vmi_reconciler.go
@@ -247,11 +247,6 @@ func (r *VMIReconciler) UpdateStatus(_ context.Context, _ reconcile.Request, sta
 	}
 
 	vmiStatus := state.VMI.Current().Status.DeepCopy()
-
-	//if vmiStatus.Phase != virtv2.ImageReady {
-	//	vmiStatus.ImportDuration = helper.GetAge(state.VMI.Current()).String()
-	//}
-
 	switch {
 	case vmiStatus.Phase == "":
 		vmiStatus.Phase = virtv2.ImagePending

--- a/images/virtualization-artifact/pkg/controller/vmi_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/vmi_reconciler.go
@@ -248,9 +248,9 @@ func (r *VMIReconciler) UpdateStatus(_ context.Context, _ reconcile.Request, sta
 
 	vmiStatus := state.VMI.Current().Status.DeepCopy()
 
-	if vmiStatus.Phase != virtv2.ImageReady {
-		vmiStatus.ImportDuration = helper.GetAge(state.VMI.Current()).String()
-	}
+	//if vmiStatus.Phase != virtv2.ImageReady {
+	//	vmiStatus.ImportDuration = helper.GetAge(state.VMI.Current()).String()
+	//}
 
 	switch {
 	case vmiStatus.Phase == "":


### PR DESCRIPTION
## Description

remove tag importDuration from image status and similar resources
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
