### PR TITLE
refactor(kube-api-rewriter): remove dvp prefixes

### DIFF
--- a/crds/embedded/cdi.yaml
+++ b/crds/embedded/cdi.yaml
@@ -3,19 +3,19 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
-  name: dvpinternalcdis.internal.virtualization.deckhouse.io
+  name: internalvirtualizationcdis.internal.virtualization.deckhouse.io
 spec:
   group: internal.virtualization.deckhouse.io
   names:
     categories:
-      - dvpinternal
-    kind: DVPInternalCDI
-    listKind: DVPInternalCDIList
-    plural: dvpinternalcdis
+      - intvirt
+    kind: InternalVirtualizationCDI
+    listKind: InternalVirtualizationCDIList
+    plural: internalvirtualizationcdis
     shortNames:
-      - dvpcdi
-      - dvpcdis
-    singular: dvpinternalcdi
+      - intvirtcdi
+      - intvirtcdis
+    singular: internalvirtualizationcdi
   scope: Cluster
   versions:
     - additionalPrinterColumns:

--- a/crds/embedded/kubevirt.yaml
+++ b/crds/embedded/kubevirt.yaml
@@ -1,6 +1,8 @@
 # Source:
 # https://github.com/kubevirt/kubevirt/releases/download/v1.0.0/kubevirt-operator.yaml
 # Changes:
+# - 2024.06.19
+#   - Remove DVP prefixes.
 # - 2024.04.16
 #   - Add prefixes xinternal, XInternal
 # - 2023.12.12
@@ -14,15 +16,15 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     operator.kubevirt.io: ""
-  name: dvpinternalkubevirts.internal.virtualization.deckhouse.io
+  name: internalvirtualizationkubevirts.internal.virtualization.deckhouse.io
 spec:
   group: internal.virtualization.deckhouse.io
   names:
     categories:
-      - dvpinternal
-    kind: DVPInternalKubeVirt
-    plural: dvpinternalkubevirts
-    singular: dvpinternalkubevirt
+      - intvirt
+    kind: InternalVirtualizationKubeVirt
+    plural: internalvirtualizationkubevirts
+    singular: internalvirtualizationkubevirt
   scope: Namespaced
   versions:
     - additionalPrinterColumns:

