### PR TITLE
refactor(kube-api-rewriter): fix rewriting metadata for CRD patching

### DIFF
--- a/images/kube-api-proxy/pkg/rewriter/admission_review.go
+++ b/images/kube-api-proxy/pkg/rewriter/admission_review.go
@@ -221,14 +221,11 @@ func RestoreAdmissionReviewObject(rules *RewriteRules, obj []byte, origGroup str
 		return nil, fmt.Errorf("restore resource group, kind: %w", err)
 	}
 
-	obj, err = RewriteMetadata(rules, obj, Restore)
+	obj, err = TransformObject(obj, "metadata", func(metadataObj []byte) ([]byte, error) {
+		return RewriteMetadata(rules, metadataObj, Restore)
+	})
 	if err != nil {
 		return nil, fmt.Errorf("restore resource metadata: %w", err)
-	}
-
-	obj, err = RewriteOwnerReferences(rules, obj, Restore)
-	if err != nil {
-		return nil, fmt.Errorf("restore resource ownerReferences: %w", err)
 	}
 
 	return obj, nil

--- a/images/kube-api-proxy/pkg/rewriter/crd.go
+++ b/images/kube-api-proxy/pkg/rewriter/crd.go
@@ -254,5 +254,5 @@ func RenameCRDPatch(rules *RewriteRules, resourceRule *ResourceRule, obj []byte)
 		return obj, nil
 	}
 
-	return newPatches, nil
+	return RenameMetadataPatch(rules, newPatches)
 }

--- a/images/kube-api-proxy/pkg/rewriter/resource.go
+++ b/images/kube-api-proxy/pkg/rewriter/resource.go
@@ -142,8 +142,8 @@ func RestoreAPIVersionAndKind(rules *RewriteRules, obj []byte, origGroupName str
 	return sjson.SetBytes(obj, "kind", rules.RestoreKind(kind))
 }
 
-func RewriteOwnerReferences(rules *RewriteRules, obj []byte, action Action) ([]byte, error) {
-	return RewriteArray(obj, "metadata.ownerReferences", func(ownerRefObj []byte) ([]byte, error) {
+func RewriteOwnerReferences(rules *RewriteRules, obj []byte, path string, action Action) ([]byte, error) {
+	return RewriteArray(obj, path, func(ownerRefObj []byte) ([]byte, error) {
 		kind := gjson.GetBytes(ownerRefObj, "kind").String()
 		apiVersion := gjson.GetBytes(ownerRefObj, "apiVersion").String()
 

--- a/images/kube-api-proxy/pkg/rewriter/rule_rewriter.go
+++ b/images/kube-api-proxy/pkg/rewriter/rule_rewriter.go
@@ -311,12 +311,9 @@ func (rw *RuleBasedRewriter) RewriteJSONPayload(targetReq *TargetRequest, obj []
 	// Always rewrite metadata: labels, annotations, finalizers, ownerReferences.
 	// TODO: add rewriter for managedFields.
 	return RewriteResourceOrList2(rwrBytes, func(singleObj []byte) ([]byte, error) {
-		var err error
-		singleObj, err = RewriteMetadata(rw.Rules, singleObj, action)
-		if err != nil {
-			return nil, err
-		}
-		return RewriteOwnerReferences(rw.Rules, singleObj, action)
+		return TransformObject(singleObj, "metadata", func(metadataObj []byte) ([]byte, error) {
+			return RewriteMetadata(rw.Rules, metadataObj, action)
+		})
 	})
 }
 


### PR DESCRIPTION

## Description


- Add rewrite for JSON patch path /metadata/ownerReferences

## Why do we need it, and what problem does it solve?

Patch from mutating hook may leave original kind and apiGroup in ownerReferences and resource may be deleted, e.g. VirtualMachineInstance.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
