### PR TITLE
feat(api): adjust image size

### DIFF
--- a/images/virtualization-artifact/pkg/controller/monitoring/final_report.go
+++ b/images/virtualization-artifact/pkg/controller/monitoring/final_report.go
@@ -27,7 +27,7 @@ import (
 	"github.com/deckhouse/virtualization-controller/pkg/util"
 )
 
-// FinalReport example: { "source-image-size": "1111", "source-image-virtual-size": "8888", "source-image-format": "qcow2"}
+// FinalReport example: { "source-image-size": 1111, "source-image-virtual-size": 8888, "source-image-format": "qcow2"}
 type FinalReport struct {
 	StoredSizeBytes   uint64        `json:"source-image-size,omitempty"`
 	UnpackedSizeBytes uint64        `json:"source-image-virtual-size,omitempty"`
@@ -35,14 +35,6 @@ type FinalReport struct {
 	Duration          time.Duration `json:"duration,omitempty"`
 	AverageSpeed      uint64        `json:"average-speed,omitempty"`
 	ErrMessage        string        `json:"error-message,omitempty"`
-}
-
-func (r *FinalReport) StoredSize() string {
-	return util.HumanizeIBytes(r.StoredSizeBytes)
-}
-
-func (r *FinalReport) UnpackedSize() string {
-	return util.HumanizeIBytes(r.UnpackedSizeBytes)
 }
 
 func (r *FinalReport) GetAverageSpeed() string {

--- a/images/virtualization-artifact/pkg/controller/service/internal/size_test.go
+++ b/images/virtualization-artifact/pkg/controller/service/internal/size_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package datavolume
+package internal
 
 import (
 	"testing"
@@ -29,6 +29,11 @@ func TestAdjustPVCSize(t *testing.T) {
 		in   int64
 		out  int64
 	}{
+		{
+			"zero",
+			0,
+			0,
+		},
 		{
 			"less than 512Mi",
 			100 * 1024 * 1024,
@@ -48,7 +53,7 @@ func TestAdjustPVCSize(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			res := AdjustPVCSize(*resource.NewQuantity(tt.in, resource.BinarySI))
+			res := AdjustImageSize(*resource.NewQuantity(tt.in, resource.BinarySI))
 			require.Equal(t, tt.out, res.Value())
 		})
 	}

--- a/images/virtualization-artifact/pkg/controller/service/stat_service_test.go
+++ b/images/virtualization-artifact/pkg/controller/service/stat_service_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"fmt"
+	"log/slog"
+	"strconv"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/deckhouse/virtualization-controller/pkg/controller/service/internal"
+	"github.com/deckhouse/virtualization-controller/pkg/util"
+)
+
+var _ = Describe("StatService method GetSize", func() {
+	var pod *corev1.Pod
+	BeforeEach(func() {
+		pod = &corev1.Pod{
+			TypeMeta:   metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{},
+			Spec:       corev1.PodSpec{},
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{},
+						},
+					},
+				},
+			},
+		}
+	})
+
+	It("Adjust unpacked virtual size", func() {
+		const sourceSize = 1024
+		const sourceVirtualSize = 2048
+		terminationMsg := fmt.Sprintf(`{ "source-image-size": %d, "source-image-virtual-size": %d }`, sourceSize, sourceVirtualSize)
+		expectedAdjustedVirtualSize := internal.AdjustImageSize(resource.MustParse(strconv.FormatUint(sourceVirtualSize, 10)))
+
+		pod.Status.ContainerStatuses[0].State.Terminated.Message = terminationMsg
+
+		s := NewStatService(slog.Default())
+		size := s.GetSize(pod)
+		Expect(size.Stored).To(Equal(util.HumanizeIBytes(sourceSize)))
+		Expect(size.StoredBytes).To(Equal(strconv.FormatUint(sourceSize, 10)))
+		Expect(size.Unpacked).To(Equal(util.HumanizeIBytes(uint64(expectedAdjustedVirtualSize.Value()))))
+		Expect(size.UnpackedBytes).To(Equal(strconv.FormatUint(uint64(expectedAdjustedVirtualSize.Value()), 10)))
+	})
+
+	It("Adjust empty unpacked virtual size", func() {
+		pod.Status.ContainerStatuses[0].State.Terminated.Message = "{}"
+
+		s := NewStatService(slog.Default())
+		size := s.GetSize(pod)
+		Expect(size.Stored).To(Equal("0B"))
+		Expect(size.StoredBytes).To(Equal("0"))
+		Expect(size.Unpacked).To(Equal("0B"))
+		Expect(size.UnpackedBytes).To(Equal("0"))
+	})
+})

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/http.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/http.go
@@ -323,9 +323,5 @@ func (ds HTTPDataSource) getPVCSize(vd *virtv2.VirtualDisk, pod *corev1.Pod) (re
 		return resource.Quantity{}, fmt.Errorf("failed to parse unpacked bytes %s: %w", ds.statService.GetSize(pod).UnpackedBytes, err)
 	}
 
