### PR TITLE
fix(vmbda): write to condition message if disk is already attached to vm spec

### DIFF
--- a/api/core/v1alpha2/vmbdacondition/condition.go
+++ b/api/core/v1alpha2/vmbdacondition/condition.go
@@ -54,7 +54,9 @@ const (
 	NotAttached AttachedReason = "NotAttached"
 	// AttachmentRequestSent signifies that the attachment request has been sent and the hot-plug process has started.
 	AttachmentRequestSent AttachedReason = "AttachmentRequestSent"
-	// Conflict indicates that there is another `VirtualMachineBlockDeviceAttachment` with the same virtual machine and virtual disk to be hot-plugged.
+	// Conflict indicates that virtual disk is already attached to the virtual machine:
+	// Either there is another `VirtualMachineBlockDeviceAttachment` with the same virtual machine and virtual disk to be hot-plugged.
+	// or the virtual disk is already attached to the virtual machine spec.
 	// Only the one that was created or started sooner can be processed.
 	Conflict AttachedReason = "Conflict"
 )

--- a/images/virtualization-artifact/pkg/controller/vm/internal/validators/block_device_refs_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/validators/block_device_refs_validator.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validators
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+)
+
+type BlockDeviceSpecRefsValidator struct{}
+
+func NewBlockDeviceSpecRefsValidator() *BlockDeviceSpecRefsValidator {
+	return &BlockDeviceSpecRefsValidator{}
+}
+
+func (v *BlockDeviceSpecRefsValidator) ValidateCreate(_ context.Context, vm *v1alpha2.VirtualMachine) (admission.Warnings, error) {
+	return nil, v.noDoubles(vm)
+}
+
+func (v *BlockDeviceSpecRefsValidator) ValidateUpdate(_ context.Context, _, newVM *v1alpha2.VirtualMachine) (admission.Warnings, error) {
+	return nil, v.noDoubles(newVM)
+}
+
+func (v *BlockDeviceSpecRefsValidator) noDoubles(vm *v1alpha2.VirtualMachine) error {
+	blockDevicesByRef := make(map[v1alpha2.BlockDeviceSpecRef]struct{}, len(vm.Spec.BlockDeviceRefs))
+
+	for _, bdRef := range vm.Spec.BlockDeviceRefs {
+		if _, ok := blockDevicesByRef[bdRef]; ok {
+			return fmt.Errorf("cannot specify the same block device reference more than once: %s with name %s has a duplicate reference", bdRef.Kind, bdRef.Name)
+		}
+
+		blockDevicesByRef[bdRef] = struct{}{}
+	}
+
+	return nil
+}

--- a/images/virtualization-artifact/pkg/controller/vm/internal/validators/ipam_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/validators/ipam_validator.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validators
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/deckhouse/virtualization-controller/pkg/controller/vm/internal"
+	"github.com/deckhouse/virtualization-controller/pkg/sdk/framework/helper"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+)
+
+type IPAMValidator struct {
+	ipam   internal.IPAM
+	client client.Client
+}
+
+func NewIPAMValidator(ipam internal.IPAM, client client.Client) *IPAMValidator {
+	return &IPAMValidator{ipam: ipam, client: client}
+}
+
+func (v *IPAMValidator) ValidateCreate(ctx context.Context, vm *v1alpha2.VirtualMachine) (admission.Warnings, error) {
+	vmipName := vm.Spec.VirtualMachineIPAddress
+	if vmipName == "" {
+		vmipName = vm.Name
+	}
+
+	vmipKey := types.NamespacedName{Name: vmipName, Namespace: vm.Namespace}
+	vmip, err := helper.FetchObject(ctx, vmipKey, v.client, &v1alpha2.VirtualMachineIPAddress{})
+	if err != nil {
+		return nil, fmt.Errorf("unable to get referenced VirtualMachineIPAddress %s: %w", vmipKey, err)
+	}
+
+	if vmip == nil {
+		return nil, nil
+	}
+
+	// VM is created without ip address, but ip address resource is already exists.
+	if vm.Spec.VirtualMachineIPAddress == "" {
+		return nil, fmt.Errorf("VirtualMachineIPAddress with the name of the virtual machine"+
+			" already exists: set spec.virtualMachineIPAddress field to %s to use IP %s", vmip.Name, vmip.Status.Address)
+	}
+
+	return nil, v.ipam.CheckIpAddressAvailableForBinding(vm.Name, vmip)
+}
+
+func (v *IPAMValidator) ValidateUpdate(ctx context.Context, oldVM, newVM *v1alpha2.VirtualMachine) (admission.Warnings, error) {
+	if oldVM.Spec.VirtualMachineIPAddress == newVM.Spec.VirtualMachineIPAddress {
+		return nil, nil
+	}
+
+	if newVM.Spec.VirtualMachineIPAddress == "" {
+		return nil, fmt.Errorf("spec.virtualMachineIPAddress cannot be changed to an empty value once set")
+	}
+
+	vmipKey := types.NamespacedName{Name: newVM.Spec.VirtualMachineIPAddress, Namespace: newVM.Namespace}
+	vmip, err := helper.FetchObject(ctx, vmipKey, v.client, &v1alpha2.VirtualMachineIPAddress{})
+	if err != nil {
+		return nil, fmt.Errorf("unable to get VirtualMachineIPAddress %s: %w", vmipKey, err)
+	}
+
+	if vmip == nil {
+		return nil, nil
+	}
+
+	return nil, v.ipam.CheckIpAddressAvailableForBinding(newVM.Name, vmip)
+}

