### PR TITLE
refactor(core): stop continuous updating of deployments

### DIFF
--- a/templates/_kube_api_rewriter.tpl
+++ b/templates/_kube_api_rewriter.tpl
@@ -25,6 +25,7 @@ spec:
       volumes:
       - name: kube-api-proxy-kubeconfig
         configMap:
+          defaultMode: 0644
           name: kube-api-proxy-kubeconfig
       containers:
       - name: proxy

--- a/templates/cdi/_helpers.tpl
+++ b/templates/cdi/_helpers.tpl
@@ -13,6 +13,7 @@ spec:
       volumes:
       - name: kube-api-proxy-kubeconfig
         configMap:
+          defaultMode: 0644
           name: kube-api-proxy-kubeconfig
       containers:
       - name: proxy

--- a/templates/cdi/cdi-operator/deployment.yaml
+++ b/templates/cdi/cdi-operator/deployment.yaml
@@ -134,4 +134,5 @@ spec:
       volumes:
       - name: kube-api-proxy-kubeconfig
         configMap:
+          defaultMode: 0644
           name: kube-api-proxy-kubeconfig

--- a/templates/kubevirt/_helpers.tpl
+++ b/templates/kubevirt/_helpers.tpl
@@ -15,6 +15,7 @@ spec:
       volumes:
         - name: kube-api-proxy-kubeconfig
           configMap:
+            defaultMode: 0644
             name: kube-api-proxy-kubeconfig
       containers:
         - name: proxy

--- a/templates/kubevirt/virt-operator/deployment.yaml
+++ b/templates/kubevirt/virt-operator/deployment.yaml
@@ -187,4 +187,5 @@ spec:
         name: profile-data
       - name: kube-api-proxy-kubeconfig
         configMap:
+          defaultMode: 0644
           name: kube-api-proxy-kubeconfig

--- a/templates/virtualization-controller/deployment.yaml
+++ b/templates/virtualization-controller/deployment.yaml
@@ -117,4 +117,5 @@ spec:
             secretName: virtualization-controller-tls
         - name: kube-api-proxy-kubeconfig
           configMap:
+            defaultMode: 0644
             name: kube-api-proxy-kubeconfig


### PR DESCRIPTION

## Description

- Add defaultMode, so virt-operator and cdi-operator see no changes in deployments after patching.
- API server returns defaultMode field and operators detect changes.

## Why do we need it, and what problem does it solve?

Reduce Reconcile loops.

We can patch Deployment and Daemonset comparators in operators, but it is simpler to add defaultMode in templates and configs.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
