### PR TITLE
chore(module): relabel internal vitualization metrics

### DIFF
--- a/templates/kubevirt/service-monitor.yaml
+++ b/templates/kubevirt/service-monitor.yaml
@@ -13,19 +13,68 @@ spec:
       name: prometheus-token
     path: /metrics
     port: metrics
-    # relabelings:
-    # - action: labeldrop
-    #   regex: endpoint|namespace|pod|container
-    # - action: replace
-    #   replacement: linstor-controller
-    #   targetLabel: job
-    # - action: replace
-    #   replacement: cluster
-    #   targetLabel: tier
-    # - action: keep
-    #   regex: "true"
-    #   sourceLabels:
-    #   - __meta_kubernetes_endpoint_ready
+spec:
+  endpoints:
+    - bearerTokenSecret:
+        key: token
+        name: prometheus-token
+      path: /metrics
+      port: metrics
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true
+      metricRelabelings:
+        - sourceLabels: [__name__]
+          regex: kubevirt_vmi_(migration_)?phase_(.*)
+          action: drop
+        - sourceLabels: [__name__, drive]
+          regex: "kubevirt_vmi_storage_(.*);vd-(.*)"
+          separator: ;
+          action: replace
+          targetLabel: __name__
+          replacement: d8_virtualization_virtualdisk_$1
+        - sourceLabels: [__name__, drive]
+          regex: "kubevirt_vmi_storage_(.*);vi-(.*)"
+          separator: ;
+          action: replace
+          targetLabel: __name__
+          replacement: d8_virtualization_virtualimage_$1
+        - sourceLabels: [__name__, drive]
+          regex: "kubevirt_vmi_storage_(.*);cvi-(.*)"
+          separator: ;
+          action: replace
+          targetLabel: __name__
+          replacement: d8_virtualization_clustervirtualimage_$1
+        - sourceLabels: [__name__, drive]
+          regex: "kubevirt_vmi_storage_(.*);cloudinit"
+          separator: ;
+          action: drop
+        - sourceLabels: [__name__]
+          regex: kubevirt_vmi_(.*)
+          action: replace
+          targetLabel: __name__
+          replacement: d8_virtualization_virtualmachine_$1
+        - sourceLabels: [__name__]
+          regex: kubevirt_(.*)
+          action: replace
+          targetLabel: __name__
+          replacement: d8_internal_virtualization_kubevirt_$1
+        - action: replace
+          sourceLabels:
+          - exported_namespace
+          targetLabel: namespace
+        - action: labelmap
+          regex: kubernetes_vmi_(.+)
+          replacement: kubernetes_$1
+        - action: labeldrop
+          regex: (container|endpoint|job|service|pod|exported_namespace|kubernetes_vmi_(.+)|(.+)kubevirt_io(.+))
+  namespaceSelector:
+    matchNames:
+      - d8-virtualization
+  selector:
+    matchLabels:
+      prometheus.kubevirt.internal.virtualization.deckhouse.io: "true"
+
     scheme: https
     tlsConfig:
       insecureSkipVerify: true

--- a/templates/kubevirt/service-monitor.yaml
+++ b/templates/kubevirt/service-monitor.yaml
@@ -28,27 +28,39 @@ spec:
           regex: kubevirt_vmi_(migration_)?phase_(.*)
           action: drop
         - sourceLabels: [__name__, drive]
+          regex: "kubevirt_vmi_storage_(.*);((cvi|vi|vd)-)?(.+)"
+          separator: ;
+          action: replace
+          targetLabel: block_device_name
+          replacement: $4
+        - sourceLabels: [__name__, drive]
           regex: "kubevirt_vmi_storage_(.*);vd-(.*)"
           separator: ;
           action: replace
-          targetLabel: __name__
-          replacement: d8_virtualization_virtualdisk_$1
+          targetLabel: type
+          replacement: virtualdisk
         - sourceLabels: [__name__, drive]
           regex: "kubevirt_vmi_storage_(.*);vi-(.*)"
           separator: ;
           action: replace
-          targetLabel: __name__
-          replacement: d8_virtualization_virtualimage_$1
+          targetLabel: type
+          replacement: virtualimage
         - sourceLabels: [__name__, drive]
           regex: "kubevirt_vmi_storage_(.*);cvi-(.*)"
           separator: ;
           action: replace
