### PR TITLE
refactor(kube-api-rewriter): fix patch rewriter, fix labelSelector rewriter

### DIFF
--- a/images/kube-api-proxy/pkg/rewriter/rule_rewriter_test.go
+++ b/images/kube-api-proxy/pkg/rewriter/rule_rewriter_test.go
@@ -178,6 +178,12 @@ func TestRewriteAPIEndpoint(t *testing.T) {
 			"/api/v1/namespaces/d8-virtualization/pods",
 			"labelSelector=replacedlabelgroup.io+notin+%28value-one%2Cvalue-two%29&limit=500",
 		},
+		{
+			"labelSelector label name for deployments",
+			"/apis/apps/v1/deployments?labelSelector=labelgroup.io+notin+%28value-one%2ClabelValue%29&limit=500",
+			"/apis/apps/v1/deployments",
+			"labelSelector=replacedlabelgroup.io+notin+%28labelValue%2Cvalue-one%29&limit=500",
+		},
 	}
 
 	for _, tt := range tests {
@@ -193,7 +199,7 @@ func TestRewriteAPIEndpoint(t *testing.T) {
 			if tt.expectPath == "" {
 				require.Nil(t, newEp, "should not rewrite path '%s', got %+v", tt.path, newEp)
 			}
-			require.NotNil(t, newEp, "should rewrite path '%s', got nil endpoint. Original ep: %#v", ep)
+			require.NotNil(t, newEp, "should rewrite path '%s', got nil endpoint. Original ep: %#v", tt.path, ep)
 
 			require.Equal(t, tt.expectPath, newEp.Path(), "expect rewrite for path '%s' to be '%s', got '%s', newEp: %#v", tt.path, tt.expectPath, newEp.Path(), newEp)
 			require.Equal(t, tt.expectQuery, newEp.RawQuery, "expect rewrite query for path %q to be '%s', got '%s', newEp: %#v", tt.path, tt.expectQuery, newEp.RawQuery, newEp)


### PR DESCRIPTION

## Description

- Rewrite metadata in patches for all resources.
- Rewrite labelSelector in url queries.
- Proper rewriter for affinity: more fields to rewrite.

## Why do we need it, and what problem does it solve?

- Fix error "syncing labels to pod: the server rejected our request due to an error in our request" when main controller sends metadata patch for pods.
- Fix error when cache is empty when watching with labelSelector.
- Full rewrite for affinity.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?

Main controller updates Pod metadata without issues.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
