### PR TITLE
fix(vm): fix blockdevices status and restartawaitingchanges

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm/internal/lifecycle.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/lifecycle.go
@@ -244,7 +244,7 @@ func (h *LifeCycleHandler) syncStats(current, changed *virtv2.VirtualMachine, kv
 			}
 			var empty virtv1.VirtualMachineInstanceGuestOSInfo
 			if kvvmi != nil && empty == current.Status.GuestOSInfo && empty != kvvmi.Status.GuestOSInfo && !pt.Timestamp.IsZero() {
-				launchTimeDuration.GuestOSAgentStarting = &metav1.Duration{Duration: time.Since(pt.Timestamp.Time)}
+				launchTimeDuration.GuestOSAgentStarting = &metav1.Duration{Duration: time.Now().Truncate(1 * time.Second).Sub(pt.Timestamp.Time)}
 			}
 		}
 	}

--- a/images/virtualization-artifact/pkg/controller/vmchange/comparators.go
+++ b/images/virtualization-artifact/pkg/controller/vmchange/comparators.go
@@ -43,7 +43,7 @@ func compareRunPolicy(current, desired *v1alpha2.VirtualMachineSpec) []FieldChan
 
 func compareVirtualMachineIPAddressClaim(current, desired *v1alpha2.VirtualMachineSpec) []FieldChange {
 	return compareStrings(
-		"virtualMachineIPAddressClaim",
+		"virtualMachineIPAddressClaimName",
 		current.VirtualMachineIPAddressClaim,
 		desired.VirtualMachineIPAddressClaim,
 		"",
@@ -65,7 +65,7 @@ func compareDisruptions(current, desired *v1alpha2.VirtualMachineSpec) []FieldCh
 
 	// Disruptions are not nils, compare approvalMode fields using "Manual" as default.
 	return compareStrings(
-		"disruptions.approvalMode",
+		"disruptions.restartApprovalMode",
 		string(current.Disruptions.RestartApprovalMode),
 		string(desired.Disruptions.RestartApprovalMode),
 		string(DefaultDisruptionsApprovalMode),
@@ -139,7 +139,7 @@ func compareCPU(current, desired *v1alpha2.VirtualMachineSpec) []FieldChange {
 		return fractionChanges
 	}
 
-	modelChanges := compareStrings("cpu.virtualMachineCPUModel", current.CPU.VirtualMachineCPUModel, desired.CPU.VirtualMachineCPUModel, DefaultCPUModelName, ActionRestart)
+	modelChanges := compareStrings("cpu.virtualMachineCPUModelName", current.CPU.VirtualMachineCPUModel, desired.CPU.VirtualMachineCPUModel, DefaultCPUModelName, ActionRestart)
 	if HasChanges(modelChanges) {
 		return modelChanges
 	}


### PR DESCRIPTION
## Description
Clean irrelevant changes from status.
Sync info for block devices from KVVMI.

## Why do we need it, and what problem does it solve?
Wrong status

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
