### PR TITLE
chore: add container-name flag for mirrord

### DIFF
--- a/images/virtualization-artifact/Taskfile.dist.yaml
+++ b/images/virtualization-artifact/Taskfile.dist.yaml
@@ -619,7 +619,8 @@ tasks:
     cmd: |
       ./hack/mirrord.sh run --app=$PWD/cmd/virtualization-controller/main.go \
       --deployment=virtualization-controller                                 \
-      --namespace=d8-virtualization
+      --namespace=d8-virtualization                                          \
+      --container-name=virtualization-controller
 
   mirrord:wipe:controller:
     desc: "wipe up Mirrord's trash"

--- a/images/virtualization-artifact/hack/mirrord.sh
+++ b/images/virtualization-artifact/hack/mirrord.sh
@@ -92,7 +92,7 @@ if ! kubectl -n "${NAMESPACE}" get deployment/"${NEW_NAME}" &>/dev/null; then
   if [[ -n $CONTAINER_NAME ]]; then
     for ctr in $(kubectl -n "${NAMESPACE}" get deployment/"${DEPLOYMENT}" -o jsonpath='{.spec.template.spec.containers[*].name}'); do
       if [[ "$ctr" != "$CONTAINER_NAME" ]]; then
-         CTR_NUMBER=$(("$CTR_NUMBER" + 1));
+         CTR_NUMBER=$(echo "$CTR_NUMBER + 1" | bc)
          continue
       fi
       break

--- a/images/virtualization-artifact/hack/mirrord.sh
+++ b/images/virtualization-artifact/hack/mirrord.sh
@@ -98,11 +98,10 @@ if ! kubectl -n "${NAMESPACE}" get deployment/"${NEW_NAME}" &>/dev/null; then
       break
     done
   fi
-  export CTR_NUMBER
   kubectl -n "${NAMESPACE}" get deployment/"${DEPLOYMENT}" -ojson | \
-  jq '.metadata.name = env.NEW_NAME |
-      .spec.template.spec.containers[env.CTR_NUMBER].command = [ "/bin/bash", "-c", "--" ] |
-      .spec.template.spec.containers[env.CTR_NUMBER].args = [ "while true; do sleep 60; done;" ] |
+  jq --argjson CTR_NUMBER $CTR_NUMBER '.metadata.name = env.NEW_NAME |
+      .spec.template.spec.containers[$CTR_NUMBER].command = [ "/bin/bash", "-c", "--" ] |
+      .spec.template.spec.containers[$CTR_NUMBER].args = [ "while true; do sleep 60; done;" ] |
       .spec.replicas = 1 |
       .spec.template.metadata.labels.mirror = "true" |
       .spec.template.metadata.labels.ownerName = env.NEW_NAME' | \


### PR DESCRIPTION
## Description
add container-name flag for mirrord

## Why do we need it, and what problem does it solve?
task mirrord do not work if there is more than 1 container in the deployment
