### PR TITLE
feat(core, dvcr): generate htpasswd from hook

### DIFF
--- a/hooks/generate_secret_for_dvcr.py
+++ b/hooks/generate_secret_for_dvcr.py
@@ -17,36 +17,43 @@
 from typing import Callable
 from deckhouse.hook import Context
 from lib.hooks.hook import Hook
-from lib.password_generator import password_generator
+from lib.password_generator import password_generator, htpasswd as hd
 import common
 import lib.utils as utils
 
+class KeyHtpasswd:
+        def __init__(self, 
+                     name: str,
+                     username: str,
+                     value_path: str):
+            self.name = name
+            self.username = username
+            self.value_path = value_path
 
 class Key:
     def __init__(self,
                  name: str,
                  value_path: str,
-                 lenght: int = 64):
+                 lenght: int = 64,
+                 htpasswd: KeyHtpasswd = None):
         self.name = name
         self.value_path = value_path
         self.lenght = lenght
-
+        self.htpasswd = htpasswd
 
 class GenerateSecretHook(Hook):
     SNAPSHOT_NAME = "secrets"
 
     def __init__(self,
+                 *keys: Key,
+                 secret_name: str,
+                 namespace: str,
                  module_name: str = None):
         super().__init__(module_name=module_name)
-        self.namespace = common.NAMESPACE
-        self.secret_name = "dvcr-secrets"
-        self.keys = (
-            Key(name="passwordRW",
-                value_path=f"{self.module_name}.internal.dvcr.passwordRW",
-                lenght=32),
-            Key(name="salt",
-                value_path=f"{self.module_name}.internal.dvcr.salt")
-        )
+        self.keys = keys
+        self.secret_name = secret_name
+        self.namespace = namespace
+        self.queue = f"/modules/{self.module_name}/generate_secrets"
 
     def generate_config(self) -> dict:
         return {
@@ -67,7 +74,7 @@ class GenerateSecretHook(Hook):
                     },
                     "includeSnapshotsFrom": [self.SNAPSHOT_NAME],
                     "jqFilter": '{"data": .data}',
-                    "queue": f"/modules/{self.module_name}/generate_secrets",
+                    "queue": self.queue,
                     "keepFullObjectsInMemory": False
                 },
             ]
@@ -77,17 +84,50 @@ class GenerateSecretHook(Hook):
         def r(ctx: Context):
             for key in self.keys:
                 try:
-                    key_from_secret = ctx.snapshots[self.SNAPSHOT_NAME][0]["filterResult"]["data"][key.name]
-                    self.set_value(key.value_path, ctx.values, key_from_secret)
+                    key_base64 = ctx.snapshots[self.SNAPSHOT_NAME][0]["filterResult"]["data"][key.name]
+                    self.set_value(key.value_path, ctx.values, key_base64)
                 except (IndexError, KeyError):
                     print(
-                        f"Generate new key {key.name} for secret {self.secret_name}.")
+                        f"Generate new key {key.name} for secret={self.secret_name}.")
                     genkey = utils.base64_encode_from_str(
                         password_generator.alpha_num(key.lenght))
                     self.set_value(key.value_path, ctx.values, genkey)
+            for key in self.keys:
+                if key.htpasswd is None:
+                    continue
+                password = utils.base64_decode(self.get_value(key.value_path, ctx.values))
+                htpasswd = hd.Htpasswd(username=key.htpasswd.username, password=password)
+                regenerate = False
+                try:
+                    htpasswd_base64 = ctx.snapshots[self.SNAPSHOT_NAME][0]["filterResult"]["data"][key.htpasswd.name]
+                    if hd.validate(utils.base64_decode(htpasswd_base64)):
+                        self.set_value(key.htpasswd.value_path, ctx.values, htpasswd_base64)
+                        continue
+                    regenerate = True
+                except (IndexError, KeyError):
+                    regenerate = True
+                if regenerate:
+                    print(
+                        f"Generate new htpasswd for key={key.name} and secret={self.secret_name}.")
+                    encoded_htpasswd = utils.base64_encode_from_str(htpasswd.generate())
+                    self.set_value(key.htpasswd.value_path, ctx.values, encoded_htpasswd)
         return r
 
 
 if __name__ == "__main__":
