### PR TITLE
fix(vmip): changes to the resource name generation algorithm

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vmip/internal/state/state.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/state/state.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/deckhouse/virtualization-controller/pkg/controller/common"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/indexer"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/ipam"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vmip/internal/util"
 	"github.com/deckhouse/virtualization-controller/pkg/sdk/framework/helper"
@@ -125,10 +126,9 @@ func (s *state) VirtualMachine(ctx context.Context) (*virtv2.VirtualMachine, err
 			return nil, err
 		}
 
-		vmipNameWithoutHash := string([]rune(s.vmip.Name)[:len(s.vmip.Name)-6])
 		for i, vm := range vms.Items {
 			if vm.Spec.VirtualMachineIPAddress == s.vmip.Name ||
-				vm.Spec.VirtualMachineIPAddress == "" && vm.Name == vmipNameWithoutHash {
+				vm.Spec.VirtualMachineIPAddress == "" && vm.Name == ipam.GetVirtualMachineName(s.vmip) {
 				s.vm = &vms.Items[i]
 				break
 			}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
- The function of getting the VirtualMachine name from the VirtuslMachineIPAddress name has been redesigned
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.

-->

- Fix panic that occurs if name VirtualMachineIPAddress is shorter than 6 characters

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
