### PR TITLE
feat(vm): add the attached field to the status block device refs

### DIFF
--- a/api/core/v1alpha2/block_device.go
+++ b/api/core/v1alpha2/block_device.go
@@ -22,11 +22,13 @@ type BlockDeviceSpecRef struct {
 }
 
 type BlockDeviceStatusRef struct {
-	Kind         BlockDeviceKind `json:"kind"`
-	Name         string          `json:"name"`
-	Hotpluggable bool            `json:"hotpluggable"`
-	Target       string          `json:"target"`
-	Size         string          `json:"size"`
+	Kind                                    BlockDeviceKind `json:"kind"`
+	Name                                    string          `json:"name"`
+	Size                                    string          `json:"size"`
+	Target                                  string          `json:"target"`
+	Attached                                bool            `json:"attached"`
+	Hotpluggable                            bool            `json:"hotpluggable,omitempty"`
+	VirtualMachineBlockDeviceAttachmentName string          `json:"virtualMachineBlockDeviceAttachmentName,omitempty"`
 }
 
 type BlockDeviceKind string

--- a/api/core/v1alpha2/block_device.go
+++ b/api/core/v1alpha2/block_device.go
@@ -27,7 +27,7 @@ type BlockDeviceStatusRef struct {
 	Size                                    string          `json:"size"`
 	Target                                  string          `json:"target"`
 	Attached                                bool            `json:"attached"`
-	Hotpluggable                            bool            `json:"hotpluggable,omitempty"`
+	Hotplugged                              bool            `json:"hotplugged,omitempty"`
 	VirtualMachineBlockDeviceAttachmentName string          `json:"virtualMachineBlockDeviceAttachmentName,omitempty"`
 }
 

--- a/api/core/v1alpha2/vmcondition/condition.go
+++ b/api/core/v1alpha2/vmcondition/condition.go
@@ -53,8 +53,8 @@ const (
 	ReasonIPAddressClaimNotAssigned  Reason = "VirtualMachineIPAddressClaimNotAssigned"
 	ReasonIPAddressClaimNotAvailable Reason = "VirtualMachineIPAddressClaimNotAvailable"
 
-	ReasonBlockDevicesAttachmentReady    Reason = "BlockDevicesAttachmentReady"
-	ReasonBlockDevicesAttachmentNotReady Reason = "BlockDevicesAttachmentNotReady"
+	ReasonBlockDevicesReady    Reason = "BlockDevicesReady"
+	ReasonBlockDevicesNotReady Reason = "BlockDevicesNotReady"
 
 	ReasonProvisioningReady    Reason = "ProvisioningReady"
 	ReasonProvisioningNotReady Reason = "ProvisioningNotReady"

--- a/api/pkg/apiserver/api/generated/openapi/zz_generated.openapi.go
+++ b/api/pkg/apiserver/api/generated/openapi/zz_generated.openapi.go
@@ -702,10 +702,10 @@ func schema_virtualization_api_core_v1alpha2_BlockDeviceStatusRef(ref common.Ref
 							Format:  "",
 						},
 					},
-					"hotpluggable": {
+					"size": {
 						SchemaProps: spec.SchemaProps{
-							Default: false,
-							Type:    []string{"boolean"},
+							Default: "",
+							Type:    []string{"string"},
 							Format:  "",
 						},
 					},
@@ -716,15 +716,27 @@ func schema_virtualization_api_core_v1alpha2_BlockDeviceStatusRef(ref common.Ref
 							Format:  "",
 						},
 					},
-					"size": {
+					"attached": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
+							Default: false,
+							Type:    []string{"boolean"},
 							Format:  "",
 						},
 					},
+					"hotpluggable": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
+					"virtualMachineBlockDeviceAttachmentName": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
-				Required: []string{"kind", "name", "hotpluggable", "target", "size"},
+				Required: []string{"kind", "name", "size", "target", "attached"},
 			},
 		},
 	}

--- a/api/pkg/apiserver/api/generated/openapi/zz_generated.openapi.go
+++ b/api/pkg/apiserver/api/generated/openapi/zz_generated.openapi.go
@@ -723,7 +723,7 @@ func schema_virtualization_api_core_v1alpha2_BlockDeviceStatusRef(ref common.Ref
 							Format:  "",
 						},
 					},
-					"hotpluggable": {
+					"hotplugged": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"boolean"},
 							Format: "",

