### PR TITLE
fix(vd): set ready phase

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref.go
@@ -84,20 +84,7 @@ func (ds ObjectRefDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) 
 	case isDiskProvisioningFinished(condition):
 		logger.Info("Disk provisioning finished: clean up")
 
-		switch {
-		case pvc == nil:
-			condition.Status = metav1.ConditionFalse
-			condition.Reason = vdcondition.Lost
-			condition.Message = fmt.Sprintf("PVC %s not found.", supgen.PersistentVolumeClaim().String())
-		case pv == nil:
-			condition.Status = metav1.ConditionFalse
-			condition.Reason = vdcondition.Lost
-			condition.Message = fmt.Sprintf("PV %s not found.", pvc.Spec.VolumeName)
-		default:
-			condition.Status = metav1.ConditionTrue
-			condition.Reason = vdcondition.Ready
-			condition.Message = ""
-		}
+		setPhaseConditionForFinishedDisk(pv, pvc, &condition, &vd.Status.Phase, supgen)
 
 		// Protect Ready Disk and underlying PVC and PV.
 		err = ds.diskService.Protect(ctx, vd, nil, pvc, pv)

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/registry.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/registry.go
@@ -98,20 +98,7 @@ func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (
 	case isDiskProvisioningFinished(condition):
 		logger.Info("Disk provisioning finished: clean up")
 
-		switch {
-		case pvc == nil:
-			condition.Status = metav1.ConditionFalse
-			condition.Reason = vdcondition.Lost
-			condition.Message = fmt.Sprintf("PVC %s not found.", supgen.PersistentVolumeClaim().String())
-		case pv == nil:
-			condition.Status = metav1.ConditionFalse
-			condition.Reason = vdcondition.Lost
-			condition.Message = fmt.Sprintf("PV %s not found.", pvc.Spec.VolumeName)
-		default:
-			condition.Status = metav1.ConditionTrue
-			condition.Reason = vdcondition.Ready
-			condition.Message = ""
-		}
+		setPhaseConditionForFinishedDisk(pv, pvc, &condition, &vd.Status.Phase, supgen)
 
 		// Protect Ready Disk and underlying PVC and PV.
 		err = ds.diskService.Protect(ctx, vd, nil, pvc, pv)

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/upload.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/upload.go
@@ -106,20 +106,7 @@ func (ds UploadDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (bo
 	case isDiskProvisioningFinished(condition):
 		logger.Info("Disk provisioning finished: clean up")
 
-		switch {
-		case pvc == nil:
-			condition.Status = metav1.ConditionFalse
-			condition.Reason = vdcondition.Lost
-			condition.Message = fmt.Sprintf("PVC %s not found.", supgen.PersistentVolumeClaim().String())
-		case pv == nil:
-			condition.Status = metav1.ConditionFalse
-			condition.Reason = vdcondition.Lost
-			condition.Message = fmt.Sprintf("PV %s not found.", pvc.Spec.VolumeName)
-		default:
-			condition.Status = metav1.ConditionTrue
-			condition.Reason = vdcondition.Ready
-			condition.Message = ""
-		}
+		setPhaseConditionForFinishedDisk(pv, pvc, &condition, &vd.Status.Phase, supgen)
 
 		// Protect Ready Disk and underlying PVC and PV.
 		err = ds.diskService.Protect(ctx, vd, nil, pvc, pv)


### PR DESCRIPTION
## Description

Set the Ready or Lost phase on each reconciliation of the virtual disk.
The VD resizes only when the PVC is resizing.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
