### PR TITLE
fix(vmip): fix bug of creating two VirtualMachineIPAddress with the same name in different namespaces

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vmip/internal/state/state.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/state/state.go
@@ -77,9 +77,11 @@ func (s *state) VirtualMachineIPLease(ctx context.Context) (*virtv2.VirtualMachi
 
 	if s.lease == nil {
 		var leases virtv2.VirtualMachineIPAddressLeaseList
-		err = s.client.List(ctx, &leases, &client.MatchingFields{
-			indexer.IndexFieldVMIPLeaseByVMIP: s.vmip.Name,
-		})
+		err = s.client.List(ctx, &leases,
+			client.InNamespace(s.vmip.Namespace),
+			&client.MatchingFields{
+				indexer.IndexFieldVMIPLeaseByVMIP: s.vmip.Name,
+			})
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
- Fix bug of creating two VirtualMachineIPAddress with the same name in different namespaces

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