-	if unpackedSize.IsZero() {
-		return resource.Quantity{}, errors.New("got zero unpacked size from data source")
-	}
-
-	return ds.diskService.AdjustPVCSize(vd.Spec.PersistentVolumeClaim.Size, unpackedSize)
+	return service.GetValidatedPVCSize(vd.Spec.PersistentVolumeClaim.Size, unpackedSize)
 }

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref.go
@@ -261,9 +261,5 @@ func (ds ObjectRefDataSource) getPVCSize(vd *virtv2.VirtualDisk, dvcrDataSource 
 		return resource.Quantity{}, fmt.Errorf("failed to parse unpacked bytes %s: %w", dvcrDataSource.GetSize().UnpackedBytes, err)
 	}
 
-	if unpackedSize.IsZero() {
-		return resource.Quantity{}, errors.New("got zero unpacked size from data source")
-	}
-
-	return ds.diskService.AdjustPVCSize(vd.Spec.PersistentVolumeClaim.Size, unpackedSize)
+	return service.GetValidatedPVCSize(vd.Spec.PersistentVolumeClaim.Size, unpackedSize)
 }

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/registry.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/registry.go
@@ -346,9 +346,5 @@ func (ds RegistryDataSource) getPVCSize(vd *virtv2.VirtualDisk, pod *corev1.Pod)
 		return resource.Quantity{}, fmt.Errorf("failed to parse unpacked bytes %s: %w", ds.statService.GetSize(pod).UnpackedBytes, err)
 	}
 
-	if unpackedSize.IsZero() {
-		return resource.Quantity{}, errors.New("got zero unpacked size from data source")
-	}
-
-	return ds.diskService.AdjustPVCSize(vd.Spec.PersistentVolumeClaim.Size, unpackedSize)
+	return service.GetValidatedPVCSize(vd.Spec.PersistentVolumeClaim.Size, unpackedSize)
 }

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/upload.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/upload.go
@@ -349,9 +349,5 @@ func (ds UploadDataSource) getPVCSize(vd *virtv2.VirtualDisk, pod *corev1.Pod) (
 		return resource.Quantity{}, fmt.Errorf("failed to parse unpacked bytes %s: %w", ds.statService.GetSize(pod).UnpackedBytes, err)
 	}
 
-	if unpackedSize.IsZero() {
-		return resource.Quantity{}, errors.New("got zero unpacked size from data source")
-	}
-
-	return ds.diskService.AdjustPVCSize(vd.Spec.PersistentVolumeClaim.Size, unpackedSize)
+	return service.GetValidatedPVCSize(vd.Spec.PersistentVolumeClaim.Size, unpackedSize)
 }

