### PR TITLE
fix(vd): ensure last transition time for conditions

### DIFF
--- a/api/core/v1alpha2/vmipcondition/condition.go
+++ b/api/core/v1alpha2/vmipcondition/condition.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package vmipcondition
 
-type Type = string
+type Type string
 
 const (
 	// BoundType represents the condition type when a Virtual Machine IP is bound.
@@ -26,13 +26,25 @@ const (
 	AttachedType Type = "Attached"
 )
 
+func (t Type) String() string {
+	return string(t)
+}
+
 type (
 	// BoundReason represents specific reasons for the 'Bound' condition type.
-	BoundReason = string
+	BoundReason string
 
 	// AttachedReason represents specific reasons for the 'Attached' condition type.
-	AttachedReason = string
+	AttachedReason string
 )
+
+func (r BoundReason) String() string {
+	return string(r)
+}
+
+func (r AttachedReason) String() string {
+	return string(r)
+}
 
 const (
 	// VirtualMachineIPAddressIsOutOfTheValidRange is a BoundReason indicating when specified IP address is out of the range in controller settings.

--- a/api/core/v1alpha2/vmiplcondition/condition.go
+++ b/api/core/v1alpha2/vmiplcondition/condition.go
@@ -16,15 +16,23 @@ limitations under the License.
 
 package vmiplcondition
 
-type Type = string
+type Type string
 
 const (
 	// BoundType represents the condition type when a Virtual Machine IP is bound.
 	BoundType Type = "Bound"
 )
 
+func (t Type) String() string {
+	return string(t)
+}
+
 // BoundReason represents specific reasons for the 'Bound' condition type.
-type BoundReason = string
+type BoundReason string
+
+func (r BoundReason) String() string {
+	return string(r)
+}
 
 const (
 	// Released is a BoundReason indicating the IP address lease has been released.

--- a/images/virtualization-artifact/pkg/controller/conditions/builder.go
+++ b/images/virtualization-artifact/pkg/controller/conditions/builder.go
@@ -17,37 +17,37 @@ limitations under the License.
 package conditions
 
 import (
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type Stringer interface {
-	String() string
+type Conder interface {
+	Condition() metav1.Condition
 }
 
-func NewConditionBuilder2(name Stringer) *ConditionBuilder {
-	return &ConditionBuilder{name: name.String()}
+func SetCondition(c Conder, conditions *[]metav1.Condition) {
+	meta.SetStatusCondition(conditions, c.Condition())
 }
 
-func NewConditionBuilder(name string) *ConditionBuilder {
-	return &ConditionBuilder{name: name}
+func NewConditionBuilder(conditionType Stringer) *ConditionBuilder {
+	return &ConditionBuilder{conditionType: conditionType.String()}
 }
 
 type ConditionBuilder struct {
-	status     metav1.ConditionStatus
-	name       string
-	reason     string
-	msg        string
-	generation int64
+	status        metav1.ConditionStatus
+	conditionType string
+	reason        string
+	message       string
+	generation    int64
 }
 
 func (c *ConditionBuilder) Condition() metav1.Condition {
 	return metav1.Condition{
-		Type:               c.name,
+		Type:               c.conditionType,
 		Status:             c.status,
-		ObservedGeneration: c.generation,
-		LastTransitionTime: metav1.Now(),
 		Reason:             c.reason,
-		Message:            c.msg,
+		Message:            c.message,
+		ObservedGeneration: c.generation,
 	}
 }
 
@@ -56,18 +56,13 @@ func (c *ConditionBuilder) Status(status metav1.ConditionStatus) *ConditionBuild
 	return c
 }
 
-func (c *ConditionBuilder) Reason(reason string) *ConditionBuilder {
-	c.reason = reason
-	return c
-}
-
-func (c *ConditionBuilder) Reason2(reason Stringer) *ConditionBuilder {
+func (c *ConditionBuilder) Reason(reason Stringer) *ConditionBuilder {
 	c.reason = reason.String()
 	return c
 }
 
 func (c *ConditionBuilder) Message(msg string) *ConditionBuilder {
-	c.msg = msg
+	c.message = msg
 	return c
 }
 

--- a/images/virtualization-artifact/pkg/controller/conditions/stringer.go
+++ b/images/virtualization-artifact/pkg/controller/conditions/stringer.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions
+
+type Stringer interface {
+	String() string
+}
+
+// Deprecated: avoid using this wrapper.
+// TODO: get rif of this wrapepr.
+type DeprecatedWrappedString string
+
+func (s DeprecatedWrappedString) String() string {
+	return string(s)
+}

--- a/images/virtualization-artifact/pkg/controller/conditions/stringer.go
+++ b/images/virtualization-artifact/pkg/controller/conditions/stringer.go
@@ -21,7 +21,7 @@ type Stringer interface {
 }
 
 // Deprecated: avoid using this wrapper.
-// TODO: get rif of this wrapepr.
+// TODO: get rid of this wrapper.
 type DeprecatedWrappedString string
 
 func (s DeprecatedWrappedString) String() string {

--- a/images/virtualization-artifact/pkg/controller/service/condition.go
+++ b/images/virtualization-artifact/pkg/controller/service/condition.go
@@ -20,14 +20,13 @@ import (
 	"unicode"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	virtv1 "kubevirt.io/api/core/v1"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
-
-	"github.com/deckhouse/virtualization/api/core/v1alpha2/cvicondition"
 )
 
-func GetCondition(condType cvicondition.Type, conds []metav1.Condition) (metav1.Condition, bool) {
+func GetCondition(condType string, conds []metav1.Condition) (metav1.Condition, bool) {
 	for _, cond := range conds {
 		if cond.Type == condType {
 			return cond, true
@@ -38,18 +37,7 @@ func GetCondition(condType cvicondition.Type, conds []metav1.Condition) (metav1.
 }
 
 func SetCondition(cond metav1.Condition, conditions *[]metav1.Condition) {
-	if conditions == nil {
-		return
-	}
-
-	for i := range *conditions {
-		if (*conditions)[i].Type == cond.Type {
-			(*conditions)[i] = cond
-			return
-		}
-	}
-
-	*conditions = append(*conditions, cond)
+	meta.SetStatusCondition(conditions, cond)
 }
 
 func CapitalizeFirstLetter(s string) string {

--- a/images/virtualization-artifact/pkg/controller/vm/internal/util.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/util.go
@@ -29,6 +29,7 @@ import (
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmcondition"
 )
 
 func isDeletion(vm *virtv2.VirtualMachine) bool {
@@ -37,7 +38,8 @@ func isDeletion(vm *virtv2.VirtualMachine) bool {
 
 type updaterProtection func(p *service.ProtectionService) func(ctx context.Context, objs ...client.Object) error
 
-func addAllUnknown(vm *virtv2.VirtualMachine, conds ...string) (update bool) {
+func addAllUnknown(vm *virtv2.VirtualMachine, conds ...vmcondition.Type) (update bool) {
+	//nolint:staticcheck
 	mgr := conditions.NewManager(vm.Status.Conditions)
 	for _, c := range conds {
 		if add := mgr.Add(conditions.NewConditionBuilder(c).

--- a/images/virtualization-artifact/pkg/controller/vmclass/internal/util.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/internal/util.go
@@ -28,12 +28,13 @@ func isDeletion(class *virtv2.VirtualMachineClass) bool {
 	return class == nil || !class.GetDeletionTimestamp().IsZero()
 }
 
-func addAllUnknown(class *virtv2.VirtualMachineClass, conds ...string) (update bool) {
+func addAllUnknown(class *virtv2.VirtualMachineClass, conds ...vmclasscondition.Type) (update bool) {
+	//nolint:staticcheck
 	mgr := conditions.NewManager(class.Status.Conditions)
 	for _, c := range conds {
 		if add := mgr.Add(conditions.NewConditionBuilder(c).
 			Generation(class.GetGeneration()).
-			Reason2(vmclasscondition.ReasonUnknown).
+			Reason(vmclasscondition.ReasonUnknown).
 			Status(metav1.ConditionUnknown).
 			Condition()); add {
 			update = true

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/lifecycle_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/lifecycle_handler.go
@@ -52,6 +52,7 @@ func (h *LifecycleHandler) Handle(ctx context.Context, state state.VMIPState) (r
 		return reconcile.Result{}, err
 	}
 
+	//nolint:staticcheck
 	mgr := conditions.NewManager(vmipStatus.Conditions)
 	conditionBound := conditions.NewConditionBuilder(vmipcondition.BoundType).
 		Generation(vmip.GetGeneration())

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/state/state.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/state/state.go
@@ -87,7 +87,7 @@ func (s *state) VirtualMachineIPLease(ctx context.Context) (*virtv2.VirtualMachi
 		}
 
 		for i, lease := range leases.Items {
-			boundCondition, exist := service.GetCondition(vmiplcondition.BoundType, lease.Status.Conditions)
+			boundCondition, exist := service.GetCondition(vmiplcondition.BoundType.String(), lease.Status.Conditions)
 			if exist && boundCondition.Status == metav1.ConditionTrue {
 				s.lease = &leases.Items[i]
 				break

--- a/images/virtualization-artifact/pkg/controller/vmip/vmip_webhook.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/vmip_webhook.go
@@ -112,7 +112,7 @@ func (v *Validator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Obj
 		"old.address", oldVmip.Spec.StaticIP, "new.address", newVmip.Spec.StaticIP,
 	)
 
-	boundCondition, exist := service.GetCondition(vmipcondition.BoundType, oldVmip.Status.Conditions)
+	boundCondition, exist := service.GetCondition(vmipcondition.BoundType.String(), oldVmip.Status.Conditions)
 	if exist && boundCondition.Status == metav1.ConditionTrue {
 		if oldVmip.Spec.Type == v1alpha2.VirtualMachineIPAddressTypeAuto && newVmip.Spec.Type == v1alpha2.VirtualMachineIPAddressTypeStatic {
 			v.log.Info("Change the VirtualMachineIP address type to 'Auto' from 'Static' for ip: ", "address", newVmip.Spec.StaticIP)

--- a/images/virtualization-artifact/pkg/controller/vmiplease/internal/lifecycle_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmiplease/internal/lifecycle_handler.go
@@ -45,6 +45,7 @@ func (h *LifecycleHandler) Handle(ctx context.Context, state state.VMIPLeaseStat
 		return reconcile.Result{}, nil
 	}
 
+	//nolint:staticcheck
 	mgr := conditions.NewManager(leaseStatus.Conditions)
 	cb := conditions.NewConditionBuilder(vmiplcondition.BoundType).
 		Generation(lease.GetGeneration())

--- a/images/virtualization-artifact/pkg/controller/vmiplease/internal/retention_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmiplease/internal/retention_handler.go
@@ -61,8 +61,8 @@ func (h *RetentionHandler) Handle(ctx context.Context, state state.VMIPLeaseStat
 		}
 
 		leaseStatus := &lease.Status
-		boundCondition, _ := service.GetCondition(vmipcondition.BoundType, leaseStatus.Conditions)
-		if boundCondition.Reason == vmiplcondition.Released {
+		boundCondition, _ := service.GetCondition(vmipcondition.BoundType.String(), leaseStatus.Conditions)
+		if boundCondition.Reason == vmiplcondition.Released.String() {
 			currentTime := time.Now().UTC()
 
 			duration := currentTime.Sub(boundCondition.LastTransitionTime.Time)


### PR DESCRIPTION
## Description

1. Ensure for all controllers that LastTransitionTime reflects the last time the condition transitioned from one status to another (not just any condition update), in accordance with the Kubernetes documentation.

2. Get rid of the deprecated Reason method and NewConditionBuilder function. Use the renamed Reason2 method and NewConditionBuilder2 function instead.

3. The conditions.Manager is now deprecated. It is recommended to use conditions.SetCondition instead.

No motivation was found to use conditions.Manager over directly updating conditions. Since conditions.Manager is deprecated, it is recommended to use conditions.SetCondition instead.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
