### PR TITLE
refactor(kube-api-rewriter): remove deprecation warnings from CRDs

### DIFF
--- a/images/virt-artifact/patches/019-remove-deprecation-warnings-from-crds.patch
+++ b/images/virt-artifact/patches/019-remove-deprecation-warnings-from-crds.patch
@@ -1,0 +1,132 @@
+diff --git a/pkg/virt-operator/resource/generate/components/crds.go b/pkg/virt-operator/resource/generate/components/crds.go
+index 36126ef43..26689ee11 100644
+--- a/pkg/virt-operator/resource/generate/components/crds.go
++++ b/pkg/virt-operator/resource/generate/components/crds.go
+@@ -36,8 +36,6 @@ import (
+ 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+ 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+ 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
+-	"k8s.io/utils/pointer"
+-
+ 	virtv1 "kubevirt.io/api/core/v1"
+ 	exportv1 "kubevirt.io/api/export/v1alpha1"
+ 	instancetypev1alpha1 "kubevirt.io/api/instancetype/v1alpha1"
+@@ -227,15 +225,15 @@ func NewPresetCrd() (*extv1.CustomResourceDefinition, error) {
+ 				Name:               "v1",
+ 				Served:             true,
+ 				Storage:            false,
+-				Deprecated:         true,
+-				DeprecationWarning: pointer.String("kubevirt.io/v1 VirtualMachineInstancePresets is now deprecated and will be removed in v2."),
++				Deprecated:         false,
++				DeprecationWarning: nil,
+ 			},
+ 			{
+ 				Name:               "v1alpha3",
+ 				Served:             true,
+ 				Storage:            true,
+-				Deprecated:         true,
+-				DeprecationWarning: pointer.String("kubevirt.io/v1alpha3 VirtualMachineInstancePresets is now deprecated and will be removed in v2."),
++				Deprecated:         false,
++				DeprecationWarning: nil,
+ 			},
+ 		},
+ 		Scope: "Namespaced",
+@@ -627,14 +625,14 @@ func NewVirtualMachineInstancetypeCrd() (*extv1.CustomResourceDefinition, error)
+ 			Name:               instancetypev1alpha1.SchemeGroupVersion.Version,
+ 			Served:             true,
+ 			Storage:            false,
+-			Deprecated:         true,
+-			DeprecationWarning: pointer.String("instancetype.kubevirt.io/v1alpha1 VirtualMachineInstancetypes is now deprecated and will be removed in v1."),
++			Deprecated:         false,
++			DeprecationWarning: nil,
+ 		}, {
+ 			Name:               instancetypev1alpha2.SchemeGroupVersion.Version,
+ 			Served:             true,
+ 			Storage:            false,
+-			Deprecated:         true,
+-			DeprecationWarning: pointer.String("instancetype.kubevirt.io/v1alpha2 VirtualMachineInstancetypes is now deprecated and will be removed in v1."),
++			Deprecated:         false,
++			DeprecationWarning: nil,
+ 		}, {
+ 			Name:    instancetypev1beta1.SchemeGroupVersion.Version,
+ 			Served:  true,
+@@ -668,14 +666,14 @@ func NewVirtualMachineClusterInstancetypeCrd() (*extv1.CustomResourceDefinition,
+ 			Name:               instancetypev1alpha1.SchemeGroupVersion.Version,
+ 			Served:             true,
+ 			Storage:            false,
+-			Deprecated:         true,
+-			DeprecationWarning: pointer.String("instancetype.kubevirt.io/v1alpha1 VirtualMachineClusterInstanceTypes is now deprecated and will be removed in v1."),
++			Deprecated:         false,
++			DeprecationWarning: nil,
+ 		}, {
+ 			Name:               instancetypev1alpha2.SchemeGroupVersion.Version,
+ 			Served:             true,
+ 			Storage:            false,
+-			Deprecated:         true,
+-			DeprecationWarning: pointer.String("instancetype.kubevirt.io/v1alpha2 VirtualMachineClusterInstanceTypes is now deprecated and will be removed in v1."),
++			Deprecated:         false,
++			DeprecationWarning: nil,
+ 		}, {
+ 			Name:    instancetypev1beta1.SchemeGroupVersion.Version,
+ 			Served:  true,
+@@ -710,14 +708,14 @@ func NewVirtualMachinePreferenceCrd() (*extv1.CustomResourceDefinition, error) {
+ 			Name:               instancetypev1alpha1.SchemeGroupVersion.Version,
+ 			Served:             true,
+ 			Storage:            false,
+-			Deprecated:         true,
+-			DeprecationWarning: pointer.String("instancetype.kubevirt.io/v1alpha1 VirtualMachinePreferences is now deprecated and will be removed in v1."),
++			Deprecated:         false,
++			DeprecationWarning: nil,
+ 		}, {
+ 			Name:               instancetypev1alpha2.SchemeGroupVersion.Version,
+ 			Served:             true,
+ 			Storage:            false,
+-			Deprecated:         true,
+-			DeprecationWarning: pointer.String("instancetype.kubevirt.io/v1alpha2 VirtualMachinePreferences is now deprecated and will be removed in v1."),
++			Deprecated:         false,
++			DeprecationWarning: nil,
+ 		}, {
+ 			Name:    instancetypev1beta1.SchemeGroupVersion.Version,
+ 			Served:  true,
+@@ -751,14 +749,14 @@ func NewVirtualMachineClusterPreferenceCrd() (*extv1.CustomResourceDefinition, e
+ 			Name:               instancetypev1alpha1.SchemeGroupVersion.Version,
+ 			Served:             true,
+ 			Storage:            false,
+-			Deprecated:         true,
+-			DeprecationWarning: pointer.String("instancetype.kubevirt.io/v1alpha1 VirtualMachineClusterPreferences is now deprecated and will be removed in v1."),
++			Deprecated:         false,
++			DeprecationWarning: nil,
+ 		}, {
+ 			Name:               instancetypev1alpha2.SchemeGroupVersion.Version,
+ 			Served:             true,
+ 			Storage:            false,
+-			Deprecated:         true,
+-			DeprecationWarning: pointer.String("instancetype.kubevirt.io/v1alpha2 VirtualMachineClusterPreferences is now deprecated and will be removed in v1."),
++			Deprecated:         false,
++			DeprecationWarning: nil,
+ 		}, {
+ 			Name:    instancetypev1beta1.SchemeGroupVersion.Version,
+ 			Served:  true,
+diff --git a/staging/src/kubevirt.io/api/core/v1/register.go b/staging/src/kubevirt.io/api/core/v1/register.go
+index ac213dce0..7096192c7 100644
+--- a/staging/src/kubevirt.io/api/core/v1/register.go
++++ b/staging/src/kubevirt.io/api/core/v1/register.go
+@@ -23,7 +23,6 @@ import (
+ 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+ 	"k8s.io/apimachinery/pkg/runtime"
+ 	"k8s.io/apimachinery/pkg/runtime/schema"
+-	"k8s.io/utils/pointer"
+ 
+ 	"kubevirt.io/api/core"
+ )
+@@ -45,8 +44,8 @@ var (
+ 			Name:               "v1alpha3",
+ 			Served:             true,
+ 			Storage:            false,
+-			Deprecated:         true,
+-			DeprecationWarning: pointer.String("kubevirt.io/v1alpha3 is now deprecated and will be removed in a future release."),
++			Deprecated:         false,
++			DeprecationWarning: nil,
+ 		},
+ 	}
+ )

--- a/images/virt-artifact/patches/README.md
+++ b/images/virt-artifact/patches/README.md
@@ -88,6 +88,6 @@ Rename additional resources previded with Device Plugin API to not overlap with 
 
 Rename unix-socket path used for register devices.
 
-#### `/019-remove-deprecation-warnings-from-crds.patch`
+#### `019-remove-deprecation-warnings-from-crds.patch`
 
-Virtualization-controller don't use deprecated versions. Deprecation warning are distracting in our case.
+Virtualization-controller doesn't use deprecated apiGroup versions. Deprecation warnings are distracting in our case.

--- a/images/virt-artifact/patches/README.md
+++ b/images/virt-artifact/patches/README.md
@@ -78,6 +78,9 @@ Rename apiGroup to internal.virtualization.deckhouse.io for ClusterRole for virt
 {"component":"virt-operator","level":"info","msg":"clusterrole kubevirt-internal-virtualization-controller patched","pos":"core.go:142","timestamp":"2024-07-09T16:03:18.138751Z"}
 ```
 
+#### `017-fix-vmi-subresource-url.patch`
+
+Use virtualization-api instead subresources.kubevirt.io for vmi operations.
 
 #### `018-rename-devices-kubevirt-io.patch`
 
@@ -85,3 +88,6 @@ Rename additional resources previded with Device Plugin API to not overlap with 
 
 Rename unix-socket path used for register devices.
 
+#### `/019-remove-deprecation-warnings-from-crds.patch`
+
+Virtualization-controller don't use deprecated versions. Deprecation warning are distracting in our case.


### PR DESCRIPTION
## Description

Make DeprecationWarning fields empty for all KubeVirt CRDs.

## Why do we need it, and what problem does it solve?

Virtualization-controller don't use deprecated versions. Deprecation warning are distracting in our case.


## What is the expected result?

No deprecation warning in `kubectl -n ns get all` output.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
