### PR TITLE
chore(api, dvcr): upgrade go version to 1.21

### DIFF
--- a/images/dvcr-artifact/werf.inc.yaml
+++ b/images/dvcr-artifact/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 artifact: {{ $.ImageName }}-builder
-fromImage: base-golang-20-bookworm
+fromImage: base-golang-21-bookworm
 git:
 - add: /images/{{ $.ImageName }}
   to: /usr/local/go/src/dvcr_importers

--- a/images/virtualization-artifact/werf.inc.yaml
+++ b/images/virtualization-artifact/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ $.ImageName }}
-fromImage: base-golang-20-bookworm
+fromImage: base-golang-21-bookworm
 git:
 - add: /api
   to: /usr/local/go/api


### PR DESCRIPTION
## Description
upgrade go version to 1.21

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
