### PR TITLE
fix(vm): add value of the guest os info

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/vm_reconciler.go
@@ -321,7 +321,16 @@ func (r *VMReconciler) UpdateStatus(_ context.Context, _ reconcile.Request, stat
 	case state.vmIsRunning():
 		// TODO We need to rerun this block because KVVMI status fields may be updated with a delay.
 		state.VM.Changed().Status.Phase = virtv2.MachineRunning
-		state.VM.Changed().Status.GuestOSInfo = state.KVVMI.Status.GuestOSInfo
+		//state.VM.Changed().Status.GuestOSInfo = state.KVVMI.Status.GuestOSInfo
+		count := 0
+		for range time.Tick(5 * time.Second) {
+			if count >= 120 || state.KVVMI.Status.GuestOSInfo.Name != "" {
+				state.VM.Changed().Status.GuestOSInfo = state.KVVMI.Status.GuestOSInfo
+				break
+			}
+			count++
+			opts.Log.Info(fmt.Sprintf("dlopatindebugout count=%d", count))
+		}
 		state.VM.Changed().Status.Node = state.KVVMI.Status.NodeName
 		for _, iface := range state.KVVMI.Status.Interfaces {
 			if iface.Name == kvbuilder.NetworkInterfaceName {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
add simple wait for value of the guest os info with test period
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
solves the problem of missing guest os info field value
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
