### PR TITLE
chore(core): use scratch and alt-p10 as base images

### DIFF
--- a/images/dvcr-artifact/werf.inc.yaml
+++ b/images/dvcr-artifact/werf.inc.yaml
@@ -1,5 +1,5 @@
 ---
-artifact: {{ $.ImageName }}-builder
+image: {{ $.ImageName }}-builder
 fromImage: base-golang-21-bookworm
 git:
 - add: /images/{{ $.ImageName }}
@@ -23,9 +23,20 @@ shell:
   - go build ./cmd/dvcr_uploader
 
 ---
-artifact: {{ $.ImageName }}
-fromImage: base-debian-bookworm-slim
+image: {{ $.ImageName }}
+fromImage: base-alt-p10
 shell:
   install:
   - apt-get -qq update
-  - apt-get -qq install -y --no-install-recommends ca-certificates libnbd0 qemu-utils file
+  - |
+    apt-get -qq install -y \
+    qemu-img==8.2.2-alt0.p10.1:p10+345290.260.6.1 \
+    file==5.44-alt3:p10+320107.300.8.1
+  # Install packages from Sisyphus repository because p10 repository does not have required versions.
+  - echo "rpm [alt] http://ftp.altlinux.org/pub/distributions/ALTLinux/Sisyphus x86_64 classic" >> /etc/apt/sources.list.d/sisyphus.list
+  - echo "rpm [alt] http://ftp.altlinux.org/pub/distributions/ALTLinux/Sisyphus noarch classic" >> /etc/apt/sources.list.d/sisyphus.list
+  - apt-get update -qq
+  - |
+    apt-get install -qq -y \
+    ca-certificates==2024.06.08-alt1:sisyphus+350631.200.1.1 \
+    libnbd0==1.19.11-alt1:sisyphus+347436.100.3.1

--- a/images/dvcr-importer/werf.inc.yaml
+++ b/images/dvcr-importer/werf.inc.yaml
@@ -1,12 +1,12 @@
 ---
 image: {{ $.ImageName }}
-fromArtifact: dvcr-artifact
+fromImage: dvcr-artifact
 import:
-- artifact: dvcr-artifact-builder
+- image: dvcr-artifact-builder
   add: /usr/local/go/src/dvcr_importers/dvcr_importer
   to: /usr/local/bin/dvcr_importer
   after: install
-- artifact: dvcr-artifact-builder
+- image: dvcr-artifact-builder
   add: /usr/local/go/src/dvcr_importers/build/importer_entrypoint.sh
   to: /importer_entrypoint.sh
   after: install

--- a/images/dvcr-uploader/werf.inc.yaml
+++ b/images/dvcr-uploader/werf.inc.yaml
@@ -1,12 +1,12 @@
 ---
 image: {{ $.ImageName }}
-fromArtifact: dvcr-artifact
+fromImage: dvcr-artifact
 import:
-- artifact: dvcr-artifact-builder
+- image: dvcr-artifact-builder
   add: /usr/local/go/src/dvcr_importers/dvcr_uploader
   to: /usr/local/bin/dvcr_uploader
   after: install
-- artifact: dvcr-artifact-builder
+- image: dvcr-artifact-builder
   add: /usr/local/go/src/dvcr_importers/build/uploader_entrypoint.sh
   to: /uploader_entrypoint.sh
   after: install

--- a/images/dvcr/werf.inc.yaml
+++ b/images/dvcr/werf.inc.yaml
@@ -1,3 +1,14 @@
 ---
-image: {{ $.ImageName }}
+image: {{ $.ImageName }}-source-image
 from: docker.io/registry:2.8.2@sha256:da1fbcd13a7ddc77d0d964a5c5c4cb707b5d440a028b0b42fe574b9e99077e27
+---
+image: {{ $.ImageName }}
+fromImage: base-scratch
+import:
+- image: {{ $.ImageName }}-source-image
+  add: /bin
+  to: /bin
+  after: install
+  includePaths:
+  - registry
+# Registry configuration is stored in configmap: templates/dvcr/configmap.yaml 

--- a/images/dvcr/werf.inc.yaml
+++ b/images/dvcr/werf.inc.yaml
@@ -1,11 +1,11 @@
 ---
-image: {{ $.ImageName }}-source-image
+image: {{ $.ImageName }}-original-registry2
 from: docker.io/registry:2.8.2@sha256:da1fbcd13a7ddc77d0d964a5c5c4cb707b5d440a028b0b42fe574b9e99077e27
 ---
 image: {{ $.ImageName }}
 fromImage: base-scratch
 import:
-- image: {{ $.ImageName }}-source-image
+- image: {{ $.ImageName }}-original-registry2
   add: /bin
   to: /bin
   after: install

