### PR TITLE
ci: add skip labels for doc_changes and no_cyrillic validations

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -14,6 +14,7 @@ defaults:
 
 jobs:
   no_cyrillic:
+    if: "!contains(github.event.pull_request.labels.*.name, 'validation/skip/no_cyrillic')"
     runs-on: ubuntu-latest
     name: Validation no-cyrillic
     steps:
@@ -34,6 +35,7 @@ jobs:
           task validation:no-cyrillic
 
   doc_changes:
+    if: "!contains(github.event.pull_request.labels.*.name, 'validation/skip/doc_changes')"
     runs-on: ubuntu-latest
     name: Validation doc-changes
     steps:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Added condition for skip job doc_changes and no_cyrillic validations.

Added labels:
validation/skip/no_cyrillic
validation/skip/doc_changes
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
In some cases, we need to skip checking the Cyrillic alphabet or document changes.
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
