### PR TITLE
fix(vd): write error to condition if pvc size is smaller than virtual size of source image

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/blank.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/blank.go
@@ -92,9 +92,13 @@ func (ds BlankDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (boo
 	case dv == nil:
 		log.Info("Start import to PVC")
 
+		vd.Status.Progress = "0%"
+
 		var diskSize resource.Quantity
 		diskSize, err = ds.getPVCSize(vd)
 		if err != nil {
+			setPhaseConditionToFailed(&condition, &vd.Status.Phase, err)
+
 			return false, err
 		}
 
@@ -110,8 +114,6 @@ func (ds BlankDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (boo
 		condition.Status = metav1.ConditionFalse
 		condition.Reason = vdcondition.Provisioning
 		condition.Message = "PVC Provisioner not found: create the new one."
-
-		vd.Status.Progress = "0%"
 
 		return true, nil
 	case pvc == nil:

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/errors.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/errors.go
@@ -21,10 +21,7 @@ import (
 	"fmt"
 )
 
-var (
-	ErrSecretNotFound                 = errors.New("container registry secret not found")
-	ErrPVCSizeSmallerImageVirtualSize = errors.New("persistentVolumeClaim size is smaller than image virtual size")
-)
+var ErrSecretNotFound = errors.New("container registry secret not found")
 
 type ImageNotReadyError struct {
 	name string

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/http.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/http.go
@@ -28,7 +28,6 @@ import (
 
 	cc "github.com/deckhouse/virtualization-controller/pkg/common"
 	"github.com/deckhouse/virtualization-controller/pkg/common/datasource"
-	vdutil "github.com/deckhouse/virtualization-controller/pkg/common/datavolume"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/common"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/importer"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
@@ -179,9 +178,18 @@ func (ds HTTPDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (bool
 			}
 		}
 
+		vd.Status.Progress = "50%"
+		vd.Status.DownloadSpeed = ds.statService.GetDownloadSpeed(vd.GetUID(), pod)
+
 		var diskSize resource.Quantity
 		diskSize, err = ds.getPVCSize(vd, pod)
 		if err != nil {
+			setPhaseConditionToFailed(&condition, &vd.Status.Phase, err)
+
+			if errors.Is(err, service.ErrInsufficientPVCSize) {
+				return false, nil
+			}
+
 			return false, err
 		}
 
@@ -197,9 +205,6 @@ func (ds HTTPDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (bool
 		condition.Status = metav1.ConditionFalse
 		condition.Reason = vdcondition.Provisioning
 		condition.Message = "PVC Provisioner not found: create the new one."
-
-		vd.Status.Progress = "50%"
-		vd.Status.DownloadSpeed = ds.statService.GetDownloadSpeed(vd.GetUID(), pod)
 
 		return true, nil
 	case pvc == nil:
@@ -326,18 +331,5 @@ func (ds HTTPDataSource) getPVCSize(vd *virtv2.VirtualDisk, pod *corev1.Pod) (re
 		return resource.Quantity{}, errors.New("got zero unpacked size from data source")
 	}
 
-	pvcSize := vd.Spec.PersistentVolumeClaim.Size
-	if pvcSize != nil && !pvcSize.IsZero() && pvcSize.Cmp(unpackedSize) == -1 {
-		return resource.Quantity{}, ErrPVCSizeSmallerImageVirtualSize
-	}
-
-	// Adjust PVC size to feat image onto scratch PVC.
-	// TODO(future): remove size adjusting after get rid of scratch.
-	adjustedSize := vdutil.AdjustPVCSize(unpackedSize)
-
-	if pvcSize != nil && pvcSize.Cmp(adjustedSize) == 1 {
-		return *pvcSize, nil
-	}
-
-	return adjustedSize, nil
+	return ds.diskService.AdjustPVCSize(vd.Spec.PersistentVolumeClaim.Size, unpackedSize)
 }

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/registry.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/registry.go
@@ -30,7 +30,6 @@ import (
 
 	cc "github.com/deckhouse/virtualization-controller/pkg/common"
 	"github.com/deckhouse/virtualization-controller/pkg/common/datasource"
-	vdutil "github.com/deckhouse/virtualization-controller/pkg/common/datavolume"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/common"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/importer"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
@@ -184,9 +183,17 @@ func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (
 			}
 		}
 
+		vd.Status.Progress = "50%"
+
 		var diskSize resource.Quantity
 		diskSize, err = ds.getPVCSize(vd, pod)
 		if err != nil {
+			setPhaseConditionToFailed(&condition, &vd.Status.Phase, err)
+
+			if errors.Is(err, service.ErrInsufficientPVCSize) {
+				return false, nil
+			}
+
 			return false, err
 		}
 
@@ -202,8 +209,6 @@ func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (
 		condition.Status = metav1.ConditionFalse
 		condition.Reason = vdcondition.Provisioning
 		condition.Message = "PVC Provisioner not found: create the new one."
-
-		vd.Status.Progress = "50%"
 
 		return true, nil
 	case pvc == nil:
@@ -349,18 +354,5 @@ func (ds RegistryDataSource) getPVCSize(vd *virtv2.VirtualDisk, pod *corev1.Pod)
 		return resource.Quantity{}, errors.New("got zero unpacked size from data source")
 	}
 
-	pvcSize := vd.Spec.PersistentVolumeClaim.Size
-	if pvcSize != nil && !pvcSize.IsZero() && pvcSize.Cmp(unpackedSize) == -1 {
-		return resource.Quantity{}, ErrPVCSizeSmallerImageVirtualSize
-	}
-
-	// Adjust PVC size to feat image onto scratch PVC.
-	// TODO(future): remove size adjusting after get rid of scratch.
-	adjustedSize := vdutil.AdjustPVCSize(unpackedSize)
-
-	if pvcSize != nil && pvcSize.Cmp(adjustedSize) == 1 {
-		return *pvcSize, nil
-	}
-
-	return adjustedSize, nil
+	return ds.diskService.AdjustPVCSize(vd.Spec.PersistentVolumeClaim.Size, unpackedSize)
 }


### PR DESCRIPTION
## Description

Write error to Ready condition, if pvc.persistentVolumeClaim.size is smaller than source image virtual size

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
