### PR TITLE
chore(core): install necessary packages for redos when selinux enabled

### DIFF
--- a/templates/nodegroupconfiguration-redos.yaml
+++ b/templates/nodegroupconfiguration-redos.yaml
@@ -24,11 +24,11 @@ spec:
     # See the License for the specific language governing permissions and
     # limitations under the License.
 
-    bb-event-on 'bb-package-installed' 'post-install'
-    post-install() {
-      bb-log-info "Setting reboot flag due to selinux-policy was installed"
-      bb-flag-set reboot
-    }
+    # bb-event-on 'bb-package-installed' 'post-install'
+    # post-install() {
+    #   bb-log-info "Setting reboot flag due to selinux-policy was installed"
+    #   bb-flag-set reboot
+    # }
 
     # Check if SELinux is enabled
     function is_selinux_enabled() {
@@ -57,8 +57,14 @@ spec:
     if is_selinux_enabled; then
 
       if is_package_installed "selinux-policy"; then
+        bb-log-info "install container-selinux"
         install_package "container-selinux"
       else
+        bb-event-on 'bb-package-installed' 'post-install'
+        post-install() {
+          bb-log-info "Setting reboot flag due to selinux-policy was installed"
+          bb-flag-set reboot
+        }
         bb-deckhouse-get-disruptive-update-approval
         install_package "selinux-policy"
         install_package "container-selinux"

--- a/templates/nodegroupconfiguration-redos.yaml
+++ b/templates/nodegroupconfiguration-redos.yaml
@@ -1,0 +1,69 @@
+apiVersion: deckhouse.io/v1alpha1
+kind: NodeGroupConfiguration
+metadata:
+  name: redos-selinux-packages
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+spec:
+  bundles:
+  - 'redos'
+  weight: 100
+  nodeGroups:
+   - '*'
+  content: |
+    # Copyright 2024 Flant JSC
+    #
+    # Licensed under the Apache License, Version 2.0 (the "License");
+    # you may not use this file except in compliance with the License.
+    # You may obtain a copy of the License at
+    #
+    #     http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
+
+    bb-event-on 'bb-package-installed' 'post-install'
+    post-install() {
+      bb-log-info "Setting reboot flag due to selinux-policy was installed"
+      bb-flag-set reboot
+    }
+
+    # Check if SELinux is enabled
+    function is_selinux_enabled() {
+        selinux_status=$(getenforce 2>/dev/null)
+        if [[ "$selinux_status" == "Enforcing" || "$selinux_status" == "Permissive" ]]; then
+            return 0
+        else
+            return 1
+        fi
+    }
+
+    # Check if a package is installed
+    function is_package_installed() {
+        if rpm -q "$1" &>/dev/null; then
+            return 0
+        else
+            return 1
+        fi
+    }
+
+    # Install a package
+    function install_package() {
+        bb-yum-install "$1"
+    }
+
+    if is_selinux_enabled; then
+
+      if is_package_installed "selinux-policy"; then
+        install_package "container-selinux"
+      else
+        bb-deckhouse-get-disruptive-update-approval
+        install_package "selinux-policy"
+        install_package "container-selinux"
+      fi
+
+    else
+      exit 0
+    fi

--- a/templates/nodegroupconfiguration-redos.yaml
+++ b/templates/nodegroupconfiguration-redos.yaml
@@ -1,12 +1,12 @@
 apiVersion: deckhouse.io/v1alpha1
 kind: NodeGroupConfiguration
 metadata:
-  name: redos-selinux-packages
+  name: virt-redos-selinux-packages
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 spec:
   bundles:
   - 'redos'
-  weight: 100
+  weight: 30
   nodeGroups:
    - '*'
   content: |
@@ -23,12 +23,6 @@ spec:
     # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     # See the License for the specific language governing permissions and
     # limitations under the License.
-
-    # bb-event-on 'bb-package-installed' 'post-install'
-    # post-install() {
-    #   bb-log-info "Setting reboot flag due to selinux-policy was installed"
-    #   bb-flag-set reboot
-    # }
 
     # Check if SELinux is enabled
     function is_selinux_enabled() {
@@ -57,6 +51,11 @@ spec:
     if is_selinux_enabled; then
 
       if is_package_installed "selinux-policy"; then
+        
+        if is_package_installed "container-selinux"; then 
+          exit 0
+        fi
+        
         bb-log-info "install container-selinux"
         install_package "container-selinux"
       else


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
When selinux is enabled on RedOS, `selinux-policy` and `container-selinux` packages must be installed on the system for virtualization to work properly.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
When selinux is enabled, virt-handler will not be able to run on nodes and creating virtual machines will not be possible
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Virtualmachine can be started if selinux is enabled.

> Package `selinux-policy` require restart system, if not previously installed

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