--- a/images/virtualization-artifact/pkg/controller/vm/internal/validators/meta_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/validators/meta_validator.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validators
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"kubevirt.io/api/core"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+)
+
+type MetaValidator struct {
+	client client.Client
+}
+
+func NewMetaValidator(client client.Client) *MetaValidator {
+	return &MetaValidator{client: client}
+}
+
+func (v *MetaValidator) ValidateCreate(_ context.Context, vm *v1alpha2.VirtualMachine) (admission.Warnings, error) {
+	for key := range vm.Annotations {
+		if strings.Contains(key, core.GroupName) {
+			return nil, fmt.Errorf("using the %s group's name in the annotation is prohibited", core.GroupName)
+		}
+	}
+
+	for key := range vm.Labels {
+		if strings.Contains(key, core.GroupName) {
+			return nil, fmt.Errorf("using the %s group's name in the label is prohibited", core.GroupName)
+		}
+	}
+
+	return nil, nil
+}
+
+func (v *MetaValidator) ValidateUpdate(_ context.Context, _, newVM *v1alpha2.VirtualMachine) (admission.Warnings, error) {
+	for key := range newVM.Annotations {
+		if strings.Contains(key, core.GroupName) {
+			return nil, fmt.Errorf("using the %s group's name in the annotation is prohibited", core.GroupName)
+		}
+	}
+
+	for key := range newVM.Labels {
+		if strings.Contains(key, core.GroupName) {
+			return nil, fmt.Errorf("using the %s group's name in the label is prohibited", core.GroupName)
+		}
+	}
+
+	return nil, nil
+}

