### PR TITLE
refactor(kubevirt): stop continuous patching of Services

### DIFF
--- a/images/virt-artifact/patches/005-prevent-permanent-patching-of-services.patch
+++ b/images/virt-artifact/patches/005-prevent-permanent-patching-of-services.patch
@@ -1,0 +1,23 @@
+diff --git a/pkg/virt-operator/resource/apply/core.go b/pkg/virt-operator/resource/apply/core.go
+index 3315598a3..66a5b1dce 100644
+--- a/pkg/virt-operator/resource/apply/core.go
++++ b/pkg/virt-operator/resource/apply/core.go
+@@ -431,6 +431,18 @@ func generateServicePatch(
+ 	if service.Spec.SessionAffinity == "" {
+ 		service.Spec.SessionAffinity = cachedService.Spec.SessionAffinity
+ 	}
++	if service.Spec.InternalTrafficPolicy == nil {
++		service.Spec.InternalTrafficPolicy = cachedService.Spec.InternalTrafficPolicy
++	}
++	if service.Spec.ClusterIPs == nil {
++		service.Spec.ClusterIPs = cachedService.Spec.ClusterIPs
++	}
++	if service.Spec.IPFamilies == nil {
++		service.Spec.IPFamilies = cachedService.Spec.IPFamilies
++	}
++	if service.Spec.IPFamilyPolicy == nil {
++		service.Spec.IPFamilyPolicy = cachedService.Spec.IPFamilyPolicy
++	}
+ 
+ 	// If the Specs don't equal each other, replace it
+ 	if !equality.Semantic.DeepEqual(cachedService.Spec, service.Spec) {

--- a/images/virt-artifact/patches/README.md
+++ b/images/virt-artifact/patches/README.md
@@ -29,6 +29,16 @@ Fix ton of errors in virt-controller logs:
 {"component":"virt-controller","level":"error","msg":"Failed to create metric for VMIs phase","pos":"collector.go:256","reason":"inconsistent label cardinality: expected 7 label values but got 6
 in []string{\"virtlab-rs-1\", \"running\", \"<none>\", \"<none>\", \"<none>\", \"<none>\"}",...
 
+#### `005-prevent-permanent-patching-of-services.patch`
+
+Fix patching of Services during each reconcile:
+
+```
+{"component":"virt-operator","level":"info","msg":"service kubevirt-prometheus-metrics patched","pos":"core.go:142","timestamp":"2024-07-09T16:03:18.136326Z"}
+{"component":"virt-operator","level":"info","msg":"service virt-api patched","pos":"core.go:142","timestamp":"2024-07-09T16:03:18.138751Z"}
+{"component":"virt-operator","level":"info","msg":"service kubevirt-operator-webhook patched","pos":"core.go:142","timestamp":"2024-07-09T16:03:18.140853Z"}
+{"component":"virt-operator","level":"info","msg":"service virt-exportproxy patched","pos":"core.go:142","timestamp":"2024-07-09T16:03:18.142806Z"}
+```
 
 #### `007-tolerations-for-strategy-dumper-job.patch`
 


### PR DESCRIPTION

## Description

- add more defaults into comparing


## Why do we need it, and what problem does it solve?

virt-operator Reconcile loop never stops spaming these messages:

```

{"component":"virt-operator","level":"info","msg":"service kubevirt-prometheus-metrics patched","pos":"core.go:142","timestamp":"2024-07-08T17:44:20.322657Z"}
{"component":"virt-operator","level":"info","msg":"service virt-api patched","pos":"core.go:142","timestamp":"2024-07-08T17:44:20.324827Z"}
{"component":"virt-operator","level":"info","msg":"service kubevirt-operator-webhook patched","pos":"core.go:142","timestamp":"2024-07-08T17:44:20.326965Z"}
{"component":"virt-operator","level":"info","msg":"service virt-exportproxy patched","pos":"core.go:142","timestamp":"2024-07-08T17:44:20.328917Z"}
```

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
