### PR TITLE
refactor(core): set the parameters of the Qemu/KVM domain of the d8 virtual machine

### DIFF
--- a/templates/kubevirt/kubevirt.yaml
+++ b/templates/kubevirt/kubevirt.yaml
@@ -15,6 +15,10 @@ metadata:
 spec:
   certificateRotateStrategy: {}
   configuration:
+    smbios:
+      manufacturer: Flant
+      family: Deckhouse
+      product: DeckhouseVirtualizationPlatform
     evictionStrategy: LiveMigrate
     developerConfiguration:
       featureGates:


### PR DESCRIPTION
## Description
Set the parameters of the Qemu/KVM domain of the d8 virtual machine.

## Why do we need it, and what problem does it solve?
For automation purposes, we must unambiguously determine that the VM is running under the d8-virtualization module

## What is the expected result?
```
root@linux-vm-virt-node:~# dmidecode -H 0x100
# dmidecode 3.3
Getting SMBIOS data from sysfs.
SMBIOS 3.0.0 present.
Table at 0x7FFFFD90.

Handle 0x0100, DMI type 1, 27 bytes
System Information
        Manufacturer: Flant
        Product Name: DeckhouseVirtualizationPlatform
        Version: pc-q35-8.2
        Serial Number: Not Specified
        UUID: dcbdb049-9d5f-5ff7-bd48-0aa6343bb1ed
        Wake-up Type: Power Switch
        SKU Number: Not Specified
        Family: Deckhouse
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