--- a/images/kube-api-proxy/pkg/kubevirt/kubevirt_rules.go
+++ b/images/kube-api-proxy/pkg/kubevirt/kubevirt_rules.go
@@ -23,14 +23,14 @@ import (
 const (
 	internalPrefix = "internal.virtualization.deckhouse.io"
 	nodePrefix     = "node.virtualization.deckhouse.io"
-	dvpPrefix      = "virtualization.deckhouse.io"
+	rootPrefix     = "virtualization.deckhouse.io"
 )
 
 var KubevirtRewriteRules = &RewriteRules{
-	KindPrefix:         "DVPInternal", // KV
-	ResourceTypePrefix: "dvpinternal", // kv
-	ShortNamePrefix:    "dvp",
-	Categories:         []string{"dvpinternal"},
+	KindPrefix:         "InternalVirtualization", // VirtualMachine -> InternalVirtualizationVirtualMachine
+	ResourceTypePrefix: "internalvirtualization", // virtualmachines -> internalvirtualizationvirtualmachines
+	ShortNamePrefix:    "intvirt",                // kubectl get intvirtvm
+	Categories:         []string{"intvirt"},      // kubectl get intvirt to see all KubeVirt and CDI resources.
 	RenamedGroup:       "internal.virtualization.deckhouse.io",
 	Rules:              KubevirtAPIGroupsRules,
 	Webhooks:           KubevirtWebhooks,
@@ -41,7 +41,7 @@ var KubevirtRewriteRules = &RewriteRules{
 			{Original: "prometheus.kubevirt.io", Renamed: "prometheus.kubevirt." + internalPrefix},
 			{Original: "prometheus.cdi.kubevirt.io", Renamed: "prometheus.cdi." + internalPrefix},
 			// Special cases.
-			{Original: "node-labeller.kubevirt.io/skip-node", Renamed: "node-labeller." + dvpPrefix + "/skip-node"},
+			{Original: "node-labeller.kubevirt.io/skip-node", Renamed: "node-labeller." + rootPrefix + "/skip-node"},
 			{Original: "node-labeller.kubevirt.io/obsolete-host-model", Renamed: "node-labeller." + internalPrefix + "/obsolete-host-model"},
 		},
 		Prefixes: []MetadataReplaceRule{
@@ -473,7 +473,7 @@ var KubevirtWebhooks = map[string]WebhookRule{
 	"/dataimportcron-validate": {
 		Path:     "/dataimportcron-validate",
 		Group:    "cdi.kubevirt.io",
-		Resource: "dvpinternaldataimportcrons",
+		Resource: "dataimportcrons",
 	},
 	"/datavolume-validate": {
 		Path:     "/datavolume-validate",

--- a/images/kube-api-proxy/pkg/rewriter/discovery.go
+++ b/images/kube-api-proxy/pkg/rewriter/discovery.go
@@ -461,23 +461,23 @@ func RestoreAggregatedGroupDiscovery(rules *RewriteRules, obj []byte) ([][]byte,
 // Example of the APIResourceDiscovery object:
 //
 //	{
-//	  "resource": "dvpinternalkubevirts",
+//	  "resource": "internalvirtualizationkubevirts",
 //	  "responseKind": {
 //	    "group": "internal.virtualization.deckhouse.io",
 //	    "version": "v1",
-//	    "kind": "DVPInternalKubeVirt"
+//	    "kind": "InternalVirtualizationKubeVirt"
 //	  },
 //	  "scope": "Namespaced",
-//	  "singularResource": "dvpinternalkubevirt",
+//	  "singularResource": "internalvirtualizationkubevirt",
 //	  "verbs": [ "delete", "deletecollection", "get", ... ], // Optional
-//	  "categories": [ "dvpinternal" ], // Optional
+//	  "categories": [ "intvirt" ], // Optional
 //	  "subresources": [ // Optional
 //	    {
 //	      "subresource": "status",
 //	      "responseKind": {
 //	        "group": "internal.virtualization.deckhouse.io",
 //	        "version": "v1",
-//	        "kind": "DVPInternalKubeVirt"
+//	        "kind": "InternalVirtualizationKubeVirt"
 //	      },
 //	      "verbs": [ "get", "patch", "update" ]
 //	    }

--- a/images/pre-delete-hook/entrypoint.sh
+++ b/images/pre-delete-hook/entrypoint.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Copyright 2024 Flant JSC
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,13 +15,13 @@
 # limitations under the License.
 set -eu -o pipefail
 
-KUBEVIRT_RESOURCE="dvpinternalkubevirts.internal.virtualization.deckhouse.io"
+KUBEVIRT_RESOURCE="internalvirtualizationkubevirts.internal.virtualization.deckhouse.io"
 echo "Delete Kubevirt configuration ..."
 kubectl delete -n d8-virtualization ${KUBEVIRT_RESOURCE} config || true
 echo "Wait for Kubevirt deletion ..."
 kubectl wait --for=delete -n d8-virtualization ${KUBEVIRT_RESOURCE} config --timeout=180s || true
 
-CDI_RESOURCE="dvpinternalcdis.internal.virtualization.deckhouse.io"
+CDI_RESOURCE="internalvirtualizationcdis.internal.virtualization.deckhouse.io"
 echo "Delete CDI configuration ..."
 kubectl delete ${CDI_RESOURCE} config || true
 echo "Wait for CDI deletion ..."

--- a/templates/cdi/cdi-operator/rbac-for-us.yaml
+++ b/templates/cdi/cdi-operator/rbac-for-us.yaml
@@ -125,26 +125,26 @@ rules:
 - apiGroups:
     - internal.virtualization.deckhouse.io
   resources:
-    - dvpinternaldatavolumes
+    - internalvirtualizationdatavolumes
   verbs:
     - list
     - get
 - apiGroups:
     - internal.virtualization.deckhouse.io
   resources:
-    - dvpinternaldatasources
+    - internalvirtualizationdatasources
   verbs:
     - get
 - apiGroups:
     - internal.virtualization.deckhouse.io
   resources:
-    - dvpinternalcdis
+    - internalvirtualizationcdis
   verbs:
     - get
 - apiGroups:
     - internal.virtualization.deckhouse.io
   resources:
-    - dvpinternalcdis/finalizers
+    - internalvirtualizationcdis/finalizers
   verbs:
     - update
 - apiGroups:
@@ -288,7 +288,7 @@ rules:
 - apiGroups:
     - internal.virtualization.deckhouse.io
   resources:
-    - dvpinternaldataimportcrons
+    - internalvirtualizationdataimportcrons
   verbs:
     - get
     - list

--- a/templates/cdi/cdi.yaml
+++ b/templates/cdi/cdi.yaml
@@ -7,7 +7,7 @@
 {{- $webhookProxyPort :=  24192 }}
 ---
 apiVersion: internal.virtualization.deckhouse.io/v1beta1
-kind: DVPInternalCDI
+kind: InternalVirtualizationCDI
 metadata:
   name: config
   namespace: d8-{{ .Chart.Name }}

--- a/templates/kubevirt/kubevirt.yaml
+++ b/templates/kubevirt/kubevirt.yaml
@@ -7,7 +7,7 @@
 {{- $webhookProxyPort :=  24192 }}
 ---
 apiVersion: internal.virtualization.deckhouse.io/v1
-kind: DVPInternalKubeVirt
+kind: InternalVirtualizationKubeVirt
 metadata:
   name: config
   namespace: d8-{{ .Chart.Name }}

--- a/templates/kubevirt/virt-operator/rbac-for-us.yaml
+++ b/templates/kubevirt/virt-operator/rbac-for-us.yaml
@@ -88,7 +88,7 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalkubevirts
+  - internalvirtualizationkubevirts
   verbs:
   - get
   - list
@@ -296,8 +296,8 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalvirtualmachines
-  - dvpinternalvirtualmachineinstances
+  - internalvirtualizationvirtualmachines
+  - internalvirtualizationvirtualmachineinstances
   verbs:
   - get
   - list
@@ -313,13 +313,13 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalvirtualmachines/status
+  - internalvirtualizationvirtualmachines/status
   verbs:
   - patch
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalvirtualmachineinstancemigrations
+  - internalvirtualizationvirtualmachineinstancemigrations
   verbs:
   - create
   - get
@@ -329,7 +329,7 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalvirtualmachineinstancepresets
+  - internalvirtualizationvirtualmachineinstancepresets
   verbs:
   - watch
   - list
@@ -359,7 +359,7 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalkubevirts
+  - internalvirtualizationkubevirts
   verbs:
   - get
   - list
@@ -367,9 +367,9 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalvirtualmachinesnapshots
-  - dvpinternalvirtualmachinerestores
-  - dvpinternalvirtualmachinesnapshotcontents
+  - internalvirtualizationvirtualmachinesnapshots
+  - internalvirtualizationvirtualmachinerestores
+  - internalvirtualizationvirtualmachinesnapshotcontents
   verbs:
   - get
   - list
@@ -377,8 +377,8 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternaldatasources
-  - dvpinternaldatavolumes
+  - internalvirtualizationdatasources
+  - internalvirtualizationdatavolumes
   verbs:
   - get
   - list
@@ -386,10 +386,10 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalvirtualmachineinstancetypes
-  - dvpinternalvirtualmachineclusterinstancetypes
-  - dvpinternalvirtualmachinepreferences
-  - dvpinternalvirtualmachineclusterpreferences
+  - internalvirtualizationvirtualmachineinstancetypes
+  - internalvirtualizationvirtualmachineclusterinstancetypes
+  - internalvirtualizationvirtualmachinepreferences
+  - internalvirtualizationvirtualmachineclusterpreferences
   verbs:
   - get
   - list
@@ -397,10 +397,10 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalvirtualmachineinstancetypes
-  - dvpinternalvirtualmachineclusterinstancetypes
-  - dvpinternalvirtualmachinepreferences
-  - dvpinternalvirtualmachineclusterpreferences
+  - internalvirtualizationvirtualmachineinstancetypes
+  - internalvirtualizationvirtualmachineclusterinstancetypes
+  - internalvirtualizationvirtualmachinepreferences
+  - internalvirtualizationvirtualmachineclusterpreferences
   verbs:
   - delete
   - create
@@ -410,7 +410,7 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalmigrationpolicies
+  - internalvirtualizationmigrationpolicies
   verbs:
   - get
   - list
@@ -564,10 +564,10 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalvirtualmachinepools
-  - dvpinternalvirtualmachinepools/finalizers
-  - dvpinternalvirtualmachinepools/status
-  - dvpinternalvirtualmachinepools/scale
+  - internalvirtualizationvirtualmachinepools
+  - internalvirtualizationvirtualmachinepools/finalizers
+  - internalvirtualizationvirtualmachinepools/status
+  - internalvirtualizationvirtualmachinepools/scale
   verbs:
   - watch
   - list
@@ -650,10 +650,10 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalvirtualmachineinstancetypes
-  - dvpinternalvirtualmachineclusterinstancetypes
-  - dvpinternalvirtualmachinepreferences
-  - dvpinternalvirtualmachineclusterpreferences
+  - internalvirtualizationvirtualmachineinstancetypes
+  - internalvirtualizationvirtualmachineclusterinstancetypes
+  - internalvirtualizationvirtualmachinepreferences
+  - internalvirtualizationvirtualmachineclusterpreferences
   verbs:
   - get
   - list
@@ -661,7 +661,7 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalmigrationpolicies
+  - internalvirtualizationmigrationpolicies
   verbs:
   - get
   - list
@@ -669,9 +669,9 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalvirtualmachineclones
-  - dvpinternalvirtualmachineclones/status
-  - dvpinternalvirtualmachineclones/finalizers
+  - internalvirtualizationvirtualmachineclones
+  - internalvirtualizationvirtualmachineclones/status
+  - internalvirtualizationvirtualmachineclones/finalizers
   verbs:
   - get
   - list
@@ -719,7 +719,7 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalvirtualmachineinstances
+  - internalvirtualizationvirtualmachineinstances
   verbs:
   - update
   - list
@@ -759,7 +759,7 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalkubevirts
+  - internalvirtualizationkubevirts
   verbs:
   - get
   - list
@@ -767,7 +767,7 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalmigrationpolicies
+  - internalvirtualizationmigrationpolicies
   verbs:
   - get
   - list
@@ -783,7 +783,7 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalvirtualmachineexports
+  - internalvirtualizationvirtualmachineexports
   verbs:
   - get
   - list
@@ -791,7 +791,7 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalkubevirts
+  - internalvirtualizationkubevirts
   verbs:
   - list
   - watch
@@ -866,11 +866,11 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalvirtualmachines
-  - dvpinternalvirtualmachineinstances
-  - dvpinternalvirtualmachineinstancepresets
-  - dvpinternalvirtualmachineinstancereplicasets
-  - dvpinternalvirtualmachineinstancemigrations
+  - internalvirtualizationvirtualmachines
+  - internalvirtualizationvirtualmachineinstances
+  - internalvirtualizationvirtualmachineinstancepresets
+  - internalvirtualizationvirtualmachineinstancereplicasets
+  - internalvirtualizationvirtualmachineinstancemigrations
   verbs:
   - get
   - delete
@@ -883,9 +883,9 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalvirtualmachinesnapshots
-  - dvpinternalvirtualmachinesnapshotcontents
-  - dvpinternalvirtualmachinerestores
+  - internalvirtualizationvirtualmachinesnapshots
+  - internalvirtualizationvirtualmachinesnapshotcontents
+  - internalvirtualizationvirtualmachinerestores
   verbs:
   - get
   - delete
@@ -898,7 +898,7 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalvirtualmachineexports
+  - internalvirtualizationvirtualmachineexports
   verbs:
   - get
   - delete
@@ -911,7 +911,7 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalvirtualmachineclones
+  - internalvirtualizationvirtualmachineclones
   verbs:
   - get
   - delete
@@ -924,10 +924,10 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalvirtualmachineinstancetypes
-  - dvpinternalvirtualmachineclusterinstancetypes
-  - dvpinternalvirtualmachinepreferences
-  - dvpinternalvirtualmachineclusterpreferences
+  - internalvirtualizationvirtualmachineinstancetypes
+  - internalvirtualizationvirtualmachineclusterinstancetypes
+  - internalvirtualizationvirtualmachinepreferences
+  - internalvirtualizationvirtualmachineclusterpreferences
   verbs:
   - get
   - delete
@@ -940,7 +940,7 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalvirtualmachinepools
+  - internalvirtualizationvirtualmachinepools
   verbs:
   - get
   - delete
@@ -953,7 +953,7 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalmigrationpolicies
+  - internalvirtualizationmigrationpolicies
   verbs:
   - get
   - list
@@ -1011,11 +1011,11 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalvirtualmachines
-  - dvpinternalvirtualmachineinstances
-  - dvpinternalvirtualmachineinstancepresets
-  - dvpinternalvirtualmachineinstancereplicasets
-  - dvpinternalvirtualmachineinstancemigrations
+  - internalvirtualizationvirtualmachines
+  - internalvirtualizationvirtualmachineinstances
+  - internalvirtualizationvirtualmachineinstancepresets
+  - internalvirtualizationvirtualmachineinstancereplicasets
+  - internalvirtualizationvirtualmachineinstancemigrations
   verbs:
   - get
   - delete
@@ -1027,9 +1027,9 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalvirtualmachinesnapshots
-  - dvpinternalvirtualmachinesnapshotcontents
-  - dvpinternalvirtualmachinerestores
+  - internalvirtualizationvirtualmachinesnapshots
+  - internalvirtualizationvirtualmachinesnapshotcontents
+  - internalvirtualizationvirtualmachinerestores
   verbs:
   - get
   - delete
@@ -1041,7 +1041,7 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalvirtualmachineexports
+  - internalvirtualizationvirtualmachineexports
   verbs:
   - get
   - delete
@@ -1053,7 +1053,7 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalvirtualmachineclones
+  - internalvirtualizationvirtualmachineclones
   verbs:
   - get
   - delete
@@ -1065,10 +1065,10 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalvirtualmachineinstancetypes
-  - dvpinternalvirtualmachineclusterinstancetypes
-  - dvpinternalvirtualmachinepreferences
-  - dvpinternalvirtualmachineclusterpreferences
+  - internalvirtualizationvirtualmachineinstancetypes
+  - internalvirtualizationvirtualmachineclusterinstancetypes
+  - internalvirtualizationvirtualmachinepreferences
+  - internalvirtualizationvirtualmachineclusterpreferences
   verbs:
   - get
   - delete
@@ -1080,7 +1080,7 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalvirtualmachinepools
+  - internalvirtualizationvirtualmachinepools
   verbs:
   - get
   - delete
@@ -1092,14 +1092,14 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalkubevirts
+  - internalvirtualizationkubevirts
   verbs:
   - get
   - list
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalmigrationpolicies
+  - internalvirtualizationmigrationpolicies
   verbs:
   - get
   - list
@@ -1122,11 +1122,11 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalvirtualmachines
-  - dvpinternalvirtualmachineinstances
-  - dvpinternalvirtualmachineinstancepresets
-  - dvpinternalvirtualmachineinstancereplicasets
-  - dvpinternalvirtualmachineinstancemigrations
+  - internalvirtualizationvirtualmachines
+  - internalvirtualizationvirtualmachineinstances
+  - internalvirtualizationvirtualmachineinstancepresets
+  - internalvirtualizationvirtualmachineinstancereplicasets
+  - internalvirtualizationvirtualmachineinstancemigrations
   verbs:
   - get
   - list
@@ -1134,9 +1134,9 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalvirtualmachinesnapshots
-  - dvpinternalvirtualmachinesnapshotcontents
-  - dvpinternalvirtualmachinerestores
+  - internalvirtualizationvirtualmachinesnapshots
+  - internalvirtualizationvirtualmachinesnapshotcontents
+  - internalvirtualizationvirtualmachinerestores
   verbs:
   - get
   - list
@@ -1144,7 +1144,7 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalvirtualmachineexports
+  - internalvirtualizationvirtualmachineexports
   verbs:
   - get
   - list
@@ -1152,7 +1152,7 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalvirtualmachineclones
+  - internalvirtualizationvirtualmachineclones
   verbs:
   - get
   - list
@@ -1160,10 +1160,10 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalvirtualmachineinstancetypes
-  - dvpinternalvirtualmachineclusterinstancetypes
-  - dvpinternalvirtualmachinepreferences
-  - dvpinternalvirtualmachineclusterpreferences
+  - internalvirtualizationvirtualmachineinstancetypes
+  - internalvirtualizationvirtualmachineclusterinstancetypes
+  - internalvirtualizationvirtualmachinepreferences
+  - internalvirtualizationvirtualmachineclusterpreferences
   verbs:
   - get
   - list
@@ -1171,7 +1171,7 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalvirtualmachinepools
+  - internalvirtualizationvirtualmachinepools
   verbs:
   - get
   - list
@@ -1180,7 +1180,7 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalmigrationpolicies
+  - internalvirtualizationmigrationpolicies
   verbs:
   - get
   - list

--- a/templates/pre-delete-hook/rbac-for-us.yaml
+++ b/templates/pre-delete-hook/rbac-for-us.yaml
@@ -17,8 +17,8 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalcdis
-  - dvpinternalkubevirts
+  - internalvirtualizationcdis
+  - internalvirtualizationkubevirts
   verbs:
   - get
   - delete

--- a/templates/virtualization-controller/rbac-for-us.yaml
+++ b/templates/virtualization-controller/rbac-for-us.yaml
@@ -89,7 +89,7 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternaldatavolumes
+  - internalvirtualizationdatavolumes
   verbs:
   - get
   - create
@@ -100,8 +100,8 @@ rules:
 - apiGroups:
   - internal.virtualization.deckhouse.io
   resources:
-  - dvpinternalvirtualmachines
-  - dvpinternalvirtualmachineinstances
+  - internalvirtualizationvirtualmachines
+  - internalvirtualizationvirtualmachineinstances
   verbs:
   - get
   - watch
@@ -113,7 +113,7 @@ rules:
 - apiGroups:
     - internal.virtualization.deckhouse.io
   resources:
-    - dvpinternalkubevirts
+    - internalvirtualizationkubevirts
   verbs:
     - get
     - list
@@ -121,7 +121,7 @@ rules:
 - apiGroups:
     - internal.virtualization.deckhouse.io
   resources:
-    - dvpinternalvirtualmachines/status
+    - internalvirtualizationvirtualmachines/status
   verbs:
     - patch
     - update


### PR DESCRIPTION
- DVP is a product name, use more generic prefix
- Change configuration CRDs for KubeVirt and CDI.
- Change manifests in templates: RBAC and configurations.
- Change pre-delete-hook.

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
