### PR TITLE
fix(vm): controller panic if using sysprep

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm/internal/provisioning.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/provisioning.go
@@ -96,9 +96,9 @@ func (h *ProvisioningHandler) Handle(ctx context.Context, s state.VirtualMachine
 		if p.SysprepRef == nil || p.SysprepRef.Kind != "Secret" {
 			cb.Status(metav1.ConditionFalse).
 				Reason2(vmcondition.ReasonProvisioningNotReady).
-				Message("userdataRef must be \"Secret\"")
+				Message("sysprepRef must be \"Secret\"")
 		}
-		key := types.NamespacedName{Name: p.UserDataRef.Name, Namespace: current.GetNamespace()}
+		key := types.NamespacedName{Name: p.SysprepRef.Name, Namespace: current.GetNamespace()}
 		err := h.genConditionFromSecret(ctx, cb, key)
 		if err != nil {
 			return reconcile.Result{}, err


### PR DESCRIPTION
## Description
controller panic if using sysprep

## Why do we need it, and what problem does it solve?
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x16d10f4]
...
(*ProvisioningHandler).Handle(0xc0000cddd0?, {0x1da3f90, 0xc000153b00}, {0x1dab240, 0xc0002d0800})
	/usr/local/go/src/virtualization-controller/pkg/controller/vm/internal/provisioning.go:101 +0x554

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
