### PR TITLE
refactor(vmip): remove requeue

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vmip/internal/iplease_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/iplease_handler.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -75,9 +74,8 @@ func (h IPLeaseHandler) Handle(ctx context.Context, state state.VMIPState) (reco
 		return h.createNewLease(ctx, state)
 
 	case lease.Status.Phase == "":
-		// TODO: Replace this requeue with proper UpdateFunc in VirtualMachineIPAddressLease watch setup.
 		h.logger.Info("Lease is not ready: waiting for the lease")
-		return reconcile.Result{Requeue: true, RequeueAfter: 2 * time.Second}, nil
+		return reconcile.Result{}, nil
 
 	case util.IsBoundLease(lease, vmip):
 		h.logger.Info("Lease already exists, VirtualMachineIP ref is valid")

--- a/images/virtualization-artifact/pkg/controller/vmip/vmip_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/vmip_reconciler.go
@@ -63,7 +63,7 @@ func (r *Reconciler) SetupController(_ context.Context, mgr manager.Manager, ctr
 		predicate.Funcs{
 			CreateFunc: func(e event.CreateEvent) bool { return true },
 			DeleteFunc: func(e event.DeleteEvent) bool { return true },
-			UpdateFunc: func(e event.UpdateEvent) bool { return false },
+			UpdateFunc: func(e event.UpdateEvent) bool { return true },
 		},
 	); err != nil {
 		return fmt.Errorf("error setting watch on leases: %w", err)


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Remove from controller requeue when waiting for VirtualMachineIPAddressLease

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