--- a/images/kube-api-proxy/werf.inc.yaml
+++ b/images/kube-api-proxy/werf.inc.yaml
@@ -27,7 +27,7 @@ shell:
 
 ---
 image: {{ $.ImageName }}
-fromImage: base-alt-p10
+fromImage: base-scratch
 import:
   - image: {{ $.ImageName }}-builder
     add: /src/kube-api-proxy/kube-api-proxy

--- a/images/pre-delete-hook/werf.inc.yaml
+++ b/images/pre-delete-hook/werf.inc.yaml
@@ -1,4 +1,12 @@
 ---
+image: {{ $.ImageName }}-builder
+fromImage: base-alt-p10
+shell:
+  beforeInstall:
+  - apt-get update -q && apt-get install -yq curl
+  install:
+  - curl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl
+---
 image: {{ $.ImageName }}
 fromImage: base-alt-p10
 git:
@@ -7,11 +15,15 @@ git:
   stageDependencies:
     setup:
     - "*.sh"
+import:
+- image: {{ $.ImageName }}-builder
+  add: /usr/local/bin
+  includePaths:
+  - kubectl
+  to: /usr/local/bin
+  before: install
 shell:
-  beforeInstall:
-  - apt-get update -q && apt-get install -yq curl && rm -rf /var/lib/apt/lists/*
   install:
-  - curl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl
   - chmod +x /usr/local/bin/kubectl /usr/local/bin/entrypoint.sh
 docker:
   USER: "64535:64535"

--- a/images/virt-exportproxy/werf.inc.yaml
+++ b/images/virt-exportproxy/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ $.ImageName }}
-fromImage: base-alt-p10
+fromImage: base-scratch
 import:
 - image: virt-artifact
   add: /images/kubevirt/{{ $.ImageName }}:latest/usr/bin
@@ -14,16 +14,8 @@ import:
   - .version
   to: /
   before: setup
-shell:
-  install:
-  # Install packages from Sisyphus repository because p10 repository does not have required versions.
-  - echo "rpm [alt] http://ftp.altlinux.org/pub/distributions/ALTLinux/Sisyphus x86_64 classic" > /etc/apt/sources.list.d/sisyphus.list
-  - |
-    apt-get update && apt-get install --yes \
-    glibc==6:2.38.0.76.e9f05fa1c6-alt1:sisyphus+347163.100.1.1
-  - apt-get clean
-  - rm --recursive --force /var/lib/apt/lists/ftp.altlinux.org*
 # Source https://github.com/kubevirt/kubevirt/blob/v1.0.0/cmd/virt-exportproxy/BUILD.bazel
 docker:
+  WORKDIR: /usr/bin/
   ENTRYPOINT: ["/usr/bin/virt-exportproxy"]
   USER: 1001

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -122,7 +122,7 @@ shell:
     pkg-config==0.29.2-alt3:sisyphus+278099.3600.1.1 \
     gcc==10-alt1:sisyphus+263054.200.3.1 \
     make==2:4.3.0-alt1:sisyphus+278158.1100.1.1 \
-    git==2.33.8-alt1:p10+319522.100.1.1 \
+    git==2.42.2-alt1:p10+350723.100.3.1 \
     perl-IPC-Cmd==1.04-alt1:sisyphus+234736.100.1.1 \
     wget==1.21.3-alt1:p10+305270.100.3.1 \
     gcc-c++==10-alt1:sisyphus+263054.200.3.1

--- a/images/virtualization-api/werf.inc.yaml
+++ b/images/virtualization-api/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ $.ImageName }}
-fromImage: base-alt-p10
+fromImage: base-scratch
 import:
   - image: virtualization-artifact
     add: /usr/local/go/src/virtualization-controller/virtualization-api

--- a/images/virtualization-controller/werf.inc.yaml
+++ b/images/virtualization-controller/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ $.ImageName }}
-fromImage: base-alt-p10
+fromImage: base-scratch
 import:
   - image: virtualization-artifact
     add: /usr/local/go/src/virtualization-controller/virtualization-controller

--- a/images/vmi-router/werf.inc.yaml
+++ b/images/vmi-router/werf.inc.yaml
@@ -30,7 +30,7 @@ shell:
   - go build -v -a -o vmi-router main.go
 ---
 image: {{ $.ImageName }}
-fromImage: base-alt-p10
+fromImage: base-scratch
 import:
 - image: vmi-router-builder
   add: /app/images/vmi-router/vmi-router


### PR DESCRIPTION
## Description
- dvcr-importer // alt-p10
- dvcr-uploader // alt-p10
- dvcr // scratch
- kube-api-proxy // scratch
- pre-delete-hook // alt-p10
- virtualization-api // scratch
- virtualization-controller // scratch
- vmi-router // scratch

## Why do we need it, and what problem does it solve?
Target - distroless images.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
