### PR TITLE
fix(vd): add stats reconciliation

### DIFF
--- a/images/virtualization-artifact/pkg/controller/cvi/internal/datasource_ready.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/datasource_ready.go
@@ -68,19 +68,23 @@ func (h DatasourceReadyHandler) Handle(ctx context.Context, cvi *virtv2.ClusterV
 		condition.Status = metav1.ConditionTrue
 		condition.Reason = cvicondition.DatasourceReady
 		condition.Message = ""
+		return reconcile.Result{}, nil
 	case errors.Is(err, source.ErrSecretNotFound):
 		condition.Status = metav1.ConditionFalse
 		condition.Reason = cvicondition.ContainerRegistrySecretNotFound
 		condition.Message = service.CapitalizeFirstLetter(err.Error())
+		return reconcile.Result{}, nil
 	case errors.As(err, &source.ImageNotReadyError{}):
 		condition.Status = metav1.ConditionFalse
 		condition.Reason = cvicondition.ImageNotReady
 		condition.Message = service.CapitalizeFirstLetter(err.Error())
+		return reconcile.Result{}, nil
 	case errors.As(err, &source.ClusterImageNotReadyError{}):
 		condition.Status = metav1.ConditionFalse
 		condition.Reason = cvicondition.ClusterImageNotReady
 		condition.Message = service.CapitalizeFirstLetter(err.Error())
+		return reconcile.Result{}, nil
+	default:
+		return reconcile.Result{}, err
 	}
-
-	return reconcile.Result{}, err
 }

