### PR TITLE
fix(vd,vi,cvi): fix capacity and cdrom

### DIFF
--- a/api/core/v1alpha2/image_status.go
+++ b/api/core/v1alpha2/image_status.go
@@ -33,7 +33,7 @@ type ImageStatus struct {
 	Format        string           `json:"format,omitempty"`
 	// FIXME: create ClusterImageStatus without Capacity and PersistentVolumeClaim.
 	Capacity      string            `json:"capacity,omitempty"`
-	CDROM         bool              `json:"cdrom,omitempty"`
+	CDROM         bool              `json:"cdrom"`
 	Target        ImageStatusTarget `json:"target"`
 	Phase         ImagePhase        `json:"phase,omitempty"`
 	Progress      string            `json:"progress,omitempty"`

--- a/api/core/v1alpha2/zz_generated.deepcopy.go
+++ b/api/core/v1alpha2/zz_generated.deepcopy.go
@@ -764,7 +764,7 @@ func (in *VirtualImage) DeepCopyInto(out *VirtualImage) {
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
 	in.Spec.DeepCopyInto(&out.Spec)
-	out.Status = in.Status
+	in.Status.DeepCopyInto(&out.Status)
 	return
 }
 
@@ -909,6 +909,13 @@ func (in *VirtualImageSpec) DeepCopy() *VirtualImageSpec {
 func (in *VirtualImageStatus) DeepCopyInto(out *VirtualImageStatus) {
 	*out = *in
 	out.ImageStatus = in.ImageStatus
+	if in.Conditions != nil {
+		in, out := &in.Conditions, &out.Conditions
+		*out = make([]v1.Condition, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/api/pkg/apiserver/api/generated/openapi/zz_generated.openapi.go
+++ b/api/pkg/apiserver/api/generated/openapi/zz_generated.openapi.go
@@ -1003,8 +1003,9 @@ func schema_virtualization_api_core_v1alpha2_ClusterVirtualImageStatus(ref commo
 					},
 					"cdrom": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
-							Format: "",
+							Default: false,
+							Type:    []string{"boolean"},
+							Format:  "",
 						},
 					},
 					"target": {
@@ -1031,18 +1032,6 @@ func schema_virtualization_api_core_v1alpha2_ClusterVirtualImageStatus(ref commo
 							Format: "",
 						},
 					},
-					"failureReason": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
-					"failureMessage": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
 					"conditions": {
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
@@ -1063,7 +1052,7 @@ func schema_virtualization_api_core_v1alpha2_ClusterVirtualImageStatus(ref commo
 						},
 					},
 				},
-				Required: []string{"downloadSpeed", "size", "target"},
+				Required: []string{"downloadSpeed", "size", "cdrom", "target"},
 			},
 		},
 		Dependencies: []string{
@@ -1237,8 +1226,9 @@ func schema_virtualization_api_core_v1alpha2_ImageStatus(ref common.ReferenceCal
 					},
 					"cdrom": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
-							Format: "",
+							Default: false,
+							Type:    []string{"boolean"},
+							Format:  "",
 						},
 					},
 					"target": {
@@ -1265,20 +1255,8 @@ func schema_virtualization_api_core_v1alpha2_ImageStatus(ref common.ReferenceCal
 							Format: "",
 						},
 					},
-					"failureReason": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
-					"failureMessage": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
 				},
-				Required: []string{"downloadSpeed", "size", "target"},
+				Required: []string{"downloadSpeed", "size", "cdrom", "target"},
 			},
 		},
 		Dependencies: []string{
@@ -2153,8 +2131,9 @@ func schema_virtualization_api_core_v1alpha2_VirtualImageStatus(ref common.Refer
 					},
 					"cdrom": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
-							Format: "",
+							Default: false,
+							Type:    []string{"boolean"},
+							Format:  "",
 						},
 					},
 					"target": {
@@ -2181,24 +2160,31 @@ func schema_virtualization_api_core_v1alpha2_VirtualImageStatus(ref common.Refer
 							Format: "",
 						},
 					},
-					"failureReason": {
+					"conditions": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.Condition"),
+									},
+								},
+							},
 						},
 					},
-					"failureMessage": {
+					"observedGeneration": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Type:   []string{"integer"},
+							Format: "int64",
 						},
 					},
 				},
-				Required: []string{"downloadSpeed", "size", "target"},
+				Required: []string{"downloadSpeed", "size", "cdrom", "target"},
 			},
 		},
 		Dependencies: []string{
-			"github.com/deckhouse/virtualization/api/core/v1alpha2.ImageStatusSize", "github.com/deckhouse/virtualization/api/core/v1alpha2.ImageStatusSpeed", "github.com/deckhouse/virtualization/api/core/v1alpha2.ImageStatusTarget"},
+			"github.com/deckhouse/virtualization/api/core/v1alpha2.ImageStatusSize", "github.com/deckhouse/virtualization/api/core/v1alpha2.ImageStatusSpeed", "github.com/deckhouse/virtualization/api/core/v1alpha2.ImageStatusTarget", "k8s.io/apimachinery/pkg/apis/meta/v1.Condition"},
 	}
 }
 

