### PR TITLE
refactor(core): more renames to not overlap with original Kubevirt and CDI

### DIFF
--- a/images/cdi-artifact/Taskfile.yaml
+++ b/images/cdi-artifact/Taskfile.yaml
@@ -12,6 +12,7 @@ tasks:
       - task: status
 
   status:
+    desc: "Show git status in cloned repo"
     cmds:
       - |
         dir=$(find . -type d -name __containerized-data-importer_\* -depth 1 | head -n1)
@@ -25,6 +26,7 @@ tasks:
         git status
 
   cleanup:
+    desc: "Remove cloned CDI git repo"
     cmds:
       - |
         find . -type d -name __containerized-data-importer_\* -depth 1

--- a/images/cdi-artifact/patches/009-remove-upload-apiservice.patch
+++ b/images/cdi-artifact/patches/009-remove-upload-apiservice.patch
@@ -1,0 +1,46 @@
+diff --git a/pkg/operator/resources/cluster/apiserver.go b/pkg/operator/resources/cluster/apiserver.go
+index adf8093fa..f737bba55 100644
+--- a/pkg/operator/resources/cluster/apiserver.go
++++ b/pkg/operator/resources/cluster/apiserver.go
+@@ -48,7 +48,7 @@ func createStaticAPIServerResources(args *FactoryArgs) []client.Object {
+ 
+ func createDynamicAPIServerResources(args *FactoryArgs) []client.Object {
+ 	return []client.Object{
+-		createAPIService("v1beta1", args.Namespace, args.Client, args.Logger),
++		// createAPIService("v1beta1", args.Namespace, args.Client, args.Logger),
+ 		createDataVolumeValidatingWebhook(args.Namespace, args.Client, args.Logger),
+ 		createDataVolumeMutatingWebhook(args.Namespace, args.Client, args.Logger),
+ 		createCDIValidatingWebhook(args.Namespace, args.Client, args.Logger),
+diff --git a/pkg/operator/resources/cluster/rbac.go b/pkg/operator/resources/cluster/rbac.go
+index 88e14c39a..85635efd9 100644
+--- a/pkg/operator/resources/cluster/rbac.go
++++ b/pkg/operator/resources/cluster/rbac.go
+@@ -58,17 +58,17 @@ func getAdminPolicyRules() []rbacv1.PolicyRule {
+ 				"create",
+ 			},
+ 		},
+-		{
+-			APIGroups: []string{
+-				"upload.cdi.kubevirt.io",
+-			},
+-			Resources: []string{
+-				"uploadtokenrequests",
+-			},
+-			Verbs: []string{
+-				"*",
+-			},
+-		},
++		// {
++		//	APIGroups: []string{
++		//		"upload.cdi.kubevirt.io",
++		//	},
++		//	Resources: []string{
++		//		"uploadtokenrequests",
++		//	},
++		//	Verbs: []string{
++		//		"*",
++		//	},
++		// },
+ 	}
+ }
+ 

--- a/images/cdi-artifact/patches/README.md
+++ b/images/cdi-artifact/patches/README.md
@@ -22,6 +22,11 @@ set ContentTypeJson for kubernetes clients.
 #### `008-rename-core-resources.patch`
 Replace "cdi" with "cdi-internal-virtualziation" in the core resource names.
 
+#### `009-remove-upload-apiservice.patch`
+
+Do not install apiservice v1beta1.upload.cdi.kubevirt.io. This APIService is not used
+by DVP, but conflicts with original CDI.
+
 #### `010-rename-apigroups-in-starred-rbac.patch`
 
 Rename apiGroup to internal.virtualization.deckhouse.io for ClusterRole for cdi-deployment to prevent permanent patching:

--- a/images/kube-api-proxy/Taskfile.dist.yaml
+++ b/images/kube-api-proxy/Taskfile.dist.yaml
@@ -11,6 +11,9 @@ vars:
   DevRegistry: "dev-registry.deckhouse.io/virt/dev/$USER"
 
 tasks:
+  default:
+    cmds:
+      - task: dev:status
   dev:build:
     desc: "build latest image with proxy and test-controller"
     cmds:
@@ -27,7 +30,7 @@ tasks:
           exit 1
         fi
       - |
-        kubectl -n kproxy apply -f local/proxy.yaml
+        cat local/proxy.yaml | USER=${USER} envsubst | kubectl -n kproxy apply -f -
 
   dev:restart:
     desc: "restart deployment"

--- a/images/kube-api-proxy/local/proxy.yaml
+++ b/images/kube-api-proxy/local/proxy.yaml
@@ -24,7 +24,7 @@ spec:
         - name: "deckhouse-registry"
       containers:
         - name: proxy-only
-          image: dev-registry.deckhouse.io/virt/dev/{{ .USER }}/kube-api-proxy:latest
+          image: dev-registry.deckhouse.io/virt/dev/${USER}/kube-api-proxy:latest
           imagePullPolicy: Always
           command:
             - /proxy