--- a/images/virtualization-artifact/pkg/controller/vm/vm_webhook.go
+++ b/images/virtualization-artifact/pkg/controller/vm/vm_webhook.go
@@ -20,29 +20,32 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
-	"kubevirt.io/api/core"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vm/internal"
-	"github.com/deckhouse/virtualization-controller/pkg/sdk/framework/helper"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/vm/internal/validators"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
+type VirtualMachineValidator interface {
+	ValidateCreate(ctx context.Context, vm *v1alpha2.VirtualMachine) (admission.Warnings, error)
+	ValidateUpdate(ctx context.Context, oldVM, newVM *v1alpha2.VirtualMachine) (admission.Warnings, error)
+}
+
 type Validator struct {
-	validators []vmValidator
+	validators []VirtualMachineValidator
 	log        *slog.Logger
 }
 
 func NewValidator(ipam internal.IPAM, client client.Client, log *slog.Logger) *Validator {
 	return &Validator{
-		validators: []vmValidator{
-			newMetaVMValidator(client),
-			newIPAMVMValidator(ipam, client),
+		validators: []VirtualMachineValidator{
+			validators.NewMetaValidator(client),
+			validators.NewIPAMValidator(ipam, client),
+			validators.NewBlockDeviceSpecRefsValidator(),
 		},
 		log: log.With("webhook", "validation"),
 	}
@@ -59,7 +62,7 @@ func (v *Validator) ValidateCreate(ctx context.Context, obj runtime.Object) (adm
 	var warnings admission.Warnings
 
 	for _, validator := range v.validators {
-		warn, err := validator.validateCreate(ctx, vm)
+		warn, err := validator.ValidateCreate(ctx, vm)
 		if err != nil {
 			return nil, err
 		}
@@ -88,7 +91,7 @@ func (v *Validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.O
 	var warnings admission.Warnings
 
 	for _, validator := range v.validators {
-		warn, err := validator.validateUpdate(ctx, oldVM, newVM)
+		warn, err := validator.ValidateUpdate(ctx, oldVM, newVM)
 		if err != nil {
 			return nil, err
 		}
@@ -102,105 +105,4 @@ func (v *Validator) ValidateDelete(_ context.Context, _ runtime.Object) (admissi
 	err := fmt.Errorf("misconfigured webhook rules: delete operation not implemented")
 	v.log.Error("Ensure the correctness of ValidatingWebhookConfiguration", "err", err.Error())
 	return nil, nil
-}
-
-type vmValidator interface {
-	validateCreate(ctx context.Context, vm *v1alpha2.VirtualMachine) (admission.Warnings, error)
-	validateUpdate(ctx context.Context, oldVM, newVM *v1alpha2.VirtualMachine) (admission.Warnings, error)
-}
-
-type metaVMValidator struct {
-	client client.Client
-}
-
-func newMetaVMValidator(client client.Client) *metaVMValidator {
-	return &metaVMValidator{client: client}
-}
-
-func (v *metaVMValidator) validateCreate(_ context.Context, vm *v1alpha2.VirtualMachine) (admission.Warnings, error) {
-	for key := range vm.Annotations {
-		if strings.Contains(key, core.GroupName) {
-			return nil, fmt.Errorf("using the %s group's name in the annotation is prohibited", core.GroupName)
-		}
-	}
-
-	for key := range vm.Labels {
-		if strings.Contains(key, core.GroupName) {
-			return nil, fmt.Errorf("using the %s group's name in the label is prohibited", core.GroupName)
-		}
-	}
-
-	return nil, nil
-}
-
-func (v *metaVMValidator) validateUpdate(_ context.Context, _, newVM *v1alpha2.VirtualMachine) (admission.Warnings, error) {
-	for key := range newVM.Annotations {
-		if strings.Contains(key, core.GroupName) {
-			return nil, fmt.Errorf("using the %s group's name in the annotation is prohibited", core.GroupName)
-		}
-	}
-
-	for key := range newVM.Labels {
-		if strings.Contains(key, core.GroupName) {
-			return nil, fmt.Errorf("using the %s group's name in the label is prohibited", core.GroupName)
-		}
-	}
-
-	return nil, nil
-}
-
-type ipamVMValidator struct {
-	ipam   internal.IPAM
-	client client.Client
-}
-
-func newIPAMVMValidator(ipam internal.IPAM, client client.Client) *ipamVMValidator {
-	return &ipamVMValidator{ipam: ipam, client: client}
-}
-
-func (v *ipamVMValidator) validateCreate(ctx context.Context, vm *v1alpha2.VirtualMachine) (admission.Warnings, error) {
-	vmipName := vm.Spec.VirtualMachineIPAddress
-	if vmipName == "" {
-		vmipName = vm.Name
-	}
-
-	vmipKey := types.NamespacedName{Name: vmipName, Namespace: vm.Namespace}
-	vmip, err := helper.FetchObject(ctx, vmipKey, v.client, &v1alpha2.VirtualMachineIPAddress{})
-	if err != nil {
-		return nil, fmt.Errorf("unable to get referenced VirtualMachineIPAddress %s: %w", vmipKey, err)
-	}
-
-	if vmip == nil {
-		return nil, nil
-	}
-
-	// VM is created without ip address, but ip address resource is already exists.
-	if vm.Spec.VirtualMachineIPAddress == "" {
-		return nil, fmt.Errorf("VirtualMachineIPAddress with the name of the virtual machine"+
-			" already exists: set spec.virtualMachineIPAddress field to %s to use IP %s", vmip.Name, vmip.Status.Address)
-	}
-
-	return nil, v.ipam.CheckIpAddressAvailableForBinding(vm.Name, vmip)
-}
-
-func (v *ipamVMValidator) validateUpdate(ctx context.Context, oldVM, newVM *v1alpha2.VirtualMachine) (admission.Warnings, error) {
-	if oldVM.Spec.VirtualMachineIPAddress == newVM.Spec.VirtualMachineIPAddress {
-		return nil, nil
-	}
-
-	if newVM.Spec.VirtualMachineIPAddress == "" {
-		return nil, fmt.Errorf("spec.virtualMachineIPAddress cannot be changed to an empty value once set")
-	}
-
-	vmipKey := types.NamespacedName{Name: newVM.Spec.VirtualMachineIPAddress, Namespace: newVM.Namespace}
-	vmip, err := helper.FetchObject(ctx, vmipKey, v.client, &v1alpha2.VirtualMachineIPAddress{})
-	if err != nil {
-		return nil, fmt.Errorf("unable to get VirtualMachineIPAddress %s: %w", vmipKey, err)
-	}
-
-	if vmip == nil {
-		return nil, nil
-	}
-
-	return nil, v.ipam.CheckIpAddressAvailableForBinding(newVM.Name, vmip)
 }


### PR DESCRIPTION
## Description

1. For vmbda, added a message to the condition that indicates a disk conflict if disk is already added to the virtual machine spec
2. Fixed an issue that prevented adding a disk to the spec when the vmbda with that disk was deleted for the virtual machine.
3. Failed phase is no longer final for vmbda (it can transition to Pending).
4. New validator for VM: BlockDeviceSpecRefsValidator, which prevents duplicate spec.BlockDeviceRef entries.
5. VM validators have been moved to internal/validators.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