--- a/crds/doc-ru-virtualmachine.yaml
+++ b/crds/doc-ru-virtualmachine.yaml
@@ -532,6 +532,10 @@ spec:
                     Список блочных устройств, подключенных к ВМ.
                   items:
                     properties:
+                      attached:
+                        type: boolean
+                        description: |
+                          Блочное устройство подключено к виртуальной машине.
                       hotpluggable:
                         description: |
                           Блочное устройство доступно для горячего подключения.
@@ -547,6 +551,9 @@ spec:
                       target:
                         description: |
                           Название подключенного блочного устройства.
+                      virtualMachineBlockDeviceAttachmentName:
+                        description: |
+                          Имя ресурса `VirtualMachineBlockDeviceAttachment`, обеспечивающего «горячее» подключение диска.
                 conditions:
                   description: |
                     Состояния во время работы виртуальной машины.

--- a/crds/doc-ru-virtualmachine.yaml
+++ b/crds/doc-ru-virtualmachine.yaml
@@ -536,9 +536,9 @@ spec:
                         type: boolean
                         description: |
                           Блочное устройство подключено к виртуальной машине.
-                      hotpluggable:
+                      hotplugged:
                         description: |
-                          Блочное устройство доступно для горячего подключения.
+                          Блочное устройство подключено к виртуальной машине «на лету».
                       kind:
                         description: |
                           Тип блочного устройства.
@@ -553,7 +553,7 @@ spec:
                           Название подключенного блочного устройства.
                       virtualMachineBlockDeviceAttachmentName:
                         description: |
-                          Имя ресурса `VirtualMachineBlockDeviceAttachment`, обеспечивающего «горячее» подключение диска.
+                          Имя ресурса `VirtualMachineBlockDeviceAttachment`, который описывает подключение диска к виртуальной машине «на лету».
                 conditions:
                   description: |
                     Состояния во время работы виртуальной машины.

--- a/crds/virtualmachine.yaml
+++ b/crds/virtualmachine.yaml
@@ -974,10 +974,10 @@ spec:
                         type: boolean
                         description: |
                           The block device is attached to the virtual machine.
-                      hotpluggable:
+                      hotplugged:
                         type: boolean
                         description: |
-                          Block device is available for hot plug.
+                          Block device is attached via hot plug connection.
                       kind:
                         type: string
                         description: The type of block device.
@@ -1000,7 +1000,7 @@ spec:
                       virtualMachineBlockDeviceAttachmentName:
                         type: string
                         description: |
-                          The name of the `VirtualMachineBlockDeviceAttachment` resource that provides hot plug disk connection.
+                          The name of the `VirtualMachineBlockDeviceAttachment` resource that defines hot plug disk connection to the virtual machine.
                 migrationState:
                   type: object
                   description: "Migration info."

--- a/crds/virtualmachine.yaml
+++ b/crds/virtualmachine.yaml
@@ -968,8 +968,12 @@ spec:
                     The list of attached block device attachments.
                   items:
                     type: object
-                    required: ["kind", "name", "size"]
+                    required: ["kind", "name", "size", "attached"]
                     properties:
+                      attached:
+                        type: boolean
+                        description: |
+                          The block device is attached to the virtual machine.
                       hotpluggable:
                         type: boolean
                         description: |
@@ -993,6 +997,10 @@ spec:
                         type: string
                         description: |
                           The size of attached block device.
+                      virtualMachineBlockDeviceAttachmentName:
+                        type: string
+                        description: |
+                          The name of the `VirtualMachineBlockDeviceAttachment` resource that provides hot plug disk connection.
                 migrationState:
                   type: object
                   description: "Migration info."