@@ -32,7 +32,7 @@ spec:
             - name: CLIENT_PROXY_PORT
               value: "23916"
         - name: proxy
-          image: dev-registry.deckhouse.io/virt/dev/{{ .USER }}/kube-api-proxy:latest
+          image: dev-registry.deckhouse.io/virt/dev/${USER}/kube-api-proxy:latest
           imagePullPolicy: Always
           command:
             - /proxy
@@ -51,7 +51,7 @@ spec:
             - mountPath: /tmp/proxy-webhook/serving-certs
               name: test-admission-webhook
         - name: controller
-          image: dev-registry.deckhouse.io/virt/dev/{{ .USER }}/kube-api-proxy:latest
+          image: dev-registry.deckhouse.io/virt/dev/${USER}/kube-api-proxy:latest
           imagePullPolicy: Always
           command:
             - /test-controller

--- a/images/kube-api-proxy/pkg/kubevirt/kubevirt_rules.go
+++ b/images/kube-api-proxy/pkg/kubevirt/kubevirt_rules.go
@@ -44,6 +44,22 @@ var KubevirtRewriteRules = &RewriteRules{
 			// Special cases.
 			{Original: "node-labeller.kubevirt.io/skip-node", Renamed: "node-labeller." + rootPrefix + "/skip-node"},
 			{Original: "node-labeller.kubevirt.io/obsolete-host-model", Renamed: "node-labeller." + internalPrefix + "/obsolete-host-model"},
+			{
+				Original: "app.kubernetes.io/managed-by", OriginalValue: "cdi-operator",
+				Renamed: "app.kubernetes.io/managed-by", RenamedValue: "cdi-operator-internal-virtualization",
+			},
+			{
+				Original: "app.kubernetes.io/managed-by", OriginalValue: "cdi-controller",
+				Renamed: "app.kubernetes.io/managed-by", RenamedValue: "cdi-controller-internal-virtualization",
+			},
+			{
+				Original: "app.kubernetes.io/managed-by", OriginalValue: "virt-operator",
+				Renamed: "app.kubernetes.io/managed-by", RenamedValue: "virt-operator-internal-virtualization",
+			},
+			{
+				Original: "app.kubernetes.io/managed-by", OriginalValue: "kubevirt-operator",
+				Renamed: "app.kubernetes.io/managed-by", RenamedValue: "kubevirt-operator-internal-virtualization",
+			},
 		},
 		Prefixes: []MetadataReplaceRule{
 			// CDI related labels.
@@ -83,6 +99,26 @@ var KubevirtRewriteRules = &RewriteRules{
 		Prefixes: []MetadataReplaceRule{
 			{Original: "kubevirt.io", Renamed: "kubevirt." + internalPrefix},
 			{Original: "operator.cdi.kubevirt.io", Renamed: "operator.cdi." + internalPrefix},
+		},
+	},
+	Excludes: []ExcludeRule{
+		ExcludeRule{
+			Kinds: []string{
+				"PersistentVolumeClaim",
+				"PersistentVolume",
+				"Pod",
+			},
+			MatchLabels: map[string]string{
+				"app.kubernetes.io/managed-by": "cdi-controller",
+			},
+		},
+		ExcludeRule{
+			Kinds: []string{
+				"CDI",
+			},
+			MatchNames: []string{
+				"cdi",
+			},
 		},
 	},
 }

--- a/images/kube-api-proxy/pkg/rewriter/app_test.go
+++ b/images/kube-api-proxy/pkg/rewriter/app_test.go
@@ -90,6 +90,10 @@ func createTestRewriterForApp() *RuleBasedRewriter {
 			},
 			Names: []MetadataReplaceRule{
 				{Original: "labelgroup.io", Renamed: "replacedlabelgroup.io"},
+				{
+					Original: "labelgroup.io", OriginalValue: "some-value",
+					Renamed: "replacedlabelgroup.io", RenamedValue: "some-value-renamed",
+				},
 			},
 		},
 		Annotations: MetadataReplace{
@@ -232,7 +236,9 @@ Host: 127.0.0.1
 		{`metadata.annotations.component\.replacedannogroup\.io/annoName`, "annoValue"},
 		{`metadata.annotations.component\.annogroup\.io/annoName`, ""},
 		{`spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution.0.podAffinityTerm.labelSelector.matchExpressions.0.key`, "replacedlabelgroup.io"},
+		{`spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution.0.podAffinityTerm.labelSelector.matchExpressions.0.values`, `["some-value-renamed"]`},
 		{`spec.template.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution.0.preference.matchExpressions.0.key`, "replacedlabelgroup.io"},
+		{`spec.template.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution.0.preference.matchExpressions.0.values`, `["some-value-renamed"]`},
 	}
 
 	for _, tt := range tests {

--- a/images/kube-api-proxy/pkg/rewriter/discovery.go
+++ b/images/kube-api-proxy/pkg/rewriter/discovery.go
@@ -51,6 +51,10 @@ func RewriteAPIGroupList(rules *RewriteRules, objBytes []byte) ([]byte, error) {
 			rwrGroups = append(rwrGroups, rules.GetAPIGroupList()...)
 			continue
 		}
+		// Remove duplicates if cluster have CRDs with original group names.
+		if rules.HasGroup(groupName) {
+			continue
+		}
 		rwrGroups = append(rwrGroups, runtime.RawExtension{Raw: []byte(group.Raw)})
 	}
 
