### PR TITLE
feat(api): add importer's requests and limits for virtualization config

### DIFF
--- a/images/virtualization-artifact/pkg/common/common.go
+++ b/images/virtualization-artifact/pkg/common/common.go
@@ -186,6 +186,9 @@ const (
 	KubevirtAPIServerEndpointVar     = "KUBEVIRT_APISERVER_ENDPOINT"
 	KubevirtAPIServerCABundlePathVar = "KUBEVIRT_APISERVER_CABUNDLE"
 
+	ImporterLimitsVar   = "IMPORTER_LIMITS"
+	ImporterRequestsVar = "IMPORTER_REQUESTS"
+
 	VirtualizationApiAuthServiceAccountNameVar      = "VIRTUALIZATION_API_AUTH_SERVICE_ACCOUNT_NAME"
 	VirtualizationApiAuthServiceAccountNamespaceVar = "VIRTUALIZATION_API_AUTH_SERVICE_ACCOUNT_NAMESPACE"
 )

--- a/images/virtualization-artifact/pkg/config/load_import_settings.go
+++ b/images/virtualization-artifact/pkg/config/load_import_settings.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/deckhouse/virtualization-controller/pkg/common"
+)
+
+type ImportSettings struct {
+	ImporterImage string
+	UploaderImage string
+	Requirements  corev1.ResourceRequirements
+}
+
+func LoadImportSettingsFromEnv() (ImportSettings, error) {
+	var settings ImportSettings
+	var err error
+	settings.ImporterImage, err = GetRequiredEnvVar(common.ImporterPodImageNameVar)
+	if err != nil {
+		return ImportSettings{}, err
+	}
+
+	settings.UploaderImage, err = GetRequiredEnvVar(common.UploaderPodImageNameVar)
+	if err != nil {
+		return ImportSettings{}, err
+	}
+
+	limits := os.Getenv(common.ImporterLimitsVar)
+	if limits != "" {
+		err = json.Unmarshal([]byte(limits), &settings.Requirements.Limits)
+		if err != nil {
+			return ImportSettings{}, err
+		}
+	}
+	requests := os.Getenv(common.ImporterRequestsVar)
+	if requests != "" {
+		err = json.Unmarshal([]byte(requests), &settings.Requirements.Requests)
+		if err != nil {
+			return ImportSettings{}, err
+		}
+	}
+
+	return settings, nil
+}
+
+func GetRequiredEnvVar(name string) (string, error) {
+	val := os.Getenv(name)
+	if val == "" {
+		return "", fmt.Errorf("environment variable %q undefined", name)
+	}
+	return val, nil
+}

