### PR TITLE
chore(core): fix debug level for proxy in virtualization-controller

### DIFF
--- a/templates/virtualization-controller/deployment.yaml
+++ b/templates/virtualization-controller/deployment.yaml
@@ -65,6 +65,8 @@ spec:
         - name: proxy
           image: {{ include "helm_lib_module_image" (list . "kubeApiProxy") }}
           imagePullPolicy: IfNotPresent
+          env:
+          {{- include "kube_api_rewriter.env" . | nindent 10 }}
           resources:
             requests:
               {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}


### PR DESCRIPTION

## Description

- add env: section to proxy container in virtualization-controller


## Why do we need it, and what problem does it solve?



## What is the expected result?
logLevel: debug should enable debug for proxy container in virtualization-controller

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