-    hook = GenerateSecretHook()
+    hook = GenerateSecretHook(
+            Key(name="passwordRW",
+                value_path=f"{common.MODULE_NAME}.internal.dvcr.passwordRW",
+                lenght=32,
+                htpasswd=KeyHtpasswd(
+                    name="htpasswd",
+                    username="admin", 
+                    value_path=f"{common.MODULE_NAME}.internal.dvcr.htpasswd",
+                    )
+                ),
+            Key(name="salt",
+                value_path=f"{common.MODULE_NAME}.internal.dvcr.salt"),
+            secret_name="dvcr-secrets",
+            namespace=common.NAMESPACE
+            )
     hook.run()

--- a/hooks/lib/password_generator/htpasswd.py
+++ b/hooks/lib/password_generator/htpasswd.py
@@ -1,0 +1,18 @@
+import bcrypt
+
+class Htpasswd:
+    def __init__(self,
+                 username: str,
+                 password: str,) -> None:
+        self.username = username
+        self.password = password
+
+    def generate(self) -> str:
+        bcrypted = bcrypt.hashpw(self.password.encode("utf-8"), bcrypt.gensalt(prefix=b"2a")).decode("utf-8")
+        return f"{self.username}:{bcrypted}"
+
+    def validate(self, htpasswd: str) -> bool:
+        user, hashed = htpasswd.strip().split(':')
+        if user != self.username:
+            return False
+        return bcrypt.checkpw(self.password.encode("utf-8"), hashed.encode("utf-8"))

--- a/hooks/lib/password_generator/htpasswd.py
+++ b/hooks/lib/password_generator/htpasswd.py
@@ -1,3 +1,18 @@
+#
+# Copyright 2024 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import bcrypt
 
 class Htpasswd:

--- a/hooks/lib/password_generator/htpasswd.py
+++ b/hooks/lib/password_generator/htpasswd.py
@@ -15,6 +15,7 @@
 
 import bcrypt
 
