### PR TITLE
fix(vm): proper boot from VirtualImage and ClusterVirtualImage

### DIFF
--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
@@ -241,6 +241,8 @@ type SetDiskOptions struct {
 	IsEphemeral  bool
 
 	Serial string
+
+	BootOrder uint
 }
 
 func (b *KVVM) ClearDisks() {
@@ -266,6 +268,10 @@ func (b *KVVM) SetDisk(name string, opts SetDiskOptions) error {
 		Name:       name,
 		DiskDevice: dd,
 		Serial:     opts.Serial,
+	}
+
+	if opts.BootOrder > 0 {
+		disk.BootOrder = &opts.BootOrder
 	}
 
 	b.Resource.Spec.Template.Spec.Domain.Devices.Disks = util.SetArrayElem(


### PR DESCRIPTION
## Description

- Add bootOrder field to all disks in KVVM.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

Qemu uses Seabios firmware when bootloader is set to BIOS. Unlike UEFI, Seabios doesn't scan devices and boot only from the first attached hdd. bootOrder should be set on each disk to tell qemu to boot from other disks.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Before

CDROM position is not important, VM always boots from the first HDD:

```
spec:
  blockDeviceRefs:
  - kind: VirtualDisk
    name: ubuntu-iso-boot-root
  - kind: ClusterVirtualImage
    name: ubuntu-22-04-server-iso
  bootloader: BIOS
```

```
spec:
  blockDeviceRefs:
  - kind: ClusterVirtualImage
    name: ubuntu-22-04-server-iso
  - kind: VirtualDisk
    name: ubuntu-iso-boot-root
  bootloader: BIOS
```

The result is this:

![image](https://github.com/user-attachments/assets/9b573225-b153-46b4-a760-6264d05ebd72)


## After

Set HDD as a first disk and a CDROM as a second to boot from HDD after installer reboots VM:

```
spec:
  blockDeviceRefs:
  - kind: VirtualDisk
    name: ubuntu-iso-boot-root
  - kind: ClusterVirtualImage
    name: ubuntu-22-04-server-iso
  bootloader: BIOS
```

Adding bootOrder fields help to boot into Ubuntu installer from CDROM:

<img width="1392" alt="image" src="https://github.com/user-attachments/assets/ea4bda76-2d37-4917-839e-aebdaa42abd7">

<details><summary>VM, CVI, and VD manifests</summary>
<p>
```
---
apiVersion: virtualization.deckhouse.io/v1alpha2
kind: ClusterVirtualImage
metadata:
  name: ubuntu-22-04-server-iso
  labels:
    dir: vm-ubuntu
spec:
  dataSource:
    type: "HTTP"
    http:
      url: "https://releases.ubuntu.com/22.04.3/ubuntu-22.04.3-live-server-amd64.iso"
---
apiVersion: virtualization.deckhouse.io/v1alpha2
kind: VirtualDisk
metadata:
  name: ubuntu-iso-boot-root
  labels:
    dir: vm-ubuntu
spec:
  persistentVolumeClaim:
    size: 40Gi
    storageClassName: "linstor-thick-data-r1"
---
apiVersion: virtualization.deckhouse.io/v1alpha2
kind: VirtualMachine
metadata:
  name: ubuntu-iso-boot
  labels:
    dir: vm-ubuntu
spec:
  blockDeviceRefs:
  - kind: VirtualDisk
    name: ubuntu-iso-boot-root
  - kind: ClusterVirtualImage
    name: ubuntu-22-04-server-iso
  bootloader: BIOS
  virtualMachineClassName: generic
  cpu:
    coreFraction: 100%
    cores: 4
  enableParavirtualization: true
  memory:
    size: 4Gi
  osType: Generic
  runPolicy: AlwaysOn
  terminationGracePeriodSeconds: 60
```
</p>
</details> 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
