### PR TITLE
fix(vm): fix vm-router panics when we delete a virtual machine. 

### DIFF
--- a/images/vmi-router/controllers/vmirouter_reconciler.go
+++ b/images/vmi-router/controllers/vmirouter_reconciler.go
@@ -76,7 +76,7 @@ func (r *VMRouterReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 	// Start with retrieving affected VMI.
 	vm := &virtv1alpha2.VirtualMachine{}
 	err := r.client.Get(ctx, req.NamespacedName, vm)
-	if err != nil && k8serrors.IsNotFound(err) {
+	if err != nil && !k8serrors.IsNotFound(err) {
 		r.log.Error(err, fmt.Sprintf("fail to retrieve vm/%s", req.String()))
 		return reconcile.Result{}, err
 	}

--- a/images/vmi-router/controllers/vmirouter_reconciler.go
+++ b/images/vmi-router/controllers/vmirouter_reconciler.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	virtv1alpha2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 	"github.com/go-logr/logr"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -34,6 +33,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	virtv1alpha2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 	"vmi-router/netlinkmanager"
 )
 
@@ -73,29 +74,24 @@ func (r *VMRouterReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 	r.log.V(4).Info(fmt.Sprintf("Got reconcile request for %s", req.String()))
 
 	// Start with retrieving affected VMI.
-	var vm virtv1alpha2.VirtualMachine
-	var isAbsent bool
-	err := r.client.Get(ctx, req.NamespacedName, &vm)
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			isAbsent = true
-		} else {
-			r.log.Error(err, fmt.Sprintf("fail to retrieve vm/%s", req.String()))
-			return reconcile.Result{}, err
-		}
+	vm := &virtv1alpha2.VirtualMachine{}
+	err := r.client.Get(ctx, req.NamespacedName, vm)
+	if err != nil && k8serrors.IsNotFound(err) {
+		r.log.Error(err, fmt.Sprintf("fail to retrieve vm/%s", req.String()))
+		return reconcile.Result{}, err
+	}
+
+	var ipAddr string
+	if vm != nil {
+		ipAddr = vm.Status.IPAddress
 	}
 
 	// Delete route on VM deletion.
-	if vm.GetDeletionTimestamp() != nil {
-		r.netlinkMgr.DeleteRoute(&vm)
+	if vm == nil || vm.DeletionTimestamp != nil {
+		r.netlinkMgr.DeleteRoute(req.NamespacedName, ipAddr)
 		return reconcile.Result{}, nil
 	}
 
-	if isAbsent {
-		r.netlinkMgr.DeleteRoute(nil)
-		return reconcile.Result{}, nil
-	}
-
-	r.netlinkMgr.UpdateRoute(ctx, &vm)
+	r.netlinkMgr.UpdateRoute(ctx, vm)
 	return reconcile.Result{}, nil
 }

--- a/images/vmi-router/netlinkmanager/manager.go
+++ b/images/vmi-router/netlinkmanager/manager.go
@@ -18,6 +18,7 @@ package netlinkmanager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -27,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/node/addressing"
 	"github.com/go-logr/logr"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -301,7 +303,7 @@ func (m *Manager) DeleteRoute(vmKey types.NamespacedName, vmIP string) {
 		Table: m.tableId,
 	}
 
-	if err := m.nlWrapper.RouteDel(&route); err != nil && !os.IsNotExist(err) {
+	if err := m.nlWrapper.RouteDel(&route); err != nil && !os.IsNotExist(err) && !errors.Is(err, unix.ESRCH) {
 		m.log.Error(err, "failed to delete route")
 	}
 	m.log.Info(fmt.Sprintf("route %s deleted for VM %q", fmtRoute(route), vmKey))

--- a/images/vmi-router/netlinkmanager/manager.go
+++ b/images/vmi-router/netlinkmanager/manager.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023,2024 Flant JSC
+Copyright 2024 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description
fix reconsile VM. refactor DeleteRoute. 

## Why do we need it, and what problem does it solve?
vm-router panics when we delete a virtual machine.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
