### PR TITLE
fix: force legacy discovery for Kubernetes 1.27+

### DIFF
--- a/images/kube-api-proxy/pkg/proxy/handler.go
+++ b/images/kube-api-proxy/pkg/proxy/handler.go
@@ -268,8 +268,15 @@ func (h *Handler) transformRequest(targetReq *rewriter.TargetRequest, req *http.
 				newAccept = append(newAccept, "application/json")
 				continue
 			}
+			// TODO Add rewriting support for Table format.
 			// Quickly support kubectl with simple hack
 			if strings.Contains(hdr, "application/json") && strings.Contains(hdr, "as=Table") {
+				newAccept = append(newAccept, "application/json")
+				continue
+			}
+			// TODO Add rewriting support for aggregated discovery: kind=APIGroupDiscoveryList.
+			// Quick support for "Aggregated discovery": force legacy discovery.
+			if strings.Contains(hdr, "application/json") && strings.Contains(hdr, "as=APIGroupDiscoveryList") {
 				newAccept = append(newAccept, "application/json")
 				continue
 			}


### PR DESCRIPTION
## Description

Replace Accept header with aggregated discovery request with legacy discovery header (plain application/json). 

## Why do we need it, and what problem does it solve?

It is a workaround before implementing rewriter for the kind=APIGroupDiscoveryList
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
