### PR TITLE
fix(vm): set min max for blockdevicerefs list

### DIFF
--- a/crds/virtualmachine.yaml
+++ b/crds/virtualmachine.yaml
@@ -895,6 +895,8 @@ spec:
 
                 blockDeviceRefs:
                   type: array
+                  minItems: 1
+                  maxItems: 16
                   description: |
                     List of block devices that can be mounted by disks belonging to the virtual machine.
                     The order of booting is determined by the order in the list.


### PR DESCRIPTION
## Description
Set min max for blockdevicerefs list.

## Why do we need it, and what problem does it solve?
The blockDeviceRefs list can't be empty.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
