### PR TITLE
chore(templates): fix pre-delete-hook

### DIFF
--- a/templates/pre-delete-hook/job.yaml
+++ b/templates/pre-delete-hook/job.yaml
@@ -20,8 +20,8 @@ spec:
       containers:
       - name: virtualization-pre-delete-hook
         image: {{ include "helm_lib_module_image" (list . "preDeleteHook") }}
-      {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
         resources:
           requests:
             cpu: 10m
             memory: 150Mi
+      {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}


### PR DESCRIPTION
## Description
fix wrong templates

## Why do we need it, and what problem does it solve?
```
❯ helm uninstall virtualization 
Error: unable to build kubernetes object for pre-delete hook virtualization/templates/pre-delete-hook/job.yaml: error validating "": error validating data: ValidationError(Job.spec.template.spec.tolerations[8]): unknown field "resources" in io.k8s.api.core.v1.Toleration
```
manifest:
```
❯ helm get hooks virtualization | yq '.spec.template.spec'
restartPolicy: Never
serviceAccountName: virtualization-pre-delete-hook
containers:
  - name: virtualization-pre-delete-hook
    image: ...
tolerations:
  - key: node-role.kubernetes.io/master
  ...
  - key: drbd.linbit.com/ignore-fail-over
    resources:
      requests:
        cpu: 10m
        memory: 150Mi
```
