### PR TITLE
fix(vmip): create double lease

### DIFF
--- a/images/virtualization-artifact/pkg/controller/indexer/indexer.go
+++ b/images/virtualization-artifact/pkg/controller/indexer/indexer.go
@@ -30,6 +30,8 @@ const (
 	IndexFieldVMByVD    = "spec.blockDeviceRefs.VirtualDisk"
 	IndexFieldVMByVI    = "spec.blockDeviceRefs.VirtualImage"
 	IndexFieldVMByCVI   = "spec.blockDeviceRefs.ClusterVirtualImage"
+
+	IndexFieldVMIPLeaseByVMIP = "spec.virtualMachineIPAddressRef.Name"
 )
 
 type indexFunc func(ctx context.Context, mgr manager.Manager) error
@@ -40,6 +42,7 @@ func IndexALL(ctx context.Context, mgr manager.Manager) error {
 		IndexVMByVD,
 		IndexVMByVI,
 		IndexVMByCVI,
+		IndexVMIPLeaseByVMIP,
 	} {
 		if err := fn(ctx, mgr); err != nil {
 			return err
@@ -89,4 +92,14 @@ func getBlockDeviceNamesByKind(obj client.Object, kind virtv2.BlockDeviceKind) [
 		res = append(res, bdr.Name)
 	}
 	return res
+}
+
+func IndexVMIPLeaseByVMIP(ctx context.Context, mgr manager.Manager) error {
+	return mgr.GetFieldIndexer().IndexField(ctx, &virtv2.VirtualMachineIPAddressLease{}, IndexFieldVMIPLeaseByVMIP, func(object client.Object) []string {
+		lease, ok := object.(*virtv2.VirtualMachineIPAddressLease)
+		if !ok || lease == nil {
+			return nil
+		}
+		return []string{lease.Spec.VirtualMachineIPAddressRef.Name}
+	})
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
- fix the issue of creating a lease duplicate
- fix the issue of lease sticking
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
