### PR TITLE
fix(vm):  lifecycle vm

### DIFF
--- a/api/core/v1alpha2/virtual_machine.go
+++ b/api/core/v1alpha2/virtual_machine.go
@@ -167,7 +167,7 @@ type VirtualMachineStatus struct {
 	Conditions                   []metav1.Condition                       `json:"conditions,omitempty"`
 	Stats                        *VirtualMachineStats                     `json:"stats,omitempty"`
 	MigrationState               *VirtualMachineMigrationState            `json:"migrationState,omitempty"`
-
+	ObservedGeneration           int64                                    `json:"observedGeneration,omitempty"`
 	// RestartAwaitingChanges holds operations to be manually approved
 	// before applying to the virtual machine spec.
 	//

--- a/api/core/v1alpha2/zz_generated.deepcopy.go
+++ b/api/core/v1alpha2/zz_generated.deepcopy.go
@@ -764,7 +764,7 @@ func (in *VirtualImage) DeepCopyInto(out *VirtualImage) {
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
 	in.Spec.DeepCopyInto(&out.Spec)
-	out.Status = in.Status
+	in.Status.DeepCopyInto(&out.Status)
 	return
 }
 
@@ -909,6 +909,13 @@ func (in *VirtualImageSpec) DeepCopy() *VirtualImageSpec {
 func (in *VirtualImageStatus) DeepCopyInto(out *VirtualImageStatus) {
 	*out = *in
 	out.ImageStatus = in.ImageStatus
+	if in.Conditions != nil {
+		in, out := &in.Conditions, &out.Conditions
+		*out = make([]v1.Condition, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/api/pkg/apiserver/api/generated/openapi/zz_generated.openapi.go
+++ b/api/pkg/apiserver/api/generated/openapi/zz_generated.openapi.go
@@ -1031,18 +1031,6 @@ func schema_virtualization_api_core_v1alpha2_ClusterVirtualImageStatus(ref commo
 							Format: "",
 						},
 					},
-					"failureReason": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
-					"failureMessage": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
 					"conditions": {
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
@@ -1260,18 +1248,6 @@ func schema_virtualization_api_core_v1alpha2_ImageStatus(ref common.ReferenceCal
 						},
 					},
 					"uploadCommand": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
-					"failureReason": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
-					"failureMessage": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
 							Format: "",
@@ -2181,16 +2157,23 @@ func schema_virtualization_api_core_v1alpha2_VirtualImageStatus(ref common.Refer
 							Format: "",
 						},
 					},
-					"failureReason": {
+					"conditions": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.Condition"),
+									},
+								},
+							},
 						},
 					},
-					"failureMessage": {
+					"observedGeneration": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Type:   []string{"integer"},
+							Format: "int64",
 						},
 					},
 				},
@@ -2198,7 +2181,7 @@ func schema_virtualization_api_core_v1alpha2_VirtualImageStatus(ref common.Refer
 			},
 		},
 		Dependencies: []string{
-			"github.com/deckhouse/virtualization/api/core/v1alpha2.ImageStatusSize", "github.com/deckhouse/virtualization/api/core/v1alpha2.ImageStatusSpeed", "github.com/deckhouse/virtualization/api/core/v1alpha2.ImageStatusTarget"},
+			"github.com/deckhouse/virtualization/api/core/v1alpha2.ImageStatusSize", "github.com/deckhouse/virtualization/api/core/v1alpha2.ImageStatusSpeed", "github.com/deckhouse/virtualization/api/core/v1alpha2.ImageStatusTarget", "k8s.io/apimachinery/pkg/apis/meta/v1.Condition"},
 	}
 }
 
