### PR TITLE
feat(vm): add pod handler

### DIFF
--- a/api/core/v1alpha2/finalizers.go
+++ b/api/core/v1alpha2/finalizers.go
@@ -24,6 +24,7 @@ const (
 	FinalizerVMOPProtection      = "virtualization.deckhouse.io/vmop-protection"
 	FinalizerVMCPUProtection     = "virtualization.deckhouse.io/vmcpu-protection"
 	FinalizerIPAddressProtection = "virtualization.deckhouse.io/vmip-protection"
+	FinalizerPodProtection       = "virtualization.deckhouse.io/pod-protection"
 
 	FinalizerCVICleanup            = "virtualization.deckhouse.io/cvi-cleanup"
 	FinalizerVDCleanup             = "virtualization.deckhouse.io/vd-cleanup"

--- a/images/virtualization-artifact/pkg/controller/powerstate/shutdown_reason.go
+++ b/images/virtualization-artifact/pkg/controller/powerstate/shutdown_reason.go
@@ -85,6 +85,6 @@ func ShutdownReason(kvvmi *kvv1.VirtualMachineInstance, kvPods *corev1.PodList) 
 
 type ShutdownInfo struct {
 	Reason      GuestSignalReason
-	PodCompeted bool
+	PodCompleted bool
 	Pod         corev1.Pod
 }

--- a/images/virtualization-artifact/pkg/controller/powerstate/shutdown_reason.go
+++ b/images/virtualization-artifact/pkg/controller/powerstate/shutdown_reason.go
@@ -73,18 +73,18 @@ func ShutdownReason(kvvmi *kvv1.VirtualMachineInstance, kvPods *corev1.PodList) 
 			msg = contStatus.State.Terminated.Message
 		}
 		if strings.Contains(msg, string(GuestResetReason)) {
-			return ShutdownInfo{PodCompeted: true, Reason: GuestResetReason, Pod: recentPod}
+			return ShutdownInfo{PodCompleted: true, Reason: GuestResetReason, Pod: recentPod}
 		}
 		if strings.Contains(msg, string(GuestShutdownReason)) {
-			return ShutdownInfo{PodCompeted: true, Reason: GuestShutdownReason, Pod: recentPod}
+			return ShutdownInfo{PodCompleted: true, Reason: GuestShutdownReason, Pod: recentPod}
 		}
 	}
 
-	return ShutdownInfo{PodCompeted: true, Pod: recentPod}
+	return ShutdownInfo{PodCompleted: true, Pod: recentPod}
 }
 
 type ShutdownInfo struct {
-	Reason      GuestSignalReason
+	Reason       GuestSignalReason
 	PodCompleted bool
-	Pod         corev1.Pod
+	Pod          corev1.Pod
 }