--- a/images/virtualization-artifact/pkg/controller/cvi/cvi_controller.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/cvi_controller.go
@@ -51,6 +51,7 @@ func NewController(
 	log *slog.Logger,
 	importerImage string,
 	uploaderImage string,
+	requirements corev1.ResourceRequirements,
 	dvcr *dvcr.Settings,
 	ns string,
 ) (controller.Controller, error) {
@@ -58,8 +59,8 @@ func NewController(
 
 	stat := service.NewStatService(log)
 	protection := service.NewProtectionService(mgr.GetClient(), virtv2.FinalizerCVIProtection)
-	importer := service.NewImporterService(dvcr, mgr.GetClient(), importerImage, PodPullPolicy, PodVerbose, ControllerName, protection)
-	uploader := service.NewUploaderService(dvcr, mgr.GetClient(), uploaderImage, PodPullPolicy, PodVerbose, ControllerName, protection)
+	importer := service.NewImporterService(dvcr, mgr.GetClient(), importerImage, requirements, PodPullPolicy, PodVerbose, ControllerName, protection)
+	uploader := service.NewUploaderService(dvcr, mgr.GetClient(), uploaderImage, requirements, PodPullPolicy, PodVerbose, ControllerName, protection)
 
 	sources := source.NewSources()
 	sources.Set(virtv2.DataSourceTypeHTTP, source.NewHTTPDataSource(stat, importer, dvcr, ns))

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/registry.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/registry.go
@@ -96,21 +96,20 @@ func (ds RegistryDataSource) Sync(ctx context.Context, cvi *virtv2.ClusterVirtua
 
 		log.Info("Cleaning up...")
 	case pod == nil:
-		condition.Status = metav1.ConditionFalse
-		condition.Reason = cvicondition.Provisioning
-		condition.Message = "DVCR Provisioner not found: create the new one."
-
 		envSettings := ds.getEnvSettings(cvi, supgen)
 		err = ds.importerService.Start(ctx, envSettings, cvi, supgen, datasource.NewCABundleForCVMI(cvi.Spec.DataSource))
+		var requeue bool
+		requeue, err = setPhaseConditionForImporterStart(&condition, &cvi.Status.Phase, err)
 		if err != nil {
 			return false, err
 		}
 
-		cvi.Status.Phase = virtv2.ImageProvisioning
 		cvi.Status.Progress = "0%"
 		cvi.Status.Target.RegistryURL = ds.dvcrSettings.RegistryImageForCVMI(cvi.Name)
 
 		log.Info("Create importer pod...", "progress", cvi.Status.Progress, "pod.phase", "nil")
+
+		return requeue, nil
 	case common.IsPodComplete(pod):
 		err = ds.statService.CheckPod(pod)
 		if err != nil {

--- a/images/virtualization-artifact/pkg/controller/service/importer_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/importer_service.go
@@ -35,6 +35,7 @@ type ImporterService struct {
 	dvcrSettings   *dvcr.Settings
 	client         client.Client
 	image          string
+	requirements   corev1.ResourceRequirements
 	pullPolicy     string
 	verbose        string
 	controllerName string
@@ -45,6 +46,7 @@ func NewImporterService(
 	dvcrSettings *dvcr.Settings,
 	client client.Client,
 	image string,
+	requirements corev1.ResourceRequirements,
 	pullPolicy string,
 	verbose string,
 	controllerName string,
@@ -54,6 +56,7 @@ func NewImporterService(
 		dvcrSettings:   dvcrSettings,
 		client:         client,
 		image:          image,
+		requirements:   requirements,
 		pullPolicy:     pullPolicy,
 		verbose:        verbose,
 		controllerName: controllerName,
@@ -131,12 +134,13 @@ func (s ImporterService) GetPod(ctx context.Context, sup *supplements.Generator)
 func (s ImporterService) getPodSettings(ownerRef *metav1.OwnerReference, sup *supplements.Generator) *importer.PodSettings {
 	importerPod := sup.ImporterPod()
 	return &importer.PodSettings{
-		Name:            importerPod.Name,
-		Namespace:       importerPod.Namespace,
-		Image:           s.image,
-		PullPolicy:      s.pullPolicy,
-		OwnerReference:  *ownerRef,
-		ControllerName:  s.controllerName,
-		InstallerLabels: map[string]string{},
+		Name:                 importerPod.Name,
+		Namespace:            importerPod.Namespace,
+		Image:                s.image,
+		PullPolicy:           s.pullPolicy,
+		OwnerReference:       *ownerRef,
+		ControllerName:       s.controllerName,
+		InstallerLabels:      map[string]string{},
+		ResourceRequirements: &s.requirements,
 	}
 }

--- a/images/virtualization-artifact/pkg/controller/service/uploader_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/uploader_service.go
@@ -36,6 +36,7 @@ type UploaderService struct {
 	dvcrSettings   *dvcr.Settings
 	client         client.Client
 	image          string
+	requirements   corev1.ResourceRequirements
 	pullPolicy     string
 	verbose        string
 	controllerName string
@@ -46,6 +47,7 @@ func NewUploaderService(
 	dvcrSettings *dvcr.Settings,
 	client client.Client,
 	image string,
+	requirements corev1.ResourceRequirements,
 	pullPolicy string,
 	verbose string,
 	controllerName string,
@@ -55,6 +57,7 @@ func NewUploaderService(
 		dvcrSettings:   dvcrSettings,
 		client:         client,
 		image:          image,
+		requirements:   requirements,
 		pullPolicy:     pullPolicy,
 		verbose:        verbose,
 		controllerName: controllerName,
@@ -190,14 +193,15 @@ func (s UploaderService) getPodSettings(ownerRef *metav1.OwnerReference, sup *su
 	uploaderPod := sup.UploaderPod()
 	uploaderSvc := sup.UploaderService()
 	return &uploader.PodSettings{
-		Name:            uploaderPod.Name,
-		Image:           s.image,
-		PullPolicy:      s.pullPolicy,
-		Namespace:       uploaderPod.Namespace,
-		OwnerReference:  *ownerRef,
-		ControllerName:  s.controllerName,
-		InstallerLabels: map[string]string{},
-		ServiceName:     uploaderSvc.Name,
+		Name:                 uploaderPod.Name,
+		Image:                s.image,
+		PullPolicy:           s.pullPolicy,
+		Namespace:            uploaderPod.Namespace,
+		OwnerReference:       *ownerRef,
+		ControllerName:       s.controllerName,
+		InstallerLabels:      map[string]string{},
+		ServiceName:          uploaderSvc.Name,
+		ResourceRequirements: &s.requirements,
 	}
 }
 

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/http.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/http.go
@@ -115,18 +115,17 @@ func (ds HTTPDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (bool
 	case pod == nil:
 		log.Info("Start import to DVCR")
 
-		vd.Status.Phase = virtv2.DiskProvisioning
-		condition.Status = metav1.ConditionFalse
-		condition.Reason = vdcondition.Provisioning
-		condition.Message = "DVCR Provisioner not found: create the new one."
-
 		vd.Status.Progress = "0%"
 
 		envSettings := ds.getEnvSettings(vd, supgen)
 		err = ds.importerService.Start(ctx, envSettings, vd, supgen, datasource.NewCABundleForVMD(vd.Spec.DataSource))
+		var requeue bool
+		requeue, err = setPhaseConditionForImporterStart(&condition, &vd.Status.Phase, err)
 		if err != nil {
 			return false, err
 		}
+
+		return requeue, nil
 	case !common.IsPodComplete(pod):
 		log.Info("Provisioning to DVCR is in progress", "podPhase", pod.Status.Phase)
 

--- a/images/virtualization-artifact/pkg/controller/vd/vd_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vd/vd_controller.go
@@ -54,14 +54,15 @@ func NewController(
 	log *slog.Logger,
 	importerImage string,
 	uploaderImage string,
+	requirements corev1.ResourceRequirements,
 	dvcr *dvcr.Settings,
 ) (controller.Controller, error) {
 	log = log.With(logger.SlogController(ControllerName))
 
 	stat := service.NewStatService(log)
 	protection := service.NewProtectionService(mgr.GetClient(), virtv2.FinalizerVDProtection)
-	importer := service.NewImporterService(dvcr, mgr.GetClient(), importerImage, PodPullPolicy, PodVerbose, ControllerName, protection)
-	uploader := service.NewUploaderService(dvcr, mgr.GetClient(), uploaderImage, PodPullPolicy, PodVerbose, ControllerName, protection)
+	importer := service.NewImporterService(dvcr, mgr.GetClient(), importerImage, requirements, PodPullPolicy, PodVerbose, ControllerName, protection)
+	uploader := service.NewUploaderService(dvcr, mgr.GetClient(), uploaderImage, requirements, PodPullPolicy, PodVerbose, ControllerName, protection)
 	disk := service.NewDiskService(mgr.GetClient(), dvcr, protection)
 
 	blank := source.NewBlankDataSource(stat, disk)

--- a/images/virtualization-artifact/pkg/controller/vi/vi_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vi/vi_controller.go
@@ -51,14 +51,15 @@ func NewController(
 	log *slog.Logger,
 	importerImage string,
 	uploaderImage string,
+	requirements corev1.ResourceRequirements,
 	dvcr *dvcr.Settings,
 ) (controller.Controller, error) {
 	log = log.With(logger.SlogController(ControllerName))
 
 	stat := service.NewStatService(log)
 	protection := service.NewProtectionService(mgr.GetClient(), virtv2.FinalizerVIProtection)
-	importer := service.NewImporterService(dvcr, mgr.GetClient(), importerImage, PodPullPolicy, PodVerbose, ControllerName, protection)
-	uploader := service.NewUploaderService(dvcr, mgr.GetClient(), uploaderImage, PodPullPolicy, PodVerbose, ControllerName, protection)
+	importer := service.NewImporterService(dvcr, mgr.GetClient(), importerImage, requirements, PodPullPolicy, PodVerbose, ControllerName, protection)
+	uploader := service.NewUploaderService(dvcr, mgr.GetClient(), uploaderImage, requirements, PodPullPolicy, PodVerbose, ControllerName, protection)
 
 	sources := source.NewSources()
 	sources.Set(virtv2.DataSourceTypeHTTP, source.NewHTTPDataSource(stat, importer, dvcr))

--- a/openapi/config-values.yaml
+++ b/openapi/config-values.yaml
@@ -201,3 +201,37 @@ properties:
     enum:
       - "text"
       - "json"
+  importerResourceRequirements:
+    type: object
+    description: ResourceRequirements describes the compute resource requirements.
+    default:
+      limits:
+        cpu: 750m
+        memory: 600M
+      requests:
+        cpu: 100m
+        memory: 60M
+    properties:
+      limits:
+        type: object
+        description: |
+          Limits describes the maximum amount of compute resources allowed.
+          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+        additionalProperties:
+          x-kubernetes-int-or-string: true
+          anyOf:
+            - type: integer
+            - type: string
+          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+      requests:
+        type: object
+        additionalProperties:
+          x-kubernetes-int-or-string: true
+          anyOf:
+            - type: integer
+            - type: string
+          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+        description: |
+          Requests describes the minimum amount of compute resources required.
+          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value.
+          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/

--- a/openapi/doc-ru-config-values.yaml
+++ b/openapi/doc-ru-config-values.yaml
@@ -105,3 +105,19 @@ properties:
 
       Работает для следующих компонентов:
       - `virtualization-controller`
+  importerResourceRequirements:
+    type: object
+    description: |
+      ResourceRequirements describes the compute resource requirements.
+    properties:
+      limits:
+        type: object
+        description: |
+          Ограничения описывают максимальный разрешенный объем вычислительных ресурсов.
+          Подробнее: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+      requests:
+        type: object
+        description: |
+          Запросы описывают минимальный объем требуемых вычислительных ресурсов.
+          Если параметр запросов для контейнера опущен, то по умолчанию используются значения лимитов, если это явно указано, в противном случае - значение, определенное реализацией.
+          Подробнее: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/

--- a/templates/cdi/cdi.yaml
+++ b/templates/cdi/cdi.yaml
@@ -18,6 +18,19 @@ spec:
     {{- include "helm_lib_node_selector" (tuple . "system") | nindent 4 }}
     {{- include "helm_lib_tolerations" (tuple . "system") | nindent 4 }}
   config:
+    {{- with .Values.virtualization.importerResourceRequirements }}
+    {{- if or (hasKey . "limits") (hasKey . "requests") }}
+    podResourceRequirements:
+      {{- if hasKey . "limits" }}
+      limits:
+        {{- .limits | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if hasKey . "requests" }}
+      requests:
+        {{- .requests | toYaml | nindent 8 }}
+      {{- end }}
+    {{- end }}
+    {{- end }}
     imagePullSecrets:
     - name: virtualization-module-registry
   {{- if .Values.global.modules.publicDomainTemplate }}

--- a/templates/virtualization-controller/_helpers.tpl
+++ b/templates/virtualization-controller/_helpers.tpl
@@ -40,8 +40,18 @@
   value: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
 - name: UPLOADER_INGRESS_CLASS
   value: {{ include "helm_lib_module_ingress_class" . | quote }}
-  {{- if eq .Values.virtualization.logLevel "debug" }}
+{{- with .Values.virtualization.importerResourceRequirements }}
+{{- if hasKey . "limits" }}
+- name: IMPORTER_LIMITS
+  value: {{ .limits | toJson | quote }}
+{{- end }}
+{{- if hasKey . "requests" }}
+- name: IMPORTER_REQUESTS
+  value: {{ .requests | toJson | quote }}
+{{- end }}
+{{- end }}
+{{- if eq .Values.virtualization.logLevel "debug" }}
 - name: PPROF_BIND_ADDRESS
   value: ":8081"
-  {{- end }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
## Description

- Disk and image controllers can now handle 'quota exceeded' errors and update the condition with a corresponding message.
- A new field in the module configuration, `importerResourceRequirements`, specifies the requests and limits for importers.
- These values are applied to both our importers and CDI importers.
- The default values are taken from the previous CDIConfig.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