--- a/images/virtualization-artifact/pkg/controller/vd/internal/validators/pvc_size_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/validators/pvc_size_validator.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validators
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/deckhouse/virtualization-controller/pkg/controller"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+)
+
+type PVCSizeValidator struct {
+	client client.Client
+}
+
+func NewPVCSizeValidator(client client.Client) *PVCSizeValidator {
+	return &PVCSizeValidator{client: client}
+}
+
+func (v *PVCSizeValidator) ValidateCreate(ctx context.Context, vd *virtv2.VirtualDisk) (admission.Warnings, error) {
+	if vd.Spec.PersistentVolumeClaim.Size != nil && vd.Spec.PersistentVolumeClaim.Size.IsZero() {
+		return nil, fmt.Errorf("virtual disk size must be greater than 0")
+	}
+
+	if vd.Spec.DataSource == nil && vd.Spec.PersistentVolumeClaim.Size == nil {
+		return nil, fmt.Errorf("if the data source is not specified, it's necessary to set spec.PersistentVolumeClaim.size to create blank virtual disk")
+	}
+
+	if vd.Spec.DataSource == nil || vd.Spec.DataSource.Type != virtv2.DataSourceTypeObjectRef || vd.Spec.DataSource.ObjectRef == nil {
+		return nil, nil
+	}
+
+	var unpackedBytes string
+
+	switch vd.Spec.DataSource.ObjectRef.Kind {
+	case virtv2.VirtualDiskObjectRefKindVirtualImage,
+		virtv2.VirtualDiskObjectRefKindClusterVirtualImage:
+		dvcrDataSource, err := controller.NewDVCRDataSourcesForVMD(ctx, vd.Spec.DataSource, vd, v.client)
+		if err != nil {
+			return nil, err
+		}
+
+		if !dvcrDataSource.IsReady() {
+			return nil, nil
+		}
+
+		unpackedBytes = dvcrDataSource.GetSize().UnpackedBytes
+
+	// TODO validate for snapshot kind also.
+	default:
+		return nil, nil
+	}
+
+	unpackedSize, err := resource.ParseQuantity(unpackedBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse unpacked bytes %s: %w", unpackedBytes, err)
+	}
+
+	_, err = service.GetValidatedPVCSize(vd.Spec.PersistentVolumeClaim.Size, unpackedSize)
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func (v *PVCSizeValidator) ValidateUpdate(ctx context.Context, oldVD, newVD *virtv2.VirtualDisk) (admission.Warnings, error) {
+	if oldVD.Spec.PersistentVolumeClaim.Size == newVD.Spec.PersistentVolumeClaim.Size {
+		return nil, nil
+	}
+
+	if newVD.Spec.PersistentVolumeClaim.Size == nil {
+		return nil, errors.New("spec.persistentVolumeClaim.size cannot be omitted once set")
+	}
+
+	if newVD.Spec.PersistentVolumeClaim.Size.IsZero() {
+		return nil, fmt.Errorf("virtual disk size must be greater than 0")
+	}
+
+	if oldVD.Spec.PersistentVolumeClaim.Size != nil && newVD.Spec.PersistentVolumeClaim.Size.Cmp(*oldVD.Spec.PersistentVolumeClaim.Size) == -1 {
+		return nil, fmt.Errorf(
+			"spec.persistentVolumeClaim.size value (%s) should be greater than or equal to the current value (%s)",
+			newVD.Spec.PersistentVolumeClaim.Size.String(),
+			oldVD.Spec.PersistentVolumeClaim.Size.String(),
+		)
+	}
+
+	if newVD.Spec.DataSource == nil || newVD.Spec.DataSource.Type != virtv2.DataSourceTypeObjectRef || newVD.Spec.DataSource.ObjectRef == nil {
+		return nil, nil
+	}
+
+	var unpackedBytes string
+
+	switch newVD.Spec.DataSource.ObjectRef.Kind {
+	case virtv2.VirtualDiskObjectRefKindVirtualImage,
+		virtv2.VirtualDiskObjectRefKindClusterVirtualImage:
+		dvcrDataSource, err := controller.NewDVCRDataSourcesForVMD(ctx, newVD.Spec.DataSource, newVD, v.client)
+		if err != nil {
+			return nil, err
+		}
+
+		if !dvcrDataSource.IsReady() {
+			return nil, nil
+		}
+
+		unpackedBytes = dvcrDataSource.GetSize().UnpackedBytes
+
+	// TODO validate for snapshot kind also.
+	default:
+		return nil, nil
+	}
+
+	unpackedSize, err := resource.ParseQuantity(unpackedBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse unpacked bytes %s: %w", unpackedBytes, err)
+	}
+
+	_, err = service.GetValidatedPVCSize(newVD.Spec.PersistentVolumeClaim.Size, unpackedSize)
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}

--- a/images/virtualization-artifact/pkg/controller/vd/internal/validators/spec_changes_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/validators/spec_changes_validator.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validators
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
+)
+
+type SpecChangesValidator struct{}
+
+func NewSpecChangesValidator() *SpecChangesValidator {
+	return &SpecChangesValidator{}
+}
+
+func (v *SpecChangesValidator) ValidateCreate(_ context.Context, _ *virtv2.VirtualDisk) (admission.Warnings, error) {
+	return nil, nil
+}
+
+func (v *SpecChangesValidator) ValidateUpdate(_ context.Context, oldVD, newVD *virtv2.VirtualDisk) (admission.Warnings, error) {
+	if oldVD.Generation == newVD.Generation {
+		return nil, nil
+	}
+
+	ready, _ := service.GetCondition(vdcondition.ReadyType, newVD.Status.Conditions)
+	if ready.Status == metav1.ConditionTrue || newVD.Status.Phase == virtv2.DiskReady || newVD.Status.Phase == virtv2.DiskLost || newVD.Status.Phase == virtv2.DiskTerminating {
+		if !reflect.DeepEqual(oldVD.Spec.DataSource, newVD.Spec.DataSource) {
+			return nil, fmt.Errorf("VirtualDisk has already been created: data source cannot be changed after disk is created")
+		}
+
+		if !reflect.DeepEqual(oldVD.Spec.PersistentVolumeClaim.StorageClass, newVD.Spec.PersistentVolumeClaim.StorageClass) {
+			return nil, fmt.Errorf("VirtualDisk has already been created: storage class cannot be changed after disk is created")
+		}
+	}
+
+	return nil, nil
+}