--- a/images/virtualization-artifact/pkg/controller/vm/internal/pod.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/pod.go
@@ -53,11 +53,12 @@ func (h *PodHandler) Handle(ctx context.Context, s state.VirtualMachineState) (r
 	}
 
 	if isDeletion(current) {
-		objs := make([]client.Object, len(pods.Items))
-		for i, p := range pods.Items {
-			objs[i] = p.DeepCopy()
+		for _, p := range pods.Items {
+			if err = h.protection.RemoveProtection(ctx, &p); err != nil {
+				return reconcile.Result{}, err
+			}
 		}
-		return reconcile.Result{}, h.protection.RemoveProtection(ctx, objs...)
+		return reconcile.Result{}, nil
 	}
 	kvvmi, err := s.KVVMI(ctx)
 	if err != nil {

--- a/images/virtualization-artifact/pkg/controller/vm/internal/pod.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/pod.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package internal
 
 import (

--- a/images/virtualization-artifact/pkg/controller/vm/internal/pod.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/pod.go
@@ -64,7 +64,7 @@ func (h *PodHandler) Handle(ctx context.Context, s state.VirtualMachineState) (r
 		return reconcile.Result{}, err
 	}
 	info := powerstate.ShutdownReason(kvvmi, pods)
-	if info.PodCompeted {
+	if info.PodCompleted {
 		s.Shared(func(s *state.Shared) {
 			s.ShutdownInfo = info
 		})

--- a/images/virtualization-artifact/pkg/controller/vm/internal/pod.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/pod.go
@@ -1,0 +1,71 @@
+package internal
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/deckhouse/virtualization-controller/pkg/controller/powerstate"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/vm/internal/state"
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+)
+
+const namePodHandler = "PodHandler "
+
+func NewPodHandler(client client.Client) *PodHandler {
+	return &PodHandler{
+		client:     client,
+		protection: service.NewProtectionService(client, virtv2.FinalizerPodProtection),
+	}
+}
+
+type PodHandler struct {
+	client     client.Client
+	protection *service.ProtectionService
+}
+
+func (h *PodHandler) Handle(ctx context.Context, s state.VirtualMachineState) (reconcile.Result, error) {
+	if s.VirtualMachine().IsEmpty() {
+		return reconcile.Result{}, nil
+	}
+	current := s.VirtualMachine().Current()
+	pods, err := s.Pods(ctx)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if isDeletion(current) {
+		objs := make([]client.Object, len(pods.Items))
+		for i, p := range pods.Items {
+			objs[i] = p.DeepCopy()
+		}
+		return reconcile.Result{}, h.protection.RemoveProtection(ctx, objs...)
+	}
+	kvvmi, err := s.KVVMI(ctx)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	info := powerstate.ShutdownReason(kvvmi, pods)
+	if info.PodCompeted {
+		s.Shared(func(s *state.Shared) {
+			s.ShutdownInfo = info
+		})
+		return reconcile.Result{}, h.protection.RemoveProtection(ctx, &info.Pod)
+	}
+
+	for _, p := range pods.Items {
+		if podFinal(p) {
+			continue
+		}
+		if err := h.protection.AddProtection(ctx, &p); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+	return reconcile.Result{}, nil
+}
+
+func (h *PodHandler) Name() string {
+	return namePodHandler
+}

--- a/images/virtualization-artifact/pkg/controller/vm/internal/state/state.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/state/state.go
@@ -57,7 +57,7 @@ func New(c client.Client, vm *service.Resource[*virtv2.VirtualMachine, virtv2.Vi
 }
 
 type state struct {
-	client         client.Client
+	client    client.Client
 	mu        sync.RWMutex
 	vm        *service.Resource[*virtv2.VirtualMachine, virtv2.VirtualMachineStatus]
 	kvvm      *virtv1.VirtualMachine
@@ -69,7 +69,7 @@ type state struct {
 	cviByName map[string]*virtv2.ClusterVirtualImage
 	ipAddress *virtv2.VirtualMachineIPAddress
 	cpuModel  *virtv2.VirtualMachineCPUModel
-	shared         Shared
+	shared    Shared
 }
 
 type Shared struct {

--- a/images/virtualization-artifact/pkg/controller/vm/internal/state/state.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/state/state.go
@@ -77,8 +77,6 @@ type Shared struct {
 }
 
 func (s *state) Shared(fn func(s *Shared)) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	fn(&s.shared)
 }
 

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
@@ -553,7 +553,7 @@ func (h *SyncKvvmHandler) syncPowerState(ctx context.Context, s state.VirtualMac
 		}
 		if kvvmi != nil && kvvmi.DeletionTimestamp == nil {
 			if kvvmi.Status.Phase == virtv1.Succeeded {
-				if shutdownInfo.PodCompeted {
+				if shutdownInfo.PodCompleted {
 					// Request to start new KVVMI if guest was restarted.
 					// Cleanup KVVMI is enough if VM was stopped from inside.
 					switch shutdownInfo.Reason {
@@ -586,7 +586,7 @@ func (h *SyncKvvmHandler) syncPowerState(ctx context.Context, s state.VirtualMac
 		// Manual policy requires to handle only guest-reset event.
 		// All types of shutdown are a final state.
 		if kvvmi != nil && kvvmi.DeletionTimestamp == nil {
-			if kvvmi.Status.Phase == virtv1.Succeeded && shutdownInfo.PodCompeted {
+			if kvvmi.Status.Phase == virtv1.Succeeded && shutdownInfo.PodCompleted {
 				// Request to start new KVVMI (with updated settings).
 				switch shutdownInfo.Reason {
 				case powerstate.GuestResetReason:

--- a/images/virtualization-artifact/pkg/controller/vm/internal/util.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/util.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	virtv1 "kubevirt.io/api/core/v1"
@@ -135,4 +136,8 @@ var mapPhases = map[virtv1.VirtualMachinePrintableStatus]virtv2.MachinePhase{
 	// the virtual machine volume are still not bound.
 	virtv1.VirtualMachineStatusWaitingForVolumeBinding: virtv2.MachinePending,
 	kvvmEmptyPhase: virtv2.MachinePending,
+}
+
+func podFinal(pod corev1.Pod) bool {
+	return pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed
 }

--- a/images/virtualization-artifact/pkg/controller/vm/vm_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vm/vm_controller.go
@@ -57,6 +57,7 @@ func NewController(
 		internal.NewBlockDeviceHandler(client, recorder, logger),
 		internal.NewProvisioningHandler(client),
 		internal.NewAgentHandler(),
+		internal.NewPodHandler(client),
 		internal.NewSyncKvvmHandler(dvcrSettings, client, recorder, logger),
 		internal.NewSyncMetadataHandler(client),
 		internal.NewLifeCycleHandler(client, recorder, logger),


### PR DESCRIPTION
## Description
Add pod  handler

## Why do we need it, and what problem does it solve?
We should protect the pods because we need to receive a termination message.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