@@ -312,6 +316,10 @@ func RewriteAPIGroupDiscoveryList(rules *RewriteRules, obj []byte) ([]byte, erro
 		groupName := gjson.GetBytes(itemBytes, "metadata.name").String()
 
 		if groupName != rules.RenamedGroup {
+			// Remove duplicates if cluster have CRDs with original group names.
+			if rules.HasGroup(groupName) {
+				continue
+			}
 			// No transform for non-renamed groups.
 			rwrItems, err = sjson.SetRawBytes(rwrItems, "-1", itemBytes)
 			if err != nil {

--- a/images/kube-api-proxy/pkg/rewriter/metadata.go
+++ b/images/kube-api-proxy/pkg/rewriter/metadata.go
@@ -104,13 +104,13 @@ func RenameMetadataPatch(rules *RewriteRules, patch []byte) ([]byte, error) {
 
 func RewriteLabelsMap(rules *RewriteRules, obj []byte, path string, action Action) ([]byte, error) {
 	return RewriteMapStringString(obj, path, func(k, v string) (string, string) {
-		return rules.LabelsRewriter().Rewrite(k, action), v
+		return rules.LabelsRewriter().RewriteNameValue(k, v, action)
 	})
 }
 
 func RewriteAnnotationsMap(rules *RewriteRules, obj []byte, path string, action Action) ([]byte, error) {
 	return RewriteMapStringString(obj, path, func(k, v string) (string, string) {
-		return rules.AnnotationsRewriter().Rewrite(k, action), v
+		return rules.AnnotationsRewriter().RewriteNameValue(k, v, action)
 	})
 }
 

--- a/images/kube-api-proxy/pkg/rewriter/prefixed_name_rewriter.go
+++ b/images/kube-api-proxy/pkg/rewriter/prefixed_name_rewriter.go
@@ -18,6 +18,8 @@ package rewriter
 
 import "strings"
 
+const PreservedPrefix = "preserved-original-"
+
 type PrefixedNameRewriter struct {
 	namesRenameIdx   map[string]string
 	namesRestoreIdx  map[string]string
@@ -37,11 +39,34 @@ func NewPrefixedNameRewriter(replaceRules MetadataReplace) *PrefixedNameRewriter
 func (p *PrefixedNameRewriter) Rewrite(name string, action Action) string {
 	switch action {
 	case Rename:
-		return p.rename(name)
+		name, _ = p.rename(name, "")
 	case Restore:
-		return p.restore(name)
+		name, _ = p.restore(name, "")
 	}
 	return name
+}
+
+func (p *PrefixedNameRewriter) RewriteNameValue(name, value string, action Action) (string, string) {
+	switch action {
+	case Rename:
+		return p.rename(name, value)
+	case Restore:
+		return p.restore(name, value)
+	}
+	return name, value
+}
+
+func (p *PrefixedNameRewriter) RewriteNameValues(name string, values []string, action Action) (string, []string) {
+	if len(values) == 0 {
+		return p.Rewrite(name, action), values
+	}
+	switch action {
+	case Rename:
+		return p.rewriteNameValues(name, values, p.rename)
+	case Restore:
+		return p.rewriteNameValues(name, values, p.restore)
+	}
+	return name, values
 }
 
 func (p *PrefixedNameRewriter) RewriteSlice(names []string, action Action) []string {
@@ -64,12 +89,12 @@ func (p *PrefixedNameRewriter) RewriteMap(names map[string]string, action Action
 	return names
 }
 
-func (p *PrefixedNameRewriter) Rename(name string) string {
-	return p.rename(name)
+func (p *PrefixedNameRewriter) Rename(name, value string) (string, string) {
+	return p.rename(name, value)
 }
 
-func (p *PrefixedNameRewriter) Restore(name string) string {
-	return p.restore(name)
+func (p *PrefixedNameRewriter) Restore(name, value string) (string, string) {
+	return p.restore(name, value)
 }
 
 func (p *PrefixedNameRewriter) RenameSlice(names []string) []string {
@@ -88,61 +113,153 @@ func (p *PrefixedNameRewriter) RestoreMap(names map[string]string) map[string]st
 	return p.rewriteMap(names, p.restore)
 }
 
-func (p *PrefixedNameRewriter) rewriteMap(names map[string]string, fn func(string) string) map[string]string {
+// rewriteNameValues rewrite name and values, e.g. for matchExpressions.
+// Method uses all rules to detect a new name, first matching rule is applied.
+// Values may be rewritten partially depending on specified name-value rules.
+func (p *PrefixedNameRewriter) rewriteNameValues(name string, values []string, fn func(string, string) (string, string)) (string, []string) {
+	rwrName := name
+	rwrValues := make([]string, 0, len(values))
+
+	for _, value := range values {
+		n, v := fn(name, value)
+		// Set new name only for the first matching rule.
+		if n != name && rwrName == name {
+			rwrName = n
+		}
+		rwrValues = append(rwrValues, v)
+	}
+
+	return rwrName, rwrValues
+}
+
+func (p *PrefixedNameRewriter) rewriteMap(names map[string]string, fn func(string, string) (string, string)) map[string]string {
 	if names == nil {
 		return nil
 	}
 	result := make(map[string]string)
 	for name, value := range names {
-		result[fn(name)] = value
+		rwrName, rwrValue := fn(name, value)
+		result[rwrName] = rwrValue
 	}
 	return result
 }
 
-func (p *PrefixedNameRewriter) rewriteSlice(names []string, fn func(string) string) []string {
+// rewriteSlice do not rewrite values, only names.
+func (p *PrefixedNameRewriter) rewriteSlice(names []string, fn func(string, string) (string, string)) []string {
 	if names == nil {
 		return nil
 	}
 	result := make([]string, 0, len(names))
 	for _, name := range names {
-		result = append(result, fn(name))
+		rwrName, _ := fn(name, "")
+		result = append(result, rwrName)
 	}
 	return result
 }
 
-func (p *PrefixedNameRewriter) rename(name string) string {
+// rename rewrites original names and values. If label was preserved, rewrite it to original state.
+func (p *PrefixedNameRewriter) rename(name, value string) (string, string) {
+	if p.isPreserved(name) {
+		return p.restorePreservedName(name), value
+	}
+
+	// First try to find name and value.
+	if value != "" {
+		idxKey := joinKV(name, value)
+		if renamedIdxValue, ok := p.namesRenameIdx[idxKey]; ok {
+			return splitKV(renamedIdxValue)
+		}
+	}
+	// No exact rule for name and value, try to find exact name match.
 	if renamed, ok := p.namesRenameIdx[name]; ok {
-		return renamed
+		return renamed, value
 	}
 	// No exact name, find prefix.
 	prefix, remainder, found := strings.Cut(name, "/")
 	if !found {
-		return name
+		return name, value
 	}
 	if renamedPrefix, ok := p.prefixRenameIdx[prefix]; ok {
-		return renamedPrefix + "/" + remainder
+		return renamedPrefix + "/" + remainder, value
 	}
-	return name
+	return name, value
 }
 
-func (p *PrefixedNameRewriter) restore(name string) string {
+// restore rewrites renamed names and values to their original state.
+// If name is already original, preserve it with prefix, to make it unknown for client but keep in place for UPDATE/PATCH operations.
+func (p *PrefixedNameRewriter) restore(name, value string) (string, string) {
+	if p.isOriginal(name, value) {
+		return p.preserveName(name), value
+	}
+
+	// First try to find name and value.
+	if value != "" {
+		idxKey := joinKV(name, value)
+		if restoredIdxValue, ok := p.namesRestoreIdx[idxKey]; ok {
+			return splitKV(restoredIdxValue)
+		}
+	}
+	// No exact rule for name and value, try to find exact name match.
 	if restored, ok := p.namesRestoreIdx[name]; ok {
-		return restored
+		return restored, value
 	}
 	// No exact name, find prefix.
 	prefix, remainder, found := strings.Cut(name, "/")
 	if !found {
-		return name
+		return name, value
 	}
 	if restoredPrefix, ok := p.prefixRestoreIdx[prefix]; ok {
-		return restoredPrefix + "/" + remainder
+		return restoredPrefix + "/" + remainder, value
 	}
-	return name
+	return name, value
+}
+
+// isOriginal returns true if label should be renamed.
+func (p *PrefixedNameRewriter) isOriginal(name, value string) bool {
+	if value != "" {
+		// Label is "original" if there is rule for renaming name and value.
+		idxKey := joinKV(name, value)
+		if _, ok := p.namesRenameIdx[idxKey]; ok {
+			return true
+		}
+	}
+
+	// Try to find rule for exact name match.
+	if _, ok := p.namesRenameIdx[name]; ok {
+		return true
+	}
+	// No exact name, find rule for prefix.
+	prefix, _, found := strings.Cut(name, "/")
+	if !found {
+		// Label is only a name, but no rule for name found, so it is not "original".
+		return false
+	}
+	if _, ok := p.prefixRenameIdx[prefix]; ok {
+		return true
+	}
+	return false
+}
+
+func (p *PrefixedNameRewriter) isPreserved(name string) bool {
+	return strings.HasSuffix(name, PreservedPrefix)
+}
+
+func (p *PrefixedNameRewriter) preserveName(name string) string {
+	return PreservedPrefix + name
+}
+
+func (p *PrefixedNameRewriter) restorePreservedName(name string) string {
+	return strings.TrimPrefix(name, PreservedPrefix)
 }
 
 func indexRules(rules []MetadataReplaceRule) map[string]string {
 	idx := make(map[string]string, len(rules))
 	for _, rule := range rules {
+		if rule.OriginalValue != "" && rule.RenamedValue != "" {
+			idxKey := joinKV(rule.Original, rule.OriginalValue)
+			idx[idxKey] = rule.Renamed + "=" + rule.RenamedValue
+			continue
+		}
 		idx[rule.Original] = rule.Renamed
 	}
 	return idx
@@ -151,7 +268,21 @@ func indexRules(rules []MetadataReplaceRule) map[string]string {
 func indexRulesReverse(rules []MetadataReplaceRule) map[string]string {
 	idx := make(map[string]string, len(rules))
 	for _, rule := range rules {
+		if rule.OriginalValue != "" && rule.RenamedValue != "" {
+			idxKey := joinKV(rule.Renamed, rule.RenamedValue)
+			idx[idxKey] = rule.Original + "=" + rule.OriginalValue
+			continue
+		}
 		idx[rule.Renamed] = rule.Original
 	}
 	return idx
+}
+
+func joinKV(name, value string) string {
+	return name + "=" + value
+}
+
+func splitKV(idxValue string) (name, value string) {
+	name, value, _ = strings.Cut(idxValue, "=")
+	return
 }

--- a/images/kube-api-proxy/pkg/rewriter/rule_rewriter_test.go
+++ b/images/kube-api-proxy/pkg/rewriter/rule_rewriter_test.go
@@ -100,6 +100,10 @@ func createTestRewriter() *RuleBasedRewriter {
 			},
 			Names: []MetadataReplaceRule{
 				{Original: "labelgroup.io", Renamed: "replacedlabelgroup.io"},
+				{
+					Original: "labelgroup.io", OriginalValue: "labelValueToRename",
+					Renamed: "replacedlabelgroup.io", RenamedValue: "renamedLabelValue",
+				},
 			},
 		},
 		Annotations: MetadataReplace{
@@ -192,6 +196,24 @@ func TestRewriteAPIEndpoint(t *testing.T) {
 			"/apis/apps/v1/deployments?labelSelector=labelgroup.io+notin+%28value-one%2ClabelValue%29&limit=500",
 			"/apis/apps/v1/deployments",
 			"labelSelector=replacedlabelgroup.io+notin+%28labelValue%2Cvalue-one%29&limit=500",
+		},
+		{
+			"labelSelector label name and renamed value",
+			"/api/v1/namespaces/d8-virtualization/pods?labelSelector=labelgroup.io%3DlabelValueToRename&limit=500",
+			"/api/v1/namespaces/d8-virtualization/pods",
+			"labelSelector=replacedlabelgroup.io%3DrenamedLabelValue&limit=500",
+		},
+		{
+			"labelSelector label name and renamed values",
+			"/api/v1/namespaces/d8-virtualization/pods?labelSelector=labelgroup.io+notin+%28value-one%2ClabelValueToRename%29&limit=500",
+			"/api/v1/namespaces/d8-virtualization/pods",
+			"labelSelector=replacedlabelgroup.io+notin+%28renamedLabelValue%2Cvalue-one%29&limit=500",
+		},
+		{
+			"labelSelector label name and renamed values for deployments",
+			"/apis/apps/v1/deployments?labelSelector=labelgroup.io+notin+%28value-one%2ClabelValueToRename%29&limit=500",
+			"/apis/apps/v1/deployments",
+			"labelSelector=replacedlabelgroup.io+notin+%28renamedLabelValue%2Cvalue-one%29&limit=500",
 		},
 	}
 

--- a/images/kube-api-proxy/pkg/rewriter/rules_test.go
+++ b/images/kube-api-proxy/pkg/rewriter/rules_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rewriter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newTestExcludeRules() *RewriteRules {
+	rules := RewriteRules{
+		Rules: map[string]APIGroupRule{
+			"originalgroup.io": {
+				ResourceRules: map[string]ResourceRule{
+					"someresources": {
+						Kind:     "SomeResource",
+						ListKind: "SomeResourceList",
+					},
+				},
+			},
+			"anothergroup.io": {
+				ResourceRules: map[string]ResourceRule{
+					"anotheresources": {
+						Kind:     "AnotherResource",
+						ListKind: "AnotherResourceList",
+					},
+				},
+			},
+		},
+		Excludes: []ExcludeRule{
+			{
+				Kinds: []string{"RoleBinding"},
+				MatchLabels: map[string]string{
+					"labelName": "labelValue",
+				},
+			},
+			{
+				Kinds:      []string{"Role"},
+				MatchNames: []string{"role1", "role2"},
+			},
+		},
+	}
+	rules.Init()
+	return &rules
+}
+
+func TestExcludeRuleKindsOnly(t *testing.T) {
+	rules := newTestExcludeRules()
+
+	tests := []struct {
+		name           string
+		obj            string
+		expectExcluded bool
+	}{
+		{
+			"original kind SomeResource in excludes",
+			`{"kind":"SomeResource"}`,
+			true,
+		},
+		{
+			"kind UnknownResource not in excludes",
+			`{"kind":"UnknownResource"}`,
+			false,
+		},
+		{
+			"RoleBinding with label in excludes",
+			`{"kind":"RoleBinding","metadata":{"labels":{"labelName":"labelValue"}}}`,
+			true,
+		},
+		{
+			"RoleBinding with label not in excludes",
+			`{"kind":"RoleBinding","metadata":{"labels":{"labelName":"nonExcludedValue"}}}`,
+			false,
+		},
+		{
+			"Role with name in excludes",
+			`{"kind":"Role","metadata":{"name":"role1"}}`,
+			true,
+		},
+		{
+			"Role with name not in excludes",
+			`{"kind":"Role","metadata":{"name":"role-not-excluded"}}`,
+			false,
+		},
+		{
+			"RoleBinding with name as role in excludes",
+			`{"kind":"RoleBinding","metadata":{"name":"role1"}}`,
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := rules.ShouldExclude([]byte(tt.obj), "")
+
+			if tt.expectExcluded {
+				require.True(t, actual, "'%s' should be excluded. Not excluded obj: %s", tt.name, tt.obj)
+			} else {
+				require.False(t, actual, "'%s' should not be excluded. Excluded obj: %s", tt.name, tt.obj)
+
+			}
+		})
+	}
+}

--- a/images/virt-artifact/Taskfile.yaml
+++ b/images/virt-artifact/Taskfile.yaml
@@ -12,6 +12,7 @@ tasks:
       - task: status
 
   status:
+    desc: "Show git status in cloned repo"
     cmds:
       - |
         dir=$(find . -type d -name __kubevirt_\* -depth 1 | head -n1)
@@ -25,6 +26,7 @@ tasks:
         git status
 
   cleanup:
+    desc: "Remove cloned kubevirt git repo"
     cmds:
       - |
         find . -type d -name __kubevirt_\* -depth 1

--- a/images/virt-artifact/patches/015-rename-core-resources.patch
+++ b/images/virt-artifact/patches/015-rename-core-resources.patch
@@ -92,7 +92,7 @@ index 0948629bb..9aca3b3bd 100644
 +++ b/pkg/virt-operator/resource/generate/components/serviceaccountnames.go
 @@ -1,9 +1,9 @@
  package components
- 
+
  const (
 -	ApiServiceAccountName         = "kubevirt-apiserver"
 -	ControllerServiceAccountName  = "kubevirt-controller"
@@ -104,6 +104,29 @@ index 0948629bb..9aca3b3bd 100644
 +	HandlerServiceAccountName     = "kubevirt-internal-virtualization-handler"
  	OperatorServiceAccountName    = "kubevirt-operator"
  )
+diff --git a/pkg/virt-operator/resource/generate/components/webhooks.go b/pkg/virt-operator/resource/generate/components/webhooks.go
+index 2600f8f39..22381d9e9 100644
+--- a/pkg/virt-operator/resource/generate/components/webhooks.go
++++ b/pkg/virt-operator/resource/generate/components/webhooks.go
+@@ -833,15 +833,15 @@ const VirtHandlerServiceName = "virt-handler"
+
+ const VirtExportProxyServiceName = "virt-exportproxy"
+
+-const VirtAPIValidatingWebhookName = "virt-api-validator"
++const VirtAPIValidatingWebhookName = "virt-internal-virtualization-api-validator"
+
+ const VirtOperatorServiceName = "kubevirt-operator-webhook"
+
+-const VirtAPIMutatingWebhookName = "virt-api-mutator"
++const VirtAPIMutatingWebhookName = "virt-internal-virtualization-api-mutator"
+
+ const KubevirtOperatorWebhookServiceName = "kubevirt-operator-webhook"
+
+-const KubeVirtOperatorValidatingWebhookName = "virt-operator-validator"
++const KubeVirtOperatorValidatingWebhookName = "virt-internal-virtualization-operator-validator"
+
+ const VMSnapshotValidatePath = "/virtualmachinesnapshots-validate"
+
 diff --git a/pkg/virt-operator/resource/generate/rbac/apiserver.go b/pkg/virt-operator/resource/generate/rbac/apiserver.go
 index 932f7391e..76c79d452 100644
 --- a/pkg/virt-operator/resource/generate/rbac/apiserver.go
@@ -166,13 +189,13 @@ index 071ed91f9..ebc9f2adb 100644
  	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
  	"k8s.io/apimachinery/pkg/runtime"
 +	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
- 
+
  	virtv1 "kubevirt.io/api/core/v1"
  )
- 
+
 -const ExportProxyServiceAccountName = "kubevirt-exportproxy"
 +const ExportProxyServiceAccountName = components.ExportProxyServiceAccountName
- 
+
  func GetAllExportProxy(namespace string) []runtime.Object {
  	return []runtime.Object{
 diff --git a/pkg/virt-operator/resource/generate/rbac/operator.go b/pkg/virt-operator/resource/generate/rbac/operator.go

--- a/images/virt-artifact/patches/016-rename-install-strategy-labels.patch
+++ b/images/virt-artifact/patches/016-rename-install-strategy-labels.patch
@@ -1,3 +1,16 @@
+diff --git a/pkg/virt-operator/resource/generate/install/strategy.go b/pkg/virt-operator/resource/generate/install/strategy.go
+index 2f7c0c51b..f88108fdd 100644
+--- a/pkg/virt-operator/resource/generate/install/strategy.go
++++ b/pkg/virt-operator/resource/generate/install/strategy.go
+@@ -253,7 +253,7 @@ func NewInstallStrategyConfigMap(config *operatorutil.KubeVirtDeploymentConfig,
+ 			GenerateName: "kubevirt-install-strategy-",
+ 			Namespace:    config.GetNamespace(),
+ 			Labels: map[string]string{
+-				v1.ManagedByLabel:       v1.ManagedByLabelOperatorValue,
++				v1.ManagedByLabel:       "virt-operator-internal-virtualization",
+ 				v1.InstallStrategyLabel: "",
+ 			},
+ 			Annotations: map[string]string{
 diff --git a/staging/src/kubevirt.io/api/core/v1/types.go b/staging/src/kubevirt.io/api/core/v1/types.go
 index cf7648a1f..e633c3919 100644
 --- a/staging/src/kubevirt.io/api/core/v1/types.go

--- a/images/virt-artifact/patches/018-rename-devices-kubevirt-io.patch
+++ b/images/virt-artifact/patches/018-rename-devices-kubevirt-io.patch
@@ -1,0 +1,49 @@
+diff --git a/pkg/virt-controller/services/template.go b/pkg/virt-controller/services/template.go
+index d4124ea56..6285dacf6 100644
+--- a/pkg/virt-controller/services/template.go
++++ b/pkg/virt-controller/services/template.go
+@@ -66,12 +66,12 @@ const (
+ 	virtExporter     = "virt-exporter"
+ )
+
+-const KvmDevice = "devices.kubevirt.io/kvm"
+-const TunDevice = "devices.kubevirt.io/tun"
+-const VhostNetDevice = "devices.kubevirt.io/vhost-net"
+-const SevDevice = "devices.kubevirt.io/sev"
+-const VhostVsockDevice = "devices.kubevirt.io/vhost-vsock"
+-const PrDevice = "devices.kubevirt.io/pr-helper"
++const KvmDevice = "devices.virtualization.deckhouse.io/kvm"
++const TunDevice = "devices.virtualization.deckhouse.io/tun"
++const VhostNetDevice = "devices.virtualization.deckhouse.io/vhost-net"
++const SevDevice = "devices.virtualization.deckhouse.io/sev"
++const VhostVsockDevice = "devices.virtualization.deckhouse.io/vhost-vsock"
++const PrDevice = "devices.virtualization.deckhouse.io/pr-helper"
+
+ const debugLogs = "debugLogs"
+ const logVerbosity = "logVerbosity"
+diff --git a/pkg/virt-handler/device-manager/common.go b/pkg/virt-handler/device-manager/common.go
+index e3f86b117..d7a6d3456 100644
+--- a/pkg/virt-handler/device-manager/common.go
++++ b/pkg/virt-handler/device-manager/common.go
+@@ -230,7 +230,7 @@ func gRPCConnect(socketPath string, timeout time.Duration) (*grpc.ClientConn, er
+ }
+
+ func SocketPath(deviceName string) string {
+-	return filepath.Join(v1beta1.DevicePluginPath, fmt.Sprintf("kubevirt-%s.sock", deviceName))
++	return filepath.Join(v1beta1.DevicePluginPath, fmt.Sprintf("virtualization-deckhouse-%s.sock", deviceName))
+ }
+
+ func IsChanClosed(ch <-chan struct{}) bool {
+diff --git a/pkg/virt-handler/device-manager/generic_device.go b/pkg/virt-handler/device-manager/generic_device.go
+index 7baceee6c..3b12f94fd 100644
+--- a/pkg/virt-handler/device-manager/generic_device.go
++++ b/pkg/virt-handler/device-manager/generic_device.go
+@@ -41,7 +41,7 @@ import (
+ )
+
+ const (
+-	DeviceNamespace   = "devices.kubevirt.io"
++	DeviceNamespace   = "devices.virtualization.deckhouse.io"
+ 	connectionTimeout = 5 * time.Second
+ )
+

--- a/images/virt-artifact/patches/README.md
+++ b/images/virt-artifact/patches/README.md
@@ -62,6 +62,14 @@ Do not create Kubevirt APIService.
 #### `015-rename-core-resources.patch`
 Replace "kubevirt" with "kubevirt-internal-virtualziation" in the core resource names.
 
+#### `016-rename-install-strategy-labels.patch`
+
+Rename kubevirt.io/install-strategy-registry labels to install.internal.virtualization.deckhouse.io/install-strategy-registry.
+Rename app.kubernetes.io/managed-b value from virt-operator to virt-operator-internal-virtualization.
+
+Rewrite these labels with patch, because strategy generator Job starts without kube-api-rewriter.
+
+
 #### `016-rename-apigroups-in-starred-rbac.patch`
 
 Rename apiGroup to internal.virtualization.deckhouse.io for ClusterRole for virt-controller to prevent permanent patching:
@@ -69,3 +77,11 @@ Rename apiGroup to internal.virtualization.deckhouse.io for ClusterRole for virt
 ```
 {"component":"virt-operator","level":"info","msg":"clusterrole kubevirt-internal-virtualization-controller patched","pos":"core.go:142","timestamp":"2024-07-09T16:03:18.138751Z"}
 ```
+
+
+#### `018-rename-devices-kubevirt-io.patch`
+
+Rename additional resources previded with Device Plugin API to not overlap with original Kubevirt.
+
+Rename unix-socket path used for register devices.
+

--- a/templates/kubevirt/kubevirt.yaml
+++ b/templates/kubevirt/kubevirt.yaml
@@ -124,7 +124,8 @@ spec:
     # Patch was produced with this jq command:
     # kubectl get validatingwebhookconfigurations.admissionregistration.k8s.io virt-api-validator -o json | jq '{"webhooks": .webhooks|map({"name":.name, "clientConfig":{"service":{"port":24192}}}) }'
     # virt-api-webhook-proxy service is created separately.
-    - resourceName: virt-api-validator
+    # NOTE virt-api-validator is renamed to virt-internal-virtualization-api-validator.
+    - resourceName: virt-internal-virtualization-api-validator
       resourceType: ValidatingWebhookConfiguration
       patch: |
         {
@@ -212,7 +213,8 @@ spec:
     # Patch was produced with this jq command:
     # kubectl get mutatingwebhookconfigurations.admissionregistration.k8s.io virt-api-mutator -o json | jq '{"webhooks": .webhooks|map({"name":.name, "clientConfig":{"service":{"port":24192}}}) }'
     # virt-api-webhook-proxy service is created separately.
-    - resourceName: virt-api-mutator
+    # NOTE virt-api-mutator is renamed to virt-internal-virtualization-api-mutator.
+    - resourceName: virt-internal-virtualization-api-mutator
       resourceType: MutatingWebhookConfiguration
       patch: |
         {
@@ -238,9 +240,10 @@ spec:
       type: strategic
     # Change service in webhook configuration to point to the rewriter proxy.
     # Patch was produced with this jq command:
-    # kubectl get validatingwebhookconfigurations.admissionregistration.k8s.io virt-operator-validator -o json | jq '{"webhooks": .webhooks|map({"name":.name, "clientConfig":{"service":{"port":24192}}}) }'
+    # kubectl get validatingwebhookconfigurations.admissionregistration.k8s.io virt-internal-virtualization-operator-validator -o json | jq '{"webhooks": .webhooks|map({"name":.name, "clientConfig":{"service":{"port":24192}}}) }'
     # kubevirt-operator-webhook-proxy service is created separately.
-    - resourceName: virt-operator-validator
+    # NOTE: original virt-operator-validator is renamed to virt-internal-virtualization-operator-validator.
+    - resourceName: virt-internal-virtualization-operator-validator
       resourceType: ValidatingWebhookConfiguration
       patch: |
         {


### PR DESCRIPTION
## Description

- Rewrite app.kubernetes.io/managed-by labels value
- Rewrite names for validatingwebhooks, mutatingwebhooks in Kubevirt.
- Add deduplication and anti-shadowing algorithms: delete original resources from discovery and CRD list, prefix original labels on restore, un-prefix on rename.
- Rename devices on nodes and change device plugin socket path, so virt-handlers can live together.
- Remove upload.cdi.kubevirt.io ApiService.

## Why do we need it, and what problem does it solve?

DVP can work together with original CDI and KubeVirt in the same cluster.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?

Working scenarios:

### Install original cdi+kubevirt along with DVP

1. Ensure DVP is installed
2. Install CDI and KubeVirt, enable LiveMigration in Kubevirt CR.
3. Launch VM in DVP and in original KubeVirt. Ensure PVCs are created and both VMs are in the Running state.
4. Migrate both VMs. Ensure both are migrated.
5. Uninstall KubeVirt and CDI.
6. Ensure no cluster resources are left from original CDI and Kubevirt.
7. Ensure no errors in logs in DVP components.

### Install DVP along with original cdi+kubevirt

1. Ensure original CDI and KubeVirt are installed.
2. Enable DVP module.
3. Launch VM in DVP and in original KubeVirt. Ensure PVCs are created and both VMs are in the Running state.
4. Migrate both VMs. Ensure both are migrated.
5. Disable DVP module. Ensure deckhouse queue is empty, no d8-virtualization namespace.
6. Ensure no cluster resources are left from DVP (NodeGroupConfiguration, ClusterRole, internalvirtualization* CRDs etc.). Only 2 CRDs should remain: internalvirtualizationkubevirts and internalvirtualizationcdis.
7. Ensure no errors in logs in original KubeVirt and CDI.


<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