@@ -3732,6 +3715,12 @@ func schema_virtualization_api_core_v1alpha2_VirtualMachineStatus(ref common.Ref
 					"migrationState": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("github.com/deckhouse/virtualization/api/core/v1alpha2.VirtualMachineMigrationState"),
+						},
+					},
+					"observedGeneration": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int64",
 						},
 					},
 					"restartAwaitingChanges": {

--- a/crds/doc-ru-virtualmachine.yaml
+++ b/crds/doc-ru-virtualmachine.yaml
@@ -639,3 +639,6 @@ spec:
                           description: "Время ожидания запуска виртуальной машины. starting -> running."
                         guestOSAgentStarting:
                           description: "Время ожидания запуска guestOsAgent. running -> running с guestOSAgent."
+                observedGeneration:
+                  description: |
+                    Поколение ресурса, которое в последний раз обрабатывалось контроллером

--- a/crds/virtualmachine.yaml
+++ b/crds/virtualmachine.yaml
@@ -1121,6 +1121,10 @@ spec:
                   items:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
+                observedGeneration:
+                  type: integer
+                  description: "Generating a resource that was last processed by the controller"
+                  format: int64
       additionalPrinterColumns:
         - name: Phase
           type: string

--- a/images/virtualization-artifact/pkg/controller/service/disk_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/disk_service.go
@@ -153,12 +153,14 @@ func (s DiskService) CleanUpSupplements(ctx context.Context, sup *supplements.Ge
 		if err != nil {
 			return false, err
 		}
-		pvc.ObjectMeta.OwnerReferences = slices.DeleteFunc(pvc.ObjectMeta.OwnerReferences, func(ref metav1.OwnerReference) bool {
-			return ref.Kind == "DataVolume"
-		})
-		err = s.client.Update(ctx, pvc)
-		if err != nil && !k8serrors.IsNotFound(err) {
-			return false, err
+		if pvc != nil {
+			pvc.ObjectMeta.OwnerReferences = slices.DeleteFunc(pvc.ObjectMeta.OwnerReferences, func(ref metav1.OwnerReference) bool {
+				return ref.Kind == "DataVolume"
+			})
+			err = s.client.Update(ctx, pvc)
+			if err != nil && !k8serrors.IsNotFound(err) {
+				return false, err
+			}
 		}
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vm/internal/provisioning.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/provisioning.go
@@ -142,7 +142,7 @@ func (h *ProvisioningHandler) genConditionFromSecret(ctx context.Context, builde
 	if !found {
 		builder.Status(metav1.ConditionFalse).
 			Reason2(vmcondition.ReasonProvisioningNotReady).
-			Message(fmt.Sprintf("Secret %q doesn't have any keys such as %v.", keys, secretKey.String()))
+			Message(fmt.Sprintf("Secret %q should has one of data fields %v.", keys, secretKey.String()))
 		return nil
 	}
 	builder.Reason2(vmcondition.ReasonProvisioningReady).Status(metav1.ConditionTrue)

--- a/images/virtualization-artifact/pkg/controller/vm/internal/provisioning.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/provisioning.go
@@ -131,10 +131,18 @@ func (h *ProvisioningHandler) genConditionFromSecret(ctx context.Context, builde
 			Message(fmt.Sprintf("Secret %q not found.", secretKey.String()))
 		return nil
 	}
-	if _, ok := secret.Data["userdata"]; !ok {
+	found := false
+	keys := []string{"userdata", "userData"}
+	for _, key := range keys {
+		if _, ok := secret.Data[key]; ok {
+			found = true
+			break
+		}
+	}
+	if !found {
 		builder.Status(metav1.ConditionFalse).
 			Reason2(vmcondition.ReasonProvisioningNotReady).
-			Message(fmt.Sprintf("Secret %q doesn't have key \"userdata\".", secretKey.String()))
+			Message(fmt.Sprintf("Secret %q doesn't have any keys such as %v.", keys, secretKey.String()))
 		return nil
 	}
 	builder.Reason2(vmcondition.ReasonProvisioningReady).Status(metav1.ConditionTrue)


### PR DESCRIPTION
## Description
fix secret keys for provisioning. [userData, userdata]
add observedGeneration to VirtualMachine.Status
remove OwnerReference from pvc when DataVolume is removed

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
