### PR TITLE
feat(vm-route-forge): add route interface

### DIFF
--- a/images/vm-route-forge/cmd/vm-route-forge/app/options/options.go
+++ b/images/vm-route-forge/cmd/vm-route-forge/app/options/options.go
@@ -36,7 +36,7 @@ type Options struct {
 	ProbeAddr        string
 	PprofAddr        string
 	NodeName         string
-	TableID          string
+	RouteTableID     string
 	KindRouteWatcher string
 }
 
@@ -56,7 +56,7 @@ const (
 	PprofBindAddressEnv       = "PPROF_BIND_ADDRESS"
 	VerbosityEnv              = "VERBOSITY"
 	NodeNameEnv               = "NODE_NAME"
-	TableIDEnv                = "TABLE_ID"
+	RouteTableIDEnv           = "ROUTE_TABLE_ID"
 	KindRouteWatcherEnv       = "KIND_ROUTE_WATCHER"
 )
 
@@ -74,7 +74,7 @@ func (o *Options) Flags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.ProbeAddr, flagProbeAddr, os.Getenv(HealthProbeBindAddressEnv), "The address the probe endpoint binds to.")
 	fs.StringVar(&o.PprofAddr, flagPprofAddr, os.Getenv(PprofBindAddressEnv), "The address the pprof endpoint binds to.")
 	fs.StringVarP(&o.NodeName, flagNodeName, flagNodeNameShort, os.Getenv(NodeNameEnv), "The name of the node.")
-	fs.StringVarP(&o.TableID, flagTableId, flagTableIdShort, os.Getenv(TableIDEnv), "The id of the table.")
+	fs.StringVarP(&o.RouteTableID, flagTableId, flagTableIdShort, os.Getenv(RouteTableIDEnv), "The id of the table.")
 	fs.IntVarP(&o.Verbosity, flagVerbosity, flagVerbosityShort, getDefaultVerbosity(), "Verbosity of output.")
 	fs.StringVar(&o.KindRouteWatcher, flagKindRouteWatcher, getEnvWithDefault(KindRouteWatcherEnv, string(route.TickerKind)), "Kind of route watcher.")
 }

--- a/images/vm-route-forge/cmd/vm-route-forge/app/root.go
+++ b/images/vm-route-forge/cmd/vm-route-forge/app/root.go
@@ -159,12 +159,16 @@ func run(opts options.Options) error {
 		log.Error(err, "Failed to run pre sync")
 		return err
 	}
