### PR TITLE
fix(core, kubevirt): add ability to configure qps for virt-api rate l…

### DIFF
--- a/images/virt-artifact/patches/013-virt-api-rate-limiter-qps.patch
+++ b/images/virt-artifact/patches/013-virt-api-rate-limiter-qps.patch
@@ -1,0 +1,40 @@
+diff --git a/pkg/virt-api/api.go b/pkg/virt-api/api.go
+index 120f2d68f..3c11d4fc3 100644
+--- a/pkg/virt-api/api.go
++++ b/pkg/virt-api/api.go
+@@ -27,6 +27,7 @@ import (
+ 	"net/http"
+ 	"os"
+ 	"os/signal"
++	"strconv"
+ 	"sync"
+ 	"syscall"
+ 	"time"
+@@ -92,6 +93,8 @@ const (
+ 	httpStatusNotFoundMessage     = "Not Found"
+ 	httpStatusBadRequestMessage   = "Bad Request"
+ 	httpStatusInternalServerError = "Internal Server Error"
++
++	VirtAPIRateLimiterQPSEnvVar = "VIRT_API_RATE_LIMITER_QPS"
+ )
+ 
+ type VirtApi interface {
+@@ -1089,7 +1092,18 @@ func (app *virtAPIApp) shouldChangeLogVerbosity() {
+ // Update virt-handler rate limiter
+ func (app *virtAPIApp) shouldChangeRateLimiter() {
+ 	config := app.clusterConfig.GetConfig()
++
+ 	qps := config.APIConfiguration.RestClient.RateLimiter.TokenBucketRateLimiter.QPS
++	if os.Getenv(VirtAPIRateLimiterQPSEnvVar) != "" {
++		qpsFromEnv, err := strconv.ParseFloat(os.Getenv(VirtAPIRateLimiterQPSEnvVar), 32)
++		if err != nil {
++			log.Log.Errorf("failed to parse %s: %s", VirtAPIRateLimiterQPSEnvVar, err)
++		} else {
++			qps = float32(qpsFromEnv)
++			log.Log.V(2).Infof("use rate limiter QPS %v from %s", qps, VirtAPIRateLimiterQPSEnvVar)
++		}
++	}
++
+ 	burst := config.APIConfiguration.RestClient.RateLimiter.TokenBucketRateLimiter.Burst
+ 	app.reloadableRateLimiter.Set(flowcontrol.NewTokenBucketRateLimiter(qps, burst))
+ 	log.Log.V(2).Infof("setting rate limiter for the API to %v QPS and %v Burst", qps, burst)

--- a/images/virt-artifact/patches/README.md
+++ b/images/virt-artifact/patches/README.md
@@ -31,3 +31,6 @@ Added the ability for virt-api to authenticate clients with certificates signed 
 
 #### `012-support-kubeconfig-env.patch`
 Support `KUBECONFIG` environment variable. 
+
+#### `013-virt-api-rate-limiter-qps.patch`
+A patch has been added to enable the configuration of QPS for the rate limiter via an environment variable VIRT_API_RATE_LIMITER_QPS.

--- a/templates/kubevirt/kubevirt.yaml
+++ b/templates/kubevirt/kubevirt.yaml
@@ -254,6 +254,25 @@ spec:
 
       type: strategic
     {{- end }}
+    - resourceType: Deployment
+      resourceName: virt-api
+      patch: |
+        {
+          "spec": {
+            "template": {
+              "spec": {
+                "containers": [{
+                  "name": "virt-api",
+                  "env": [{
+                    "name": "VIRT_API_RATE_LIMITER_QPS",
+                    "value": "5000"
+                  }]
+                }]
+              }
+            }
+          }
+        }
+      type: strategic
 
   imagePullPolicy: IfNotPresent
   imagePullSecrets:


### PR DESCRIPTION
## Description
When migrating a big number of virtual machines (>50), we encounter a bottleneck in virt-api in the form of a rate limiter that prevents migration completion.

A patch has been added to virt-api, enabling the configuration of QPS for the rate limiter via an environment variable VIRT_API_RATE_LIMITER_QPS.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
