### PR TITLE
refactor(kube-api-rewriter): fix "non-empty body produces empty rewrite"

### DIFF
--- a/images/kube-api-proxy/pkg/log/differ.go
+++ b/images/kube-api-proxy/pkg/log/differ.go
@@ -31,6 +31,12 @@ func DebugBodyChanges(logger *slog.Logger, msg string, resourceType string, inBy
 		return
 	}
 
+	// No changes were made to inBytes.
+	if rwrBytes == nil {
+		logger.Debug(fmt.Sprintf("%s: no changes after rewrite", msg))
+		return
+	}
+
 	if len(inBytes) == 0 && len(rwrBytes) == 0 {
 		logger.Debug(fmt.Sprintf("%s: empty body", msg))
 		return
@@ -43,7 +49,7 @@ func DebugBodyChanges(logger *slog.Logger, msg string, resourceType string, inBy
 	}
 
 	if len(inBytes) != 0 && len(rwrBytes) == 0 {
-		logger.Error(fmt.Sprintf("%s: non-empty body [%d] produces empty rewrite", msg, len(inBytes)))
+		logger.Error(fmt.Sprintf("%s: possible bug: non-empty body [%d] produces empty rewrite", msg, len(inBytes)))
 		DebugBodyHead(logger, msg, resourceType, inBytes)
 		return
 	}

--- a/images/kube-api-proxy/pkg/proxy/handler.go
+++ b/images/kube-api-proxy/pkg/proxy/handler.go
@@ -164,9 +164,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	if req.Method == http.MethodPatch {
 		logutil.DebugBodyHead(logger, "Request PATCH", "patch", origRequestBytes)
-		if len(rwrRequestBytes) > 0 {
-			logutil.DebugBodyChanges(logger, "Request PATCH", "patch", origRequestBytes, rwrRequestBytes)
-		}
+		logutil.DebugBodyChanges(logger, "Request PATCH", "patch", origRequestBytes, rwrRequestBytes)
 	} else {
 		logutil.DebugBodyChanges(logger, "Request", resource, origRequestBytes, rwrRequestBytes)
 	}


### PR DESCRIPTION
## Description

Print debug diff only if rewritten buffer is not nil.

## Why do we need it, and what problem does it solve?

Fix false negative error in logs:

```
2024-07-10 16:22:54.207 ERROR Request: non-empty body [668] produces empty rewrite proxy.name="kube-api" request="POST /api/v1/namespaces/d8-virtualization/events" resource="events"

```


## What is the expected result?

No non-empty body errors for Events.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
