### PR TITLE
fix(vmip): sticking in bound phase

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vmip/internal/lifecycle_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/lifecycle_handler.go
@@ -60,16 +60,16 @@ func (h *LifecycleHandler) Handle(ctx context.Context, state state.VMIPState) (r
 	conditionAttach := conditions.NewConditionBuilder(vmipcondition.AttachedType).
 		Generation(vmip.GetGeneration())
 
-	if vm != nil {
-		vmipStatus.VirtualMachine = vm.Name
-		mgr.Update(conditionAttach.Status(metav1.ConditionTrue).
-			Reason(vmipcondition.Attached).
-			Condition())
-	} else {
+	if vm == nil || vm.DeletionTimestamp != nil {
 		vmipStatus.VirtualMachine = ""
 		mgr.Update(conditionAttach.Status(metav1.ConditionFalse).
 			Reason(vmipcondition.VirtualMachineNotFound).
 			Message("Virtual machine not found").
+			Condition())
+	} else {
+		vmipStatus.VirtualMachine = vm.Name
+		mgr.Update(conditionAttach.Status(metav1.ConditionTrue).
+			Reason(vmipcondition.Attached).
 			Condition())
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/protection_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/protection_handler.go
@@ -47,7 +47,7 @@ func (h *ProtectionHandler) Handle(ctx context.Context, state state.VMIPState) (
 		return reconcile.Result{}, err
 	}
 
-	if vm == nil {
+	if vm == nil || vm.DeletionTimestamp != nil {
 		h.logger.Info("VirtualMachineIP is no longer attached to any VM, proceeding with detachment", "VirtualMachineIPName", vmip.Name)
 		controllerutil.RemoveFinalizer(vmip, virtv2.FinalizerIPAddressCleanup)
 	} else if vmip.GetDeletionTimestamp() == nil {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Added waiting for the virtual machine to complete.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Fix bug with sticking VirtualMachineIPAddres in 'Bound' phase after deleting the virtual machine.
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
