### PR TITLE
fix(vd): protection for deleted resource

### DIFF
--- a/images/virtualization-artifact/pkg/controller/cvi/internal/attachee.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/attachee.go
@@ -43,12 +43,13 @@ func (h AttacheeHandler) Handle(ctx context.Context, cvi *virtv2.ClusterVirtualI
 		return reconcile.Result{}, err
 	}
 
-	if hasAttachedVM {
+	switch {
+	case !hasAttachedVM:
+		controllerutil.RemoveFinalizer(cvi, virtv2.FinalizerCVIProtection)
+	case cvi.DeletionTimestamp == nil:
 		controllerutil.AddFinalizer(cvi, virtv2.FinalizerCVIProtection)
-		return reconcile.Result{}, nil
 	}
 
-	controllerutil.RemoveFinalizer(cvi, virtv2.FinalizerCVIProtection)
 	return reconcile.Result{}, nil
 }
 

--- a/images/virtualization-artifact/pkg/controller/service/resource.go
+++ b/images/virtualization-artifact/pkg/controller/service/resource.go
@@ -122,7 +122,7 @@ func (r *Resource[T, ST]) Update(ctx context.Context) error {
 		}
 
 		if err = r.client.Patch(ctx, r.changedObj, patch); err != nil {
-			return fmt.Errorf("error updating: %w", err)
+			return fmt.Errorf("error patching finalizers: %w", err)
 		}
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vd/internal/attachee.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/attachee.go
@@ -51,12 +51,13 @@ func (h AttacheeHandler) Handle(ctx context.Context, vd *virtv2.VirtualDisk) (re
 		})
 	}
 
-	if len(vd.Status.AttachedToVirtualMachines) > 0 {
+	switch {
+	case len(vd.Status.AttachedToVirtualMachines) == 0:
+		controllerutil.RemoveFinalizer(vd, virtv2.FinalizerVDProtection)
+	case vd.DeletionTimestamp == nil:
 		controllerutil.AddFinalizer(vd, virtv2.FinalizerVDProtection)
-		return reconcile.Result{}, nil
 	}
 
-	controllerutil.RemoveFinalizer(vd, virtv2.FinalizerVDProtection)
 	return reconcile.Result{}, nil
 }
 

--- a/images/virtualization-artifact/pkg/controller/vd/internal/datasource_ready.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/datasource_ready.go
@@ -93,6 +93,6 @@ func (h DatasourceReadyHandler) Handle(ctx context.Context, vd *virtv2.VirtualDi
 		condition.Message = service.CapitalizeFirstLetter(err.Error()) + "."
 		return reconcile.Result{}, nil
 	default:
-		return reconcile.Result{}, err
+		return reconcile.Result{}, fmt.Errorf("validation failed for data source %s: %w", ds.Name(), err)
 	}
 }

--- a/images/virtualization-artifact/pkg/controller/vd/internal/life_cycle.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/life_cycle.go
@@ -107,7 +107,7 @@ func (h LifeCycleHandler) Handle(ctx context.Context, vd *virtv2.VirtualDisk) (r
 
 	requeue, err := ds.Sync(ctx, vd)
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to sync virtual disk data source: %w", err)
+		return reconcile.Result{}, fmt.Errorf("failed to sync virtual disk data source %s: %w", ds.Name(), err)
 	}
 
 	return reconcile.Result{Requeue: requeue}, nil

--- a/images/virtualization-artifact/pkg/controller/vd/internal/mock.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/mock.go
@@ -26,6 +26,9 @@ var _ Handler = &HandlerMock{}
 //			CleanUpFunc: func(ctx context.Context, vd *virtv2.VirtualDisk) (bool, error) {
 //				panic("mock out the CleanUp method")
 //			},
+//			NameFunc: func() string {
+//				panic("mock out the Name method")
+//			},
 //			SyncFunc: func(ctx context.Context, vd *virtv2.VirtualDisk) (bool, error) {
 //				panic("mock out the Sync method")
 //			},
@@ -42,6 +45,9 @@ type HandlerMock struct {
 	// CleanUpFunc mocks the CleanUp method.
 	CleanUpFunc func(ctx context.Context, vd *virtv2.VirtualDisk) (bool, error)
 
+	// NameFunc mocks the Name method.
+	NameFunc func() string
+
 	// SyncFunc mocks the Sync method.
 	SyncFunc func(ctx context.Context, vd *virtv2.VirtualDisk) (bool, error)
 
@@ -56,6 +62,9 @@ type HandlerMock struct {
 			Ctx context.Context
 			// Vd is the vd argument value.
 			Vd *virtv2.VirtualDisk
+		}
+		// Name holds details about calls to the Name method.
+		Name []struct {
 		}
 		// Sync holds details about calls to the Sync method.
 		Sync []struct {
@@ -73,6 +82,7 @@ type HandlerMock struct {
 		}
 	}
 	lockCleanUp  sync.RWMutex
+	lockName     sync.RWMutex
 	lockSync     sync.RWMutex
 	lockValidate sync.RWMutex
 }
