### PR TITLE
refactor(kube-api-rewriter): fix APIResourcesList rewriter

### DIFF
--- a/images/kube-api-proxy/Taskfile.dist.yaml
+++ b/images/kube-api-proxy/Taskfile.dist.yaml
@@ -8,7 +8,7 @@ includes:
     optional: true
 
 vars:
-  DevRegistry: "dev-registry.deckhouse.io/virt/dev/$USER"
+  DevImage: "localhost:5000/$USER/kube-api-proxy:latest"
 
 tasks:
   default:
@@ -18,8 +18,8 @@ tasks:
     desc: "build latest image with proxy and test-controller"
     cmds:
       - |
-        docker build . -t {{.DevRegistry}}/kube-api-proxy:latest -f local/Dockerfile
-        docker push {{.DevRegistry}}/kube-api-proxy:latest
+        docker build . -t {{.DevImage}} -f local/Dockerfile
+        docker push {{.DevImage}}
 
   dev:deploy:
     desc: "apply manifest with proxy and test-controller"
@@ -30,7 +30,7 @@ tasks:
           exit 1
         fi
       - |
-        cat local/proxy.yaml | USER=${USER} envsubst | kubectl -n kproxy apply -f -
+        cat local/proxy.yaml | IMAGE={{.DevImage}} envsubst | kubectl -n kproxy apply -f -
 
   dev:restart:
     desc: "restart deployment"
@@ -74,8 +74,8 @@ tasks:
     desc: "run kubectl in proxy deployment"
     cmds:
       - |
-        kubectl -n kproxy exec -ti deploy/kube-api-proxy -c proxy-only -- kubectl -s 127.0.0.1:23916 {{.CLI_ARGS}}
-        #kubectl -n d8-virtualization exec -ti deploy/virt-operator -- kubectl -s 127.0.0.1:23915 {{.CLI_ARGS}}
+        kubectl -n kproxy exec deploy/kube-api-proxy -c proxy-only -- kubectl -s 127.0.0.1:23916 {{.CLI_ARGS}}
+        #kubectl -n d8-virtualization exec  deploy/virt-operator -- kubectl -s 127.0.0.1:23915 {{.CLI_ARGS}}
 
   logs:proxy:
     desc: "Logs for proxy container"

--- a/images/kube-api-proxy/local/proxy.yaml
+++ b/images/kube-api-proxy/local/proxy.yaml
@@ -24,7 +24,7 @@ spec:
         - name: "deckhouse-registry"
       containers:
         - name: proxy-only
-          image: dev-registry.deckhouse.io/virt/dev/${USER}/kube-api-proxy:latest
+          image: "${IMAGE}"
           imagePullPolicy: Always
           command:
             - /proxy
@@ -32,7 +32,7 @@ spec:
             - name: CLIENT_PROXY_PORT
               value: "23916"
         - name: proxy
-          image: dev-registry.deckhouse.io/virt/dev/${USER}/kube-api-proxy:latest
+          image: "${IMAGE}"
           imagePullPolicy: Always
           command:
             - /proxy
@@ -51,7 +51,7 @@ spec:
             - mountPath: /tmp/proxy-webhook/serving-certs
               name: test-admission-webhook
         - name: controller
-          image: dev-registry.deckhouse.io/virt/dev/${USER}/kube-api-proxy:latest
+          image: "${IMAGE}"
           imagePullPolicy: Always
           command:
             - /test-controller

--- a/images/kube-api-proxy/pkg/rewriter/rule_rewriter.go
+++ b/images/kube-api-proxy/pkg/rewriter/rule_rewriter.go
@@ -225,7 +225,8 @@ func (rw *RuleBasedRewriter) rewriteLabelSelector(rawQuery string) string {
 }
 
 // RewriteJSONPayload does rewrite based on kind.
