### PR TITLE
refactor(kube-api-rewriter): fix errors related to BOOKMARK WatchEvents

### DIFF
--- a/images/kube-api-proxy/pkg/rewriter/rule_rewriter.go
+++ b/images/kube-api-proxy/pkg/rewriter/rule_rewriter.go
@@ -320,6 +320,12 @@ func (rw *RuleBasedRewriter) RewriteJSONPayload(targetReq *TargetRequest, obj []
 	})
 }
 
+// RestoreBookmark restores apiVersion and kind in an object in WatchEvent with type BOOKMARK. Bookmark is not a full object, so RewriteJSONPayload may add unexpected fields.
+// Bookmark example: {"kind":"ConfigMap","apiVersion":"v1","metadata":{"resourceVersion":"438083871","creationTimestamp":null}}
+func (rw *RuleBasedRewriter) RestoreBookmark(targetReq *TargetRequest, obj []byte) ([]byte, error) {
+	return RestoreAPIVersionAndKind(rw.Rules, obj, targetReq.OrigGroup())
+}
+
 // RewritePatch rewrites patches for some known objects.
 // Only rename action is required for patches.
 func (rw *RuleBasedRewriter) RewritePatch(targetReq *TargetRequest, patchBytes []byte) ([]byte, error) {


### PR DESCRIPTION
## Description

Add rewriter for BOOKMARK WatchEvents. This rewriter restores only kind and apiVersion.

## Why do we need it, and what problem does it solve?

Stop errors in stream handler, prevent re-establising watch on each CRD event by the client, prevent excessive Lists.

```
main controller:
W0710 11:55:53.470204       1 reflector.go:347] pkg/controller/virtinformers.go:348: watch of *v1.CustomResourceDefinition ended with: an error on the server ("unable to decode an event from the watch stream: unable to decode watch event: couldn't get version/kind; json parse error: unexpected end of JSON input") has prevented the request from succeeding

proxy:
{"time":"2024-07-10T13:13:34.143132596Z","level":"ERROR","msg":"Watch event 'BOOKMARK': transform error","request":"GET /apis/apiextensions.k8s.io/v1/customresourcedefinitions","resource":"customresourcedefinitions","proxy.name":"kube-api","err":"error rewriting object: malformed CRD name: should be resourcetype.group, got "}        

```

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