-	routeCtrl, err := route.NewRouteController(
+	routeWatcher, err := route.WatchFactory(route.NetlinkKind, parsedCIDRs, sharedCache, log)
+	if err != nil {
+		log.Error(err, "Failed to create route watcher")
+		return err
+	}
+	routeCtrl, err := route.NewController(
 		vmSharedInformerFactory.Virtualization().V1alpha2().VirtualMachines(),
 		ciliumSharedInformerFactory.Cilium().V2().CiliumNodes(),
+		routeWatcher,
 		netMgr,
-		sharedCache,
-		parsedCIDRs,
 		log,
 	)
 	if err != nil {

--- a/images/vm-route-forge/cmd/vm-route-forge/app/root.go
+++ b/images/vm-route-forge/cmd/vm-route-forge/app/root.go
@@ -159,7 +159,13 @@ func run(opts options.Options) error {
 		log.Error(err, "Failed to run pre sync")
 		return err
 	}
-	routeWatcher, err := route.WatchFactory(route.NetlinkKind, parsedCIDRs, sharedCache, log)
+	routeWatcher, err := route.WatchFactory(
+		route.KindRouteWatcher(opts.KindRouteWatcher),
+		parsedCIDRs,
+		sharedCache,
+		tableID,
+		log,
+	)
 	if err != nil {
 		log.Error(err, "Failed to create route watcher")
 		return err

--- a/images/vm-route-forge/internal/cache/cache.go
+++ b/images/vm-route-forge/internal/cache/cache.go
@@ -29,6 +29,7 @@ type Cache interface {
 	Set(k types.NamespacedName, addrs Addresses)
 	DeleteByKey(k types.NamespacedName)
 	DeleteByIP(ip net.IP)
+	Iterate(fn func(key types.NamespacedName, v Addresses) (next bool))
 }
 
 func NewCache() Cache {
@@ -85,7 +86,25 @@ func (c *defaultCache) DeleteByIP(ip net.IP) {
 	delete(c.addrVm, ip.String())
 }
 
+func (c *defaultCache) Iterate(fn func(k types.NamespacedName, v Addresses) (next bool)) {
+	for k, v := range c.vmAddr {
+		if next := fn(k, v); !next {
+			break
+		}
+	}
+}
+
 type Addresses struct {
-	NodeIP net.IP
-	VMIP   net.IP
+	NodeIP IP
+	VMIP   IP
+}
+
+type IP string
+
+func (ip IP) String() string {
+	return string(ip)
+}
+
+func (ip IP) NetIP() net.IP {
+	return net.ParseIP(string(ip))
 }

--- a/images/vm-route-forge/internal/controller/route/ebpf.go
+++ b/images/vm-route-forge/internal/controller/route/ebpf.go
@@ -24,16 +24,17 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/types"
 
-	"vm-route-forge/internal/cache"
+	vmipcache "vm-route-forge/internal/cache"
+	"vm-route-forge/internal/netlinkwrap"
 )
 
-func NewEbpfWatcher(cidrs []*net.IPNet, cache cache.Cache, log logr.Logger) (*EbpfWatcher, error) {
+func NewEbpfWatcher(cidrs []*net.IPNet, cache vmipcache.Cache, nlWrapper *netlinkwrap.Funcs, log logr.Logger) (*EbpfWatcher, error) {
 	return &EbpfWatcher{}, fmt.Errorf("not implemented")
 }
 
 type EbpfWatcher struct {
 }
 
-func (w *EbpfWatcher) Watch(ctx context.Context) (chan types.NamespacedName, error) {
+func (w *EbpfWatcher) Watch(ctx context.Context) (<-chan types.NamespacedName, error) {
 	return nil, nil
 }

--- a/images/vm-route-forge/internal/controller/route/ebpf.go
+++ b/images/vm-route-forge/internal/controller/route/ebpf.go
@@ -1,0 +1,23 @@
+package route
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/types"
+
+	"vm-route-forge/internal/cache"
+)
+
+func NewEbpfWatcher(cidrs []*net.IPNet, cache cache.Cache, log logr.Logger) (*EbpfWatcher, error) {
+	return &EbpfWatcher{}, fmt.Errorf("not implemented")
+}
+
+type EbpfWatcher struct {
+}
+
+func (w *EbpfWatcher) Watch(ctx context.Context) (chan types.NamespacedName, error) {
+	return nil, nil
+}

--- a/images/vm-route-forge/internal/controller/route/ebpf.go
+++ b/images/vm-route-forge/internal/controller/route/ebpf.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package route
 
 import (

--- a/images/vm-route-forge/internal/controller/route/ticker.go
+++ b/images/vm-route-forge/internal/controller/route/ticker.go
@@ -1,0 +1,135 @@
+package route
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/vishvananda/netlink"
+	"k8s.io/apimachinery/pkg/types"
+
+	"vm-route-forge/internal/cache"
+	"vm-route-forge/internal/netlinkwrap"
+)
+
+func NewTickerWatcher(cidrs []*net.IPNet, cache cache.Cache, tableID int, log logr.Logger) *TickerWatcher {
+	return &TickerWatcher{
+		ch:        make(chan types.NamespacedName, defaultChanSize),
+		cidrs:     cidrs,
+		cache:     cache,
+		tableID:   tableID,
+		log:       log.WithValues("watcher", TickerKind),
+		routeGet:  netlinkwrap.NewFuncs().RouteGet,
+		routeList: netlinkwrap.NewFuncs().RouteListFiltered,
+	}
+}
+
+type TickerWatcher struct {
+	ch        chan types.NamespacedName
+	cidrs     []*net.IPNet
+	cache     cache.Cache
+	tableID   int
+	log       logr.Logger
+	routeGet  func(net.IP) ([]netlink.Route, error)
+	routeList func(int, *netlink.Route, uint64) ([]netlink.Route, error)
+}
+
+func (w *TickerWatcher) Watch(ctx context.Context) (chan types.NamespacedName, error) {
+	ticker := time.NewTicker(500 * time.Millisecond)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				ticker.Stop()
+				return
+			case <-ticker.C:
+				if err := w.sync(); err != nil {
+					w.log.Error(err, "failed to sync routes")
+				}
+			}
+		}
+	}()
+	return w.ch, nil
+}
+
+func (w *TickerWatcher) sync() error {
+	routes, err := w.routeList(netlink.FAMILY_V4, &netlink.Route{Table: w.tableID}, netlink.RT_FILTER_TABLE)
+	if err != nil {
+		return fmt.Errorf("failed to list routes: %w", err)
+	}
+	routeMap := make(map[string]*netlink.Route, len(routes))
+	for _, route := range routes {
+		routeMap[route.Dst.IP.String()] = &route
+	}
+
+	// enqueue vm with missing routes
+	w.cache.Iterate(func(k types.NamespacedName, v cache.Addresses) (next bool) {
+		if _, found := routeMap[v.VMIP.String()]; !found {
+			w.log.Info(fmt.Sprintf("Missing route. Add the VM %q to the queue.", k))
+			w.enqueueKey(k)
+		}
+		return true
+	})
+
+	for vmIP, route := range routeMap {
+		if err = w.syncRoute(route); err != nil {
+			w.log.Error(err, "failed to sync route", "vmIP", vmIP)
+		}
+	}
+	return nil
+}
+
+func (w *TickerWatcher) syncRoute(route *netlink.Route) error {
+	if route == nil {
+		return nil
+	}
+	vmIP := route.Dst.IP
+	if vmIP == nil {
+		return nil
+	}
+	isManaged, err := isManagedIP(vmIP, w.cidrs)
+	if err != nil {
+		return err
+	}
+	if !isManaged {
+		return nil
+	}
+	ciliumInternalIP := route.Src
+	key, found := w.cache.GetName(vmIP)
+	// if the route was added but not added to cache, then do nothing, because we can't get name of vm.
+	if !found {
+		return nil
+	}
+
+	log := w.log.WithValues(
+		"ciliumInternalIP", ciliumInternalIP,
+		"inHostVMIP", vmIP.String(),
+		"virtualMachine", key)
+
+	addrs, found := w.cache.GetAddresses(key)
+	if !found {
+		log.Info("The route was added, but there is no addresses in the cache. Add the VM to the queue.")
+		w.enqueueKey(key)
+		return nil
+	}
+	routes, err := w.routeGet(addrs.NodeIP.NetIP())
+	if err != nil || len(routes) == 0 {
+		return fmt.Errorf("failed to get routes: %w", err)
+	}
+	ciliumInternalIPByNodeIP := routes[0].Src
+	if !ciliumInternalIP.Equal(ciliumInternalIPByNodeIP) || !addrs.VMIP.NetIP().Equal(vmIP) {
+		log.Info("The route was added, but the addresses from the cache and from the route do not match. Add the VM to the queue.",
+			"inCacheNodeIP", addrs.NodeIP.String(),
+			"inCacheVMIP", addrs.VMIP.String(),
+			"ciliumInternalIPByNodeIP", ciliumInternalIPByNodeIP.String(),
+		)
+		w.enqueueKey(key)
+	}
+	return nil
+}
+
+func (w *TickerWatcher) enqueueKey(key types.NamespacedName) {
+	w.ch <- key
+}

--- a/images/vm-route-forge/internal/controller/route/ticker.go
+++ b/images/vm-route-forge/internal/controller/route/ticker.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package route
 
 import (

--- a/images/vm-route-forge/internal/controller/route/util.go
+++ b/images/vm-route-forge/internal/controller/route/util.go
@@ -1,0 +1,20 @@
+package route
+
+import (
+	"fmt"
+	"net"
+)
+
+func isManagedIP(ip net.IP, cidrs []*net.IPNet) (bool, error) {
+	if len(ip) == 0 {
+		return false, fmt.Errorf("invalid IP address %s", ip)
+	}
+
+	for _, cidr := range cidrs {
+		if cidr.Contains(ip) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/images/vm-route-forge/internal/controller/route/util.go
+++ b/images/vm-route-forge/internal/controller/route/util.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package route
 
 import (

--- a/images/vm-route-forge/internal/controller/route/watch.go
+++ b/images/vm-route-forge/internal/controller/route/watch.go
@@ -1,0 +1,31 @@
+package route
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/types"
+
+	"vm-route-forge/internal/cache"
+)
+
+type Watcher interface {
+	Watch(ctx context.Context) (chan types.NamespacedName, error)
+}
+
+type KindRouteWatcher string
+
+const (
+	NetlinkKind KindRouteWatcher = "netlink"
+)
+
+func WatchFactory(kind KindRouteWatcher, cidrs []*net.IPNet, cache cache.Cache, log logr.Logger) (Watcher, error) {
+	switch kind {
+	case NetlinkKind:
+		return NewNetlinkWatcher(cidrs, cache, log), nil
+	default:
+		return nil, fmt.Errorf("unknown kind %s", kind)
+	}
+}

--- a/images/vm-route-forge/internal/controller/route/watch.go
+++ b/images/vm-route-forge/internal/controller/route/watch.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package route
 
 import (

--- a/images/vm-route-forge/internal/controller/route/watch.go
+++ b/images/vm-route-forge/internal/controller/route/watch.go
@@ -11,6 +11,10 @@ import (
 	"vm-route-forge/internal/cache"
 )
 
+const (
+	defaultChanSize = 100
+)
+
 type Watcher interface {
 	Watch(ctx context.Context) (chan types.NamespacedName, error)
 }
@@ -19,12 +23,23 @@ type KindRouteWatcher string
 
 const (
 	NetlinkKind KindRouteWatcher = "netlink"
+	TickerKind  KindRouteWatcher = "ticker"
+	EbpfKind    KindRouteWatcher = "ebpf"
 )
 
-func WatchFactory(kind KindRouteWatcher, cidrs []*net.IPNet, cache cache.Cache, log logr.Logger) (Watcher, error) {
+func WatchFactory(kind KindRouteWatcher,
+	cidrs []*net.IPNet,
+	cache cache.Cache,
+	tableID int,
+	log logr.Logger,
+) (Watcher, error) {
 	switch kind {
 	case NetlinkKind:
 		return NewNetlinkWatcher(cidrs, cache, log), nil
+	case TickerKind:
+		return NewTickerWatcher(cidrs, cache, tableID, log), nil
+	case EbpfKind:
+		return NewEbpfWatcher(cidrs, cache, log)
 	default:
 		return nil, fmt.Errorf("unknown kind %s", kind)
 	}

--- a/images/vm-route-forge/internal/netlinkmanager/manager.go
+++ b/images/vm-route-forge/internal/netlinkmanager/manager.go
@@ -35,10 +35,10 @@ import (
 
 	virtinformers "github.com/deckhouse/virtualization/api/client/generated/informers/externalversions/core/v1alpha2"
 	virtlisters "github.com/deckhouse/virtualization/api/client/generated/listers/core/v1alpha2"
-	cache2 "vm-route-forge/internal/cache"
+	vmipcache "vm-route-forge/internal/cache"
 
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
-	netlinkwrap2 "vm-route-forge/internal/netlinkwrap"
+	"vm-route-forge/internal/netlinkwrap"
 	"vm-route-forge/internal/netutil"
 )
 
@@ -50,29 +50,25 @@ const (
 )
 
 type Manager struct {
-	vmLister  virtlisters.VirtualMachineLister
-	cnIndexer cache.Indexer
-	hasSynced cache.InformerSynced
-	log       logr.Logger
-	nlWrapper *netlinkwrap2.Funcs
-	tableId   int
-	cidrs     []*net.IPNet
-	nodeName  string
-	cache     cache2.Cache
+	vmLister     virtlisters.VirtualMachineLister
+	cnIndexer    cache.Indexer
+	hasSynced    cache.InformerSynced
+	log          logr.Logger
+	nlWrapper    *netlinkwrap.Funcs
+	routeTableID int
+	cidrs        []*net.IPNet
+	nodeName     string
+	cache        vmipcache.Cache
 }
 
 func New(vmInformer virtinformers.VirtualMachineInformer,
 	cnInformer ciliumv2Informers.CiliumNodeInformer,
-	cache cache2.Cache,
+	cache vmipcache.Cache,
 	log logr.Logger,
-	tableId int,
+	routeTableID int,
 	cidrs []*net.IPNet,
-	dryRun bool,
+	nlWrapper *netlinkwrap.Funcs,
 ) *Manager {
-	nlWrapper := netlinkwrap2.NewFuncs()
-	if dryRun {
-		nlWrapper = netlinkwrap2.DryRunFuncs()
-	}
 	return &Manager{
 		//client:    client,
 		vmLister:  vmInformer.Lister(),
@@ -80,11 +76,11 @@ func New(vmInformer virtinformers.VirtualMachineInformer,
 		hasSynced: func() bool {
 			return vmInformer.Informer().HasSynced() && cnInformer.Informer().HasSynced()
 		},
-		log:       log.WithValues("manager", netlinkManager),
-		tableId:   tableId,
-		cidrs:     cidrs,
-		nlWrapper: nlWrapper,
-		cache:     cache,
+		log:          log.WithValues("manager", netlinkManager),
+		routeTableID: routeTableID,
+		cidrs:        cidrs,
+		nlWrapper:    nlWrapper,
+		cache:        cache,
 	}
 }
 
@@ -92,7 +88,7 @@ func New(vmInformer virtinformers.VirtualMachineInformer,
 // Also, it removes existing rules for previously configured CIDRs.
 func (m *Manager) SyncRules() error {
 	// Get rules state.
-	rules, err := m.nlWrapper.RuleListFiltered(netlinkwrap2.FAMILY_ALL, &netlink.Rule{Table: m.tableId}, netlink.RT_FILTER_TABLE)
+	rules, err := m.nlWrapper.RuleListFiltered(netlink.FAMILY_ALL, &netlink.Rule{Table: m.routeTableID}, netlink.RT_FILTER_TABLE)
 	if err != nil {
 		return fmt.Errorf("failed to list rules: %v", err)
 	}
@@ -101,8 +97,8 @@ func (m *Manager) SyncRules() error {
 	cidrIdx := make(map[string]struct{})
 	for _, cidr := range m.cidrs {
 		rule := netlink.NewRule()
-		rule.Table = m.tableId
-		rule.Priority = m.tableId
+		rule.Table = m.routeTableID
+		rule.Priority = m.routeTableID
 		rule.Dst = cidr
 		cidrIdx[cidr.String()] = struct{}{}
 		if err := m.nlWrapper.RuleAdd(rule); err != nil && !os.IsExist(err) {
@@ -166,7 +162,7 @@ func (m *Manager) SyncRoutes(ctx context.Context) error {
 	}
 
 	// Remove routes unknown for vm IPs.
-	nodeRoutes, err := m.nlWrapper.RouteListFiltered(netlinkwrap2.FAMILY_ALL, &netlink.Route{Table: m.tableId}, netlink.RT_FILTER_TABLE)
+	nodeRoutes, err := m.nlWrapper.RouteListFiltered(netlink.FAMILY_ALL, &netlink.Route{Table: m.routeTableID}, netlink.RT_FILTER_TABLE)
 	if err != nil {
 		return fmt.Errorf("failed to list node routes: %v", err)
 	}
@@ -258,7 +254,7 @@ func (m *Manager) UpdateRoute(vm *virtv2.VirtualMachine) error {
 	if len(nodeIPx) == 0 {
 		return fmt.Errorf("invalid IP address %s", nodeIP)
 	}
-	m.cache.Set(vmKey, cache2.Addresses{VMIP: cache2.IP(vmIP), NodeIP: cache2.IP(nodeIP)})
+	m.cache.Set(vmKey, vmipcache.Addresses{VMIP: vmipcache.IP(vmIP), NodeIP: vmipcache.IP(nodeIP)})
 
 	// Get route for specific nodeIP and create similar for our Virtual Machine.
 	routes, err := m.nlWrapper.RouteGet(nodeIPx)
@@ -279,7 +275,7 @@ func (m *Manager) UpdateRoute(vm *virtv2.VirtualMachine) error {
 	}
 
 	route.Dst = vmRouteDst
-	route.Table = m.tableId
+	route.Table = m.routeTableID
 	route.Type = 1
 
 	if err = m.nlWrapper.RouteReplace(&route); err != nil {
@@ -323,7 +319,7 @@ func (m *Manager) DeleteRoute(vmKey types.NamespacedName, vmIP string) error {
 
 	route := netlink.Route{
 		Dst:   vmRouteDst,
-		Table: m.tableId,
+		Table: m.routeTableID,
 	}
 
 	if err := m.nlWrapper.RouteDel(&route); err != nil && !os.IsNotExist(err) && !errors.Is(err, unix.ESRCH) {

--- a/images/vm-route-forge/internal/netlinkmanager/manager.go
+++ b/images/vm-route-forge/internal/netlinkmanager/manager.go
@@ -258,7 +258,7 @@ func (m *Manager) UpdateRoute(vm *virtv2.VirtualMachine) error {
 	if len(nodeIPx) == 0 {
 		return fmt.Errorf("invalid IP address %s", nodeIP)
 	}
-	m.cache.Set(vmKey, cache2.Addresses{VMIP: net.ParseIP(vmIP), NodeIP: net.ParseIP(nodeIP)})
+	m.cache.Set(vmKey, cache2.Addresses{VMIP: cache2.IP(vmIP), NodeIP: cache2.IP(nodeIP)})
 
 	// Get route for specific nodeIP and create similar for our Virtual Machine.
 	routes, err := m.nlWrapper.RouteGet(nodeIPx)

--- a/images/vm-route-forge/internal/netlinkwrap/funcs_linux.go
+++ b/images/vm-route-forge/internal/netlinkwrap/funcs_linux.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 /*
 Copyright 2024 Flant JSC
 
@@ -14,9 +17,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//go:build linux
-// +build linux
-
 package netlinkwrap
 
 import (
@@ -25,12 +25,6 @@ import (
 
 // Aliases for some netlink functions and constants available only for Linux.
 
-const (
-	FAMILY_ALL = orignetlink.FAMILY_ALL
-)
-
 var RuleAdd = orignetlink.RuleAdd
-
 var RuleDel = orignetlink.RuleDel
-
 var RuleListFiltered = orignetlink.RuleListFiltered

--- a/images/vm-route-forge/internal/netlinkwrap/funcs_others.go
+++ b/images/vm-route-forge/internal/netlinkwrap/funcs_others.go
@@ -1,3 +1,6 @@
+//go:build !linux
+// +build !linux
+
 /*
 Copyright 2024 Flant JSC
 
@@ -14,9 +17,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//go:build !linux
-// +build !linux
-
 package netlinkwrap
 
 import (
@@ -25,14 +25,8 @@ import (
 
 // Aliases for netlink functions and constants not available for non-Linux.
 
-const (
-	FAMILY_ALL = 0
-)
-
 var RuleAdd = func(*orignetlink.Rule) error { return orignetlink.ErrNotImplemented }
-
 var RuleDel = func(*orignetlink.Rule) error { return orignetlink.ErrNotImplemented }
-
 var RuleListFiltered = func(int, *orignetlink.Rule, uint64) ([]orignetlink.Rule, error) {
 	return nil, orignetlink.ErrNotImplemented
 }


### PR DESCRIPTION
## Description
add route Watcher interface (Watcher tracks routes on the host)
add a new Watcher implementation - ticker

## Why do we need it, and what problem does it solve?
We needs to track routes on the host. Therefore, a new interface is being introduced. Now there are 2 implementations, ticker and netlink

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