+          targetLabel: type
+          replacement: clustervirtualimage
+        - sourceLabels: [__name__]
+          regex: kubevirt_vmi_storage_(.*)
+          action: replace
           targetLabel: __name__
-          replacement: d8_virtualization_clustervirtualimage_$1
-        - sourceLabels: [__name__, drive]
-          regex: "kubevirt_vmi_storage_(.*);cloudinit"
-          separator: ;
-          action: drop
+          replacement: d8_virtualization_virtualmachine_block_device_$1
+        - sourceLabels: [__name__]
+          regex: kubevirt_vmi_filesystem_(.*)
+          action: replace
+          targetLabel: __name__
+          replacement: d8_virtualization_virtualmachine_block_device_filesystem_$1
         - sourceLabels: [__name__]
           regex: kubevirt_vmi_(.*)
           action: replace
@@ -67,10 +79,10 @@ spec:
           regex: kubernetes_vmi_(.+)
           replacement: kubernetes_$1
         - action: labeldrop
-          regex: (container|endpoint|job|service|pod|exported_namespace|kubernetes_vmi_(.+)|(.+)kubevirt_io(.+))
+          regex: (drive|container|endpoint|job|service|pod|exported_namespace|kubernetes_vmi_(.+)|(.+)kubevirt_io(.+))
   namespaceSelector:
     matchNames:
-      - d8-virtualization
+      - d8-{{ .Chart.Name }}
   selector:
     matchLabels:
       prometheus.kubevirt.internal.virtualization.deckhouse.io: "true"

--- a/templates/kubevirt/service-monitor.yaml
+++ b/templates/kubevirt/service-monitor.yaml
@@ -24,62 +24,108 @@ spec:
       tlsConfig:
         insecureSkipVerify: true
       metricRelabelings:
-        - sourceLabels: [__name__]
+        # drop _phases
+        - action: drop
           regex: kubevirt_vmi_(migration_)?phase_(.*)
-          action: drop
-        - sourceLabels: [__name__, drive]
-          regex: "kubevirt_vmi_storage_(.*);((cvi|vi|vd)-)?(.+)"
+          sourceLabels:
+          - __name__
+        # add block_device_name without prefix only for cvi, vi, vd
+        - action: replace
+          regex: kubevirt_vmi_storage_.*;(cvi|vi|vd)-(.+)
+          replacement: $2
           separator: ;
-          action: replace
+          sourceLabels:
+          - __name__
+          - drive
           targetLabel: block_device_name
-          replacement: $4
-        - sourceLabels: [__name__, drive]
-          regex: "kubevirt_vmi_storage_(.*);vd-(.*)"
-          separator: ;
-          action: replace
-          targetLabel: type
+        # add type for vd
+        - action: replace
+          regex: kubevirt_vmi_storage_(.*);vd-(.*)
           replacement: virtualdisk
-        - sourceLabels: [__name__, drive]
-          regex: "kubevirt_vmi_storage_(.*);vi-(.*)"
           separator: ;
-          action: replace
+          sourceLabels:
+          - __name__
+          - drive
           targetLabel: type
+        # add type for vi
+        - action: replace
+          regex: kubevirt_vmi_storage_(.*);vi-(.*)
           replacement: virtualimage
-        - sourceLabels: [__name__, drive]
-          regex: "kubevirt_vmi_storage_(.*);cvi-(.*)"
           separator: ;
-          action: replace
+          sourceLabels:
+          - __name__
+          - drive
           targetLabel: type
+        # add type for cvi
+        - action: replace
+          regex: kubevirt_vmi_storage_(.*);cvi-(.*)
           replacement: clustervirtualimage
