### PR TITLE
chore(dev): use alpine for mirrord

### DIFF
--- a/images/virtualization-artifact/hack/mirrord.sh
+++ b/images/virtualization-artifact/hack/mirrord.sh
@@ -103,7 +103,7 @@ chmod +x "${BIN_DIR}/${BINARY}"
 if ! kubectl -n "${NAMESPACE}" get "deployment/${NEW_NAME}" &>/dev/null; then
   kubectl -n "${NAMESPACE}" get "deployment/${DEPLOYMENT}" -ojson | \
   jq --arg CONTAINER_NAME "$CONTAINER_NAME" --arg NEW_NAME "$NEW_NAME" '.metadata.name = $NEW_NAME |
-    (.spec.template.spec.containers[] | select(.name == $CONTAINER_NAME) ) |= (.command= [ "/bin/bash", "-c", "--" ] | .args = [ "while true; do sleep 60; done;" ] ) |
+    (.spec.template.spec.containers[] | select(.name == $CONTAINER_NAME) ) |= (.command= [ "/bin/sh", "-c", "--" ] | .args = [ "while true; do sleep 60; done;" ] | .image = "alpine:3.20.1") |
     .spec.replicas = 1 |
     .spec.template.metadata.labels.mirror = "true" |
     .spec.template.metadata.labels.ownerName = $NEW_NAME' | \


### PR DESCRIPTION
## Description
Change the image virtualization-controller to alpine.

## Why do we need it, and what problem does it solve?
The virtualization controller is based on a scratch image and does not support cmd bash or sleep. That's why  tasks using mirrord are failed.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
