### PR TITLE
chore(module): change last artifact to image in werf.yaml

### DIFF
--- a/werf.yaml
+++ b/werf.yaml
@@ -100,7 +100,7 @@ git:
       - hooks/lib/tests
       - hooks/test*
 ---
-artifact: release-channel-version-artifact
+image: release-channel-version-artifact
 from: alpine:3.17
 git:
   - add: /
@@ -120,7 +120,7 @@ shell:
 image: release-channel-version
 from: spotify/scratch
 import:
-  - artifact: release-channel-version-artifact
+  - image: release-channel-version-artifact
     add: /
     to: /
     after: install


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

Get rid of huge deprecation warning after build.

### Before

<img width="1060" alt="Снимок экрана 2024-07-19 в 14 31 07" src="https://github.com/user-attachments/assets/c92b5d3a-3714-4f2e-9370-50e62fab8133">


### After

<img width="1060" alt="Снимок экрана 2024-07-19 в 14 31 51" src="https://github.com/user-attachments/assets/8d5e5cf4-5ec6-46ea-b63b-2ed958403eed">


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
