### PR TITLE
refactor(kubevirt): backport fix for VMIs metric

### DIFF
--- a/images/virt-artifact/patches/004-backport-10001-from-upstream.patch
+++ b/images/virt-artifact/patches/004-backport-10001-from-upstream.patch
@@ -1,0 +1,13 @@
+diff --git a/pkg/monitoring/vmistats/collector.go b/pkg/monitoring/vmistats/collector.go
+index 51c0ef620..674e0bb0d 100644
+--- a/pkg/monitoring/vmistats/collector.go
++++ b/pkg/monitoring/vmistats/collector.go
+@@ -250,7 +250,7 @@ func (co *VMICollector) updateVMIsPhase(vmis []*k6tv1.VirtualMachineInstance, ch
+ 		mv, err := prometheus.NewConstMetric(
+ 			vmiCountDesc, prometheus.GaugeValue,
+ 			float64(count),
+-			vmc.NodeName, vmc.Phase, vmc.OS, vmc.Workload, vmc.Flavor, vmc.InstanceType,
++			vmc.NodeName, vmc.Phase, vmc.OS, vmc.Workload, vmc.Flavor, vmc.InstanceType, vmc.Preference,
+ 		)
+ 		if err != nil {
+ 			log.Log.Reason(err).Errorf("Failed to create metric for VMIs phase")

--- a/images/virt-artifact/patches/README.md
+++ b/images/virt-artifact/patches/README.md
@@ -19,6 +19,17 @@ This PR adds macvtap networking mode for binding podNetwork.
 - https://github.com/kubevirt/community/pull/186
 - https://github.com/kubevirt/kubevirt/pull/7648
 
+#### `004-backport-10001-from-upstream.patch`
+
+Backport fix for VMI metric kubevirt_vmi_phase_count.
+
+- https://github.com/kubevirt/kubevirt/pull/10001
+
+Fix ton of errors in virt-controller logs:
+{"component":"virt-controller","level":"error","msg":"Failed to create metric for VMIs phase","pos":"collector.go:256","reason":"inconsistent label cardinality: expected 7 label values but got 6
+in []string{\"virtlab-rs-1\", \"running\", \"<none>\", \"<none>\", \"<none>\", \"<none>\"}",...
+
+
 #### `007-tolerations-for-strategy-dumper-job.patch`
 
 There is a problem when all nodes in cluster have taints, KubeVirt can't run virt-operator-strategy-dumper job.


### PR DESCRIPTION

## Description

Backport PR 10001 from upstream

## Why do we need it, and what problem does it solve?

Fix errors "Failed to create metric for VMIs phase" in virt-controller.


## What is the expected result?

No errors about VMIs metrics in virt-controller logs.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