--- a/images/virtualization-artifact/pkg/controller/vd/vd_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vd/vd_controller.go
@@ -99,7 +99,7 @@ func NewController(
 
 	if err = builder.WebhookManagedBy(mgr).
 		For(&virtv2.VirtualDisk{}).
-		WithValidator(NewValidator(log)).
+		WithValidator(NewValidator(mgr.GetClient(), log)).
 		Complete(); err != nil {
 		return nil, err
 	}

--- a/images/virtualization-artifact/pkg/controller/vm/vm_webhook.go
+++ b/images/virtualization-artifact/pkg/controller/vm/vm_webhook.go
@@ -27,12 +27,12 @@ import (
 
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vm/internal"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vm/internal/validators"
-	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
 type VirtualMachineValidator interface {
-	ValidateCreate(ctx context.Context, vm *v1alpha2.VirtualMachine) (admission.Warnings, error)
-	ValidateUpdate(ctx context.Context, oldVM, newVM *v1alpha2.VirtualMachine) (admission.Warnings, error)
+	ValidateCreate(ctx context.Context, vm *virtv2.VirtualMachine) (admission.Warnings, error)
+	ValidateUpdate(ctx context.Context, oldVM, newVM *virtv2.VirtualMachine) (admission.Warnings, error)
 }
 
 type Validator struct {
@@ -52,7 +52,7 @@ func NewValidator(ipam internal.IPAM, client client.Client, log *slog.Logger) *V
 }
 
 func (v *Validator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
-	vm, ok := obj.(*v1alpha2.VirtualMachine)
+	vm, ok := obj.(*virtv2.VirtualMachine)
 	if !ok {
 		return nil, fmt.Errorf("expected a new VirtualMachine but got a %T", obj)
 	}
@@ -73,12 +73,12 @@ func (v *Validator) ValidateCreate(ctx context.Context, obj runtime.Object) (adm
 }
 
 func (v *Validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
-	oldVM, ok := oldObj.(*v1alpha2.VirtualMachine)
+	oldVM, ok := oldObj.(*virtv2.VirtualMachine)
 	if !ok {
 		return nil, fmt.Errorf("expected an old VirtualMachine but got a %T", oldObj)
 	}
 
-	newVM, ok := newObj.(*v1alpha2.VirtualMachine)
+	newVM, ok := newObj.(*virtv2.VirtualMachine)
 	if !ok {
 		return nil, fmt.Errorf("expected a new VirtualMachine but got a %T", newObj)
 	}

--- a/images/virtualization-artifact/pkg/util/util_test.go
+++ b/images/virtualization-artifact/pkg/util/util_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHumanizeIBytes(t *testing.T) {
+	type testCase struct {
+		in  uint64
+		out string
+	}
+
+	testCases := []testCase{
+		{
+			in:  0,
+			out: "0B",
+		},
+		{
+			in:  1,
+			out: "1B",
+		},
+		{
+			in:  2,
+			out: "2B",
+		},
+		{
+			in:  2 * 1024,
+			out: "2Ki",
+		},
+		{
+			in:  2*1024 + 1,
+			out: "2Ki",
+		},
+		{
+			in:  2*1024 - 1,
+			out: "2Ki",
+		},
+		{
+			in:  2 * 1024 * 1024,
+			out: "2Mi",
+		},
+		{
+			in:  2*1024*1024 + 1,
+			out: "2Mi",
+		},
+		{
+			in:  2*1024*1024 - 1,
+			out: "2Mi",
+		},
+	}
+
+	for _, tc := range testCases {
+		require.Equal(t, tc.out, HumanizeIBytes(tc.in))
+	}
+}


### PR DESCRIPTION
## Description

To support importing images into virtual disks, now automatically increase the image size when creating the image, rather than increasing the disk size when creating the disk (adjust a percentage of the size to all images for creating a CDI scratch pvc).

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
