### PR TITLE
refactor(kube-api-rewriter): rewrite ownerReferences for Lists

### DIFF
--- a/images/kube-api-proxy/pkg/rewriter/resource.go
+++ b/images/kube-api-proxy/pkg/rewriter/resource.go
@@ -155,20 +155,14 @@ func RestoreAPIVersionAndKind(rules *RewriteRules, obj []byte, origGroupName str
 }
 
 func RewriteOwnerReferences(rules *RewriteRules, obj []byte, action Action) ([]byte, error) {
-	ownerRefs := gjson.GetBytes(obj, "metadata.ownerReferences")
-	// Prevent adding empty ownereReferences to rewritten JSON.
-	if !ownerRefs.Exists() {
-		return obj, nil
-	}
-
-	ownerRefsArray := ownerRefs.Array()
-	if len(ownerRefsArray) == 0 {
+	ownerRefs := gjson.GetBytes(obj, "metadata.ownerReferences").Array()
+	if len(ownerRefs) == 0 {
 		return obj, nil
 	}
 
 	rwrOwnerRefs := []byte(`[]`)
 	rewritten := false
-	for _, ownerRef := range ownerRefsArray {
+	for _, ownerRef := range ownerRefs {
 		kind := ownerRef.Get("kind").String()
 		if action == Restore {
 			kind = rules.RestoreKind(kind)
@@ -219,20 +213,14 @@ func RewriteOwnerReferences(rules *RewriteRules, obj []byte, action Action) ([]b
 
 // RenameOwnerReferences renames kind and apiVersion to send request to server.
 func RenameOwnerReferences(rules *RewriteRules, obj []byte) ([]byte, error) {
-	ownerRefs := gjson.GetBytes(obj, "metadata.ownerReferences")
-	// Prevent adding empty ownereReferences to rewritten JSON.
-	if !ownerRefs.Exists() {
-		return obj, nil
-	}
-
-	ownerRefsArray := ownerRefs.Array()
-	if len(ownerRefsArray) == 0 {
+	ownerRefs := gjson.GetBytes(obj, "metadata.ownerReferences").Array()
+	if len(ownerRefs) == 0 {
 		return obj, nil
 	}
 
 	rwrOwnerRefs := []byte(`[]`)
 	var err error
-	for _, ownerRef := range ownerRefsArray {
+	for _, ownerRef := range ownerRefs {
 		apiVersion := ownerRef.Get("apiVersion").String()
 		kind := ownerRef.Get("kind").String()
 

--- a/images/kube-api-proxy/pkg/rewriter/rule_rewriter.go
+++ b/images/kube-api-proxy/pkg/rewriter/rule_rewriter.go
@@ -282,13 +282,17 @@ func (rw *RuleBasedRewriter) RewriteJSONPayload(targetReq *TargetRequest, obj []
 
 	// Always rewrite metadata: labels, annotations, finalizers, ownerReferences.
 	// TODO: add rewriter for managedFields.
-	return RewriteResourceOrList2(rwrBytes, func(singleObj []byte) ([]byte, error) {
+	rwrBytes, err = RewriteResourceOrList2(rwrBytes, func(singleObj []byte) ([]byte, error) {
 		singleObj, err := RewriteMetadata(rw.Rules, singleObj, action)
 		if err != nil {
 			return nil, err
 		}
 		return RewriteOwnerReferences(rw.Rules, singleObj, action)
 	})
+	if err != nil {
+		return obj, err
+	}
+	return rwrBytes, nil
 }
 
 // RewritePatch rewrites patches for some known objects.


### PR DESCRIPTION
## Description

- Add ResourceOrList tranformer around ownerReferences rewriter.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

Fix KubeVirt error: "Failure while starting VMI: controllerrevisions.apps "revision-start-vm-NNNN-N" already exists'" when restarting VM

## What is the expected result?

1. Create VM with runPolicy AlwaysOn
2. Restart virt-controller (scale replicas=0, scale replicas=1)
3. Restart VM from inside (d8 v console, sudo reboot)
4. VM should terminate and then start.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
