### PR TITLE
chore(api/vm): fix vm crd

### DIFF
--- a/crds/virtualmachine.yaml
+++ b/crds/virtualmachine.yaml
@@ -110,7 +110,7 @@ spec:
                   oneOf:
                     - properties:
                         type:
-                          enum: ["Sysprep"]
+                          enum: ["SysprepRef"]
                         sysprepRef: {}
                       required: ["sysprepRef"]
                       not:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix vm crd sysprep for windows
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Fix error when create vm with sysprep
```
The VirtualMachine "win-vm" is invalid: 
* <nil>: Invalid value: "": "spec.provisioning" must validate one and only one schema (oneOf). Found none valid
* spec.provisioning.type: Unsupported value: "SysprepRef": supported values: "Sysprep"

```
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
VM with sysprep create successfully

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
