### PR TITLE
fix(vm): fix panic and virtClient

### DIFF
--- a/api/client/kubeclient/client.go
+++ b/api/client/kubeclient/client.go
@@ -62,7 +62,7 @@ type Client interface {
 	VirtualMachineIPAddresses(namespace string) virtualizationv1alpha2.VirtualMachineIPAddressInterface
 	VirtualMachineIPAddressLeases() virtualizationv1alpha2.VirtualMachineIPAddressLeaseInterface
 	VirtualMachineOperations(namespace string) virtualizationv1alpha2.VirtualMachineOperationInterface
-	VirtualMachineCPUModels() virtualizationv1alpha2.VirtualMachineCPUModelInterface
+	VirtualMachineClasses() virtualizationv1alpha2.VirtualMachineClassInterface
 }
 type StreamOptions struct {
 	In  io.Reader
@@ -126,6 +126,6 @@ func (c client) VirtualMachineOperations(namespace string) virtualizationv1alpha
 	return c.virtClient.VirtualizationV1alpha2().VirtualMachineOperations(namespace)
 }
 
-func (c client) VirtualMachineCPUModels() virtualizationv1alpha2.VirtualMachineCPUModelInterface {
-	return c.virtClient.VirtualizationV1alpha2().VirtualMachineCPUModels()
+func (c client) VirtualMachineClasses() virtualizationv1alpha2.VirtualMachineClassInterface {
+	return c.virtClient.VirtualizationV1alpha2().VirtualMachineClasses()
 }

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
@@ -165,13 +165,16 @@ func (b *KVVM) SetAffinity(vmAffinity *corev1.Affinity, classMatchExpressions []
 		return
 	}
 	if vmAffinity == nil {
-		vmAffinity = &corev1.Affinity{
-			NodeAffinity: &corev1.NodeAffinity{
-				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-					NodeSelectorTerms: []corev1.NodeSelectorTerm{},
-				},
-			},
-		}
+		vmAffinity = &corev1.Affinity{}
+	}
+	if vmAffinity.NodeAffinity == nil {
+		vmAffinity.NodeAffinity = &corev1.NodeAffinity{}
+	}
+	if vmAffinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		vmAffinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &corev1.NodeSelector{}
+	}
+	if vmAffinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms == nil {
+		vmAffinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = []corev1.NodeSelectorTerm{}
 	}
 
 	vmAffinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = append(

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
@@ -160,8 +160,8 @@ func (b *KVVM) SetPriorityClassName(priorityClassName string) {
 }
 
 func (b *KVVM) SetAffinity(vmAffinity *corev1.Affinity, classMatchExpressions []corev1.NodeSelectorRequirement) {
-	if vmAffinity == nil && len(classMatchExpressions) == 0 {
-		b.Resource.Spec.Template.Spec.Affinity = nil
+	if len(classMatchExpressions) == 0 {
+		b.Resource.Spec.Template.Spec.Affinity = vmAffinity
 		return
 	}
 	if vmAffinity == nil {
@@ -173,12 +173,12 @@ func (b *KVVM) SetAffinity(vmAffinity *corev1.Affinity, classMatchExpressions []
 			},
 		}
 	}
-	if len(classMatchExpressions) > 0 {
-		vmAffinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = append(
-			vmAffinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
-			corev1.NodeSelectorTerm{MatchExpressions: classMatchExpressions},
-		)
-	}
+
+	vmAffinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = append(
+		vmAffinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
+		corev1.NodeSelectorTerm{MatchExpressions: classMatchExpressions},
+	)
+
 	b.Resource.Spec.Template.Spec.Affinity = vmAffinity
 }
 

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_test.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_test.go
@@ -1,0 +1,101 @@
+package kvbuilder
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestSetAffinity(t *testing.T) {
+	name := "test-name"
+	namespace := "test-namespace"
+
+	getDefaultMatchExpressions := func() []corev1.NodeSelectorRequirement {
+		return []corev1.NodeSelectorRequirement{
+			{
+				Key:      "node-role.kubernetes.io/worker",
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{""},
+			},
+		}
+	}
+	getDefaultAffinity := func() *corev1.Affinity {
+		return &corev1.Affinity{
+			NodeAffinity: &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{
+						{
+							MatchExpressions: getDefaultMatchExpressions(),
+						},
+					},
+				},
+			},
+		}
+	}
+	tests := []struct {
+		name                  string
+		expect                *corev1.Affinity
+		affinity              *corev1.Affinity
+		classMatchExpressions []corev1.NodeSelectorRequirement
+	}{
+		{
+			name:                  "test affinity and classMatchExpressions is nil",
+			expect:                nil,
+			affinity:              nil,
+			classMatchExpressions: nil,
+		},
+		{
+			name:                  "test only affinity nil",
+			expect:                getDefaultAffinity(),
+			affinity:              nil,
+			classMatchExpressions: getDefaultMatchExpressions(),
+		},
+		{
+			name:                  "test only classMatchExpressions nil",
+			expect:                getDefaultAffinity(),
+			affinity:              getDefaultAffinity(),
+			classMatchExpressions: nil,
+		},
+		{
+			name: "test affinity and classMatchExpressions exist",
+			expect: &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchExpressions: getDefaultMatchExpressions(),
+							},
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									{
+										Key:      "node-role.kubernetes.io/master",
+										Operator: corev1.NodeSelectorOpIn,
+										Values:   []string{""},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			affinity: getDefaultAffinity(),
+			classMatchExpressions: []corev1.NodeSelectorRequirement{
+				{
+					Key:      "node-role.kubernetes.io/master",
+					Operator: corev1.NodeSelectorOpIn,
+					Values:   []string{""},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		builder := NewEmptyKVVM(types.NamespacedName{Name: name, Namespace: namespace}, KVVMOptions{})
+		builder.SetAffinity(test.affinity, test.classMatchExpressions)
+		if !reflect.DeepEqual(builder.Resource.Spec.Template.Spec.Affinity, test.expect) {
+			t.Errorf("test %s failed.expected affinity %v, got %v", test.name, test.expect, builder.Resource.Spec.Template.Spec.Affinity)
+		}
+	}
+}

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_test.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package kvbuilder
 
 import (

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_test.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_test.go
@@ -105,6 +105,12 @@ func TestSetAffinity(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:                  "test affinity is nil, but nodeAffinity nil",
+			expect:                getDefaultAffinity(),
+			affinity:              &corev1.Affinity{},
+			classMatchExpressions: getDefaultMatchExpressions(),
+		},
 	}
 
 	for _, test := range tests {

--- a/tests/performance/shatal/internal/shatal/creator.go
+++ b/tests/performance/shatal/internal/shatal/creator.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
@@ -109,17 +110,17 @@ func (s *Creator) createVMs(ctx context.Context) {
 				},
 			},
 			Spec: v1alpha2.VirtualMachineSpec{
+				VirtualMachineClassName:  "generic-v1",
 				RunPolicy:                v1alpha2.AlwaysOnPolicy,
 				EnableParavirtualization: true,
 				OsType:                   v1alpha2.GenericOs,
 				Bootloader:               "BIOS",
 				CPU: v1alpha2.CPUSpec{
-					VirtualMachineCPUModel: "generic-v1",
-					Cores:                  1,
-					CoreFraction:           "10%",
+					Cores:        1,
+					CoreFraction: "10%",
 				},
 				Memory: v1alpha2.MemorySpec{
-					Size: "500Mi",
+					Size: resource.MustParse("512Mi"),
 				},
 				BlockDeviceRefs: []v1alpha2.BlockDeviceSpecRef{
 					{


### PR DESCRIPTION
## Description
* fix panic when generating kvvm with affinity
* fix virtclient. Add VirtualMachineClass and remove old VirtualMachineCpuModel
* fix shatal 

## Checklist
- [X] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
