### PR TITLE
feat(vd): deny iso source

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/errors.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/errors.go
@@ -21,7 +21,10 @@ import (
 	"fmt"
 )
 
-var ErrSecretNotFound = errors.New("container registry secret not found")
+var (
+	ErrSecretNotFound        = errors.New("container registry secret not found")
+	ErrISOSourceNotSupported = errors.New("creating a virtual disk from an ISO image is not supported: please use a virtual image or a cluster virtual image instead")
+)
 
 type ImageNotReadyError struct {
 	name string

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref.go
@@ -31,6 +31,7 @@ import (
 	"github.com/deckhouse/virtualization-controller/pkg/controller/common"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/supplements"
+	"github.com/deckhouse/virtualization-controller/pkg/imageformat"
 	"github.com/deckhouse/virtualization-controller/pkg/logger"
 	"github.com/deckhouse/virtualization-controller/pkg/util"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
@@ -112,6 +113,11 @@ func (ds ObjectRefDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) 
 
 		vd.Status.Progress = "0%"
 		vd.Status.SourceUID = util.GetPointer(dvcrDataSource.GetUID())
+
+		if imageformat.IsISO(dvcrDataSource.GetFormat()) {
+			setPhaseConditionToFailed(&condition, &vd.Status.Phase, ErrISOSourceNotSupported)
+			return false, nil
+		}
 
 		var diskSize resource.Quantity
 		diskSize, err = ds.getPVCSize(vd, dvcrDataSource)

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/registry.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/registry.go
@@ -35,6 +35,7 @@ import (
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/supplements"
 	"github.com/deckhouse/virtualization-controller/pkg/dvcr"
+	"github.com/deckhouse/virtualization-controller/pkg/imageformat"
 	"github.com/deckhouse/virtualization-controller/pkg/logger"
 	"github.com/deckhouse/virtualization-controller/pkg/sdk/framework/helper"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
@@ -180,6 +181,11 @@ func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (
 		}
 
 		vd.Status.Progress = "50%"
+
+		if imageformat.IsISO(ds.statService.GetFormat(pod)) {
+			setPhaseConditionToFailed(&condition, &vd.Status.Phase, ErrISOSourceNotSupported)
+			return false, nil
+		}
 
 		var diskSize resource.Quantity
 		diskSize, err = ds.getPVCSize(vd, pod)

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/sources.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/sources.go
@@ -214,5 +214,5 @@ func setPhaseConditionToFailed(ready *metav1.Condition, phase *virtv2.DiskPhase,
 	*phase = virtv2.DiskFailed
 	ready.Status = metav1.ConditionFalse
 	ready.Reason = vdcondition.ProvisioningFailed
-	ready.Message = service.CapitalizeFirstLetter(err.Error())
+	ready.Message = service.CapitalizeFirstLetter(err.Error()) + "."
 }

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/upload.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/upload.go
@@ -33,6 +33,7 @@ import (
 	"github.com/deckhouse/virtualization-controller/pkg/controller/supplements"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/uploader"
 	"github.com/deckhouse/virtualization-controller/pkg/dvcr"
+	"github.com/deckhouse/virtualization-controller/pkg/imageformat"
 	"github.com/deckhouse/virtualization-controller/pkg/logger"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
@@ -201,6 +202,11 @@ func (ds UploadDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (bo
 
 		vd.Status.Progress = "50%"
 		vd.Status.DownloadSpeed = ds.statService.GetDownloadSpeed(vd.GetUID(), pod)
+
+		if imageformat.IsISO(ds.statService.GetFormat(pod)) {
+			setPhaseConditionToFailed(&condition, &vd.Status.Phase, ErrISOSourceNotSupported)
+			return false, nil
+		}
 
 		var diskSize resource.Quantity
 		diskSize, err = ds.getPVCSize(vd, pod)

--- a/images/virtualization-artifact/pkg/controller/vd/internal/validators/iso_source_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/validators/iso_source_validator.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validators
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/deckhouse/virtualization-controller/pkg/controller"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/vd/internal/source"
+	"github.com/deckhouse/virtualization-controller/pkg/imageformat"
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+)
+
+type ISOSourceValidator struct {
+	client client.Client
+}
+
+func NewISOSourceValidator(client client.Client) *ISOSourceValidator {
+	return &ISOSourceValidator{client: client}
+}
+
+func (v *ISOSourceValidator) ValidateCreate(ctx context.Context, vd *virtv2.VirtualDisk) (admission.Warnings, error) {
+	if vd.Spec.DataSource == nil {
+		return nil, nil
+	}
+
+	switch vd.Spec.DataSource.Type {
+	case virtv2.DataSourceTypeObjectRef:
+		if vd.Spec.DataSource.ObjectRef == nil {
+			return nil, errors.New("data source object ref is omitted, but expected")
+		}
+
+		switch vd.Spec.DataSource.ObjectRef.Kind {
+		case virtv2.VirtualDiskObjectRefKindVirtualImage,
+			virtv2.VirtualDiskObjectRefKindClusterVirtualImage:
+			dvcrDataSource, err := controller.NewDVCRDataSourcesForVMD(ctx, vd.Spec.DataSource, vd, v.client)
+			if err != nil {
+				return nil, err
+			}
+
+			if !dvcrDataSource.IsReady() {
+				return nil, nil
+			}
+
+			if imageformat.IsISO(dvcrDataSource.GetFormat()) {
+				return nil, source.ErrISOSourceNotSupported
+			}
+		}
+	case virtv2.DataSourceTypeHTTP:
+		if vd.Spec.DataSource.HTTP == nil {
+			return nil, errors.New("data source http is omitted, but expected")
+		}
+
+		if strings.HasSuffix(strings.ToLower(vd.Spec.DataSource.HTTP.URL), imageformat.FormatISO) {
+			return nil, source.ErrISOSourceNotSupported
+		}
+	}
+
+	return nil, nil
+}
+
+func (v *ISOSourceValidator) ValidateUpdate(ctx context.Context, _, newVD *virtv2.VirtualDisk) (admission.Warnings, error) {
+	if newVD.Spec.DataSource == nil {
+		return nil, nil
+	}
+
+	switch newVD.Spec.DataSource.Type {
+	case virtv2.DataSourceTypeObjectRef:
+		if newVD.Spec.DataSource.ObjectRef == nil {
+			return nil, errors.New("data source object ref is omitted, but expected")
+		}
+
+		switch newVD.Spec.DataSource.ObjectRef.Kind {
+		case virtv2.VirtualDiskObjectRefKindVirtualImage,
+			virtv2.VirtualDiskObjectRefKindClusterVirtualImage:
+			dvcrDataSource, err := controller.NewDVCRDataSourcesForVMD(ctx, newVD.Spec.DataSource, newVD, v.client)
+			if err != nil {
+				return nil, err
+			}
+
+			if !dvcrDataSource.IsReady() {
+				return nil, nil
+			}
+
+			if imageformat.IsISO(dvcrDataSource.GetFormat()) {
+				return nil, source.ErrISOSourceNotSupported
+			}
+		}
+
+		return nil, nil
+	case virtv2.DataSourceTypeHTTP:
+		if newVD.Spec.DataSource.HTTP == nil {
+			return nil, errors.New("data source http is omitted, but expected")
+		}
+
+		if strings.HasSuffix(strings.ToLower(newVD.Spec.DataSource.HTTP.URL), imageformat.FormatISO) {
+			return nil, source.ErrISOSourceNotSupported
+		}
+
+		return nil, nil
+	default:
+		return nil, nil
+	}
+}

--- a/images/virtualization-artifact/pkg/controller/vd/vd_webhook.go
+++ b/images/virtualization-artifact/pkg/controller/vd/vd_webhook.go
@@ -44,6 +44,7 @@ func NewValidator(client client.Client, logger *slog.Logger) *Validator {
 		validators: []VirtualDiskValidator{
 			validators.NewPVCSizeValidator(client),
 			validators.NewSpecChangesValidator(),
+			validators.NewISOSourceValidator(client),
 		},
 		logger: logger.With("webhook", "validator"),
 	}


### PR DESCRIPTION
## Description

Deny disks creation with iso data source (object ref or http):
1. write error message to Faield condition
2. validate image format in webhook

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