--- a/images/virtualization-artifact/pkg/controller/common/util.go
+++ b/images/virtualization-artifact/pkg/controller/common/util.go
@@ -374,6 +374,11 @@ func IsDataVolumeComplete(dv *cdiv1.DataVolume) bool {
 	return dv != nil && dv.Status.Phase == cdiv1.Succeeded
 }
 
+// IsPVCBound returns true if a PersistentVolumeClaim is in 'Bound' phase, false if not.
+func IsPVCBound(pvc *corev1.PersistentVolumeClaim) bool {
+	return pvc != nil && pvc.Status.Phase == corev1.ClaimBound
+}
+
 func IsTerminating(obj client.Object) bool {
 	return !reflect.ValueOf(obj).IsNil() && obj.GetDeletionTimestamp() != nil
 }

--- a/images/virtualization-artifact/pkg/controller/service/disk_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/disk_service.go
@@ -194,6 +194,10 @@ func (s DiskService) Resize(ctx context.Context, pvc *corev1.PersistentVolumeCla
 	}
 }
 
+func (s DiskService) IsImportDone(dv *cdiv1.DataVolume, pvc *corev1.PersistentVolumeClaim) bool {
+	return common.IsDataVolumeComplete(dv) && common.IsPVCBound(pvc)
+}
+
 func (s DiskService) GetProgress(dv *cdiv1.DataVolume, prevProgress string, opts ...GetProgressOption) string {
 	if dv == nil {
 		return prevProgress

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/blank.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/blank.go
@@ -127,7 +127,7 @@ func (ds BlankDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (boo
 		ds.logger.Info("Create data volume...", "vd", vd.Name, "progress", vd.Status.Progress, "dv.phase", "nil")
 
 		return true, nil
-	case common.IsDataVolumeComplete(dv):
+	case ds.diskService.IsImportDone(dv, pvc):
 		vd.Status.Phase = virtv2.DiskReady
 		condition.Status = metav1.ConditionTrue
 		condition.Reason = vdcondition.Ready

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/http.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/http.go
@@ -216,7 +216,7 @@ func (ds HTTPDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (bool
 		ds.logger.Info("Create data volume...", "vd", vd.Name, "progress", vd.Status.Progress, "dv.phase", "nil")
 
 		return true, nil
-	case common.IsDataVolumeComplete(dv):
+	case ds.diskService.IsImportDone(dv, pvc):
 		vd.Status.Phase = virtv2.DiskReady
 		condition.Status = metav1.ConditionTrue
 		condition.Reason = vdcondition.Ready

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref.go
@@ -140,7 +140,7 @@ func (ds ObjectRefDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) 
 		ds.logger.Info("Create data volume...", "vd", vd.Name, "progress", vd.Status.Progress, "dv.phase", "nil")
 
 		return true, nil
-	case common.IsDataVolumeComplete(dv):
+	case ds.diskService.IsImportDone(dv, pvc):
 		vd.Status.Phase = virtv2.DiskReady
 		condition.Status = metav1.ConditionTrue
 		condition.Reason = vdcondition.Ready

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/registry.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/registry.go
@@ -221,7 +221,7 @@ func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (
 		ds.logger.Info("Create data volume...", "vd", vd.Name, "progress", vd.Status.Progress, "dv.phase", "nil")
 
 		return true, nil
-	case common.IsDataVolumeComplete(dv):
+	case ds.diskService.IsImportDone(dv, pvc):
 		vd.Status.Phase = virtv2.DiskReady
 		condition.Status = metav1.ConditionTrue
 		condition.Reason = vdcondition.Ready

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/upload.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/upload.go
@@ -243,7 +243,7 @@ func (ds UploadDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (bo
 		ds.logger.Info("Create data volume...", "vd", vd.Name, "progress", vd.Status.Progress, "dv.phase", "nil")
 
 		return true, nil
-	case common.IsDataVolumeComplete(dv):
+	case ds.diskService.IsImportDone(dv, pvc):
 		vd.Status.Phase = virtv2.DiskReady
 		condition.Status = metav1.ConditionTrue
 		condition.Reason = vdcondition.Ready


### PR DESCRIPTION
## Description

- Fixed the display of CD-ROM when calling `kubectl get vd` (previously, a false value was shown as empty).
- Now we wait for the PVC to reach the `Bound` phase to set the actual value for disk Capacity.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
