### PR TITLE
fix(vm): do not check keys for sysprep secret

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm/internal/provisioning.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/provisioning.go
@@ -130,10 +130,7 @@ func (h *ProvisioningHandler) genConditionFromSecret(ctx context.Context, builde
 			Message(fmt.Sprintf("Secret %q not found.", secretKey.String()))
 		return nil
 	}
-	validate := false
-	if len(checkKeys) == 0 {
-		validate = true
-	}
+	validate := true
 	for _, key := range checkKeys {
 		if _, ok := secret.Data[key]; !ok {
 			validate = false


### PR DESCRIPTION
## Description
fix(vm): do not check keys for sysprep secret

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
