### PR TITLE
chore(ci): remove python tests from image bundle

### DIFF
--- a/werf.yaml
+++ b/werf.yaml
@@ -96,6 +96,9 @@ git:
       - templates
       - Chart.yaml
       - .helmignore
+    excludePaths:
+      - hooks/lib/tests
+      - hooks/test*
 ---
 artifact: release-channel-version-artifact
 from: alpine:3.17


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Exclude python tests hooks from image
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Tests should not be included in the final image
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

No such warning messages:
`{"level":"warning","msg":"File '/deckhouse/external-modules/virtualization/dev/hooks/lib/tests/testing.py' is skipped: no executable permissions, chmod +x is required to run this hook","time":"2024-07-01T12:20:20Z"}
`
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
