### PR TITLE
fix(vd): synchronize PVC status changes with VD status updates

### DIFF
--- a/images/virtualization-artifact/pkg/controller/service/condition.go
+++ b/images/virtualization-artifact/pkg/controller/service/condition.go
@@ -19,6 +19,7 @@ package service
 import (
 	"unicode"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
@@ -63,6 +64,15 @@ func CapitalizeFirstLetter(s string) string {
 }
 
 func GetDataVolumeCondition(conditionType cdiv1.DataVolumeConditionType, conditions []cdiv1.DataVolumeCondition) *cdiv1.DataVolumeCondition {
+	for i, condition := range conditions {
+		if condition.Type == conditionType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}
+
+func GetPersistentVolumeClaimCondition(conditionType corev1.PersistentVolumeClaimConditionType, conditions []corev1.PersistentVolumeClaimCondition) *corev1.PersistentVolumeClaimCondition {
 	for i, condition := range conditions {
 		if condition.Type == conditionType {
 			return &conditions[i]

--- a/images/virtualization-artifact/pkg/controller/service/disk_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/disk_service.go
@@ -196,6 +196,8 @@ func (s DiskService) Resize(ctx context.Context, pvc *corev1.PersistentVolumeCla
 	}
 
 	curSize := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+
+	// newSize <= curSize
 	if newSize.Cmp(curSize) != 1 {
 		return fmt.Errorf("new pvc %s/%s size %s is too low: should be > %s", pvc.Namespace, pvc.Name, newSize.String(), curSize.String())
 	}

--- a/images/virtualization-artifact/pkg/controller/vd/vd_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vd/vd_controller.go
@@ -73,7 +73,7 @@ func NewController(
 		logger,
 		internal.NewDatasourceReadyHandler(blank, sources),
 		internal.NewLifeCycleHandler(logger, blank, sources, mgr.GetClient()),
-		internal.NewResizingHandler(disk),
+		internal.NewResizingHandler(logger, disk),
 		internal.NewDeletionHandler(sources),
 		internal.NewAttacheeHandler(mgr.GetClient()),
 	)

--- a/images/virtualization-artifact/pkg/controller/vd/vd_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/vd/vd_reconciler.go
@@ -188,6 +188,11 @@ func (r *Reconciler) SetupController(_ context.Context, mgr manager.Manager, ctr
 					return true
 				}
 
+				if service.GetPersistentVolumeClaimCondition(corev1.PersistentVolumeClaimResizing, oldPVC.Status.Conditions) != nil ||
+					service.GetPersistentVolumeClaimCondition(corev1.PersistentVolumeClaimResizing, newPVC.Status.Conditions) != nil {
+					return true
+				}
+
 				return oldPVC.Status.Phase != newPVC.Status.Phase && newPVC.Status.Phase == corev1.ClaimBound
 			},
 		},


### PR DESCRIPTION
## Description

When resizing a PVC directly, the VD status did not previously update with this information. It will now be updated.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
