### PR TITLE
refactor(kubevirt): add rename for specific label/annotation/finalizer in JSON patches

### DIFF
--- a/images/kube-api-proxy/pkg/rewriter/metadata.go
+++ b/images/kube-api-proxy/pkg/rewriter/metadata.go
@@ -121,22 +121,24 @@ func RewriteFinalizers(rules *RewriteRules, obj []byte, path string, action Acti
 }
 
 const (
-	tildaPlaceholder = "~0"
+	tildeChar        = "~"
+	tildePlaceholder = "~0"
+	slashChar        = "/"
 	slashPlaceholder = "~1"
 )
 
 // decodeJSONPatchPath restores ~ and / from ~0 and ~1.
 // See https://jsonpatch.com/#json-pointer
 func decodeJSONPatchPath(path string) string {
-	// Restore / first to prevent tilda doubling.
-	res := strings.Replace(path, slashPlaceholder, "/", -1)
-	return strings.Replace(res, tildaPlaceholder, "~", -1)
+	// Restore / first to prevent tilde doubling.
+	res := strings.Replace(path, slashPlaceholder, slashChar, -1)
+	return strings.Replace(res, tildePlaceholder, tildeChar, -1)
 }
 
 // encodeJSONPatchPath replaces ~ and / to ~0 and ~1.
 // See https://jsonpatch.com/#json-pointer
 func encodeJSONPatchPath(path string) string {
-	// Replace ~ first to prevent tilda doubling.
-	res := strings.Replace(path, "~", tildaPlaceholder, -1)
-	return strings.Replace(res, "/", slashPlaceholder, -1)
+	// Replace ~ first to prevent tilde doubling.
+	res := strings.Replace(path, tildeChar, tildePlaceholder, -1)
+	return strings.Replace(res, slashChar, slashPlaceholder, -1)
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

- Support patches with paths like "/metadata/annotations/annoName", "/metadata/labels/group.io~1labelName"


<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?

No errors about PDB in virt-controller logs:
```
{"component":"virt-controller","kind":"","level":"info","msg":"shrinking pdb vm/kubevirt-internal-virtualization-disruption-budget-qzp7n due to migration completion","name":"cloud-alpine","namespace":"vm","pos":"disruptionbudget.go:549","timestamp":"2024-07-05T18:49:33.610935Z","uid":"af3bf7f8-abf3-4760-b572-463bc338b70a"}
```

Rename in patch diff in proxy logs:
```
2024-07-05 18:48:04.503 DEBUG Request PATCH: changes after rewrite for /// proxy.name="kube-api" request="PATCH /apis/policy/v1/namespaces/vm/poddisruptionbudgets/kubevirt-internal-virtualization-disruption-budget-qzp7n" resource="poddisruptionbudgets"
  body.diff:
    @ [1,"path"]
    - "/metadata/labels/kubevirt.io~1migrationName"
    + "/metadata/labels/kubevirt.internal.virtualization.deckhouse.io~1migrationName"
```

<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
