### PR TITLE
chore(virt-operator): delete kubevirt ApiService

### DIFF
--- a/images/virt-artifact/patches/014-delete-apiserver.patch
+++ b/images/virt-artifact/patches/014-delete-apiserver.patch
@@ -1,0 +1,538 @@
+diff --git a/pkg/virt-operator/application.go b/pkg/virt-operator/application.go
+index 323d0e34b..f4d52e4db 100644
+--- a/pkg/virt-operator/application.go
++++ b/pkg/virt-operator/application.go
+@@ -207,7 +207,6 @@ func Execute() {
+ 		DaemonSet:                app.informerFactory.OperatorDaemonSet(),
+ 		ValidationWebhook:        app.informerFactory.OperatorValidationWebhook(),
+ 		MutatingWebhook:          app.informerFactory.OperatorMutatingWebhook(),
+-		APIService:               app.informerFactory.OperatorAPIService(),
+ 		InstallStrategyConfigMap: app.informerFactory.OperatorInstallStrategyConfigMaps(),
+ 		InstallStrategyJob:       app.informerFactory.OperatorInstallStrategyJob(),
+ 		InfrastructurePod:        app.informerFactory.OperatorPod(),
+@@ -229,7 +228,6 @@ func Execute() {
+ 		DaemonSetCache:                app.informerFactory.OperatorDaemonSet().GetStore(),
+ 		ValidationWebhookCache:        app.informerFactory.OperatorValidationWebhook().GetStore(),
+ 		MutatingWebhookCache:          app.informerFactory.OperatorMutatingWebhook().GetStore(),
+-		APIServiceCache:               app.informerFactory.OperatorAPIService().GetStore(),
+ 		InstallStrategyConfigMapCache: app.informerFactory.OperatorInstallStrategyConfigMaps().GetStore(),
+ 		InstallStrategyJobCache:       app.informerFactory.OperatorInstallStrategyJob().GetStore(),
+ 		InfrastructurePodCache:        app.informerFactory.OperatorPod().GetStore(),
+diff --git a/pkg/virt-operator/kubevirt.go b/pkg/virt-operator/kubevirt.go
+index 9152959b4..aff0b023a 100644
+--- a/pkg/virt-operator/kubevirt.go
++++ b/pkg/virt-operator/kubevirt.go
+@@ -93,7 +93,6 @@ func NewKubeVirtController(
+ 		workqueue.NewItemExponentialFailureRateLimiter(5*time.Second, 1000*time.Second),
+ 		&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Every(5*time.Second), 1)},
+ 	)
+-
+ 	c := KubeVirtController{
+ 		clientset:        clientset,
+ 		aggregatorClient: aggregatorClient,
+@@ -114,7 +113,6 @@ func NewKubeVirtController(
+ 			DaemonSet:                controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectationsWithName("DaemonSet")),
+ 			ValidationWebhook:        controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectationsWithName("ValidationWebhook")),
+ 			MutatingWebhook:          controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectationsWithName("MutatingWebhook")),
+-			APIService:               controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectationsWithName("APIService")),
+ 			SCC:                      controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectationsWithName("SCC")),
+ 			Route:                    controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectationsWithName("Route")),
+ 			InstallStrategyConfigMap: controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectationsWithName("InstallStrategyConfigMap")),
+@@ -318,21 +316,6 @@ func NewKubeVirtController(
+ 		return nil, err
+ 	}
+ 
+-	_, err = c.informers.APIService.AddEventHandler(cache.ResourceEventHandlerFuncs{
+-		AddFunc: func(obj interface{}) {
+-			c.genericAddHandler(obj, c.kubeVirtExpectations.APIService)
+-		},
+-		DeleteFunc: func(obj interface{}) {
+-			c.genericDeleteHandler(obj, c.kubeVirtExpectations.APIService)
+-		},
+-		UpdateFunc: func(oldObj, newObj interface{}) {
+-			c.genericUpdateHandler(oldObj, newObj, c.kubeVirtExpectations.APIService)
+-		},
+-	})
+-	if err != nil {
+-		return nil, err
+-	}
+-
+ 	_, err = c.informers.SCC.AddEventHandler(cache.ResourceEventHandlerFuncs{
+ 		AddFunc: func(obj interface{}) {
+ 			c.sccAddHandler(obj, c.kubeVirtExpectations.SCC)
+diff --git a/pkg/virt-operator/kubevirt_test.go b/pkg/virt-operator/kubevirt_test.go
+index e42648749..dbd20d23c 100644
+--- a/pkg/virt-operator/kubevirt_test.go
++++ b/pkg/virt-operator/kubevirt_test.go
+@@ -211,8 +211,6 @@ func (k *KubeVirtTestData) BeforeTest() {
+ 	k.stores.ValidationWebhookCache = k.informers.ValidationWebhook.GetStore()
+ 	k.informers.MutatingWebhook, k.mutatingWebhookSource = testutils.NewFakeInformerFor(&admissionregistrationv1.MutatingWebhookConfiguration{})
+ 	k.stores.MutatingWebhookCache = k.informers.MutatingWebhook.GetStore()
+-	k.informers.APIService, k.apiserviceSource = testutils.NewFakeInformerFor(&apiregv1.APIService{})
+-	k.stores.APIServiceCache = k.informers.APIService.GetStore()
+ 
+ 	k.informers.SCC, k.sccSource = testutils.NewFakeInformerFor(&secv1.SecurityContextConstraints{})
+ 	k.stores.SCCCache = k.informers.SCC.GetStore()
+@@ -506,8 +504,6 @@ func (k *KubeVirtTestData) deleteResource(resource string, key string) {
+ 		k.deleteValidationWebhook(key)
+ 	case "mutatingwebhookconfigurations":
+ 		k.deleteMutatingWebhook(key)
+-	case "apiservices":
+-		k.deleteAPIService(key)
+ 	case "jobs":
+ 		k.deleteInstallStrategyJob(key)
+ 	case "configmaps":
+@@ -621,14 +617,6 @@ func (k *KubeVirtTestData) deleteMutatingWebhook(key string) {
+ 	k.mockQueue.Wait()
+ }
+ 
+-func (k *KubeVirtTestData) deleteAPIService(key string) {
+-	k.mockQueue.ExpectAdds(1)
+-	if obj, exists, _ := k.informers.APIService.GetStore().GetByKey(key); exists {
+-		k.apiserviceSource.Delete(obj.(runtime.Object))
+-	}
+-	k.mockQueue.Wait()
+-}
+-
+ func (k *KubeVirtTestData) deleteInstallStrategyJob(key string) {
+ 	k.mockQueue.ExpectAdds(1)
+ 	if obj, exists, _ := k.informers.InstallStrategyJob.GetStore().GetByKey(key); exists {
+@@ -1312,12 +1300,6 @@ func (k *KubeVirtTestData) addAllWithExclusionMap(config *util.KubeVirtDeploymen
+ 	}
+ 	all = append(all, mutatingWebhook)
+ 
+-	apiServices := components.NewVirtAPIAPIServices(config.GetNamespace())
+-	for _, apiService := range apiServices {
+-		apiService.Spec.CABundle = caBundle
+-		all = append(all, apiService)
+-	}
+-
+ 	validatingWebhook = components.NewOpertorValidatingWebhookConfiguration(NAMESPACE)
+ 	for i := range validatingWebhook.Webhooks {
+ 		validatingWebhook.Webhooks[i].ClientConfig.CABundle = caBundle
+@@ -3138,7 +3120,6 @@ func syncCaches(stop chan struct{}, kvInformer cache.SharedIndexInformer, inform
+ 	go informers.DaemonSet.Run(stop)
+ 	go informers.ValidationWebhook.Run(stop)
+ 	go informers.MutatingWebhook.Run(stop)
+-	go informers.APIService.Run(stop)
+ 	go informers.SCC.Run(stop)
+ 	go informers.InstallStrategyJob.Run(stop)
+ 	go informers.InstallStrategyConfigMap.Run(stop)
+@@ -3164,7 +3145,6 @@ func syncCaches(stop chan struct{}, kvInformer cache.SharedIndexInformer, inform
+ 	cache.WaitForCacheSync(stop, informers.DaemonSet.HasSynced)
+ 	cache.WaitForCacheSync(stop, informers.ValidationWebhook.HasSynced)
+ 	cache.WaitForCacheSync(stop, informers.MutatingWebhook.HasSynced)
+-	cache.WaitForCacheSync(stop, informers.APIService.HasSynced)
+ 	cache.WaitForCacheSync(stop, informers.SCC.HasSynced)
+ 	cache.WaitForCacheSync(stop, informers.InstallStrategyJob.HasSynced)
+ 	cache.WaitForCacheSync(stop, informers.InstallStrategyConfigMap.HasSynced)
+diff --git a/pkg/virt-operator/resource/apply/apiservices.go b/pkg/virt-operator/resource/apply/apiservices.go
+deleted file mode 100644
+index 6d741321e..000000000
+--- a/pkg/virt-operator/resource/apply/apiservices.go
++++ /dev/null
+@@ -1,92 +0,0 @@
+-package apply
+-
+-import (
+-	"context"
+-	"encoding/json"
+-	"fmt"
+-
+-	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
+-	"k8s.io/apimachinery/pkg/api/equality"
+-	"k8s.io/apimachinery/pkg/api/errors"
+-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+-	"k8s.io/apimachinery/pkg/types"
+-	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+-
+-	"kubevirt.io/client-go/log"
+-)
+-
+-func (r *Reconciler) createOrUpdateAPIServices(caBundle []byte) error {
+-	for _, apiService := range r.targetStrategy.APIServices() {
+-		err := r.createOrUpdateAPIService(apiService.DeepCopy(), caBundle)
+-		if err != nil {
+-			return err
+-		}
+-	}
+-
+-	return nil
+-}
+-
+-func (r *Reconciler) createOrUpdateAPIService(apiService *apiregv1.APIService, caBundle []byte) error {
+-	version, imageRegistry, id := getTargetVersionRegistryID(r.kv)
+-	injectOperatorMetadata(r.kv, &apiService.ObjectMeta, version, imageRegistry, id, true)
+-	apiService.Spec.CABundle = caBundle
+-
+-	var cachedAPIService *apiregv1.APIService
+-	var err error
+-	obj, exists, _ := r.stores.APIServiceCache.Get(apiService)
+-	// since these objects was in the past unmanaged, reconcile and pick it up if it exists
+-	if !exists {
+-		cachedAPIService, err = r.aggregatorclient.Get(context.Background(), apiService.Name, metav1.GetOptions{})
+-		if errors.IsNotFound(err) {
+-			exists = false
+-		} else if err != nil {
+-			return err
+-		} else {
+-			exists = true
+-		}
+-	} else if exists {
+-		cachedAPIService = obj.(*apiregv1.APIService)
+-	}
+-
+-	if !exists {
+-		r.expectations.APIService.RaiseExpectations(r.kvKey, 1, 0)
+-		_, err := r.aggregatorclient.Create(context.Background(), apiService, metav1.CreateOptions{})
+-		if err != nil {
+-			r.expectations.APIService.LowerExpectations(r.kvKey, 1, 0)
+-			return fmt.Errorf("unable to create apiservice %+v: %v", apiService, err)
+-		}
+-
+-		return nil
+-	}
+-
+-	modified := resourcemerge.BoolPtr(false)
+-	resourcemerge.EnsureObjectMeta(modified, &cachedAPIService.ObjectMeta, apiService.ObjectMeta)
+-	serviceSame := equality.Semantic.DeepEqual(cachedAPIService.Spec.Service, apiService.Spec.Service)
+-	certsSame := equality.Semantic.DeepEqual(apiService.Spec.CABundle, cachedAPIService.Spec.CABundle)
+-	prioritySame := cachedAPIService.Spec.VersionPriority == apiService.Spec.VersionPriority && cachedAPIService.Spec.GroupPriorityMinimum == apiService.Spec.GroupPriorityMinimum
+-	insecureSame := cachedAPIService.Spec.InsecureSkipTLSVerify == apiService.Spec.InsecureSkipTLSVerify
+-	// there was no change to metadata, the service and priorities were right
+-	if !*modified && serviceSame && prioritySame && insecureSame && certsSame {
+-		log.Log.V(4).Infof("apiservice %v is up-to-date", apiService.GetName())
+-
+-		return nil
+-	}
+-
+-	spec, err := json.Marshal(apiService.Spec)
+-	if err != nil {
+-		return err
+-	}
+-
+-	ops, err := getPatchWithObjectMetaAndSpec([]string{}, &apiService.ObjectMeta, spec)
+-	if err != nil {
+-		return err
+-	}
+-
+-	_, err = r.aggregatorclient.Patch(context.Background(), apiService.Name, types.JSONPatchType, generatePatchBytes(ops), metav1.PatchOptions{})
+-	if err != nil {
+-		return fmt.Errorf("unable to patch apiservice %+v: %v", apiService, err)
+-	}
+-	log.Log.V(4).Infof("apiservice %v updated", apiService.GetName())
+-
+-	return nil
+-}
+diff --git a/pkg/virt-operator/resource/apply/core.go b/pkg/virt-operator/resource/apply/core.go
+index 4d507f615..3315598a3 100644
+--- a/pkg/virt-operator/resource/apply/core.go
++++ b/pkg/virt-operator/resource/apply/core.go
+@@ -363,12 +363,6 @@ func (r *Reconciler) createOrUpdateComponentsWithCertificates(queue workqueue.Ra
+ 		return err
+ 	}
+ 
+-	// create/update APIServices
+-	err = r.createOrUpdateAPIServices(caBundle)
+-	if err != nil {
+-		return err
+-	}
+-
+ 	// create/update Routes
+ 	err = r.createOrUpdateRoutes(caBundle)
+ 	if err != nil {
+diff --git a/pkg/virt-operator/resource/apply/delete.go b/pkg/virt-operator/resource/apply/delete.go
+index d2c8b96f5..ecea83a7b 100644
+--- a/pkg/virt-operator/resource/apply/delete.go
++++ b/pkg/virt-operator/resource/apply/delete.go
+@@ -36,7 +36,6 @@ import (
+ 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+ 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+ 	"k8s.io/apimachinery/pkg/types"
+-	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+ 
+ 	v1 "kubevirt.io/api/core/v1"
+ 	"kubevirt.io/client-go/kubecli"
+@@ -215,25 +214,6 @@ func DeleteAll(kv *v1.KubeVirt,
+ 		}
+ 	}
+ 
+-	// delete apiservices
+-	objects = stores.APIServiceCache.List()
+-	for _, obj := range objects {
+-		if apiservice, ok := obj.(*apiregv1.APIService); ok && apiservice.DeletionTimestamp == nil {
+-			if key, err := controller.KeyFunc(apiservice); err == nil {
+-				expectations.APIService.AddExpectedDeletion(kvkey, key)
+-				err := aggregatorclient.Delete(context.Background(), apiservice.Name, deleteOptions)
+-				if err != nil {
+-					expectations.APIService.DeletionObserved(kvkey, key)
+-					log.Log.Errorf("Failed to delete apiservice %+v: %v", apiservice, err)
+-					return err
+-				}
+-			}
+-		} else if !ok {
+-			log.Log.Errorf(castFailedFmt, obj)
+-			return nil
+-		}
+-	}
+-
+ 	// delete services
+ 	objects = stores.ServiceCache.List()
+ 	for _, obj := range objects {
+diff --git a/pkg/virt-operator/resource/apply/patches.go b/pkg/virt-operator/resource/apply/patches.go
+index 2bd0c313d..e9cd7d820 100644
+--- a/pkg/virt-operator/resource/apply/patches.go
++++ b/pkg/virt-operator/resource/apply/patches.go
+@@ -140,10 +140,6 @@ func (c *Customizer) Apply(targetStrategy *install.Strategy) error {
+ 	if err != nil {
+ 		return err
+ 	}
+-	err = c.GenericApplyPatches(targetStrategy.APIServices())
+-	if err != nil {
+-		return err
+-	}
+ 	err = c.GenericApplyPatches(targetStrategy.CertificateSecrets())
+ 	if err != nil {
+ 		return err
+diff --git a/pkg/virt-operator/resource/apply/reconcile.go b/pkg/virt-operator/resource/apply/reconcile.go
+index 5408aa41d..4e437d757 100644
+--- a/pkg/virt-operator/resource/apply/reconcile.go
++++ b/pkg/virt-operator/resource/apply/reconcile.go
+@@ -39,8 +39,6 @@ import (
+ 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+ 	"k8s.io/client-go/tools/record"
+ 	"k8s.io/client-go/util/workqueue"
+-	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+-
+ 	v1 "kubevirt.io/api/core/v1"
+ 	"kubevirt.io/client-go/kubecli"
+ 	"kubevirt.io/client-go/log"
+@@ -800,39 +798,6 @@ func (r *Reconciler) deleteObjectsNotInInstallStrategy() error {
+ 			}
+ 		}
+ 	}
+-
+-	// remove unused APIServices
+-	objects = r.stores.APIServiceCache.List()
+-	for _, obj := range objects {
+-		if apiService, ok := obj.(*apiregv1.APIService); ok && apiService.DeletionTimestamp == nil {
+-			found := false
+-			for _, targetAPIService := range r.targetStrategy.APIServices() {
+-				if targetAPIService.Name == apiService.Name {
+-					found = true
+-					break
+-				}
+-			}
+-			// This is for backward compatibility where virt-api managed the entity itself.
+-			// If someone upgrades from such an old version and then has to roll back, we want avoid deleting a resource
+-			// which was not explicitly created by an operator, but is still visible to it.
+-			// TODO: Remove this once we don't support upgrading from such old kubevirt installations.
+-			if _, ok := apiService.Annotations[v1.InstallStrategyVersionAnnotation]; !ok {
+-				found = true
+-			}
+-			if !found {
+-				if key, err := controller.KeyFunc(apiService); err == nil {
+-					r.expectations.APIService.AddExpectedDeletion(r.kvKey, key)
+-					err := r.aggregatorclient.Delete(context.Background(), apiService.Name, deleteOptions)
+-					if err != nil {
+-						r.expectations.APIService.DeletionObserved(r.kvKey, key)
+-						log.Log.Errorf("Failed to delete apiService %+v: %v", apiService, err)
+-						return err
+-					}
+-				}
+-			}
+-		}
+-	}
+-
+ 	// remove unused Secrets
+ 	objects = r.stores.SecretCache.List()
+ 	for _, obj := range objects {
+diff --git a/pkg/virt-operator/resource/generate/components/apiservices.go b/pkg/virt-operator/resource/generate/components/apiservices.go
+deleted file mode 100644
+index cde0dbfc1..000000000
+--- a/pkg/virt-operator/resource/generate/components/apiservices.go
++++ /dev/null
+@@ -1,44 +0,0 @@
+-package components
+-
+-import (
+-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+-	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+-
+-	v1 "kubevirt.io/api/core/v1"
+-)
+-
+-func NewVirtAPIAPIServices(installNamespace string) []*apiregv1.APIService {
+-	apiservices := []*apiregv1.APIService{}
+-
+-	for _, version := range v1.SubresourceGroupVersions {
+-		subresourceAggregatedApiName := version.Version + "." + version.Group
+-
+-		apiservices = append(apiservices, &apiregv1.APIService{
+-			TypeMeta: metav1.TypeMeta{
+-				APIVersion: "apiregistration.k8s.io/v1",
+-				Kind:       "APIService",
+-			},
+-			ObjectMeta: metav1.ObjectMeta{
+-				Name: subresourceAggregatedApiName,
+-				Labels: map[string]string{
+-					v1.AppLabel:       "virt-api-aggregator",
+-					v1.ManagedByLabel: v1.ManagedByLabelOperatorValue,
+-				},
+-				Annotations: map[string]string{
+-					certificatesSecretAnnotationKey: VirtApiCertSecretName,
+-				},
+-			},
+-			Spec: apiregv1.APIServiceSpec{
+-				Service: &apiregv1.ServiceReference{
+-					Namespace: installNamespace,
+-					Name:      VirtApiServiceName,
+-				},
+-				Group:                version.Group,
+-				Version:              version.Version,
+-				GroupPriorityMinimum: 1000,
+-				VersionPriority:      15,
+-			},
+-		})
+-	}
+-	return apiservices
+-}
+diff --git a/pkg/virt-operator/resource/generate/components/apiservices_test.go b/pkg/virt-operator/resource/generate/components/apiservices_test.go
+deleted file mode 100644
+index 8cef02889..000000000
+--- a/pkg/virt-operator/resource/generate/components/apiservices_test.go
++++ /dev/null
+@@ -1,19 +0,0 @@
+-package components
+-
+-import (
+-	. "github.com/onsi/ginkgo/v2"
+-	. "github.com/onsi/gomega"
+-
+-	v1 "kubevirt.io/api/core/v1"
+-)
+-
+-var _ = Describe("APIServices", func() {
+-
+-	It("should load one APIService with the correct namespace", func() {
+-		services := NewVirtAPIAPIServices("mynamespace")
+-		// a subresource aggregated api endpoint should be registered for
+-		// each vm/vmi api version
+-		Expect(services).To(HaveLen(len(v1.SubresourceGroupVersions)))
+-		Expect(services[0].Spec.Service.Namespace).To(Equal("mynamespace"))
+-	})
+-})
+diff --git a/pkg/virt-operator/resource/generate/install/strategy.go b/pkg/virt-operator/resource/generate/install/strategy.go
+index 65cf88913..2f7c0c51b 100644
+--- a/pkg/virt-operator/resource/generate/install/strategy.go
++++ b/pkg/virt-operator/resource/generate/install/strategy.go
+@@ -87,7 +87,6 @@ type Strategy struct {
+ 	daemonSets                      []*appsv1.DaemonSet
+ 	validatingWebhookConfigurations []*admissionregistrationv1.ValidatingWebhookConfiguration
+ 	mutatingWebhookConfigurations   []*admissionregistrationv1.MutatingWebhookConfiguration
+-	apiServices                     []*apiregv1.APIService
+ 	certificateSecrets              []*corev1.Secret
+ 	sccs                            []*secv1.SecurityContextConstraints
+ 	serviceMonitors                 []*promv1.ServiceMonitor
+@@ -177,10 +176,6 @@ func (ins *Strategy) MutatingWebhookConfigurations() []*admissionregistrationv1.
+ 	return ins.mutatingWebhookConfigurations
+ }
+ 
+-func (ins *Strategy) APIServices() []*apiregv1.APIService {
+-	return ins.apiServices
+-}
+-
+ func (ins *Strategy) CertificateSecrets() []*corev1.Secret {
+ 	return ins.certificateSecrets
+ }
+@@ -362,9 +357,6 @@ func dumpInstallStrategyToBytes(strategy *Strategy) []byte {
+ 	for _, entry := range strategy.mutatingWebhookConfigurations {
+ 		marshalutil.MarshallObject(entry, writer)
+ 	}
+-	for _, entry := range strategy.apiServices {
+-		marshalutil.MarshallObject(entry, writer)
+-	}
+ 	for _, entry := range strategy.deployments {
+ 		marshalutil.MarshallObject(entry, writer)
+ 	}
+@@ -520,7 +512,6 @@ func GenerateCurrentInstallStrategy(config *operatorutil.KubeVirtDeploymentConfi
+ 
+ 	strategy.daemonSets = append(strategy.daemonSets, handler)
+ 	strategy.sccs = append(strategy.sccs, components.GetAllSCC(config.GetNamespace())...)
+-	strategy.apiServices = components.NewVirtAPIAPIServices(config.GetNamespace())
+ 	strategy.certificateSecrets = components.NewCertSecrets(config.GetNamespace(), operatorNamespace)
+ 	strategy.certificateSecrets = append(strategy.certificateSecrets, components.NewCACertSecrets(operatorNamespace)...)
+ 	strategy.configMaps = append(strategy.configMaps, components.NewCAConfigMaps(operatorNamespace)...)
+@@ -636,12 +627,6 @@ func loadInstallStrategyFromBytes(data string) (*Strategy, error) {
+ 			}
+ 			webhook.TypeMeta = obj
+ 			strategy.mutatingWebhookConfigurations = append(strategy.mutatingWebhookConfigurations, webhook)
+-		case "APIService":
+-			apiService := &apiregv1.APIService{}
+-			if err := yaml.Unmarshal([]byte(entry), &apiService); err != nil {
+-				return nil, err
+-			}
+-			strategy.apiServices = append(strategy.apiServices, apiService)
+ 		case "Secret":
+ 			secret := &corev1.Secret{}
+ 			if err := yaml.Unmarshal([]byte(entry), &secret); err != nil {
+diff --git a/pkg/virt-operator/util/types.go b/pkg/virt-operator/util/types.go
+index 96a2a98da..edbfc5fc1 100644
+--- a/pkg/virt-operator/util/types.go
++++ b/pkg/virt-operator/util/types.go
+@@ -39,7 +39,6 @@ type Stores struct {
+ 	DaemonSetCache                cache.Store
+ 	ValidationWebhookCache        cache.Store
+ 	MutatingWebhookCache          cache.Store
+-	APIServiceCache               cache.Store
+ 	SCCCache                      cache.Store
+ 	RouteCache                    cache.Store
+ 	InstallStrategyConfigMapCache cache.Store
+@@ -68,7 +67,6 @@ func (s *Stores) AllEmpty() bool {
+ 		IsStoreEmpty(s.DaemonSetCache) &&
+ 		IsStoreEmpty(s.ValidationWebhookCache) &&
+ 		IsStoreEmpty(s.MutatingWebhookCache) &&
+-		IsStoreEmpty(s.APIServiceCache) &&
+ 		IsStoreEmpty(s.PodDisruptionBudgetCache) &&
+ 		IsSCCStoreEmpty(s.SCCCache) &&
+ 		IsStoreEmpty(s.RouteCache) &&
+@@ -114,7 +112,6 @@ type Expectations struct {
+ 	DaemonSet                *controller.UIDTrackingControllerExpectations
+ 	ValidationWebhook        *controller.UIDTrackingControllerExpectations
+ 	MutatingWebhook          *controller.UIDTrackingControllerExpectations
+-	APIService               *controller.UIDTrackingControllerExpectations
+ 	SCC                      *controller.UIDTrackingControllerExpectations
+ 	Route                    *controller.UIDTrackingControllerExpectations
+ 	InstallStrategyConfigMap *controller.UIDTrackingControllerExpectations
+@@ -138,7 +135,6 @@ type Informers struct {
+ 	DaemonSet                cache.SharedIndexInformer
+ 	ValidationWebhook        cache.SharedIndexInformer
+ 	MutatingWebhook          cache.SharedIndexInformer
+-	APIService               cache.SharedIndexInformer
+ 	SCC                      cache.SharedIndexInformer
+ 	Route                    cache.SharedIndexInformer
+ 	InstallStrategyConfigMap cache.SharedIndexInformer
+@@ -164,7 +160,6 @@ func (e *Expectations) DeleteExpectations(key string) {
+ 	e.DaemonSet.DeleteExpectations(key)
+ 	e.ValidationWebhook.DeleteExpectations(key)
+ 	e.MutatingWebhook.DeleteExpectations(key)
+-	e.APIService.DeleteExpectations(key)
+ 	e.SCC.DeleteExpectations(key)
+ 	e.Route.DeleteExpectations(key)
+ 	e.InstallStrategyConfigMap.DeleteExpectations(key)
+@@ -188,7 +183,6 @@ func (e *Expectations) ResetExpectations(key string) {
+ 	e.DaemonSet.SetExpectations(key, 0, 0)
+ 	e.ValidationWebhook.SetExpectations(key, 0, 0)
+ 	e.MutatingWebhook.SetExpectations(key, 0, 0)
+-	e.APIService.SetExpectations(key, 0, 0)
+ 	e.SCC.SetExpectations(key, 0, 0)
+ 	e.Route.SetExpectations(key, 0, 0)
+ 	e.InstallStrategyConfigMap.SetExpectations(key, 0, 0)
+@@ -212,7 +206,6 @@ func (e *Expectations) SatisfiedExpectations(key string) bool {
+ 		e.DaemonSet.SatisfiedExpectations(key) &&
+ 		e.ValidationWebhook.SatisfiedExpectations(key) &&
+ 		e.MutatingWebhook.SatisfiedExpectations(key) &&
+-		e.APIService.SatisfiedExpectations(key) &&
+ 		e.SCC.SatisfiedExpectations(key) &&
+ 		e.Route.SatisfiedExpectations(key) &&
+ 		e.InstallStrategyConfigMap.SatisfiedExpectations(key) &&

--- a/images/virt-artifact/patches/README.md
+++ b/images/virt-artifact/patches/README.md
@@ -34,3 +34,6 @@ Support `KUBECONFIG` environment variable.
 
 #### `013-virt-api-rate-limiter-qps.patch`
 A patch has been added to enable the configuration of QPS for the rate limiter via an environment variable VIRT_API_RATE_LIMITER_QPS.
+
+#### `014-delete-apiserver.patch`
+Do not create Kubevirt APIService.


### PR DESCRIPTION
## Description
Add a patch to avoid creating kubevirt Apiservice.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
