### PR TITLE
refactor(kube-api-rewriter): extra changes to #112

### DIFF
--- a/images/kube-api-proxy/pkg/log/body.go
+++ b/images/kube-api-proxy/pkg/log/body.go
@@ -57,3 +57,11 @@ func HasData(obj interface{}) bool {
 	}
 	return readLog.buf.Len() > 0
 }
+
+func Bytes(obj interface{}) []byte {
+	readLog, ok := obj.(*ReaderLogger)
+	if !ok {
+		return nil
+	}
+	return readLog.buf.Bytes()
+}


### PR DESCRIPTION
++ add ns/name into message from differ
++ log full patches on all resources
++ log full rewritten query
++ log full original watch event in case of rewrite error

