### PR TITLE
fix(vi,cvi): fix pod errors handling

### DIFF
--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/http.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/http.go
@@ -107,6 +107,21 @@ func (ds HTTPDataSource) Sync(ctx context.Context, cvi *virtv2.ClusterVirtualIma
 
 		ds.logger.Info("Create importer pod...", "cvi", cvi.Name, "progress", cvi.Status.Progress, "pod.phase", "nil")
 	case common.IsPodComplete(pod):
+		err = ds.statService.CheckPod(pod)
+		if err != nil {
+			cvi.Status.Phase = virtv2.ImageFailed
+
+			switch {
+			case errors.Is(err, service.ErrProvisioningFailed):
+				condition.Status = metav1.ConditionFalse
+				condition.Reason = cvicondition.ProvisioningFailed
+				condition.Message = service.CapitalizeFirstLetter(err.Error() + ".")
+				return false, nil
+			default:
+				return false, err
+			}
+		}
+
 		condition.Status = metav1.ConditionTrue
 		condition.Reason = cvicondition.Ready
 		condition.Message = ""

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref.go
@@ -117,6 +117,21 @@ func (ds ObjectRefDataSource) Sync(ctx context.Context, cvi *virtv2.ClusterVirtu
 
 		ds.logger.Info("Ready", "cvi", cvi.Name, "progress", cvi.Status.Progress, "pod.phase", "nil")
 	case common.IsPodComplete(pod):
+		err = ds.statService.CheckPod(pod)
+		if err != nil {
+			cvi.Status.Phase = virtv2.ImageFailed
+
+			switch {
+			case errors.Is(err, service.ErrProvisioningFailed):
+				condition.Status = metav1.ConditionFalse
+				condition.Reason = cvicondition.ProvisioningFailed
+				condition.Message = service.CapitalizeFirstLetter(err.Error() + ".")
+				return false, nil
+			default:
+				return false, err
+			}
+		}
+
 		condition.Status = metav1.ConditionTrue
 		condition.Reason = cvicondition.Ready
 		condition.Message = ""

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/upload.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/upload.go
@@ -120,6 +120,21 @@ func (ds UploadDataSource) Sync(ctx context.Context, cvi *virtv2.ClusterVirtualI
 
 		ds.logger.Info("Create uploader pod...", "cvi", cvi.Name, "progress", cvi.Status.Progress, "pod.phase", nil)
 	case common.IsPodComplete(pod):
+		err = ds.statService.CheckPod(pod)
+		if err != nil {
+			cvi.Status.Phase = virtv2.ImageFailed
+
+			switch {
+			case errors.Is(err, service.ErrProvisioningFailed):
+				condition.Status = metav1.ConditionFalse
+				condition.Reason = cvicondition.ProvisioningFailed
+				condition.Message = service.CapitalizeFirstLetter(err.Error() + ".")
+				return false, nil
+			default:
+				return false, err
+			}
+		}
+
 		condition.Status = metav1.ConditionTrue
 		condition.Reason = cvicondition.Ready
 		condition.Message = ""

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref.go
@@ -114,6 +114,21 @@ func (ds ObjectRefDataSource) Sync(ctx context.Context, vi *virtv2.VirtualImage)
 
 		ds.logger.Info("Ready", "vi", vi.Name, "progress", vi.Status.Progress, "pod.phase", "nil")
 	case cc.IsPodComplete(pod):
+		err = ds.statService.CheckPod(pod)
+		if err != nil {
+			vi.Status.Phase = virtv2.ImageFailed
+
+			switch {
+			case errors.Is(err, service.ErrProvisioningFailed):
+				condition.Status = metav1.ConditionFalse
+				condition.Reason = vicondition.ProvisioningFailed
+				condition.Message = service.CapitalizeFirstLetter(err.Error() + ".")
+				return false, nil
+			default:
+				return false, err
+			}
+		}
+
 		condition.Status = metav1.ConditionTrue
 		condition.Reason = vicondition.Ready
 		condition.Message = ""

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/registry.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/registry.go
@@ -111,6 +111,21 @@ func (ds RegistryDataSource) Sync(ctx context.Context, vi *virtv2.VirtualImage) 
 
 		ds.logger.Info("Create importer pod...", "vi", vi.Name, "progress", vi.Status.Progress, "pod.phase", "nil")
 	case common.IsPodComplete(pod):
+		err = ds.statService.CheckPod(pod)
+		if err != nil {
+			vi.Status.Phase = virtv2.ImageFailed
+
+			switch {
+			case errors.Is(err, service.ErrProvisioningFailed):
+				condition.Status = metav1.ConditionFalse
+				condition.Reason = vicondition.ProvisioningFailed
+				condition.Message = service.CapitalizeFirstLetter(err.Error() + ".")
+				return false, nil
+			default:
+				return false, err
+			}
+		}
+
 		condition.Status = metav1.ConditionTrue
 		condition.Reason = vicondition.Ready
 		condition.Message = ""

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/upload.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/upload.go
@@ -117,6 +117,21 @@ func (ds UploadDataSource) Sync(ctx context.Context, vi *virtv2.VirtualImage) (b
 
 		ds.logger.Info("Create uploader pod...", "vi", vi.Name, "progress", vi.Status.Progress, "pod.phase", nil)
 	case common.IsPodComplete(pod):
+		err = ds.statService.CheckPod(pod)
+		if err != nil {
+			vi.Status.Phase = virtv2.ImageFailed
+
+			switch {
+			case errors.Is(err, service.ErrProvisioningFailed):
+				condition.Status = metav1.ConditionFalse
+				condition.Reason = vicondition.ProvisioningFailed
+				condition.Message = service.CapitalizeFirstLetter(err.Error() + ".")
+				return false, nil
+			default:
+				return false, err
+			}
+		}
+
 		condition.Status = metav1.ConditionTrue
 		condition.Reason = vicondition.Ready
 		condition.Message = ""


### PR DESCRIPTION
## Description

Errors from the pod were ignored during the transition of the image to the Ready phase. Fixed this.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