+
 class Htpasswd:
     def __init__(self,
                  username: str,
@@ -23,7 +24,8 @@ class Htpasswd:
         self.password = password
 
     def generate(self) -> str:
-        bcrypted = bcrypt.hashpw(self.password.encode("utf-8"), bcrypt.gensalt(prefix=b"2a")).decode("utf-8")
+        bcrypted = bcrypt.hashpw(self.password.encode(
+            "utf-8"), bcrypt.gensalt(prefix=b"2a")).decode("utf-8")
         return f"{self.username}:{bcrypted}"
 
     def validate(self, htpasswd: str) -> bool:

--- a/hooks/test_generate_secret_for_dvcr.py
+++ b/hooks/test_generate_secret_for_dvcr.py
@@ -22,21 +22,21 @@ from generate_secret_for_dvcr import GenerateSecretHook, Key, KeyHtpasswd
 MODULE_NAME = "test"
 
 hook = GenerateSecretHook(
-        Key(name="key1",
-            value_path=f"{MODULE_NAME}.internal.test.key1",
-            lenght=32,
-            htpasswd=KeyHtpasswd(
-                name="htpasswd",
-                username="admin", 
-                value_path=f"{MODULE_NAME}.internal.test.htpasswd",
-                )
-            ),
-        Key(name="key2",
-            value_path=f"{MODULE_NAME}.internal.test.key2"),
-        secret_name=MODULE_NAME,
-        namespace=MODULE_NAME,
-        module_name=MODULE_NAME
+    Key(name="key1",
+        value_path=f"{MODULE_NAME}.internal.test.key1",
+        length=32,
+        htpasswd=KeyHtpasswd(
+            name="htpasswd",
+            username="admin",
+            value_path=f"{MODULE_NAME}.internal.test.htpasswd",
         )
+        ),
+    Key(name="key2",
+        value_path=f"{MODULE_NAME}.internal.test.key2"),
+    secret_name=MODULE_NAME,
+    namespace=MODULE_NAME,
+    module_name=MODULE_NAME
+)
 
 binding_context_generate_all = [
     {
@@ -118,8 +118,8 @@ class TestGenerateSecretALL(TestGenerateKeys):
 
     def test_generate_all(self):
         self.hook_run()
-        self.key_test(self.get_key(hook.keys[0].name), hook.keys[0].lenght)
-        self.key_test(self.get_key(hook.keys[1].name), hook.keys[1].lenght)
+        self.key_test(self.get_key(hook.keys[0].name), hook.keys[0].length)
+        self.key_test(self.get_key(hook.keys[1].name), hook.keys[1].length)
 
 
 class TestGenerateSecretKey1(TestGenerateKeys):
@@ -130,7 +130,7 @@ class TestGenerateSecretKey1(TestGenerateKeys):
 
     def test_generate_key1(self):
         self.hook_run()
-        self.key_test(self.get_key(hook.keys[0].name), hook.keys[0].lenght)
+        self.key_test(self.get_key(hook.keys[0].name), hook.keys[0].length)
 
     def test_generate_htpasswd(self):
         self.hook_run()
@@ -138,9 +138,11 @@ class TestGenerateSecretKey1(TestGenerateKeys):
         self.assertGreater(len(htpasswd_base64), 0)
         self.assertTrue(utils.is_base64(htpasswd_base64))
         password_base64 = self.get_key(hook.keys[0].name)
-        self.key_test(password_base64, hook.keys[0].lenght)
-        htpasswd = hd.Htpasswd(hook.keys[0].htpasswd.username, utils.base64_decode(password_base64))
-        self.assertTrue(htpasswd.validate(utils.base64_decode(htpasswd_base64)))
+        self.key_test(password_base64, hook.keys[0].length)
+        htpasswd = hd.Htpasswd(
+            hook.keys[0].htpasswd.username, utils.base64_decode(password_base64))
+        self.assertTrue(htpasswd.validate(
+            utils.base64_decode(htpasswd_base64)))
 
 
 class TestGenerateSecretKey2(TestGenerateKeys):
@@ -151,4 +153,4 @@ class TestGenerateSecretKey2(TestGenerateKeys):
 
     def test_generate_key2(self):
         self.hook_run()
-        self.key_test(self.get_key(hook.keys[1].name), hook.keys[1].lenght)
+        self.key_test(self.get_key(hook.keys[1].name), hook.keys[1].length)

--- a/lib/python/requirements.txt
+++ b/lib/python/requirements.txt
@@ -16,3 +16,4 @@ jsonschema==4.19.1
 jsonschema-specifications==2023.7.1
 kubernetes==28.1.0
 kubernetes-validate==1.28.0
+bcrypt==4.1.3

--- a/openapi/values.yaml
+++ b/openapi/values.yaml
@@ -29,6 +29,8 @@ properties:
                 type: string
           passwordRW:
             type: string
+          htpasswd:
+            type: string
           salt:
             type: string
           serviceIP:

--- a/templates/dvcr/secret.yaml
+++ b/templates/dvcr/secret.yaml
@@ -23,7 +23,7 @@ metadata:
 type: Opaque
 data:
   passwordRW: {{ .Values.virtualization.internal.dvcr.passwordRW | quote }}
-  htpasswd: {{ htpasswd "admin" ( printf "%s" .Values.virtualization.internal.dvcr.passwordRW | b64dec)  | b64enc | quote }}
+  htpasswd: {{ .Values.virtualization.internal.dvcr.htpasswd | quote }}
   salt: {{ .Values.virtualization.internal.dvcr.salt | quote }}
 ---
 {{- /* TODO: delete this secret, because containerd has credentials to auth to the dvcr.

--- a/werf.yaml
+++ b/werf.yaml
@@ -64,7 +64,7 @@ shell:
 ---
 image: python-dependencies
 from: python:3.9-slim
-fromCacheVersion: "2024-02-15.1"
+fromCacheVersion: "2024-06-25.0"
 git:
   - add: /lib/python/requirements.txt
     to: /requirements.txt


### PR DESCRIPTION
## Description
Generate htpasswd for dvcr using hook.

## Why do we need it, and what problem does it solve?
Func htpasswd in helm always generates a new hash, so the update helm-chart is equal to restarting dvcr.
Generating htpasswd from an hook solves this problem.


## Checklist
- [X] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