--- a/images/virtualization-artifact/pkg/controller/service/protection_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/protection_service.go
@@ -116,7 +116,7 @@ func (s ProtectionService) RemoveProtection(ctx context.Context, objs ...client.
 
 func MakeOwnerReference(owner client.Object) metav1.OwnerReference {
 	return metav1.OwnerReference{
-		APIVersion: owner.GetObjectKind().GroupVersionKind().Version,
+		APIVersion: owner.GetObjectKind().GroupVersionKind().GroupVersion().String(),
 		Kind:       owner.GetObjectKind().GroupVersionKind().Kind,
 		Name:       owner.GetName(),
 		UID:        owner.GetUID(),

--- a/images/virtualization-artifact/pkg/controller/vd/internal/life_cycle.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/life_cycle.go
@@ -19,6 +19,7 @@ package internal
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,13 +32,15 @@ import (
 )
 
 type LifeCycleHandler struct {
+	logger  *slog.Logger
 	client  client.Client
 	blank   source.Handler
 	sources *source.Sources
 }
 
-func NewLifeCycleHandler(blank source.Handler, sources *source.Sources, client client.Client) *LifeCycleHandler {
+func NewLifeCycleHandler(logger *slog.Logger, blank source.Handler, sources *source.Sources, client client.Client) *LifeCycleHandler {
 	return &LifeCycleHandler{
+		logger:  logger,
 		client:  client,
 		blank:   blank,
 		sources: sources,
@@ -45,6 +48,8 @@ func NewLifeCycleHandler(blank source.Handler, sources *source.Sources, client c
 }
 
 func (h LifeCycleHandler) Handle(ctx context.Context, vd *virtv2.VirtualDisk) (reconcile.Result, error) {
+	logger := h.logger.With("vdName", vd.Name, "vdNamespace", vd.Namespace)
+
 	readyCondition, ok := service.GetCondition(vdcondition.ReadyType, vd.Status.Conditions)
 	if !ok {
 		readyCondition = metav1.Condition{
@@ -74,6 +79,8 @@ func (h LifeCycleHandler) Handle(ctx context.Context, vd *virtv2.VirtualDisk) (r
 	}
 
 	if readyCondition.Status != metav1.ConditionTrue && readyCondition.Reason != vdcondition.Lost && h.sources.Changed(ctx, vd) {
+		logger.Info("Spec changes are detected: restart import process")
+
 		vd.Status = virtv2.VirtualDiskStatus{
 			Phase:              virtv2.DiskPending,
 			Conditions:         vd.Status.Conditions,
@@ -82,7 +89,7 @@ func (h LifeCycleHandler) Handle(ctx context.Context, vd *virtv2.VirtualDisk) (r
 
 		_, err := h.sources.CleanUp(ctx, vd)
 		if err != nil {
-			return reconcile.Result{}, err
+			return reconcile.Result{}, fmt.Errorf("failed to clean up to restart import process: %w", err)
 		}
 
 		return reconcile.Result{Requeue: true}, nil
@@ -100,7 +107,7 @@ func (h LifeCycleHandler) Handle(ctx context.Context, vd *virtv2.VirtualDisk) (r
 
 	requeue, err := ds.Sync(ctx, vd)
 	if err != nil {
-		return reconcile.Result{}, err
+		return reconcile.Result{}, fmt.Errorf("failed to sync virtual disk data source: %w", err)
 	}
 
 	return reconcile.Result{Requeue: requeue}, nil

--- a/images/virtualization-artifact/pkg/controller/vd/internal/life_cycle.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/life_cycle.go
@@ -48,7 +48,7 @@ func NewLifeCycleHandler(logger *slog.Logger, blank source.Handler, sources *sou
 }
 
 func (h LifeCycleHandler) Handle(ctx context.Context, vd *virtv2.VirtualDisk) (reconcile.Result, error) {
-	logger := h.logger.With("vdName", vd.Name, "vdNamespace", vd.Namespace)
+	logger := h.logger.With("name", vd.Name, "ns", vd.Namespace)
 
 	readyCondition, ok := service.GetCondition(vdcondition.ReadyType, vd.Status.Conditions)
 	if !ok {

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/blank.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/blank.go
@@ -52,7 +52,7 @@ func NewBlankDataSource(
 }
 
 func (ds BlankDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (bool, error) {
-	logger := ds.logger.With("vdName", vd.Name, "vdNamespace", vd.Namespace)
+	logger := ds.logger.With("name", vd.Name, "ns", vd.Namespace)
 	logger.Info("Sync")
 
 	condition, _ := service.GetCondition(vdcondition.ReadyType, vd.Status.Conditions)

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/blank.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/blank.go
@@ -42,16 +42,18 @@ type BlankDataSource struct {
 func NewBlankDataSource(
 	statService *service.StatService,
 	diskService *service.DiskService,
+	logger *slog.Logger,
 ) *BlankDataSource {
 	return &BlankDataSource{
 		statService: statService,
 		diskService: diskService,
-		logger:      slog.Default().With("controller", common.VDShortName, "ds", "registry"),
+		logger:      logger.With("ds", "blank"),
 	}
 }
 
 func (ds BlankDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (bool, error) {
-	ds.logger.Info("Sync", "vd", vd.Name)
+	logger := ds.logger.With("vdName", vd.Name, "vdNamespace", vd.Namespace)
+	logger.Info("Sync")
 
 	condition, _ := service.GetCondition(vdcondition.ReadyType, vd.Status.Conditions)
 	defer func() { service.SetCondition(condition, &vd.Status.Conditions) }()
@@ -72,7 +74,7 @@ func (ds BlankDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (boo
 
 	switch {
 	case isDiskProvisioningFinished(condition):
-		ds.logger.Info("Finishing...", "vd", vd.Name)
+		logger.Info("Disk provisioning finished: clean up")
 
 		switch {
 		case pvc == nil:
@@ -102,8 +104,10 @@ func (ds BlankDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (boo
 
 		return CleanUpSupplements(ctx, vd, ds)
 	case common.AnyTerminating(dv, pvc, pv):
-		ds.logger.Info("Cleaning up...", "vd", vd.Name)
+		logger.Info("Waiting for supplements to be terminated")
 	case dv == nil:
+		logger.Info("Start import to PVC")
+
 		var diskSize resource.Quantity
 		diskSize, err = ds.getPVCSize(vd)
 		if err != nil {
@@ -124,10 +128,10 @@ func (ds BlankDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (boo
 
 		vd.Status.Progress = "0%"
 
-		ds.logger.Info("Create data volume...", "vd", vd.Name, "progress", vd.Status.Progress, "dv.phase", "nil")
-
 		return true, nil
 	case ds.diskService.IsImportDone(dv, pvc):
+		logger.Info("Import has completed", "dvProgress", dv.Status.Progress, "dvPhase", dv.Status.Phase, "pvcPhase", pvc.Status.Phase)
+
 		vd.Status.Phase = virtv2.DiskReady
 		condition.Status = metav1.ConditionTrue
 		condition.Reason = vdcondition.Ready
@@ -136,10 +140,8 @@ func (ds BlankDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (boo
 		vd.Status.Progress = "100%"
 		vd.Status.Capacity = ds.diskService.GetCapacity(pvc)
 		vd.Status.Target.PersistentVolumeClaim = dv.Status.ClaimName
-
-		ds.logger.Info("Ready", "vd", vd.Name, "progress", vd.Status.Progress, "dv.phase", dv.Status.Phase)
 	default:
-		ds.logger.Info("Provisioning...", "vd", vd.Name, "progress", vd.Status.Progress, "dv.phase", dv.Status.Phase)
+		logger.Info("Provisioning to PVC is in progress", "dvProgress", dv.Status.Progress, "dvPhase", dv.Status.Phase, "pvcPhase", pvc.Status.Phase)
 
 		vd.Status.Progress = ds.diskService.GetProgress(dv, vd.Status.Progress, service.NewScaleOption(0, 100))
 		vd.Status.Capacity = ds.diskService.GetCapacity(pvc)

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/http.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/http.go
@@ -64,7 +64,7 @@ func NewHTTPDataSource(
 }
 
 func (ds HTTPDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (bool, error) {
-	logger := ds.logger.With("vdName", vd.Name, "vdNamespace", vd.Namespace)
+	logger := ds.logger.With("name", vd.Name, "ns", vd.Namespace)
 	logger.Info("Sync")
 
 	condition, _ := service.GetCondition(vdcondition.ReadyType, vd.Status.Conditions)

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref.go
@@ -60,7 +60,7 @@ func NewObjectRefDataSource(
 }
 
 func (ds ObjectRefDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (bool, error) {
-	logger := ds.logger.With("vdName", vd.Name, "vdNamespace", vd.Namespace)
+	logger := ds.logger.With("name", vd.Name, "ns", vd.Namespace)
 	logger.Info("Sync")
 
 	condition, _ := service.GetCondition(vdcondition.ReadyType, vd.Status.Conditions)

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref.go
@@ -49,17 +49,19 @@ func NewObjectRefDataSource(
 	statService *service.StatService,
 	diskService *service.DiskService,
 	client client.Client,
+	logger *slog.Logger,
 ) *ObjectRefDataSource {
 	return &ObjectRefDataSource{
 		statService: statService,
 		diskService: diskService,
 		client:      client,
-		logger:      slog.Default().With("controller", common.VDShortName, "ds", "objectref"),
+		logger:      logger.With("ds", "objectref"),
 	}
 }
 
 func (ds ObjectRefDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (bool, error) {
-	ds.logger.Info("Sync", "vd", vd.Name)
+	logger := ds.logger.With("vdName", vd.Name, "vdNamespace", vd.Namespace)
+	logger.Info("Sync")
 
 	condition, _ := service.GetCondition(vdcondition.ReadyType, vd.Status.Conditions)
 	defer func() { service.SetCondition(condition, &vd.Status.Conditions) }()
@@ -80,7 +82,7 @@ func (ds ObjectRefDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) 
 
 	switch {
 	case isDiskProvisioningFinished(condition):
-		ds.logger.Info("Finishing...", "vd", vd.Name)
+		logger.Info("Disk provisioning finished: clean up")
 
 		switch {
 		case pvc == nil:
@@ -110,10 +112,10 @@ func (ds ObjectRefDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) 
 
 		return CleanUpSupplements(ctx, vd, ds)
 	case common.AnyTerminating(dv, pvc, pv):
-		vd.Status.Phase = virtv2.DiskPending
-
-		ds.logger.Info("Cleaning up...", "vd", vd.Name)
+		logger.Info("Waiting for supplements to be terminated")
 	case dv == nil:
+		logger.Info("Start import to PVC")
+
 		var dvcrDataSource controller.DVCRDataSource
 		dvcrDataSource, err = controller.NewDVCRDataSourcesForVMD(ctx, vd.Spec.DataSource, vd, ds.client)
 		if err != nil {
@@ -151,10 +153,10 @@ func (ds ObjectRefDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) 
 
 		vd.Status.Progress = "0%"
 
-		ds.logger.Info("Create data volume...", "vd", vd.Name, "progress", vd.Status.Progress, "dv.phase", "nil")
-
 		return true, nil
 	case ds.diskService.IsImportDone(dv, pvc):
+		logger.Info("Import has completed", "dvProgress", dv.Status.Progress, "dvPhase", dv.Status.Phase, "pvcPhase", pvc.Status.Phase)
+
 		vd.Status.Phase = virtv2.DiskReady
 		condition.Status = metav1.ConditionTrue
 		condition.Reason = vdcondition.Ready
@@ -163,10 +165,8 @@ func (ds ObjectRefDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) 
 		vd.Status.Progress = "100%"
 		vd.Status.Capacity = ds.diskService.GetCapacity(pvc)
 		vd.Status.Target.PersistentVolumeClaim = dv.Status.ClaimName
-
-		ds.logger.Info("Ready", "vd", vd.Name, "progress", vd.Status.Progress, "dv.phase", dv.Status.Phase)
 	default:
-		ds.logger.Info("Provisioning...", "vd", vd.Name, "progress", vd.Status.Progress, "dv.phase", dv.Status.Phase)
+		logger.Info("Provisioning to PVC is in progress", "dvProgress", dv.Status.Progress, "dvPhase", dv.Status.Phase, "pvcPhase", pvc.Status.Phase)
 
 		vd.Status.Progress = ds.diskService.GetProgress(dv, vd.Status.Progress, service.NewScaleOption(0, 100))
 		vd.Status.Capacity = ds.diskService.GetCapacity(pvc)

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/registry.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/registry.go
@@ -70,7 +70,7 @@ func NewRegistryDataSource(
 }
 
 func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (bool, error) {
-	logger := ds.logger.With("vdName", vd.Name, "vdNamespace", vd.Namespace)
+	logger := ds.logger.With("name", vd.Name, "ns", vd.Namespace)
 	logger.Info("Sync")
 
 	condition, _ := service.GetCondition(vdcondition.ReadyType, vd.Status.Conditions)

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/registry.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/registry.go
@@ -57,6 +57,7 @@ func NewRegistryDataSource(
 	diskService *service.DiskService,
 	dvcrSettings *dvcr.Settings,
 	client client.Client,
+	logger *slog.Logger,
 ) *RegistryDataSource {
 	return &RegistryDataSource{
 		statService:     statService,
@@ -64,12 +65,13 @@ func NewRegistryDataSource(
 		diskService:     diskService,
 		dvcrSettings:    dvcrSettings,
 		client:          client,
-		logger:          slog.Default().With("controller", common.VDShortName, "ds", "http"),
+		logger:          logger.With("ds", "registry"),
 	}
 }
 
 func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (bool, error) {
-	ds.logger.Info("Sync", "vd", vd.Name)
+	logger := ds.logger.With("vdName", vd.Name, "vdNamespace", vd.Namespace)
+	logger.Info("Sync")
 
 	condition, _ := service.GetCondition(vdcondition.ReadyType, vd.Status.Conditions)
 	defer func() { service.SetCondition(condition, &vd.Status.Conditions) }()
@@ -94,7 +96,7 @@ func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (
 
 	switch {
 	case isDiskProvisioningFinished(condition):
-		ds.logger.Info("Finishing...", "vd", vd.Name)
+		logger.Info("Disk provisioning finished: clean up")
 
 		switch {
 		case pvc == nil:
@@ -130,10 +132,10 @@ func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (
 
 		return CleanUpSupplements(ctx, vd, ds)
 	case common.AnyTerminating(pod, dv, pvc):
-		vd.Status.Phase = virtv2.DiskPending
-
-		ds.logger.Info("Cleaning up...", "vd", vd.Name)
+		logger.Info("Waiting for supplements to be terminated")
 	case pod == nil:
+		logger.Info("Start import to DVCR")
+
 		envSettings := ds.getEnvSettings(vd, supgen)
 		err = ds.importerService.Start(ctx, envSettings, vd, supgen, datasource.NewCABundleForVMD(vd.Spec.DataSource))
 		if err != nil {
@@ -146,9 +148,9 @@ func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (
 		condition.Message = "DVCR Provisioner not found: create the new one."
 
 		vd.Status.Progress = "0%"
-
-		ds.logger.Info("Create importer pod...", "vd", vd.Name, "progress", vd.Status.Progress, "pod.phase", "nil")
 	case !common.IsPodComplete(pod):
+		logger.Info("Provisioning to DVCR is in progress", "podPhase", pod.Status.Phase)
+
 		err = ds.statService.CheckPod(pod)
 		if err != nil {
 			vd.Status.Phase = virtv2.DiskFailed
@@ -180,9 +182,9 @@ func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (
 		if err != nil {
 			return false, err
 		}
-
-		ds.logger.Info("Provisioning...", "vd", vd.Name, "progress", vd.Status.Progress, "pod.phase", pod.Status.Phase)
 	case dv == nil:
+		logger.Info("Start import to PVC")
+
 		err = ds.statService.CheckPod(pod)
 		if err != nil {
 			vd.Status.Phase = virtv2.DiskFailed
@@ -218,10 +220,10 @@ func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (
 
 		vd.Status.Progress = "50%"
 
-		ds.logger.Info("Create data volume...", "vd", vd.Name, "progress", vd.Status.Progress, "dv.phase", "nil")
-
 		return true, nil
 	case ds.diskService.IsImportDone(dv, pvc):
+		logger.Info("Import has completed", "dvProgress", dv.Status.Progress, "dvPhase", dv.Status.Phase, "pvcPhase", pvc.Status.Phase)
+
 		vd.Status.Phase = virtv2.DiskReady
 		condition.Status = metav1.ConditionTrue
 		condition.Reason = vdcondition.Ready
@@ -230,10 +232,8 @@ func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (
 		vd.Status.Progress = "100%"
 		vd.Status.Capacity = ds.diskService.GetCapacity(pvc)
 		vd.Status.Target.PersistentVolumeClaim = dv.Status.ClaimName
-
-		ds.logger.Info("Ready", "vd", vd.Name, "progress", vd.Status.Progress, "dv.phase", dv.Status.Phase)
 	default:
-		ds.logger.Info("Provisioning...", "vd", vd.Name, "progress", vd.Status.Progress, "dv.phase", dv.Status.Phase)
+		logger.Info("Provisioning to PVC is in progress", "dvProgress", dv.Status.Progress, "dvPhase", dv.Status.Phase, "pvcPhase", pvc.Status.Phase)
 
 		vd.Status.Progress = ds.diskService.GetProgress(dv, vd.Status.Progress, service.NewScaleOption(50, 100))
 		vd.Status.Capacity = ds.diskService.GetCapacity(pvc)

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/upload.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/upload.go
@@ -64,7 +64,7 @@ func NewUploadDataSource(
 }
 
 func (ds UploadDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (bool, error) {
-	logger := ds.logger.With("vdName", vd.Name, "vdNamespace", vd.Namespace)
+	logger := ds.logger.With("name", vd.Name, "ns", vd.Namespace)
 	logger.Info("Sync")
 
 	condition, _ := service.GetCondition(vdcondition.ReadyType, vd.Status.Conditions)

--- a/images/virtualization-artifact/pkg/controller/vi/internal/datasource_ready.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/datasource_ready.go
@@ -69,17 +69,25 @@ func (h DatasourceReadyHandler) Handle(ctx context.Context, vi *virtv2.VirtualIm
 		condition.Status = metav1.ConditionTrue
 		condition.Reason = vicondition.DatasourceReady
 		condition.Message = ""
+		return reconcile.Result{}, nil
 	case errors.Is(err, source.ErrSecretNotFound):
 		condition.Status = metav1.ConditionFalse
 		condition.Reason = vicondition.ContainerRegistrySecretNotFound
 		condition.Message = strings.ToTitle(err.Error())
+		return reconcile.Result{}, nil
 	case errors.As(err, &source.ImageNotReadyError{}):
 		condition.Status = metav1.ConditionFalse
 		condition.Reason = vicondition.ImageNotReady
 		condition.Message = strings.ToTitle(err.Error())
+		return reconcile.Result{}, nil
+	case errors.As(err, &source.ClusterImageNotReadyError{}):
+		condition.Status = metav1.ConditionFalse
+		condition.Reason = vicondition.ClusterImageNotReady
+		condition.Message = strings.ToTitle(err.Error())
+		return reconcile.Result{}, nil
+	default:
+		return reconcile.Result{}, err
 	}
-
-	return reconcile.Result{}, err
 }
 
 func (h DatasourceReadyHandler) Name() string {


### PR DESCRIPTION
## Description

- OwnerRef Version should be `owner.GetObjectKind().GroupVersionKind().GroupVersion().String() `, but not `owner.GetObjectKind().GroupVersionKind().Version`

- Reconciliation event at the end of the DataVolume import
- Add missed ClusterVirtualImage reason for VI DatasourceReady condition
- Added logs for vd controller

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
