### PR TITLE
refactor(core): replace * with resource to stop continuous updating of ClusterRoles

### DIFF
--- a/images/cdi-artifact/patches/010-rename-apigroups-in-starred-rbac.patch
+++ b/images/cdi-artifact/patches/010-rename-apigroups-in-starred-rbac.patch
@@ -1,0 +1,13 @@
+diff --git a/pkg/operator/resources/cluster/controller.go b/pkg/operator/resources/cluster/controller.go
+index 875afaf61..eac1f8cfa 100644
+--- a/pkg/operator/resources/cluster/controller.go
++++ b/pkg/operator/resources/cluster/controller.go
+@@ -160,7 +160,7 @@ func getControllerClusterPolicyRules() []rbacv1.PolicyRule {
+ 				"cdi.kubevirt.io",
+ 			},
+ 			Resources: []string{
+-				"*",
++				"cdiconfigs", "cdis", "dataimportcrons", "datasources", "datavolumes", "objecttransfers", "storageprofiles", "volumeclonesources", "volumeimportsources", "volumeuploadsources", "cdiconfigs/status", "cdis/status", "dataimportcrons/status", "datasources/status", "datavolumes/status", "objecttransfers/status", "storageprofiles/status", "volumeclonesources/status", "volumeimportsources/status", "volumeuploadsources/status", "cdiconfigs/finalizers", "cdis/finalizers", "dataimportcrons/finalizers", "datasources/finalizers", "datavolumes/finalizers", "objecttransfers/finalizers", "storageprofiles/finalizers", "volumeclonesources/finalizers", "volumeimportsources/finalizers", "volumeuploadsources/finalizers",
+ 			},
+ 			Verbs: []string{
+ 				"*",

--- a/images/cdi-artifact/patches/README.md
+++ b/images/cdi-artifact/patches/README.md
@@ -21,3 +21,11 @@ set ContentTypeJson for kubernetes clients.
 
 #### `008-rename-core-resources.patch`
 Replace "cdi" with "cdi-internal-virtualziation" in the core resource names.
+
+#### `010-rename-apigroups-in-starred-rbac.patch`
+
+Rename apiGroup to internal.virtualization.deckhouse.io for ClusterRole for cdi-deployment to prevent permanent patching:
+
+```
+{"level":"debug","ts":"2024-06-28T12:39:26Z","logger":"events","msg":"Successfully updated resource *v1.ClusterRole cdi-internal-virtualization","type":"Normal","object":{"kind":"CDI","name":"config","uid":"2e7b5bf7-2c38-4118-a80d-04a8e67ca08b","apiVersion":"cdi.kubevirt.io/v1beta1","resourceVersion":"420200766"},"reason":"UpdateResourceSuccess"}
+```

--- a/images/virt-artifact/patches/016-rename-apigroups-in-starred-rbac.patch
+++ b/images/virt-artifact/patches/016-rename-apigroups-in-starred-rbac.patch
@@ -1,0 +1,40 @@
+diff --git a/pkg/virt-operator/resource/generate/rbac/controller.go b/pkg/virt-operator/resource/generate/rbac/controller.go
+index 8b8313112..558eb7568 100644
+--- a/pkg/virt-operator/resource/generate/rbac/controller.go
++++ b/pkg/virt-operator/resource/generate/rbac/controller.go
+@@ -314,7 +314,7 @@ func newControllerClusterRole() *rbacv1.ClusterRole {
+ 					"snapshot.kubevirt.io",
+ 				},
+ 				Resources: []string{
+-					"*",
++					"virtualmachinerestores", "virtualmachinesnapshotcontents", "virtualmachinesnapshots", "virtualmachinerestores/status", "virtualmachinesnapshotcontents/status", "virtualmachinesnapshots/status", "virtualmachinerestores/finalizers", "virtualmachinesnapshotcontents/finalizers", "virtualmachinesnapshots/finalizers",
+ 				},
+ 				Verbs: []string{
+ 					"*",
+@@ -325,7 +325,7 @@ func newControllerClusterRole() *rbacv1.ClusterRole {
+ 					"export.kubevirt.io",
+ 				},
+ 				Resources: []string{
+-					"*",
++					"virtualmachineexports", "virtualmachineexports/status", "virtualmachineexports/finalizers",
+ 				},
+ 				Verbs: []string{
+ 					"*",
+@@ -357,7 +357,7 @@ func newControllerClusterRole() *rbacv1.ClusterRole {
+ 					"kubevirt.io",
+ 				},
+ 				Resources: []string{
+-					"*",
++					"kubevirts", "virtualmachines", "virtualmachineinstances", "virtualmachineinstancemigrations", "virtualmachineinstancepresets", "virtualmachineinstancereplicasets", "kubevirts/status", "virtualmachines/status", "virtualmachineinstances/status", "virtualmachineinstancemigrations/status", "virtualmachineinstancepresets/status", "virtualmachineinstancereplicasets/status", "kubevirts/finalizers", "virtualmachines/finalizers", "virtualmachineinstances/finalizers", "virtualmachineinstancemigrations/finalizers", "virtualmachineinstancepresets/finalizers", "virtualmachineinstancereplicasets/finalizers",
+ 				},
+ 				Verbs: []string{
+ 					"*",
+@@ -383,7 +383,7 @@ func newControllerClusterRole() *rbacv1.ClusterRole {
+ 					"cdi.kubevirt.io",
+ 				},
+ 				Resources: []string{
+-					"*",
++					"cdiconfigs", "cdis", "dataimportcrons", "datasources", "datavolumes", "objecttransfers", "storageprofiles", "volumeclonesources", "volumeimportsources", "volumeuploadsources", "cdiconfigs/status", "cdis/status", "dataimportcrons/status", "datasources/status", "datavolumes/status", "objecttransfers/status", "storageprofiles/status", "volumeclonesources/status", "volumeimportsources/status", "volumeuploadsources/status", "cdiconfigs/finalizers", "cdis/finalizers", "dataimportcrons/finalizers", "datasources/finalizers", "datavolumes/finalizers", "objecttransfers/finalizers", "storageprofiles/finalizers", "volumeclonesources/finalizers", "volumeimportsources/finalizers", "volumeuploadsources/finalizers",
+ 				},
+ 				Verbs: []string{
+ 					"*",

--- a/images/virt-artifact/patches/README.md
+++ b/images/virt-artifact/patches/README.md
@@ -51,3 +51,11 @@ Do not create Kubevirt APIService.
 
 #### `015-rename-core-resources.patch`
 Replace "kubevirt" with "kubevirt-internal-virtualziation" in the core resource names.
+
+#### `016-rename-apigroups-in-starred-rbac.patch`
+
+Rename apiGroup to internal.virtualization.deckhouse.io for ClusterRole for virt-controller to prevent permanent patching:
+
+```
+{"component":"virt-operator","level":"info","msg":"clusterrole kubevirt-internal-virtualization-controller patched","pos":"core.go:142","timestamp":"2024-07-09T16:03:18.138751Z"}
+```


### PR DESCRIPTION

## Description

Temporary fix to stop stop continuous updating of ClusterRoles. '*' in resources field prevent proper restoring of apiGroup in Role/ClusterRole. We should rename each apiGroup to unique value, and not to one.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

This PR reduces Reconcile loops and noise in logs for each reconcile:

```
{"component":"virt-operator","level":"info","msg":"ClusterRole kubevirt-internal-virtualization-controller updated","pos":"rbac.go:83","timestamp":"2024-07-10T15:48:23.123929Z"}
```

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
