### PR TITLE
fix(vm):  remove pod finalizers after pod completion

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm/internal/pod.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/pod.go
@@ -28,7 +28,7 @@ import (
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
-const namePodHandler = "PodHandler "
+const namePodHandler = "PodHandler"
 
 func NewPodHandler(client client.Client) *PodHandler {
 	return &PodHandler{
@@ -69,11 +69,13 @@ func (h *PodHandler) Handle(ctx context.Context, s state.VirtualMachineState) (r
 		s.Shared(func(s *state.Shared) {
 			s.ShutdownInfo = info
 		})
-		return reconcile.Result{}, h.protection.RemoveProtection(ctx, &info.Pod)
 	}
 
 	for _, p := range pods.Items {
 		if podFinal(p) {
+			if err := h.protection.RemoveProtection(ctx, &p); err != nil {
+				return reconcile.Result{}, err
+			}
 			continue
 		}
 		if err := h.protection.AddProtection(ctx, &p); err != nil {

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_metadata.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_metadata.go
@@ -101,7 +101,7 @@ func (h *SyncMetadataHandler) Handle(ctx context.Context, s state.VirtualMachine
 
 			if metaUpdated {
 				if err = h.client.Update(ctx, &pod); err != nil {
-					return reconcile.Result{}, fmt.Errorf("fauled to update KubeVirt Pod %q: %w", pod.GetName(), err)
+					return reconcile.Result{}, fmt.Errorf("failed to update KubeVirt Pod %q: %w", pod.GetName(), err)
 				}
 			}
 		}


### PR DESCRIPTION
## Description
 remove pod finalizers after pod completion

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
