### PR TITLE
fix(core, dvcr):  configure dvcr creds before contatinerd config

### DIFF
--- a/templates/dvcr/ nodegroupconfiguration.yaml
+++ b/templates/dvcr/ nodegroupconfiguration.yaml
@@ -11,7 +11,7 @@ metadata:
   name: containerd-dvcr-config.sh
   {{- include "helm_lib_module_labels" (list . (dict "app" "dvcr" )) | nindent 2 }}
 spec:
-  weight: 49
+  weight: 31
   nodeGroups: ["*"]
   bundles: ["*"]
   content: |
@@ -28,7 +28,7 @@ spec:
     # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     # See the License for the specific language governing permissions and
     # limitations under the License.
-    
+
     mkdir -p /etc/containerd/conf.d
     bb-event-on 'registry-ca-changed' '_restart_containerd'
     bb-event-on 'containerd-config-changed' '_restart_containerd'


### PR DESCRIPTION
## Description
Fix the order of configuration steps to ensure that DVCR credentials are configured before merging containerd configurations.

## Why do we need it, and what problem does it solve?
We currently have a bashible step `032_configure_containerd.sh` with a weight of 32. This step merges the containerd configurations, which requires correct DVCR (Docker V2 Container Registry) credentials. To solve the problem where DVCR credentials must be configured in advance, this PR introduces a lower weight configuration step that runs before the containerd configuration step.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
