### PR TITLE
feat(vmip): validate IP address range and improve IP address service

### DIFF
--- a/api/core/v1alpha2/vmipcondition/condition.go
+++ b/api/core/v1alpha2/vmipcondition/condition.go
@@ -35,6 +35,9 @@ type (
 )
 
 const (
+	// VirtualMachineIPAddressIsOutOfTheValidRange is a BoundReason indicating when specified IP address is out of the range in controller settings.
+	VirtualMachineIPAddressIsOutOfTheValidRange BoundReason = "VirtualMachineIPAddressIsOutOfTheValidRange"
+
 	// VirtualMachineIPAddressLeaseAlready is a BoundReason indicating the IP address lease already exists.
 	VirtualMachineIPAddressLeaseAlready BoundReason = "VirtualMachineIPAddressLeaseAlready"
 

--- a/images/virtualization-artifact/pkg/controller/service/errors.go
+++ b/images/virtualization-artifact/pkg/controller/service/errors.go
@@ -23,3 +23,8 @@ var (
 	ErrDefaultStorageClassNotFound = errors.New("default storage class not found")
 	ErrDataVolumeNotRunning        = errors.New("pvc import is not running")
 )
+
+var (
+	ErrIPAddressAlreadyExist = errors.New("the IP address is already allocated")
+	ErrIPAddressOutOfRange   = errors.New("the IP address is out of range")
+)

--- a/images/virtualization-artifact/pkg/controller/service/ip_address_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/ip_address_service.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 
 	"github.com/go-logr/logr"
 	k8snet "k8s.io/utils/net"
@@ -28,19 +29,18 @@ import (
 )
 
 type IpAddressService struct {
-	logger      logr.Logger
-	ParsedCIDRs []*net.IPNet
+	parsedCIDRs []netip.Prefix
 }
 
 func NewIpAddressService(
 	logger logr.Logger,
 	virtualMachineCIDRs []string,
 ) *IpAddressService {
-	parsedCIDRs := make([]*net.IPNet, len(virtualMachineCIDRs))
+	parsedCIDRs := make([]netip.Prefix, len(virtualMachineCIDRs))
 
 	for i, cidr := range virtualMachineCIDRs {
-		_, parsedCIDR, err := net.ParseCIDR(cidr)
-		if err != nil || parsedCIDR == nil {
+		parsedCIDR, err := netip.ParsePrefix(cidr)
+		if err != nil {
 			logger.Error(err, fmt.Sprintf("failed to parse CIDR %s:", cidr), "err", err)
 			return nil
 		}
@@ -48,46 +48,45 @@ func NewIpAddressService(
 	}
 
 	return &IpAddressService{
-		logger:      logger.WithValues("service", "IpAddressService"),
-		ParsedCIDRs: parsedCIDRs,
+		parsedCIDRs: parsedCIDRs,
 	}
 }
 
-func (s IpAddressService) IsAvailableAddress(address string, allocatedIPs common.AllocatedIPs) bool {
-	ip := net.ParseIP(address)
-
-	if _, ok := allocatedIPs[ip.String()]; !ok {
-		for _, cidr := range s.ParsedCIDRs {
-			if cidr.Contains(ip) {
-				// available
-				return true
-			}
-		}
-		// out of range
-		return false
+func (s IpAddressService) IsAvailableAddress(address string, allocatedIPs common.AllocatedIPs) error {
+	ip, err := netip.ParseAddr(address)
+	if err != nil || !ip.IsValid() {
+		return errors.New("invalid IP address format")
 	}
-	// already exists
-	return false
+
+	if _, ok := allocatedIPs[ip.String()]; ok {
+		// already exists
+		return ErrIPAddressAlreadyExist
+	}
+
+	for _, cidr := range s.parsedCIDRs {
+		if cidr.Contains(ip) {
+			// available
+			return nil
+		}
+	}
+	// out of range
+	return ErrIPAddressOutOfRange
 }
 
 func (s IpAddressService) AllocateNewIP(allocatedIPs common.AllocatedIPs) (string, error) {
-	for _, cidr := range s.ParsedCIDRs {
-		for ip := cidr.IP.Mask(cidr.Mask); cidr.Contains(ip); inc(ip) {
-			// Allow allocation of IP address explicitly specified using a 32-bit mask.
-			if k8snet.RangeSize(cidr) != 1 {
-				// Skip the allocation of the first or last addresses within the CIDR range.
+	for _, cidr := range s.parsedCIDRs {
+		for ip := cidr.Addr(); cidr.Contains(ip); ip = ip.Next() {
+			if k8snet.RangeSize(toIPNet(cidr)) != 1 {
 				isFirstLast, err := isFirstLastIP(ip, cidr)
 				if err != nil {
 					return "", err
 				}
-
 				if isFirstLast {
 					continue
 				}
 			}
 
-			_, ok := allocatedIPs[ip.String()]
-			if !ok {
+			if _, ok := allocatedIPs[ip.String()]; !ok {
 				return ip.String(), nil
 			}
 		}
@@ -95,31 +94,30 @@ func (s IpAddressService) AllocateNewIP(allocatedIPs common.AllocatedIPs) (strin
 	return "", errors.New("no remaining ips")
 }
 
-func inc(ip net.IP) {
-	for j := len(ip) - 1; j >= 0; j-- {
-		ip[j]++
-		if ip[j] > 0 {
-			break
-		}
+func toIPNet(prefix netip.Prefix) *net.IPNet {
+	return &net.IPNet{
+		IP:   prefix.Masked().Addr().AsSlice(),
+		Mask: net.CIDRMask(prefix.Bits(), prefix.Addr().BitLen()),
 	}
 }
 
-func isFirstLastIP(ip net.IP, cidr *net.IPNet) (bool, error) {
-	size := int(k8snet.RangeSize(cidr))
+func isFirstLastIP(ip netip.Addr, cidr netip.Prefix) (bool, error) {
+	ipNet := toIPNet(cidr)
+	size := int(k8snet.RangeSize(ipNet))
 
-	first, err := k8snet.GetIndexedIP(cidr, 0)
+	first, err := k8snet.GetIndexedIP(ipNet, 0)
 	if err != nil {
 		return false, err
 	}
 
-	if first.Equal(ip) {
+	if first.Equal(ip.AsSlice()) {
 		return true, nil
 	}
 
-	last, err := k8snet.GetIndexedIP(cidr, size-1)
+	last, err := k8snet.GetIndexedIP(ipNet, size-1)
 	if err != nil {
 		return false, err
 	}
 
-	return last.Equal(ip), nil
+	return last.Equal(ip.AsSlice()), nil
 }

--- a/images/virtualization-artifact/pkg/controller/service/ip_address_service_test.go
+++ b/images/virtualization-artifact/pkg/controller/service/ip_address_service_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"net/netip"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/deckhouse/virtualization-controller/pkg/controller/common"
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+)
+
+var _ = Describe("IpAddressService", func() {
+	var (
+		ipService    *IpAddressService
+		allocatedIPs common.AllocatedIPs
+		logger       logr.Logger
+	)
+
+	BeforeEach(func() {
+		virtualMachineCIDRs := []string{"192.168.1.0/24"}
+		ipService = NewIpAddressService(logger, virtualMachineCIDRs)
+		allocatedIPs = make(common.AllocatedIPs)
+	})
+
+	Describe("IsAvailableAddress", func() {
+		Context("with a valid and available IP address", func() {
+			It("should return no error", func() {
+				err := ipService.IsAvailableAddress("192.168.1.10", allocatedIPs)
+				Expect(err).To(BeNil())
+			})
+		})
+
+		Context("with an invalid IP address", func() {
+			It("should return an error", func() {
+				err := ipService.IsAvailableAddress("invalid-ip", allocatedIPs)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Context("with an already allocated IP address", func() {
+			It("should return ErrIPAddressAlreadyExist", func() {
+				ref := virtv2.VirtualMachineIPAddressLeaseIpAddressRef{
+					Name:      "test",
+					Namespace: "test",
+				}
+
+				spec := virtv2.VirtualMachineIPAddressLeaseSpec{
+					VirtualMachineIPAddressRef: &ref,
+				}
+
+				lease := &virtv2.VirtualMachineIPAddressLease{
+					Spec: spec,
+				}
+
+				allocatedIPs["192.168.1.10"] = lease
+				err := ipService.IsAvailableAddress("192.168.1.10", allocatedIPs)
+				Expect(err).To(Equal(ErrIPAddressAlreadyExist))
+			})
+		})
+
+		Context("with an IP address out of range", func() {
+			It("should return ErrIPAddressOutOfRange", func() {
+				err := ipService.IsAvailableAddress("10.0.0.1", allocatedIPs)
+				Expect(err).To(Equal(ErrIPAddressOutOfRange))
+			})
+		})
+	})
+
+	Describe("AllocateNewIP", func() {
+		Context("when there are available IP addresses in the range", func() {
+			It("should allocate a new IP address", func() {
+				ip, err := ipService.AllocateNewIP(allocatedIPs)
+				Expect(err).To(BeNil())
+				Expect(ip).ToNot(BeEmpty())
+				Expect(netip.MustParseAddr(ip).IsValid()).To(BeTrue())
+			})
+		})
+
+		Context("when there are no available IP addresses in the range", func() {
+			It("should return an error", func() {
+				virtualMachineCIDRs := []string{"192.168.1.0/31"}
+				ipService := NewIpAddressService(logger, virtualMachineCIDRs)
+				_, err := ipService.AllocateNewIP(allocatedIPs)
+				Expect(err).To(MatchError("no remaining ips"))
+			})
+		})
+	})
+})

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/iplease_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/iplease_handler.go
@@ -91,7 +91,10 @@ func (h IPLeaseHandler) Handle(ctx context.Context, state state.VMIPState) (reco
 		h.logger.Info("Lease is released: set binding")
 
 		if lease.Spec.VirtualMachineIPAddressRef.Namespace != vmip.Namespace {
-			return reconcile.Result{}, fmt.Errorf("the selected VirtualMachineIP lease belongs to a different namespace: %s", lease.Spec.VirtualMachineIPAddressRef.Namespace)
+			msg := fmt.Sprintf("the selected VirtualMachineIP lease belongs to a different namespace: %s", lease.Spec.VirtualMachineIPAddressRef.Namespace)
+			h.logger.Error(nil, msg)
+			h.recorder.Event(vmip, corev1.EventTypeWarning, vmipcondition.VirtualMachineIPAddressLeaseNotFound, msg)
+			return reconcile.Result{}, nil
 		}
 
 		lease.Spec.VirtualMachineIPAddressRef = &virtv2.VirtualMachineIPAddressLeaseIpAddressRef{

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/iplease_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/iplease_handler.go
@@ -18,6 +18,7 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -29,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/deckhouse/virtualization-controller/pkg/controller/common"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vmip/internal/state"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vmip/internal/util"
@@ -122,10 +124,36 @@ func (h IPLeaseHandler) createNewLease(ctx context.Context, state state.VMIPStat
 		vmipStatus.Address = vmip.Spec.StaticIP
 	}
 
-	if !h.ipService.IsAvailableAddress(vmipStatus.Address, state.AllocatedIPs()) {
-		msg := fmt.Sprintf("VirtualMachineIP cannot be created: the address %s has already been allocated for another vmip", vmip.Spec.StaticIP)
+	err := h.ipService.IsAvailableAddress(vmipStatus.Address, state.AllocatedIPs())
+	if err != nil {
+		vmipStatus.Address = ""
+		msg := fmt.Sprintf("the VirtualMachineIP cannot be created: %s", err.Error())
 		h.logger.Info(msg)
-		h.recorder.Event(vmip, corev1.EventTypeWarning, vmipcondition.VirtualMachineIPAddressLeaseLost, msg)
+
+		mgr := conditions.NewManager(vmipStatus.Conditions)
+		conditionBound := conditions.NewConditionBuilder(vmipcondition.BoundType).
+			Generation(vmip.GetGeneration())
+
+		switch {
+		case errors.Is(err, service.ErrIPAddressOutOfRange):
+			vmipStatus.Phase = virtv2.VirtualMachineIPAddressPhasePending
+			mgr.Update(conditionBound.Status(metav1.ConditionFalse).
+				Reason(vmipcondition.VirtualMachineIPAddressIsOutOfTheValidRange).
+				Message(fmt.Sprintf("The requested address %s is out of the valid range",
+					vmip.Spec.StaticIP)).
+				Condition())
+			h.recorder.Event(vmip, corev1.EventTypeWarning, vmipcondition.VirtualMachineIPAddressIsOutOfTheValidRange, msg)
+		case errors.Is(err, service.ErrIPAddressAlreadyExist):
+			vmipStatus.Phase = virtv2.VirtualMachineIPAddressPhasePending
+			mgr.Update(conditionBound.Status(metav1.ConditionFalse).
+				Reason(vmipcondition.VirtualMachineIPAddressLeaseAlready).
+				Message(fmt.Sprintf("VirtualMachineIPAddressLease %s is bound to another VirtualMachineIP",
+					common.IpToLeaseName(vmipStatus.Address))).
+				Condition())
+			h.recorder.Event(vmip, corev1.EventTypeWarning, vmipcondition.VirtualMachineIPAddressLeaseAlready, msg)
+		}
+
+		vmipStatus.Conditions = mgr.Generate()
 		return reconcile.Result{}, nil
 	}
 
@@ -137,7 +165,7 @@ func (h IPLeaseHandler) createNewLease(ctx context.Context, state state.VMIPStat
 		"refNamespace", vmip.Namespace,
 	)
 
-	err := h.client.Create(ctx, &virtv2.VirtualMachineIPAddressLease{
+	err = h.client.Create(ctx, &virtv2.VirtualMachineIPAddressLease{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: leaseName,
 		},

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/lifecycle_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/lifecycle_handler.go
@@ -60,16 +60,16 @@ func (h *LifecycleHandler) Handle(ctx context.Context, state state.VMIPState) (r
 	conditionAttach := conditions.NewConditionBuilder(vmipcondition.AttachedType).
 		Generation(vmip.GetGeneration())
 
-	if vm != nil {
-		vmipStatus.VirtualMachine = vm.Name
-		mgr.Update(conditionAttach.Status(metav1.ConditionTrue).
-			Reason(vmipcondition.Attached).
-			Condition())
-	} else {
+	if vm == nil || vm.DeletionTimestamp != nil {
 		vmipStatus.VirtualMachine = ""
 		mgr.Update(conditionAttach.Status(metav1.ConditionFalse).
 			Reason(vmipcondition.VirtualMachineNotFound).
 			Message("Virtual machine not found").
+			Condition())
+	} else {
+		vmipStatus.VirtualMachine = vm.Name
+		mgr.Update(conditionAttach.Status(metav1.ConditionTrue).
+			Reason(vmipcondition.Attached).
 			Condition())
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/protection_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/protection_handler.go
@@ -47,7 +47,7 @@ func (h *ProtectionHandler) Handle(ctx context.Context, state state.VMIPState) (
 		return reconcile.Result{}, err
 	}
 
-	if vm == nil {
+	if vm == nil || vm.DeletionTimestamp != nil {
 		h.logger.Info("VirtualMachineIP is no longer attached to any VM, proceeding with detachment", "VirtualMachineIPName", vmip.Name)
 		controllerutil.RemoveFinalizer(vmip, virtv2.FinalizerIPAddressCleanup)
 	} else if vmip.GetDeletionTimestamp() == nil {

--- a/images/virtualization-artifact/pkg/controller/vmip/vmip_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/vmip_controller.go
@@ -66,7 +66,7 @@ func NewController(
 
 	if err = builder.WebhookManagedBy(mgr).
 		For(&v1alpha2.VirtualMachineIPAddress{}).
-		WithValidator(NewValidator(log, mgr.GetClient())).
+		WithValidator(NewValidator(log, mgr.GetClient(), ipService)).
 		Complete(); err != nil {
 		return nil, err
 	}

--- a/images/virtualization-artifact/pkg/controller/vmiplease/internal/retention_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmiplease/internal/retention_handler.go
@@ -72,7 +72,7 @@ func (h *RetentionHandler) Handle(ctx context.Context, state state.VMIPLeaseStat
 				return reconcile.Result{}, nil
 			}
 
-			return reconcile.Result{RequeueAfter: 1 * time.Minute}, nil
+			return reconcile.Result{RequeueAfter: h.retentionDuration - duration}, nil
 		}
 	}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

- Add handling case, when trying to create VirtualMachineIPAddress outside the range specified in the module settings
- Add reason "VirtualMachineIPAddressOutOfTheValidRange" for "Bound" condition
- Refactor ip_address_service  with the use of net.IPNet to netip.Addr 
- Fix frequent reconciles for an object with the 'Released' status
- Add write to events, when the selected VirtualMachineIPLease belongs to a different namespace

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
