### PR TITLE
refactor(core): lost renames in templates

### DIFF
--- a/crds/embedded/kubevirt.yaml
+++ b/crds/embedded/kubevirt.yaml
@@ -1,6 +1,8 @@
 # Source:
 # https://github.com/kubevirt/kubevirt/releases/download/v1.0.0/kubevirt-operator.yaml
 # Changes:
+# - 2024.07.04
+#   - Rename label to operator.kubevirt.internal.virtualization.deckhouse.io
 # - 2024.06.19
 #   - Remove DVP prefixes.
 # - 2024.04.16
@@ -15,7 +17,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.kubevirt.io: ""
+    operator.kubevirt.internal.virtualization.deckhouse.io: ""
   name: internalvirtualizationkubevirts.internal.virtualization.deckhouse.io
 spec:
   group: internal.virtualization.deckhouse.io

--- a/images/kube-api-proxy/pkg/kubevirt/kubevirt_rules.go
+++ b/images/kube-api-proxy/pkg/kubevirt/kubevirt_rules.go
@@ -38,6 +38,7 @@ var KubevirtRewriteRules = &RewriteRules{
 		Names: []MetadataReplaceRule{
 			{Original: "cdi.kubevirt.io", Renamed: "cdi." + internalPrefix},
 			{Original: "kubevirt.io", Renamed: "kubevirt." + internalPrefix},
+			{Original: "operator.kubevirt.io", Renamed: "operator.kubevirt." + internalPrefix},
 			{Original: "prometheus.kubevirt.io", Renamed: "prometheus.kubevirt." + internalPrefix},
 			{Original: "prometheus.cdi.kubevirt.io", Renamed: "prometheus.cdi." + internalPrefix},
 			// Special cases.

--- a/templates/cdi/cdi-operator/rbac-for-us.yaml
+++ b/templates/cdi/cdi-operator/rbac-for-us.yaml
@@ -62,7 +62,7 @@ rules:
     - cdi-internal-virtualization-api-populator-validate
     - cdi-internal-virtualization-api-datavolume-validate
     - cdi-internal-virtualization-api-validate
-    - objecttransfer-api-validate
+    - cdi-internal-virtualization-objecttransfer-api-validate
   resources:
     - validatingwebhookconfigurations
   verbs:


### PR DESCRIPTION

## Description

- operator.kubevirt.io to operator.kubevirt.internal.virtualization.deckhouse.io
- allow operator to update renamed validatingwebhookconfiguration cdi-internal-virtualization-objecttransfer-api-validate

## Why do we need it, and what problem does it solve?

CDI installation failed because of wrong rbac.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
