### PR TITLE
chore(ci): fix false positive patch applying

### DIFF
--- a/images/cdi-artifact/werf.inc.yaml
+++ b/images/cdi-artifact/werf.inc.yaml
@@ -21,7 +21,7 @@ shell:
   - |
     for p in /patches/*.patch ; do
       echo -n "Apply ${p} ... "
-      git apply ${p} || echo FAIL && echo OK
+      git apply  --ignore-space-change --ignore-whitespace ${p} && echo OK || (echo FAIL ; exit 1)
     done
   - /entrypoint.sh make bazel-build-images DOCKER=0
   - /entrypoint.sh bazel build --config=x86_64 --define container_prefix=kubevirt --define image_prefix= --define container_tag=latest //:container-images-bundle.tar

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -22,7 +22,7 @@ shell:
   - |
     for p in /patches/*.patch ; do
       echo -n "Apply ${p} ... "
-      git apply ${p} || echo FAIL && echo OK
+      git apply  --ignore-space-change --ignore-whitespace ${p} && echo OK || (echo FAIL ; exit 1)
     done
   - mkdir -p _out
   - echo "========== Build kubevirt images ============"


### PR DESCRIPTION

## Description

- Fail build if patch is not applied

## Why do we need it, and what problem does it solve?

Wrong patch do not stop build.

Before:
```
│ │ virt-artifact/setup  Apply /patches/001-bundle-extra-images.patch ... OK
│ │ virt-artifact/setup  Apply /patches/002-fix-vcpu-count-issue.patch ... OK
│ │ virt-artifact/setup  Apply /patches/003-macvtap-binding.patch ... OK
│ │ virt-artifact/setup  Apply /patches/007-tolerations-for-strategy-dumper-job.patch ... OK
│ │ virt-artifact/setup  Apply /patches/011-virt-api-authentication.patch ... OK
│ │ virt-artifact/setup  Apply /patches/012-support-kubeconfig-env.patch ... OK
│ │ virt-artifact/setup  Apply /patches/013-virt-api-rate-limiter.patch ... OK
│ │ virt-artifact/setup  Apply /patches/014-delete-apiserver.patch ... OK
│ │ virt-artifact/setup  Apply /patches/016-rename-install-strategy-labels.patch ... error: patch failed:                        ↵
│ │ virt-artifact/setup  staging/src/kubevirt.io/api/core/v1/types.go:828
│ │ virt-artifact/setup  error: staging/src/kubevirt.io/api/core/v1/types.go: patch does not apply
│ │ virt-artifact/setup  FAIL
│ │ virt-artifact/setup  OK
│ │ virt-artifact/setup  ========== Build kubevirt images ============
... compile without patch ...
```

After:
```
│ │ virt-artifact/setup  Apply /patches/001-bundle-extra-images.patch ... OK
│ │ virt-artifact/setup  Apply /patches/002-fix-vcpu-count-issue.patch ... OK
│ │ virt-artifact/setup  Apply /patches/003-macvtap-binding.patch ... OK
│ │ virt-artifact/setup  Apply /patches/007-tolerations-for-strategy-dumper-job.patch ... OK
│ │ virt-artifact/setup  Apply /patches/011-virt-api-authentication.patch ... OK
│ │ virt-artifact/setup  Apply /patches/012-support-kubeconfig-env.patch ... OK
│ │ virt-artifact/setup  Apply /patches/013-virt-api-rate-limiter.patch ... OK
│ │ virt-artifact/setup  Apply /patches/014-delete-apiserver.patch ... OK
│ │ virt-artifact/setup  Apply /patches/016-rename-install-strategy-labels.patch ... error: patch failed:                        ↵
│ │ virt-artifact/setup  staging/src/kubevirt.io/api/core/v1/types.go:828
│ │ virt-artifact/setup  error: staging/src/kubevirt.io/api/core/v1/types.go: patch does not apply
│ │ virt-artifact/setup  FAIL
```
Build stops on bad patch.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