-        - sourceLabels: [__name__]
+          separator: ;
+          sourceLabels:
+          - __name__
+          - drive
+          targetLabel: type
+        # add type for cloudinit
+        - action: replace
+          regex: kubevirt_vmi_storage_(.*);cloudinit
+          replacement: cloudinit
+          separator: ;
+          sourceLabels:
+          - __name__
+          - drive
+          targetLabel: type
+        # add type for sysprep
+        - action: replace
+          regex: kubevirt_vmi_storage_(.*);sysprep
+          replacement: sysprep
+          separator: ;
+          sourceLabels:
+          - __name__
+          - drive
+          targetLabel: type
+        # add network=default for all kubevirt_vmi_network_
+        - action: replace
+          regex: kubevirt_vmi_network_(.*)
+          replacement: default
+          sourceLabels:
+          - __name__
+          targetLabel: network
+        # rename kubevirt_vmi_storage_ -> d8_virtualization_virtualmachine_block_device_
+        - action: replace
           regex: kubevirt_vmi_storage_(.*)
-          action: replace
-          targetLabel: __name__
           replacement: d8_virtualization_virtualmachine_block_device_$1
-        - sourceLabels: [__name__]
-          regex: kubevirt_vmi_filesystem_(.*)
-          action: replace
+          sourceLabels:
+          - __name__
           targetLabel: __name__
-          replacement: d8_virtualization_virtualmachine_block_device_filesystem_$1
-        - sourceLabels: [__name__]
+        # kubevirt_vmi_outdated_ -> d8_internal_virtualization_kubevirt_vmi_outdated_
+        - action: replace
+          regex: kubevirt_vmi_outdated_(.*)
+          replacement: d8_internal_virtualization_kubevirt_vmi_outdated_$1
+          sourceLabels:
+          - __name__
+          targetLabel: __name__
+        # renave kubevirt_vmi_ -> d8_virtualization_virtualmachine
+        - action: replace
           regex: kubevirt_vmi_(.*)
-          action: replace
-          targetLabel: __name__
           replacement: d8_virtualization_virtualmachine_$1
-        - sourceLabels: [__name__]
-          regex: kubevirt_(.*)
-          action: replace
+          sourceLabels:
+          - __name__
           targetLabel: __name__
+        # all other metrics -> d8_internal_virtualization_kubevirt_
+        - action: replace
+          regex: kubevirt_(.*)
           replacement: d8_internal_virtualization_kubevirt_$1
+          sourceLabels:
+          - __name__
+          targetLabel: __name__
+        # exported_namespace -> namespace
         - action: replace
           sourceLabels:
           - exported_namespace
           targetLabel: namespace
-        - action: labelmap
-          regex: kubernetes_vmi_(.+)
-          replacement: kubernetes_$1
+        # drop labels
         - action: labeldrop
-          regex: (drive|container|endpoint|job|service|pod|exported_namespace|kubernetes_vmi_(.+)|(.+)kubevirt_io(.+))
+          regex: (interface|drive|container|endpoint|job|service|pod|exported_namespace|kubernetes_vmi_(.+))
   namespaceSelector:
     matchNames:
       - d8-{{ .Chart.Name }}

--- a/templates/virtualization-controller/service-monitor.yaml
+++ b/templates/virtualization-controller/service-monitor.yaml
@@ -13,6 +13,13 @@ spec:
     path: /metrics
     port: metrics
     scheme: http
+    metricRelabelings:
+      - sourceLabels: [__name__]
+        regex: "(.*)"
+        separator: ;
+        action: replace
+        targetLabel: __name__
+        replacement: d8_$1
   namespaceSelector:
     matchNames:
     - d8-{{ .Chart.Name }}

--- a/templates/virtualization-controller/service-monitor.yaml
+++ b/templates/virtualization-controller/service-monitor.yaml
@@ -20,6 +20,12 @@ spec:
         action: replace
         targetLabel: __name__
         replacement: d8_$1
+      - action: replace
+        sourceLabels:
+        - exported_namespace
+        targetLabel: namespace
+      - action: labeldrop
+        regex: (container|endpoint|job|service|pod|exported_namespace|uid)
   namespaceSelector:
     matchNames:
     - d8-{{ .Chart.Name }}


### PR DESCRIPTION
## Description
Rename and relabel all internal virtualization metrics

## Why do we need it, and what problem does it solve?
Ensures clearer, more intuitive, and standardized metric names and labels, improving monitoring, ease of integration, and operational efficiency.

## What is the expected result?
All metrics are now prefixed with `d8_virtualization_*`

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
