### PR TITLE
fix(vmclass) fix sizingPolicy fields

### DIFF
--- a/api/core/v1alpha2/virtual_machine_class.go
+++ b/api/core/v1alpha2/virtual_machine_class.go
@@ -124,10 +124,10 @@ type SizingPolicyMemory struct {
 	// Memory size discretization step. I.e. min=2Gi, max=4Gi, step=1Gi allows to set virtual machine memory size to 2Gi, 3Gi, or 4Gi.
 	//
 	// +kubebuilder:example="512Mi"
-	Step resource.Quantity `json:"step"`
+	Step resource.Quantity `json:"step,omitempty"`
 
 	// Amount of memory per CPU core.
-	PerCore SizingPolicyMemoryPerCore `json:"perCore"`
+	PerCore SizingPolicyMemoryPerCore `json:"perCore,omitempty"`
 }
 
 type SizingPolicyMemoryPerCore struct {

--- a/crds/virtualmachineclasses.yaml
+++ b/crds/virtualmachineclasses.yaml
@@ -322,9 +322,6 @@ spec:
                             example: 512Mi
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                        required:
-                          - perCore
-                          - step
                         type: object
                     type: object
                   type: array


### PR DESCRIPTION
## Description
Fix .spec.sizingPolicy.memory fields: `perCore` and `step` are not required

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
