### PR TITLE
refactor(module): fix module name in webhook

### DIFF
--- a/hooks/lib/hooks/manage_tenant_secrets.py
+++ b/hooks/lib/hooks/manage_tenant_secrets.py
@@ -35,8 +35,7 @@ class ManageTenantSecretsHook(Hook):
         self.source_secret_name = source_secret_name
         self.pod_labels_to_follow = pod_labels_to_follow
         self.destination_secret_labels = destination_secret_labels
-        self.module_name = module_name
-        self.queue = f"/modules/{module_name}/manage-tenant-secrets"
+        self.queue = f"/modules/{self.module_name}/manage-tenant-secrets"
 
     def generate_config(self) -> dict:
         return {


### PR DESCRIPTION
## Description
Module name is shown incorrectly in Deckhouse queue. "None" instead of "virtualization".

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
