### PR TITLE
chore(dev): replace busybox image with musl on glibc

### DIFF
--- a/images/virtualization-artifact/hack/dlv-controller.Dockerfile
+++ b/images/virtualization-artifact/hack/dlv-controller.Dockerfile
@@ -21,7 +21,7 @@ ENV CGO_ENABLED=0
 
 RUN go build -gcflags "all=-N -l" -a -o virtualization-controller ./cmd/virtualization-controller
 
-FROM busybox:1.36.1-musl
+FROM busybox:1.36.1-glibc
 
 WORKDIR /app
 COPY --from=builder /go/bin/dlv /app/dlv

--- a/images/virtualization-artifact/hack/dlv.sh
+++ b/images/virtualization-artifact/hack/dlv.sh
@@ -54,7 +54,7 @@ function print_patches_controller {
     cat <<EOF
 
 Run commands:
-kubectl -n d8-virtualization scale deploy --replicas 1
+kubectl -n d8-virtualization scale deployment virtualization-controller --replicas 1
 kubectl -n d8-virtualization patch deployment virtualization-controller --type='json' -p '[{"op": "replace", "path": "/spec/template/spec/containers/1/image", "value": "${IMAGE}"}]'
 kubectl -n d8-virtualization patch deployment virtualization-controller --type='strategic' -p '{
     "spec": {


### PR DESCRIPTION
## Description
replace busybox image with musl on glibc

## Why do we need it, and what problem does it solve?
dlv cannot be started

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.