### PR TITLE
fix(vmip): fix bug with create VirtualMachineIPAddress in different namespace, when VirtualMahineIPAddressLease 'Released'

### DIFF
--- a/api/core/v1alpha2/vmipcondition/condition.go
+++ b/api/core/v1alpha2/vmipcondition/condition.go
@@ -38,8 +38,8 @@ const (
 	// VirtualMachineIPAddressIsOutOfTheValidRange is a BoundReason indicating when specified IP address is out of the range in controller settings.
 	VirtualMachineIPAddressIsOutOfTheValidRange BoundReason = "VirtualMachineIPAddressIsOutOfTheValidRange"
 
-	// VirtualMachineIPAddressLeaseAlreadyExist is a BoundReason indicating the IP address lease already exists.
-	VirtualMachineIPAddressLeaseAlreadyExist BoundReason = "VirtualMachineIPAddressLeaseAlreadyExist"
+	// VirtualMachineIPAddressLeaseAlreadyExists is a BoundReason indicating the IP address lease already exists.
+	VirtualMachineIPAddressLeaseAlreadyExists BoundReason = "VirtualMachineIPAddressLeaseAlreadyExists"
 
 	// VirtualMachineIPAddressLeaseLost is a BoundReason indicating the IP address lease was lost.
 	VirtualMachineIPAddressLeaseLost BoundReason = "VirtualMachineIPAddressLeaseLost"

--- a/api/core/v1alpha2/vmipcondition/condition.go
+++ b/api/core/v1alpha2/vmipcondition/condition.go
@@ -38,8 +38,8 @@ const (
 	// VirtualMachineIPAddressIsOutOfTheValidRange is a BoundReason indicating when specified IP address is out of the range in controller settings.
 	VirtualMachineIPAddressIsOutOfTheValidRange BoundReason = "VirtualMachineIPAddressIsOutOfTheValidRange"
 
-	// VirtualMachineIPAddressLeaseAlready is a BoundReason indicating the IP address lease already exists.
-	VirtualMachineIPAddressLeaseAlready BoundReason = "VirtualMachineIPAddressLeaseAlready"
+	// VirtualMachineIPAddressLeaseAlreadyExist is a BoundReason indicating the IP address lease already exists.
+	VirtualMachineIPAddressLeaseAlreadyExist BoundReason = "VirtualMachineIPAddressLeaseAlreadyExist"
 
 	// VirtualMachineIPAddressLeaseLost is a BoundReason indicating the IP address lease was lost.
 	VirtualMachineIPAddressLeaseLost BoundReason = "VirtualMachineIPAddressLeaseLost"

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/iplease_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/iplease_handler.go
@@ -66,7 +66,7 @@ func (h IPLeaseHandler) Handle(ctx context.Context, state state.VMIPState) (reco
 	condition, _ := service.GetCondition(vmipcondition.BoundType, vmipStatus.Conditions)
 
 	switch {
-	case lease == nil && vmipStatus.Address != "" && condition.Reason != vmipcondition.VirtualMachineIPAddressLeaseAlready:
+	case lease == nil && vmipStatus.Address != "" && condition.Reason != vmipcondition.VirtualMachineIPAddressLeaseAlreadyExist:
 		log.Info("Lease by name not found: waiting for the lease to be available")
 		return reconcile.Result{}, nil
 
@@ -91,7 +91,7 @@ func (h IPLeaseHandler) Handle(ctx context.Context, state state.VMIPState) (reco
 
 		if lease.Spec.VirtualMachineIPAddressRef.Namespace != vmip.Namespace {
 			log.Warn(fmt.Sprintf("The VirtualMachineIPLease belongs to a different namespace: %s", lease.Spec.VirtualMachineIPAddressRef.Namespace))
-			h.recorder.Event(vmip, corev1.EventTypeWarning, vmipcondition.VirtualMachineIPAddressLeaseAlready, "The VirtualMachineIPLease belongs to a different namespace")
+			h.recorder.Event(vmip, corev1.EventTypeWarning, vmipcondition.VirtualMachineIPAddressLeaseAlreadyExist, "The VirtualMachineIPLease belongs to a different namespace")
 
 			return reconcile.Result{}, nil
 		}
@@ -150,11 +150,11 @@ func (h IPLeaseHandler) createNewLease(ctx context.Context, state state.VMIPStat
 		case errors.Is(err, service.ErrIPAddressAlreadyExist):
 			vmipStatus.Phase = virtv2.VirtualMachineIPAddressPhasePending
 			mgr.Update(conditionBound.Status(metav1.ConditionFalse).
-				Reason(vmipcondition.VirtualMachineIPAddressLeaseAlready).
+				Reason(vmipcondition.VirtualMachineIPAddressLeaseAlreadyExist).
 				Message(fmt.Sprintf("VirtualMachineIPAddressLease %s is bound to another VirtualMachineIPAddress",
 					common.IpToLeaseName(vmipStatus.Address))).
 				Condition())
-			h.recorder.Event(vmip, corev1.EventTypeWarning, vmipcondition.VirtualMachineIPAddressLeaseAlready, msg)
+			h.recorder.Event(vmip, corev1.EventTypeWarning, vmipcondition.VirtualMachineIPAddressLeaseAlreadyExist, msg)
 		}
 
 		vmipStatus.Conditions = mgr.Generate()

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/iplease_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/iplease_handler.go
@@ -66,7 +66,7 @@ func (h IPLeaseHandler) Handle(ctx context.Context, state state.VMIPState) (reco
 	condition, _ := service.GetCondition(vmipcondition.BoundType, vmipStatus.Conditions)
 
 	switch {
-	case lease == nil && vmipStatus.Address != "" && condition.Reason != vmipcondition.VirtualMachineIPAddressLeaseAlreadyExist:
+	case lease == nil && vmipStatus.Address != "" && condition.Reason != vmipcondition.VirtualMachineIPAddressLeaseAlreadyExists:
 		log.Info("Lease by name not found: waiting for the lease to be available")
 		return reconcile.Result{}, nil
 
@@ -91,7 +91,7 @@ func (h IPLeaseHandler) Handle(ctx context.Context, state state.VMIPState) (reco
 
 		if lease.Spec.VirtualMachineIPAddressRef.Namespace != vmip.Namespace {
 			log.Warn(fmt.Sprintf("The VirtualMachineIPLease belongs to a different namespace: %s", lease.Spec.VirtualMachineIPAddressRef.Namespace))
-			h.recorder.Event(vmip, corev1.EventTypeWarning, vmipcondition.VirtualMachineIPAddressLeaseAlreadyExist, "The VirtualMachineIPLease belongs to a different namespace")
+			h.recorder.Event(vmip, corev1.EventTypeWarning, vmipcondition.VirtualMachineIPAddressLeaseAlreadyExists, "The VirtualMachineIPLease belongs to a different namespace")
 
 			return reconcile.Result{}, nil
 		}
@@ -150,11 +150,11 @@ func (h IPLeaseHandler) createNewLease(ctx context.Context, state state.VMIPStat
 		case errors.Is(err, service.ErrIPAddressAlreadyExist):
 			vmipStatus.Phase = virtv2.VirtualMachineIPAddressPhasePending
 			mgr.Update(conditionBound.Status(metav1.ConditionFalse).
-				Reason(vmipcondition.VirtualMachineIPAddressLeaseAlreadyExist).
+				Reason(vmipcondition.VirtualMachineIPAddressLeaseAlreadyExists).
 				Message(fmt.Sprintf("VirtualMachineIPAddressLease %s is bound to another VirtualMachineIPAddress",
 					common.IpToLeaseName(vmipStatus.Address))).
 				Condition())
-			h.recorder.Event(vmip, corev1.EventTypeWarning, vmipcondition.VirtualMachineIPAddressLeaseAlreadyExist, msg)
+			h.recorder.Event(vmip, corev1.EventTypeWarning, vmipcondition.VirtualMachineIPAddressLeaseAlreadyExists, msg)
 		}
 
 		vmipStatus.Conditions = mgr.Generate()

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/iplease_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/iplease_handler.go
@@ -63,9 +63,10 @@ func (h IPLeaseHandler) Handle(ctx context.Context, state state.VMIPState) (reco
 	if err != nil {
 		return reconcile.Result{}, err
 	}
+	condition, _ := service.GetCondition(vmipcondition.BoundType, vmipStatus.Conditions)
 
 	switch {
-	case lease == nil && vmipStatus.Address != "":
+	case lease == nil && vmipStatus.Address != "" && condition.Reason != vmipcondition.VirtualMachineIPAddressLeaseAlready:
 		log.Info("Lease by name not found: waiting for the lease to be available")
 		return reconcile.Result{}, nil
 
@@ -89,9 +90,9 @@ func (h IPLeaseHandler) Handle(ctx context.Context, state state.VMIPState) (reco
 		log.Info("Lease is released: set binding")
 
 		if lease.Spec.VirtualMachineIPAddressRef.Namespace != vmip.Namespace {
-			msg := fmt.Sprintf("the selected VirtualMachineIP lease belongs to a different namespace: %s", lease.Spec.VirtualMachineIPAddressRef.Namespace)
-			log.Error(msg)
-			h.recorder.Event(vmip, corev1.EventTypeWarning, vmipcondition.VirtualMachineIPAddressLeaseNotFound, msg)
+			log.Warn(fmt.Sprintf("The VirtualMachineIPLease belongs to a different namespace: %s", lease.Spec.VirtualMachineIPAddressRef.Namespace))
+			h.recorder.Event(vmip, corev1.EventTypeWarning, vmipcondition.VirtualMachineIPAddressLeaseAlready, "The VirtualMachineIPLease belongs to a different namespace")
+
 			return reconcile.Result{}, nil
 		}
 
@@ -150,7 +151,7 @@ func (h IPLeaseHandler) createNewLease(ctx context.Context, state state.VMIPStat
 			vmipStatus.Phase = virtv2.VirtualMachineIPAddressPhasePending
 			mgr.Update(conditionBound.Status(metav1.ConditionFalse).
 				Reason(vmipcondition.VirtualMachineIPAddressLeaseAlready).
-				Message(fmt.Sprintf("VirtualMachineIPAddressLease %s is bound to another VirtualMachineIP",
+				Message(fmt.Sprintf("VirtualMachineIPAddressLease %s is bound to another VirtualMachineIPAddress",
 					common.IpToLeaseName(vmipStatus.Address))).
 				Condition())
 			h.recorder.Event(vmip, corev1.EventTypeWarning, vmipcondition.VirtualMachineIPAddressLeaseAlready, msg)

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/lifecycle_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/lifecycle_handler.go
@@ -113,7 +113,7 @@ func (h *LifecycleHandler) Handle(ctx context.Context, state state.VMIPState) (r
 			log.Warn(fmt.Sprintf("VirtualMachineIPAddressLease %s is bound to another VirtualMachineIPAddress resource: %s/%s",
 				lease.Name, lease.Spec.VirtualMachineIPAddressRef.Name, lease.Spec.VirtualMachineIPAddressRef.Namespace))
 			mgr.Update(conditionBound.Status(metav1.ConditionFalse).
-				Reason(vmipcondition.VirtualMachineIPAddressLeaseAlreadyExist).
+				Reason(vmipcondition.VirtualMachineIPAddressLeaseAlreadyExists).
 				Message(fmt.Sprintf("VirtualMachineIPAddressLease %s is bound to another VirtualMachineIPAddress resource",
 					lease.Name)).
 				Condition())
@@ -123,7 +123,7 @@ func (h *LifecycleHandler) Handle(ctx context.Context, state state.VMIPState) (r
 		if vmipStatus.Phase != virtv2.VirtualMachineIPAddressPhasePending {
 			vmipStatus.Phase = virtv2.VirtualMachineIPAddressPhasePending
 			mgr.Update(conditionBound.Status(metav1.ConditionFalse).
-				Reason(vmipcondition.VirtualMachineIPAddressLeaseAlreadyExist).
+				Reason(vmipcondition.VirtualMachineIPAddressLeaseAlreadyExists).
 				Message(fmt.Sprintf("The VirtualMachineIPLease %s belongs to a different namespace", lease.Name)).
 				Condition())
 		}

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/lifecycle_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/lifecycle_handler.go
@@ -19,6 +19,7 @@ package internal
 import (
 	"context"
 	"fmt"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -76,6 +77,7 @@ func (h *LifecycleHandler) Handle(ctx context.Context, state state.VMIPState) (r
 		return reconcile.Result{}, err
 	}
 
+	needRequeue := false
 	switch {
 	case lease == nil && vmipStatus.Address != "":
 		if vmipStatus.Phase != virtv2.VirtualMachineIPAddressPhasePending {
@@ -108,12 +110,24 @@ func (h *LifecycleHandler) Handle(ctx context.Context, state state.VMIPState) (r
 	case lease.Status.Phase == virtv2.VirtualMachineIPAddressLeasePhaseBound:
 		if vmipStatus.Phase != virtv2.VirtualMachineIPAddressPhasePending {
 			vmipStatus.Phase = virtv2.VirtualMachineIPAddressPhasePending
+			log.Warn(fmt.Sprintf("VirtualMachineIPAddressLease %s is bound to another VirtualMachineIPAddress resource: %s/%s",
+				lease.Name, lease.Spec.VirtualMachineIPAddressRef.Name, lease.Spec.VirtualMachineIPAddressRef.Namespace))
 			mgr.Update(conditionBound.Status(metav1.ConditionFalse).
 				Reason(vmipcondition.VirtualMachineIPAddressLeaseAlready).
-				Message(fmt.Sprintf("VirtualMachineIPAddressLease %s is bound to another VirtualMachineIP",
-					common.IpToLeaseName(vmipStatus.Address))).
+				Message(fmt.Sprintf("VirtualMachineIPAddressLease %s is bound to another VirtualMachineIPAddress resource",
+					lease.Name)).
 				Condition())
 		}
+
+	case lease.Spec.VirtualMachineIPAddressRef.Namespace != vmip.Namespace:
+		if vmipStatus.Phase != virtv2.VirtualMachineIPAddressPhasePending {
+			vmipStatus.Phase = virtv2.VirtualMachineIPAddressPhasePending
+			mgr.Update(conditionBound.Status(metav1.ConditionFalse).
+				Reason(vmipcondition.VirtualMachineIPAddressLeaseAlready).
+				Message(fmt.Sprintf("The VirtualMachineIPLease %s belongs to a different namespace", lease.Name)).
+				Condition())
+		}
+		needRequeue = true
 
 	default:
 		if vmipStatus.Phase != virtv2.VirtualMachineIPAddressPhasePending {
@@ -121,7 +135,7 @@ func (h *LifecycleHandler) Handle(ctx context.Context, state state.VMIPState) (r
 			mgr.Update(conditionBound.Status(metav1.ConditionFalse).
 				Reason(vmipcondition.VirtualMachineIPAddressLeaseNotReady).
 				Message(fmt.Sprintf("VirtualMachineIPAddressLease %s is not ready",
-					common.IpToLeaseName(vmipStatus.Address))).
+					lease.Name)).
 				Condition())
 		}
 	}
@@ -129,8 +143,12 @@ func (h *LifecycleHandler) Handle(ctx context.Context, state state.VMIPState) (r
 	log.Info("Set VirtualMachineIP phase", "phase", vmipStatus.Phase)
 	vmipStatus.Conditions = mgr.Generate()
 	vmipStatus.ObservedGeneration = vmip.GetGeneration()
-
-	return reconcile.Result{}, nil
+	if !needRequeue {
+		return reconcile.Result{}, nil
+	} else {
+		// TODO add requeue with with exponential BackOff time interval using condition Bound -> probeTime
+		return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
+	}
 }
 
 func (h *LifecycleHandler) Name() string {

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/lifecycle_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/lifecycle_handler.go
@@ -113,7 +113,7 @@ func (h *LifecycleHandler) Handle(ctx context.Context, state state.VMIPState) (r
 			log.Warn(fmt.Sprintf("VirtualMachineIPAddressLease %s is bound to another VirtualMachineIPAddress resource: %s/%s",
 				lease.Name, lease.Spec.VirtualMachineIPAddressRef.Name, lease.Spec.VirtualMachineIPAddressRef.Namespace))
 			mgr.Update(conditionBound.Status(metav1.ConditionFalse).
-				Reason(vmipcondition.VirtualMachineIPAddressLeaseAlready).
+				Reason(vmipcondition.VirtualMachineIPAddressLeaseAlreadyExist).
 				Message(fmt.Sprintf("VirtualMachineIPAddressLease %s is bound to another VirtualMachineIPAddress resource",
 					lease.Name)).
 				Condition())
@@ -123,7 +123,7 @@ func (h *LifecycleHandler) Handle(ctx context.Context, state state.VMIPState) (r
 		if vmipStatus.Phase != virtv2.VirtualMachineIPAddressPhasePending {
 			vmipStatus.Phase = virtv2.VirtualMachineIPAddressPhasePending
 			mgr.Update(conditionBound.Status(metav1.ConditionFalse).
-				Reason(vmipcondition.VirtualMachineIPAddressLeaseAlready).
+				Reason(vmipcondition.VirtualMachineIPAddressLeaseAlreadyExist).
 				Message(fmt.Sprintf("The VirtualMachineIPLease %s belongs to a different namespace", lease.Name)).
 				Condition())
 		}

--- a/images/virtualization-artifact/pkg/controller/vmiplease/internal/retention_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmiplease/internal/retention_handler.go
@@ -57,6 +57,7 @@ func (h *RetentionHandler) Handle(ctx context.Context, state state.VMIPLeaseStat
 		if lease.Spec.VirtualMachineIPAddressRef.Name != "" {
 			log.Info("VirtualMachineIP not found: remove this ref from the spec and retain VMIPLease")
 			lease.Spec.VirtualMachineIPAddressRef.Name = ""
+
 			return reconcile.Result{RequeueAfter: h.retentionDuration}, nil
 		}
 

--- a/images/virtualization-artifact/pkg/controller/vmiplease/internal/retention_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmiplease/internal/retention_handler.go
@@ -57,7 +57,6 @@ func (h *RetentionHandler) Handle(ctx context.Context, state state.VMIPLeaseStat
 		if lease.Spec.VirtualMachineIPAddressRef.Name != "" {
 			log.Info("VirtualMachineIP not found: remove this ref from the spec and retain VMIPLease")
 			lease.Spec.VirtualMachineIPAddressRef.Name = ""
-
 			return reconcile.Result{RequeueAfter: h.retentionDuration}, nil
 		}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

- Add requeue after 30s
- Fix message in recording event
- Add log for case, when create VirtualMachineIPAddress in different namespace

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Fix bug with create VirtualMachineIPAddress in different namespace, when VirtualMahineIPAddressLease 'Released'

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
