### PR TITLE
fix(vmop): fix panic if VM is not exist

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vmop/vmop_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/vmop_reconciler.go
@@ -169,7 +169,7 @@ func (r *Reconciler) UpdateStatus(_ context.Context, _ reconcile.Request, state 
 			vmopStatus.FailureMessage = result.Message()
 		}
 	}
-	if state.IsInProgress() && r.IsCompleted(state.VMOP.Current().Spec.Type, state.VM.Status.Phase) {
+	if !state.VmIsEmpty() && state.IsInProgress() && r.IsCompleted(state.VMOP.Current().Spec.Type, state.VM.Status.Phase) {
 		vmopStatus.Phase = virtv2.VMOPPhaseCompleted
 	}
 	state.VMOP.Changed().Status = *vmopStatus


### PR DESCRIPTION
## Description

Fix panic in UpdateStatus for non existing VM

## Why do we need it, and what problem does it solve?

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x210 pc=0x1785af0]

goroutine 459 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/controller/controller.go:116 +0x1fa
panic({0x1923d80, 0x2b55c10})
        /usr/local/go/src/runtime/panic.go:884 +0x213
github.com/deckhouse/virtualization-controller/pkg/controller/vmop.(*Reconciler).UpdateStatus(0xc000297c10?, {0x1e3c078?, 0xc002a8e3c0?}, {{{0xc000297c10?, 0x1e4f0f8?}, {0xc0006406c0?, 0x1e23f20?}}}, 0xc002a8e3f0, {{0x1e442e0, 0xc0001897a0}, ...})
        /usr/local/go/src/virtualization-controller/pkg/controller/vmop/vmop_reconciler.go:172 +0xa10
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