@@ -110,6 +120,33 @@ func (mock *HandlerMock) CleanUpCalls() []struct {
 	mock.lockCleanUp.RLock()
 	calls = mock.calls.CleanUp
 	mock.lockCleanUp.RUnlock()
+	return calls
+}
+
+// Name calls NameFunc.
+func (mock *HandlerMock) Name() string {
+	if mock.NameFunc == nil {
+		panic("HandlerMock.NameFunc: method is nil but Handler.Name was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockName.Lock()
+	mock.calls.Name = append(mock.calls.Name, callInfo)
+	mock.lockName.Unlock()
+	return mock.NameFunc()
+}
+
+// NameCalls gets all the calls that were made to Name.
+// Check the length with:
+//
+//	len(mockedHandler.NameCalls())
+func (mock *HandlerMock) NameCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockName.RLock()
+	calls = mock.calls.Name
+	mock.lockName.RUnlock()
 	return calls
 }
 

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/blank.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/blank.go
@@ -32,6 +32,8 @@ import (
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
 )
 
+const blankDataSource = "blank"
+
 type BlankDataSource struct {
 	statService *service.StatService
 	diskService *service.DiskService
@@ -46,7 +48,7 @@ func NewBlankDataSource(
 	return &BlankDataSource{
 		statService: statService,
 		diskService: diskService,
-		logger:      logger.With("ds", "blank"),
+		logger:      logger.With("ds", blankDataSource),
 	}
 }
 
@@ -195,6 +197,10 @@ func (ds BlankDataSource) CleanUpSupplements(ctx context.Context, vd *virtv2.Vir
 
 func (ds BlankDataSource) Validate(_ context.Context, _ *virtv2.VirtualDisk) error {
 	return nil
+}
+
+func (ds BlankDataSource) Name() string {
+	return blankDataSource
 }
 
 func (ds BlankDataSource) getSource() *cdiv1.DataVolumeSource {

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/http.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/http.go
@@ -19,6 +19,7 @@ package source
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 
 	corev1 "k8s.io/api/core/v1"
@@ -37,6 +38,8 @@ import (
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
 )
+
+const httpDataSource = "http"
 
 type HTTPDataSource struct {
 	statService     *service.StatService
@@ -58,7 +61,7 @@ func NewHTTPDataSource(
 		importerService: importerService,
 		diskService:     diskService,
 		dvcrSettings:    dvcrSettings,
-		logger:          logger.With("ds", "http"),
+		logger:          logger.With("ds", httpDataSource),
 	}
 }
 
@@ -294,6 +297,10 @@ func (ds HTTPDataSource) CleanUpSupplements(ctx context.Context, vd *virtv2.Virt
 	return importerRequeue || diskRequeue, nil
 }
 
+func (ds HTTPDataSource) Name() string {
+	return httpDataSource
+}
+
 func (ds HTTPDataSource) getEnvSettings(vd *virtv2.VirtualDisk, supgen *supplements.Generator) *importer.Settings {
 	var settings importer.Settings
 
@@ -331,7 +338,7 @@ func (ds HTTPDataSource) getPVCSize(vd *virtv2.VirtualDisk, pod *corev1.Pod) (re
 	// Get size from the importer Pod to detect if specified PVC size is enough.
 	unpackedSize, err := resource.ParseQuantity(ds.statService.GetSize(pod).UnpackedBytes)
 	if err != nil {
-		return resource.Quantity{}, err
+		return resource.Quantity{}, fmt.Errorf("failed to parse unpacked bytes %s: %w", ds.statService.GetSize(pod).UnpackedBytes, err)
 	}
 
 	if unpackedSize.IsZero() {

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref.go
@@ -38,6 +38,8 @@ import (
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vicondition"
 )
 
+const objectRefDataSource = "objectref"
+
 type ObjectRefDataSource struct {
 	statService *service.StatService
 	diskService *service.DiskService
@@ -55,7 +57,7 @@ func NewObjectRefDataSource(
 		statService: statService,
 		diskService: diskService,
 		client:      client,
-		logger:      logger.With("ds", "objectref"),
+		logger:      logger.With("ds", objectRefDataSource),
 	}
 }
 
@@ -244,6 +246,10 @@ func (ds ObjectRefDataSource) Validate(ctx context.Context, vd *virtv2.VirtualDi
 	}
 }
 
+func (ds ObjectRefDataSource) Name() string {
+	return objectRefDataSource
+}
+
 func (ds ObjectRefDataSource) getSource(sup *supplements.Generator, dvcrDataSource controller.DVCRDataSource) (*cdiv1.DataVolumeSource, error) {
 	if !dvcrDataSource.IsReady() {
 		return nil, errors.New("dvcr data source is not ready")
@@ -269,7 +275,7 @@ func (ds ObjectRefDataSource) getPVCSize(vd *virtv2.VirtualDisk, dvcrDataSource 
 
 	unpackedSize, err := resource.ParseQuantity(dvcrDataSource.GetSize().UnpackedBytes)
 	if err != nil {
-		return resource.Quantity{}, err
+		return resource.Quantity{}, fmt.Errorf("failed to parse unpacked bytes %s: %w", dvcrDataSource.GetSize().UnpackedBytes, err)
 	}
 
 	if unpackedSize.IsZero() {

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/registry.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/registry.go
@@ -42,6 +42,8 @@ import (
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
 )
 
+const registryDataSource = "registry"
+
 type RegistryDataSource struct {
 	statService     *service.StatService
 	importerService *service.ImporterService
@@ -65,7 +67,7 @@ func NewRegistryDataSource(
 		diskService:     diskService,
 		dvcrSettings:    dvcrSettings,
 		client:          client,
-		logger:          logger.With("ds", "registry"),
+		logger:          logger.With("ds", registryDataSource),
 	}
 }
 
@@ -320,6 +322,10 @@ func (ds RegistryDataSource) Validate(ctx context.Context, vd *virtv2.VirtualDis
 	return nil
 }
 
+func (ds RegistryDataSource) Name() string {
+	return registryDataSource
+}
+
 func (ds RegistryDataSource) getEnvSettings(vd *virtv2.VirtualDisk, supgen *supplements.Generator) *importer.Settings {
 	var settings importer.Settings
 
@@ -357,7 +363,7 @@ func (ds RegistryDataSource) getPVCSize(vd *virtv2.VirtualDisk, pod *corev1.Pod)
 	// Get size from the importer Pod to detect if specified PVC size is enough.
 	unpackedSize, err := resource.ParseQuantity(ds.statService.GetSize(pod).UnpackedBytes)
 	if err != nil {
-		return resource.Quantity{}, err
+		return resource.Quantity{}, fmt.Errorf("failed to parse unpacked bytes %s: %w", ds.statService.GetSize(pod).UnpackedBytes, err)
 	}
 
 	if unpackedSize.IsZero() {

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/sources.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/sources.go
@@ -30,6 +30,7 @@ import (
 )
 
 type Handler interface {
+	Name() string
 	Sync(ctx context.Context, vd *virtv2.VirtualDisk) (bool, error)
 	CleanUp(ctx context.Context, vd *virtv2.VirtualDisk) (bool, error)
 	Validate(ctx context.Context, vd *virtv2.VirtualDisk) error
@@ -68,7 +69,7 @@ func (s Sources) CleanUp(ctx context.Context, vd *virtv2.VirtualDisk) (bool, err
 	for _, source := range s.sources {
 		ok, err := source.CleanUp(ctx, vd)
 		if err != nil {
-			return false, err
+			return false, fmt.Errorf("clean up failed for data source %s: %w", source.Name(), err)
 		}
 
 		requeue = requeue || ok

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/upload.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/upload.go
@@ -39,6 +39,8 @@ import (
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
 )
 
+const uploadDataSource = "registry"
+
 type UploadDataSource struct {
 	statService     *service.StatService
 	uploaderService *service.UploaderService
@@ -59,7 +61,7 @@ func NewUploadDataSource(
 		uploaderService: uploaderService,
 		diskService:     diskService,
 		dvcrSettings:    dvcrSettings,
-		logger:          logger.With("ds", "upload"),
+		logger:          logger.With("ds", uploadDataSource),
 	}
 }
 
@@ -322,6 +324,10 @@ func (ds UploadDataSource) Validate(_ context.Context, _ *virtv2.VirtualDisk) er
 	return nil
 }
 
+func (ds UploadDataSource) Name() string {
+	return uploadDataSource
+}
+
 func (ds UploadDataSource) getEnvSettings(supgen *supplements.Generator) *uploader.Settings {
 	var settings uploader.Settings
 
@@ -358,7 +364,7 @@ func (ds UploadDataSource) getPVCSize(vd *virtv2.VirtualDisk, pod *corev1.Pod) (
 	// Get size from the importer Pod to detect if specified PVC size is enough.
 	unpackedSize, err := resource.ParseQuantity(ds.statService.GetSize(pod).UnpackedBytes)
 	if err != nil {
-		return resource.Quantity{}, err
+		return resource.Quantity{}, fmt.Errorf("failed to parse unpacked bytes %s: %w", ds.statService.GetSize(pod).UnpackedBytes, err)
 	}
 
 	if unpackedSize.IsZero() {

--- a/images/virtualization-artifact/pkg/controller/vi/internal/attachee.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/attachee.go
@@ -43,12 +43,13 @@ func (h AttacheeHandler) Handle(ctx context.Context, vi *virtv2.VirtualImage) (r
 		return reconcile.Result{}, err
 	}
 
-	if hasAttachedVM {
+	switch {
+	case !hasAttachedVM:
+		controllerutil.RemoveFinalizer(vi, virtv2.FinalizerVIProtection)
+	case vi.DeletionTimestamp == nil:
 		controllerutil.AddFinalizer(vi, virtv2.FinalizerVIProtection)
-		return reconcile.Result{}, nil
 	}
 
-	controllerutil.RemoveFinalizer(vi, virtv2.FinalizerVIProtection)
 	return reconcile.Result{}, nil
 }
 


### PR DESCRIPTION
## Description

Do not add protection to a resource that is in the process of being deleted.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
