### PR TITLE
fix(vm): added processing of an empty phase for a VM and KVVM

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm/internal/lifecycle.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/lifecycle.go
@@ -94,7 +94,6 @@ func (h *LifeCycleHandler) Handle(ctx context.Context, s state.VirtualMachineSta
 	phase := getPhase(kvvm)
 	if phase == "" {
 		phase = virtv2.MachinePending
-		log.Error(fmt.Sprintf("unexpected KVVM state: status %q, fallback VM phase to %q", kvvm.Status.PrintableStatus, phase))
 	}
 	changed.Status.Phase = phase
 

--- a/images/virtualization-artifact/pkg/controller/vm/internal/lifecycle.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/lifecycle.go
@@ -81,7 +81,7 @@ func (h *LifeCycleHandler) Handle(ctx context.Context, s state.VirtualMachineSta
 		return reconcile.Result{}, nil
 	}
 
-	if updated := addAllUnknown(changed, lifeCycleConditions...); updated {
+	if updated := addAllUnknown(changed, lifeCycleConditions...); updated || changed.Status.Phase == "" {
 		changed.Status.Phase = virtv2.MachinePending
 		return reconcile.Result{Requeue: true}, nil
 	}
@@ -91,7 +91,12 @@ func (h *LifeCycleHandler) Handle(ctx context.Context, s state.VirtualMachineSta
 		return reconcile.Result{}, err
 	}
 
-	changed.Status.Phase = getPhase(kvvm)
+	phase := getPhase(kvvm)
+	if phase == "" {
+		phase = virtv2.MachinePending
+		log.Error(fmt.Sprintf("unexpected KVVM state: status %q, fallback VM phase to %q", kvvm.Status.PrintableStatus, phase))
+	}
+	changed.Status.Phase = phase
 
 	kvvmi, err := s.KVVMI(ctx)
 	if err != nil {

--- a/images/virtualization-artifact/pkg/controller/vm/internal/util.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/util.go
@@ -125,7 +125,11 @@ var mapPhases = map[virtv1.VirtualMachinePrintableStatus]virtv2.MachinePhase{
 	// VirtualMachineStatusWaitingForVolumeBinding indicates that some PersistentVolumeClaims backing
 	// the virtual machine volume are still not bound.
 	virtv1.VirtualMachineStatusWaitingForVolumeBinding: virtv2.MachinePending,
+
+	kvvmEmptyPhase: virtv2.MachinePending,
 }
+
+const kvvmEmptyPhase virtv1.VirtualMachinePrintableStatus = ""
 
 func isPodStarted(pod *corev1.Pod) bool {
 	if pod == nil || pod.Status.StartTime == nil {


### PR DESCRIPTION
## Description
 added processing of an empty phase for a VM and KVVM

## Why do we need it, and what problem does it solve?
Phase "" does not exist

`virtualization-controller-85dd874684-26cqc virtualization-controller {"time":"2024-08-12T14:46:13.571098442Z","level":"ERROR","msg":"Reconciler error","controller":"vm-controller","namespace":"testcases","name":"vm-c-and-a","reconcileID":"2d2a1740-56cb-44f7-84b5-63bce1eff661","err":"error updating status subresource: VirtualMachine.virtualization.deckhouse.io \"vm-c-and-a\" is invalid: status.phase: Unsupported value: \"\": supported values: \"Pending\", \"Running\", \"Degraded\", \"Terminating\", \"Stopped\", \"Stopping\", \"Starting\", \"Migrating\", \"Pause\""}`


## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
