### PR TITLE
fix(vm): force the startup of a VM with an AlwaysOnUnlessStoppedManually policy when creating

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vmchange/comparators.go
+++ b/images/virtualization-artifact/pkg/controller/vmchange/comparators.go
@@ -43,7 +43,7 @@ func compareRunPolicy(current, desired *v1alpha2.VirtualMachineSpec) []FieldChan
 
 func compareVirtualMachineIPAddressClaim(current, desired *v1alpha2.VirtualMachineSpec) []FieldChange {
 	return compareStrings(
-		"virtualMachineIPAddressClaim",
+		"virtualMachineIPAddressClaimName",
 		current.VirtualMachineIPAddressClaim,
 		desired.VirtualMachineIPAddressClaim,
 		"",
@@ -65,7 +65,7 @@ func compareDisruptions(current, desired *v1alpha2.VirtualMachineSpec) []FieldCh
 
 	// Disruptions are not nils, compare approvalMode fields using "Manual" as default.
 	return compareStrings(
-		"disruptions.approvalMode",
+		"disruptions.restartApprovalMode",
 		string(current.Disruptions.RestartApprovalMode),
 		string(desired.Disruptions.RestartApprovalMode),
 		string(DefaultDisruptionsApprovalMode),
@@ -139,7 +139,7 @@ func compareCPU(current, desired *v1alpha2.VirtualMachineSpec) []FieldChange {
 		return fractionChanges
 	}
 
-	modelChanges := compareStrings("cpu.virtualMachineCPUModel", current.CPU.VirtualMachineCPUModel, desired.CPU.VirtualMachineCPUModel, DefaultCPUModelName, ActionRestart)
+	modelChanges := compareStrings("cpu.virtualMachineCPUModelName", current.CPU.VirtualMachineCPUModel, desired.CPU.VirtualMachineCPUModel, DefaultCPUModelName, ActionRestart)
 	if HasChanges(modelChanges) {
 		return modelChanges
 	}


### PR DESCRIPTION
## Description
force the startup of a VM with an AlwaysOnUnlessStoppedManually policy when creating

## Why do we need it, and what problem does it solve?
A VM with an AlwaysOnUnlessStoppedManually policy is created stopped

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