--- a/images/virtualization-artifact/pkg/controller/vm/internal/block_device.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/block_device.go
@@ -83,7 +83,7 @@ func (h *BlockDeviceHandler) Handle(ctx context.Context, s state.VirtualMachineS
 		h.logger.Error(fmt.Sprintf("invalid disks: %s", disksMessage))
 		mgr.Update(cb.
 			Status(metav1.ConditionFalse).
-			Reason2(vmcondition.ReasonBlockDevicesAttachmentNotReady).
+			Reason2(vmcondition.ReasonBlockDevicesNotReady).
 			Message(disksMessage).Condition())
 		changed.Status.Conditions = mgr.Generate()
 		return reconcile.Result{Requeue: true}, nil
@@ -102,57 +102,67 @@ func (h *BlockDeviceHandler) Handle(ctx context.Context, s state.VirtualMachineS
 		return reconcile.Result{}, fmt.Errorf("unable to add block devices finalizers: %w", err)
 	}
 
+	// Fill BlockDeviceRefs every time without knowledge of previously kept BlockDeviceRefs.
+	changed.Status.BlockDeviceRefs = nil
+
+	// Set BlockDeviceRef from spec to the status.
+	for _, bdSpecRef := range changed.Spec.BlockDeviceRefs {
+		bdStatusRef := h.getDiskStatusRef(bdSpecRef.Kind, bdSpecRef.Name)
+		bdStatusRef.Size = h.getBlockDeviceSize(&bdStatusRef, bdState)
+
+		changed.Status.BlockDeviceRefs = append(
+			changed.Status.BlockDeviceRefs,
+			bdStatusRef,
+		)
+	}
+
+	vmbdas, err := s.VMBDAs(ctx)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// Set hot plugged BlockDeviceRef to the status.
+	for _, vmbda := range vmbdas {
+		if vmbda.Status.Phase == virtv2.BlockDeviceAttachmentPhasePending {
+			continue
+		}
+
+		var vd *virtv2.VirtualDisk
+		vd, err = s.VirtualDisk(ctx, vmbda.Spec.BlockDeviceRef.Name)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		if vd == nil {
+			continue
+		}
+
+		bdStatusRef := h.getDiskStatusRef(virtv2.DiskDevice, vmbda.Spec.BlockDeviceRef.Name)
+		bdStatusRef.Size = vd.Status.Capacity
+		bdStatusRef.Hotpluggable = true
+		bdStatusRef.VirtualMachineBlockDeviceAttachmentName = vmbda.Name
+
+		changed.Status.BlockDeviceRefs = append(
+			changed.Status.BlockDeviceRefs,
+			bdStatusRef,
+		)
+	}
+
 	kvvmi, err := s.KVVMI(ctx)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
+	// Sync BlockDeviceRef in the status with KVVMI volumes.
 	if kvvmi != nil {
-		// Fill BlockDeviceRefs every time without knowledge of previously kept BlockDeviceRefs.
-		changed.Status.BlockDeviceRefs = nil
-
-		// Set BlockDeviceRef in the status if the disk exists in KVVMI.
-		for _, ref := range changed.Spec.BlockDeviceRefs {
-			bd := h.createAttachedBlockDevice(ref, bdState, kvvmi)
-			if bd == nil {
+		for i, bdStatusRef := range changed.Status.BlockDeviceRefs {
+			vs := h.findVolumeStatus(GenerateDiskName(bdStatusRef.Kind, bdStatusRef.Name), kvvmi)
+			if vs == nil || (vs.Phase != "" && vs.Phase != virtv1.VolumeReady) {
 				continue
 			}
 
-			changed.Status.BlockDeviceRefs = append(
-				changed.Status.BlockDeviceRefs,
-				*bd,
-			)
-		}
-
-		// Set BlockDeviceRef `Hotpluggable: true` in the status if KVVMI has a hotplugged disk.
-		for _, vs := range kvvmi.Status.VolumeStatus {
-			if vs.HotplugVolume == nil {
-				continue
-			}
-
-			vdName, ok := kvbuilder.GetOriginalDiskName(vs.Name)
-			if !ok {
-				h.logger.Warn("volume %s was hot plugged to VirtualMachineInstance %s, but it is not a VirtualDisk.", vdName, kvvmi.Name)
-				h.recorder.Eventf(changed, corev1.EventTypeNormal, virtv2.ReasonUnknownHotPluggedVolume, "Volume %s was hot plugged to VirtualMachineInstance %s, but it is not a VirtualDisk.", vdName, kvvmi.Name)
-				continue
-			}
-
-			var vd *virtv2.VirtualDisk
-			vd, err = s.VirtualDisk(ctx, vdName)
-			if err != nil {
-				return reconcile.Result{}, err
-			}
-
-			if vd == nil {
-				h.logger.Warn("VirtualDisk %s not found but pvc hot plugged into VirtualMachineInstance %s", vdName, kvvmi.Name)
-				h.recorder.Eventf(changed, corev1.EventTypeNormal, virtv2.ReasonUnknownHotPluggedVolume, "VirtualDisk %s not found but pvc hot plugged into VirtualMachineInstance %s", vdName, kvvmi.Name)
-				continue
-			}
-
-			changed.Status.BlockDeviceRefs = append(
-				changed.Status.BlockDeviceRefs,
-				h.getHotPluggedDiskStatusRef(vs, vd),
-			)
+			changed.Status.BlockDeviceRefs[i].Target = vs.Target
+			changed.Status.BlockDeviceRefs[i].Attached = true
 		}
 	}
 
@@ -161,7 +171,7 @@ func (h *BlockDeviceHandler) Handle(ctx context.Context, s state.VirtualMachineS
 	if ready, count := h.countReadyBlockDevices(current, bdState); !ready {
 		// Wait until block devices are ready.
 		h.logger.Info("Waiting for block devices to become available")
-		reason := vmcondition.ReasonBlockDevicesAttachmentNotReady.String()
+		reason := vmcondition.ReasonBlockDevicesNotReady.String()
 		h.recorder.Event(changed, corev1.EventTypeNormal, reason, "Waiting for block devices to become available")
 		msg := fmt.Sprintf("Waiting for block devices to become available: %d/%d", count, countBD)
 		mgr.Update(cb.
@@ -174,7 +184,7 @@ func (h *BlockDeviceHandler) Handle(ctx context.Context, s state.VirtualMachineS
 	}
 
 	mgr.Update(cb.Status(metav1.ConditionTrue).
-		Reason2(vmcondition.ReasonBlockDevicesAttachmentReady).
+		Reason2(vmcondition.ReasonBlockDevicesReady).
 		Condition())
 	changed.Status.Conditions = mgr.Generate()
 	return reconcile.Result{}, nil
@@ -305,87 +315,53 @@ func (h *BlockDeviceHandler) updateFinalizers(ctx context.Context, vm *virtv2.Vi
 	return nil
 }
 
-func (h *BlockDeviceHandler) getHotPluggedDiskStatusRef(vs virtv1.VolumeStatus, vd *virtv2.VirtualDisk) virtv2.BlockDeviceStatusRef {
+func (h *BlockDeviceHandler) getDiskStatusRef(kind virtv2.BlockDeviceKind, name string) virtv2.BlockDeviceStatusRef {
 	return virtv2.BlockDeviceStatusRef{
-		Kind:         virtv2.DiskDevice,
-		Name:         vd.Name,
-		Target:       vs.Target,
-		Size:         vd.Status.Capacity,
-		Hotpluggable: true,
+		Kind: kind,
+		Name: name,
 	}
 }
 
-func (h *BlockDeviceHandler) createAttachedBlockDevice(spec virtv2.BlockDeviceSpecRef, state BlockDevicesState, kvvmi *virtv1.VirtualMachineInstance) *virtv2.BlockDeviceStatusRef {
+func (h *BlockDeviceHandler) getBlockDeviceSize(ref *virtv2.BlockDeviceStatusRef, state BlockDevicesState) string {
+	switch ref.Kind {
+	case virtv2.ImageDevice:
+		vi, hasVI := state.VIByName[ref.Name]
+		if !hasVI {
+			return ""
+		}
+
+		return vi.Status.Size.Unpacked
+	case virtv2.DiskDevice:
+		vd, hasVI := state.VDByName[ref.Name]
+		if !hasVI {
+			return ""
+		}
+
+		return vd.Status.Capacity
+	case virtv2.ClusterImageDevice:
+		cvi, hasCvi := state.CVIByName[ref.Name]
+		if !hasCvi {
+			return ""
+		}
+
+		return cvi.Status.Size.Unpacked
+	}
+
+	return ""
+}
+
+func (h *BlockDeviceHandler) findVolumeStatus(name string, kvvmi *virtv1.VirtualMachineInstance) *virtv1.VolumeStatus {
 	if kvvmi == nil {
 		return nil
 	}
-	switch spec.Kind {
-	case virtv2.ImageDevice:
-		vs := h.findVolumeStatus(kvbuilder.GenerateVMIDiskName(spec.Name), kvvmi)
-		if vs == nil {
-			return nil
-		}
 
-		vi, hasVI := state.VIByName[spec.Name]
-		if !hasVI {
-			return nil
-		}
-
-		return &virtv2.BlockDeviceStatusRef{
-			Kind:   virtv2.ImageDevice,
-			Name:   spec.Name,
-			Target: vs.Target,
-			Size:   vi.Status.Size.Unpacked,
-		}
-
-	case virtv2.DiskDevice:
-		vs := h.findVolumeStatus(kvbuilder.GenerateVMDDiskName(spec.Name), kvvmi)
-		if vs == nil {
-			return nil
-		}
-
-		vd, hasVd := state.VDByName[spec.Name]
-		if !hasVd {
-			return nil
-		}
-
-		return &virtv2.BlockDeviceStatusRef{
-			Kind:   virtv2.DiskDevice,
-			Name:   spec.Name,
-			Target: vs.Target,
-			Size:   vd.Status.Capacity,
-		}
-
-	case virtv2.ClusterImageDevice:
-		vs := h.findVolumeStatus(kvbuilder.GenerateCVMIDiskName(spec.Name), kvvmi)
-		if vs == nil {
-			return nil
-		}
-
-		cvi, hasCvi := state.CVIByName[spec.Name]
-		if !hasCvi {
-			return nil
-		}
-
-		return &virtv2.BlockDeviceStatusRef{
-			Kind:   virtv2.ClusterImageDevice,
-			Name:   spec.Name,
-			Target: vs.Target,
-			Size:   cvi.Status.Size.Unpacked,
+	for i := range kvvmi.Status.VolumeStatus {
+		vs := kvvmi.Status.VolumeStatus[i]
+		if vs.Name == name {
+			return &vs
 		}
 	}
-	return nil
-}
 
-func (h *BlockDeviceHandler) findVolumeStatus(volumeName string, kvvmi *virtv1.VirtualMachineInstance) *virtv1.VolumeStatus {
-	if kvvmi != nil {
-		for i := range kvvmi.Status.VolumeStatus {
-			vs := kvvmi.Status.VolumeStatus[i]
-			if vs.Name == volumeName {
-				return &vs
-			}
-		}
-	}
 	return nil
 }
 

--- a/images/virtualization-artifact/pkg/controller/vm/internal/state/state.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/state/state.go
@@ -40,7 +40,7 @@ type VirtualMachineState interface {
 	KVVMI(ctx context.Context) (*virtv1.VirtualMachineInstance, error)
 	Pods(ctx context.Context) (*corev1.PodList, error)
 	Pod(ctx context.Context) (*corev1.Pod, error)
-	VMBDAs(ctx context.Context) ([]virtv2.VirtualMachineBlockDeviceAttachment, error)
+	VMBDAList(ctx context.Context) ([]virtv2.VirtualMachineBlockDeviceAttachment, error)
 	VirtualDisk(ctx context.Context, name string) (*virtv2.VirtualDisk, error)
 	VirtualDisksByName(ctx context.Context) (map[string]*virtv2.VirtualDisk, error)
 	VirtualImagesByName(ctx context.Context) (map[string]*virtv2.VirtualImage, error)
@@ -155,7 +155,7 @@ func (s *state) Pod(ctx context.Context) (*corev1.Pod, error) {
 	return pod, nil
 }
 
-func (s *state) VMBDAs(ctx context.Context) ([]virtv2.VirtualMachineBlockDeviceAttachment, error) {
+func (s *state) VMBDAList(ctx context.Context) ([]virtv2.VirtualMachineBlockDeviceAttachment, error) {
 	var list virtv2.VirtualMachineBlockDeviceAttachmentList
 	err := s.client.List(ctx, &list, &client.ListOptions{
 		Namespace: s.vm.Name().Namespace,

--- a/images/virtualization-artifact/pkg/controller/vmbda/vmbda_webhook.go
+++ b/images/virtualization-artifact/pkg/controller/vmbda/vmbda_webhook.go
@@ -38,6 +38,8 @@ func NewValidator() *Validator {
 }
 
 func (v *Validator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	// TODO check if vmbda with this block device and vm already exists.
+
 	err := fmt.Errorf("misconfigured webhook rules: create operation not implemented")
 	v.logger.Error("Ensure the correctness of ValidatingWebhookConfiguration", "err", err)
 	return nil, nil


### PR DESCRIPTION
## Description

Add the `attached`, `hotplugged` and `virtualMachineBlockDeviceAttachmentName` fields to the status block device refs
Renamed ReasonBlockDevicesAttachmentReady and ReasonBlockDevicesAttachmentNotReady reasons 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