-func (rw *RuleBasedRewriter) RewriteJSONPayload(targetReq *TargetRequest, obj []byte, action Action) ([]byte, error) {
+// TODO(future refactor): Remove targetReq in all callers.
+func (rw *RuleBasedRewriter) RewriteJSONPayload(_ *TargetRequest, obj []byte, action Action) ([]byte, error) {
 	// Detect Kind
 	kind := gjson.GetBytes(obj, "kind").String()
 
@@ -245,7 +246,7 @@ func (rw *RuleBasedRewriter) RewriteJSONPayload(targetReq *TargetRequest, obj []
 		rwrBytes, err = RewriteAPIGroup(rw.Rules, obj)
 
 	case "APIResourceList":
-		rwrBytes, err = RewriteAPIResourceList(rw.Rules, obj, targetReq.OrigGroup())
+		rwrBytes, err = RewriteAPIResourceList(rw.Rules, obj)
 
 	case "APIGroupDiscoveryList":
 		rwrBytes, err = RewriteAPIGroupDiscoveryList(rw.Rules, obj)

--- a/images/kube-api-proxy/pkg/rewriter/rules.go
+++ b/images/kube-api-proxy/pkg/rewriter/rules.go
@@ -208,7 +208,8 @@ func (rr *RewriteRules) KindRules(apiGroup, kind string) (*GroupRule, *ResourceR
 	return nil, nil
 }
 
-func (rr *RewriteRules) ResourceRules(group, resource string) (*GroupRule, *ResourceRule) {
+func (rr *RewriteRules) ResourceRules(apiGroup, resource string) (*GroupRule, *ResourceRule) {
+	group, _, _ := strings.Cut(apiGroup, "/")
 	groupRule, ok := rr.Rules[group]
 	if !ok {
 		return nil, nil
@@ -254,6 +255,8 @@ func (rr *RewriteRules) RenameKind(kind string) string {
 	return rr.KindPrefix + kind
 }
 
+// RestoreResource restores renamed resource to its original state, keeping suffix.
+// E.g. "prefixedsomeresources/scale" will be restored to "someresources/scale".
 func (rr *RewriteRules) RestoreResource(resource string) string {
 	return strings.TrimPrefix(resource, rr.ResourceTypePrefix)
 }
@@ -302,6 +305,14 @@ func (rr *RewriteRules) RestoreCategories(resourceRule *ResourceRule) []string {
 		return []string{}
 	}
 	return resourceRule.Categories
+}
+
+func (rr *RewriteRules) RenameShortName(shortName string) string {
+	return rr.ShortNamePrefix + shortName
+}
+
+func (rr *RewriteRules) RestoreShortName(shortName string) string {
+	return strings.TrimPrefix(shortName, rr.ShortNamePrefix)
 }
 
 func (rr *RewriteRules) RenameShortNames(shortNames []string) []string {


### PR DESCRIPTION
## Description

- Fix APIResourcesList rewriter: Keep version in groupVersion, do not replace with PreferredVersion to prevent duplicates in Kubernetes <=1.26.
- Fix APIGroupList rewriter: Rewrite response instead of reconstructing group description from rules.
- Add test for APIGroupList restoring.
- Use localhost:5000 for local proxy deployment.


## Why do we need it, and what problem does it solve?

Error on Kubernetes 1.26:

```
{"level":"error","ts":"2024-07-26T15:36:03Z",
"logger":"controller-runtime.source",
"msg":"failed to get informer from cache",
"error":"cdi.kubevirt.io/, Kind=CDI matches multiple kinds
   [cdi.kubevirt.io/v1beta1, Kind=CDI cdi.kubevirt.io/v1beta1, 
Kind=CDI cdi.kubevirt.io/v1beta1, Kind=CDI cdi.kubevirt.io/v1beta1, 
Kind=CDI cdi.kubevirt.io/v1beta1, Kind=CDI cdi.kubevirt.io/v1beta1, 
Kind=CDI cdi.kubevirt.io/v1beta1, Kind=CDI cdi.kubevirt.io/v1beta1, Kind=CDI]",
"stacktrace": ...
```

- kube-api-rewriter should properly rewrite regular discovery responses
- kube-api-rewriter should work in Kubernetes 1.26

## What is the expected result?

No duplicates after restoring discovery responses.

Before:
```
task dev:kubectl -- get --raw /apis/ | jq '.groups[]|.name' -r | sort | uniq -c | grep kubevirt
   8 cdi.kubevirt.io
   8 clone.kubevirt.io
   8 export.kubevirt.io
   8 instancetype.kubevirt.io
   8 kubevirt.io
   8 migrations.kubevirt.io
   8 pool.kubevirt.io
   8 snapshot.kubevirt.io
```

After:
```
task dev:kubectl -- get --raw /apis/ | jq '.groups[]|.name' -r | sort | uniq -c | grep kubevirt
   1 cdi.kubevirt.io
   1 clone.kubevirt.io
   1 export.kubevirt.io
   1 instancetype.kubevirt.io
   1 kubevirt.io
   1 migrations.kubevirt.io
   1 pool.kubevirt.io
   1 snapshot.kubevirt.io
```

<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
