### PR TITLE
feat(vm):  VD must be attached to only one virtual machine

### DIFF
--- a/api/core/v1alpha2/events.go
+++ b/api/core/v1alpha2/events.go
@@ -53,6 +53,8 @@ const (
 	// ReasonUnknownHotPluggedVolume is event reason that volume was hot plugged to VirtualMachineInstance, but it is not a VirtualDisk.
 	ReasonUnknownHotPluggedVolume = "UnknownHotPluggedVolume"
 
+	// ReasonVDAlreadyInUse is event reason that VirtualDisk was not attached to VirtualMachine, because VirtualDisk attached to another VirtualMachine.
+	ReasonVDAlreadyInUse = "VirtualDiskAlreadyInUse"
 	// ReasonVMChangesApplied is event reason that changes applied from VM to underlying KVVM.
 	ReasonVMChangesApplied = "ChangesApplied"
 

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
@@ -50,7 +50,7 @@ func GenerateCVMIDiskName(name string) string {
 	return CVMIDiskPrefix + name
 }
 
-func GerOriginalDiskName(prefixedName string) (string, bool) {
+func GetOriginalDiskName(prefixedName string) (string, bool) {
 	if strings.HasPrefix(prefixedName, VMDDiskPrefix) {
 		return strings.TrimPrefix(prefixedName, VMDDiskPrefix), true
 	}

--- a/images/virtualization-artifact/pkg/controller/vd/internal/attachee.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/attachee.go
@@ -47,7 +47,7 @@ func (h AttacheeHandler) Handle(ctx context.Context, vd *virtv2.VirtualDisk) (re
 
 	for _, vm := range attachedVMs {
 		vd.Status.AttachedToVirtualMachines = append(vd.Status.AttachedToVirtualMachines, virtv2.AttachedVirtualMachine{
-			Name: vm.Name,
+			Name: vm.GetName(),
 		})
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vmbda/internal/watcher/kvvmi_watcher.go
+++ b/images/virtualization-artifact/pkg/controller/vmbda/internal/watcher/kvvmi_watcher.go
@@ -125,7 +125,7 @@ func (eh KVVMIEventHandler) getHotPluggedVolumeStatuses(obj client.Object) map[s
 	for _, vs := range kvvmi.Status.VolumeStatus {
 		if vs.HotplugVolume != nil {
 			var name string
-			name, ok = kvbuilder.GerOriginalDiskName(vs.Name)
+			name, ok = kvbuilder.GetOriginalDiskName(vs.Name)
 			if !ok {
 				eh.logger.Warn("VolumeStatus is not a Disk", "vsName", vs.Name, "name", kvvmi.Name, "ns", kvvmi.Namespace)
 				continue


### PR DESCRIPTION
## Description
 the virtual disk must be attached to only one virtual machine
 
## Why do we need it, and what problem does it solve?
we do not support shared disks for virtual machines

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
