### PR TITLE
fix(vm): impl delete method for subresource virtualmachine on apiserver

### DIFF
--- a/images/virtualization-artifact/pkg/apiserver/api/install.go
+++ b/images/virtualization-artifact/pkg/apiserver/api/install.go
@@ -29,6 +29,7 @@ import (
 	vmrest "github.com/deckhouse/virtualization-controller/pkg/apiserver/registry/vm/rest"
 	"github.com/deckhouse/virtualization-controller/pkg/apiserver/registry/vm/storage"
 	"github.com/deckhouse/virtualization-controller/pkg/tls/certmanager"
+	versionedv1alpha2 "github.com/deckhouse/virtualization/api/client/generated/clientset/versioned/typed/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/subresources"
 	"github.com/deckhouse/virtualization/api/subresources/install"
 	"github.com/deckhouse/virtualization/api/subresources/v1alpha2"
@@ -76,8 +77,15 @@ func Install(
 	kubevirt vmrest.KubevirtApiServerConfig,
 	proxyCertManager certmanager.CertificateManager,
 	crd *apiextensionsv1.CustomResourceDefinition,
+	virtClient versionedv1alpha2.VirtualizationV1alpha2Interface,
 ) error {
-	vmStorage := storage.NewStorage(subresources.Resource("virtualmachines"), vmLister, kubevirt, proxyCertManager, crd)
+	vmStorage := storage.NewStorage(subresources.Resource("virtualmachines"),
+		vmLister,
+		kubevirt,
+		proxyCertManager,
+		crd,
+		virtClient,
+	)
 	info := Build(vmStorage)
 	return server.InstallAPIGroup(&info)
 }

--- a/images/virtualization-artifact/pkg/apiserver/api/install.go
+++ b/images/virtualization-artifact/pkg/apiserver/api/install.go
@@ -24,12 +24,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
-	"k8s.io/client-go/tools/cache"
 
 	vmrest "github.com/deckhouse/virtualization-controller/pkg/apiserver/registry/vm/rest"
 	"github.com/deckhouse/virtualization-controller/pkg/apiserver/registry/vm/storage"
 	"github.com/deckhouse/virtualization-controller/pkg/tls/certmanager"
 	versionedv1alpha2 "github.com/deckhouse/virtualization/api/client/generated/clientset/versioned/typed/core/v1alpha2"
+	virtlisters "github.com/deckhouse/virtualization/api/client/generated/listers/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/subresources"
 	"github.com/deckhouse/virtualization/api/subresources/install"
 	"github.com/deckhouse/virtualization/api/subresources/v1alpha2"
@@ -72,19 +72,19 @@ func Build(store *storage.VirtualMachineStorage) genericapiserver.APIGroupInfo {
 }
 
 func Install(
-	vmLister cache.GenericLister,
+	vmLister virtlisters.VirtualMachineLister,
 	server *genericapiserver.GenericAPIServer,
 	kubevirt vmrest.KubevirtApiServerConfig,
 	proxyCertManager certmanager.CertificateManager,
 	crd *apiextensionsv1.CustomResourceDefinition,
-	virtClient versionedv1alpha2.VirtualizationV1alpha2Interface,
+	vmClient versionedv1alpha2.VirtualMachinesGetter,
 ) error {
 	vmStorage := storage.NewStorage(subresources.Resource("virtualmachines"),
 		vmLister,
 		kubevirt,
 		proxyCertManager,
 		crd,
-		virtClient,
+		vmClient,
 	)
 	info := Build(vmStorage)
 	return server.InstallAPIGroup(&info)

--- a/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/add_volume.go
+++ b/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/add_volume.go
@@ -24,14 +24,14 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
-	"k8s.io/client-go/tools/cache"
 
 	"github.com/deckhouse/virtualization-controller/pkg/tls/certmanager"
+	virtlisters "github.com/deckhouse/virtualization/api/client/generated/listers/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/subresources"
 )
 
 type AddVolumeREST struct {
-	vmLister         cache.GenericLister
+	vmLister         virtlisters.VirtualMachineLister
 	proxyCertManager certmanager.CertificateManager
 	kubevirt         KubevirtApiServerConfig
 }
@@ -41,7 +41,7 @@ var (
 	_ rest.Connecter = &AddVolumeREST{}
 )
 
-func NewAddVolumeREST(vmLister cache.GenericLister, kubevirt KubevirtApiServerConfig, proxyCertManager certmanager.CertificateManager) *AddVolumeREST {
+func NewAddVolumeREST(vmLister virtlisters.VirtualMachineLister, kubevirt KubevirtApiServerConfig, proxyCertManager certmanager.CertificateManager) *AddVolumeREST {
 	return &AddVolumeREST{
 		vmLister:         vmLister,
 		kubevirt:         kubevirt,
@@ -81,7 +81,7 @@ func (r AddVolumeREST) ConnectMethods() []string {
 
 func AddVolumeLocation(
 	ctx context.Context,
-	getter cache.GenericLister,
+	getter virtlisters.VirtualMachineLister,
 	name string,
 	opts *subresources.VirtualMachineAddVolume,
 	kubevirt KubevirtApiServerConfig,

--- a/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/console.go
+++ b/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/console.go
@@ -25,14 +25,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apiserver/pkg/registry/rest"
-	"k8s.io/client-go/tools/cache"
 
 	"github.com/deckhouse/virtualization-controller/pkg/tls/certmanager"
+	virtlisters "github.com/deckhouse/virtualization/api/client/generated/listers/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/subresources"
 )
 
 type ConsoleREST struct {
-	vmLister         cache.GenericLister
+	vmLister         virtlisters.VirtualMachineLister
 	proxyCertManager certmanager.CertificateManager
 	kubevirt         KubevirtApiServerConfig
 }
@@ -48,7 +48,7 @@ var (
 	_ rest.Connecter = &ConsoleREST{}
 )
 
-func NewConsoleREST(vmLister cache.GenericLister, kubevirt KubevirtApiServerConfig, proxyCertManager certmanager.CertificateManager) *ConsoleREST {
+func NewConsoleREST(vmLister virtlisters.VirtualMachineLister, kubevirt KubevirtApiServerConfig, proxyCertManager certmanager.CertificateManager) *ConsoleREST {
 	return &ConsoleREST{
 		vmLister:         vmLister,
 		kubevirt:         kubevirt,
@@ -90,7 +90,7 @@ func (r ConsoleREST) ConnectMethods() []string {
 
 func ConsoleLocation(
 	ctx context.Context,
-	getter cache.GenericLister,
+	getter virtlisters.VirtualMachineLister,
 	name string,
 	opts *subresources.VirtualMachineConsole,
 	kubevirt KubevirtApiServerConfig,

--- a/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/freeze.go
+++ b/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/freeze.go
@@ -24,14 +24,14 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
-	"k8s.io/client-go/tools/cache"
 
 	"github.com/deckhouse/virtualization-controller/pkg/tls/certmanager"
+	virtlisters "github.com/deckhouse/virtualization/api/client/generated/listers/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/subresources"
 )
 
 type FreezeREST struct {
-	vmLister         cache.GenericLister
+	vmLister         virtlisters.VirtualMachineLister
 	proxyCertManager certmanager.CertificateManager
 	kubevirt         KubevirtApiServerConfig
 }
@@ -41,7 +41,7 @@ var (
 	_ rest.Connecter = &FreezeREST{}
 )
 
-func NewFreezeREST(vmLister cache.GenericLister, kubevirt KubevirtApiServerConfig, proxyCertManager certmanager.CertificateManager) *FreezeREST {
+func NewFreezeREST(vmLister virtlisters.VirtualMachineLister, kubevirt KubevirtApiServerConfig, proxyCertManager certmanager.CertificateManager) *FreezeREST {
 	return &FreezeREST{
 		vmLister:         vmLister,
 		kubevirt:         kubevirt,
@@ -81,7 +81,7 @@ func (r FreezeREST) ConnectMethods() []string {
 
 func FreezeLocation(
 	ctx context.Context,
-	getter cache.GenericLister,
+	getter virtlisters.VirtualMachineLister,
 	name string,
 	opts *subresources.VirtualMachineFreeze,
 	kubevirt KubevirtApiServerConfig,

--- a/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/portforward.go
+++ b/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/portforward.go
@@ -26,14 +26,14 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
-	"k8s.io/client-go/tools/cache"
 
 	"github.com/deckhouse/virtualization-controller/pkg/tls/certmanager"
+	virtlisters "github.com/deckhouse/virtualization/api/client/generated/listers/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/subresources"
 )
 
 type PortForwardREST struct {
-	vmLister         cache.GenericLister
+	vmLister         virtlisters.VirtualMachineLister
 	proxyCertManager certmanager.CertificateManager
 	kubevirt         KubevirtApiServerConfig
 }
@@ -43,7 +43,7 @@ var (
 	_ rest.Connecter = &PortForwardREST{}
 )
 
-func NewPortForwardREST(vmLister cache.GenericLister, kubevirt KubevirtApiServerConfig, proxyCertManager certmanager.CertificateManager) *PortForwardREST {
+func NewPortForwardREST(vmLister virtlisters.VirtualMachineLister, kubevirt KubevirtApiServerConfig, proxyCertManager certmanager.CertificateManager) *PortForwardREST {
 	return &PortForwardREST{
 		vmLister:         vmLister,
 		kubevirt:         kubevirt,
@@ -85,7 +85,7 @@ func (r PortForwardREST) ConnectMethods() []string {
 
 func PortForwardLocation(
 	ctx context.Context,
-	getter cache.GenericLister,
+	getter virtlisters.VirtualMachineLister,
 	name string,
 	opts *subresources.VirtualMachinePortForward,
 	kubevirt KubevirtApiServerConfig,

--- a/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/remove_volume.go
+++ b/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/remove_volume.go
@@ -24,14 +24,14 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
-	"k8s.io/client-go/tools/cache"
 
 	"github.com/deckhouse/virtualization-controller/pkg/tls/certmanager"
+	virtlisters "github.com/deckhouse/virtualization/api/client/generated/listers/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/subresources"
 )
 
 type RemoveVolumeREST struct {
-	vmLister         cache.GenericLister
+	vmLister         virtlisters.VirtualMachineLister
 	proxyCertManager certmanager.CertificateManager
 	kubevirt         KubevirtApiServerConfig
 }
@@ -41,7 +41,7 @@ var (
 	_ rest.Connecter = &RemoveVolumeREST{}
 )
 
-func NewRemoveVolumeREST(vmLister cache.GenericLister, kubevirt KubevirtApiServerConfig, proxyCertManager certmanager.CertificateManager) *RemoveVolumeREST {
+func NewRemoveVolumeREST(vmLister virtlisters.VirtualMachineLister, kubevirt KubevirtApiServerConfig, proxyCertManager certmanager.CertificateManager) *RemoveVolumeREST {
 	return &RemoveVolumeREST{
 		vmLister:         vmLister,
 		kubevirt:         kubevirt,
@@ -81,7 +81,7 @@ func (r RemoveVolumeREST) ConnectMethods() []string {
 
 func RemoveVolumeRESTLocation(
 	ctx context.Context,
-	getter cache.GenericLister,
+	getter virtlisters.VirtualMachineLister,
 	name string,
 	opts *subresources.VirtualMachineRemoveVolume,
 	kubevirt KubevirtApiServerConfig,

--- a/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/stream.go
+++ b/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/stream.go
@@ -30,9 +30,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/proxy"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
-	"k8s.io/client-go/tools/cache"
 
 	"github.com/deckhouse/virtualization-controller/pkg/tls/certmanager"
+	virtlisters "github.com/deckhouse/virtualization/api/client/generated/listers/core/v1alpha2"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/subresources"
 )
@@ -47,7 +47,7 @@ var upgradeableMethods = []string{http.MethodGet, http.MethodPost}
 
 func streamLocation(
 	ctx context.Context,
-	getter cache.GenericLister,
+	getter virtlisters.VirtualMachineLister,
 	name string,
 	opts runtime.Object,
 	streamPath string,
@@ -95,16 +95,9 @@ func streamLocation(
 	return location, transport, nil
 }
 
-func getVM(getter cache.GenericLister, key types.NamespacedName) (*virtv2.VirtualMachine, error) {
-	obj, err := getter.ByNamespace(key.Namespace).Get(key.Name)
-	if err != nil {
-		return nil, err
-	}
-	vm := obj.(*virtv2.VirtualMachine)
-	if vm == nil {
-		return nil, fmt.Errorf("unexpected object type: %#v", vm)
-	}
-	return vm, nil
+func getVM(getter virtlisters.VirtualMachineLister, key types.NamespacedName) (*virtv2.VirtualMachine, error) {
+	vm, err := getter.VirtualMachines(key.Namespace).Get(key.Name)
+	return vm, err
 }
 
 // TODO: This may be useful in the future

--- a/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/stream.go
+++ b/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/stream.go
@@ -55,7 +55,7 @@ func streamLocation(
 	proxyCertManager certmanager.CertificateManager,
 ) (*url.URL, *http.Transport, error) {
 	ns, _ := request.NamespaceFrom(ctx)
-	vm, err := getVM(getter, types.NamespacedName{Namespace: ns, Name: name})
+	vm, err := getter.VirtualMachines(ns).Get(name)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -93,11 +93,6 @@ func streamLocation(
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.TLSClientConfig = tlsConfig
 	return location, transport, nil
-}
-
-func getVM(getter virtlisters.VirtualMachineLister, key types.NamespacedName) (*virtv2.VirtualMachine, error) {
-	vm, err := getter.VirtualMachines(key.Namespace).Get(key.Name)
-	return vm, err
 }
 
 // TODO: This may be useful in the future

--- a/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/unfreeze.go
+++ b/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/unfreeze.go
@@ -24,14 +24,14 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
-	"k8s.io/client-go/tools/cache"
 
 	"github.com/deckhouse/virtualization-controller/pkg/tls/certmanager"
+	virtlisters "github.com/deckhouse/virtualization/api/client/generated/listers/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/subresources"
 )
 
 type UnfreezeREST struct {
-	vmLister         cache.GenericLister
+	vmLister         virtlisters.VirtualMachineLister
 	proxyCertManager certmanager.CertificateManager
 	kubevirt         KubevirtApiServerConfig
 }
@@ -41,7 +41,7 @@ var (
 	_ rest.Connecter = &UnfreezeREST{}
 )
 
-func NewUnfreezeREST(vmLister cache.GenericLister, kubevirt KubevirtApiServerConfig, proxyCertManager certmanager.CertificateManager) *UnfreezeREST {
+func NewUnfreezeREST(vmLister virtlisters.VirtualMachineLister, kubevirt KubevirtApiServerConfig, proxyCertManager certmanager.CertificateManager) *UnfreezeREST {
 	return &UnfreezeREST{
 		vmLister:         vmLister,
 		kubevirt:         kubevirt,
@@ -81,7 +81,7 @@ func (r UnfreezeREST) ConnectMethods() []string {
 
 func UnfreezeLocation(
 	ctx context.Context,
-	getter cache.GenericLister,
+	getter virtlisters.VirtualMachineLister,
 	name string,
 	opts *subresources.VirtualMachineUnfreeze,
 	kubevirt KubevirtApiServerConfig,

--- a/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/vnc.go
+++ b/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/vnc.go
@@ -24,14 +24,14 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
-	"k8s.io/client-go/tools/cache"
 
 	"github.com/deckhouse/virtualization-controller/pkg/tls/certmanager"
+	virtlisters "github.com/deckhouse/virtualization/api/client/generated/listers/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/subresources"
 )
 
 type VNCREST struct {
-	vmLister         cache.GenericLister
+	vmLister         virtlisters.VirtualMachineLister
 	proxyCertManager certmanager.CertificateManager
 	kubevirt         KubevirtApiServerConfig
 }
@@ -41,7 +41,7 @@ var (
 	_ rest.Connecter = &VNCREST{}
 )
 
-func NewVNCREST(vmLister cache.GenericLister, kubevirt KubevirtApiServerConfig, proxyCertManager certmanager.CertificateManager) *VNCREST {
+func NewVNCREST(vmLister virtlisters.VirtualMachineLister, kubevirt KubevirtApiServerConfig, proxyCertManager certmanager.CertificateManager) *VNCREST {
 	return &VNCREST{
 		vmLister:         vmLister,
 		kubevirt:         kubevirt,
@@ -83,7 +83,7 @@ func (r VNCREST) ConnectMethods() []string {
 
 func VNCLocation(
 	ctx context.Context,
-	getter cache.GenericLister,
+	getter virtlisters.VirtualMachineLister,
 	name string,
 	opts *subresources.VirtualMachineVNC,
 	kubevirt KubevirtApiServerConfig,

--- a/images/virtualization-artifact/pkg/apiserver/registry/vm/storage/storage.go
+++ b/images/virtualization-artifact/pkg/apiserver/registry/vm/storage/storage.go
@@ -22,7 +22,6 @@ import (
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/registry/customresource/tableconvertor"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -160,9 +159,9 @@ func (store VirtualMachineStorage) Get(ctx context.Context, name string, _ *meta
 	vm, err := store.vmLister.VirtualMachines(namespace).Get(name)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return nil, apierrors.NewNotFound(store.groupResource, name)
+			return nil, k8serrors.NewNotFound(store.groupResource, name)
 		}
-		return nil, apierrors.NewInternalError(err)
+		return nil, k8serrors.NewInternalError(err)
 	}
 	return vm, nil
 }
@@ -189,7 +188,7 @@ func (store VirtualMachineStorage) List(ctx context.Context, options *internalve
 
 	items, err := store.vmLister.VirtualMachines(namespace).List(labelSelector)
 	if err != nil {
-		return nil, apierrors.NewInternalError(err)
+		return nil, k8serrors.NewInternalError(err)
 	}
 
 	filtered := &virtv2.VirtualMachineList{}
@@ -216,9 +215,9 @@ func (store VirtualMachineStorage) Delete(ctx context.Context, name string, _ re
 	}
 	if err := store.vmClient.VirtualMachines(genericreq.NamespaceValue(ctx)).Delete(ctx, name, opts); err != nil {
 		if k8serrors.IsNotFound(err) {
-			return nil, false, apierrors.NewNotFound(store.groupResource, name)
+			return nil, false, k8serrors.NewNotFound(store.groupResource, name)
 		}
-		return nil, false, apierrors.NewInternalError(err)
+		return nil, false, k8serrors.NewInternalError(err)
 	}
 	return nil, true, nil
 }

--- a/images/virtualization-artifact/pkg/apiserver/registry/vm/storage/storage.go
+++ b/images/virtualization-artifact/pkg/apiserver/registry/vm/storage/storage.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 	genericreq "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
-	"k8s.io/client-go/tools/cache"
 
 	vmrest "github.com/deckhouse/virtualization-controller/pkg/apiserver/registry/vm/rest"
 	"github.com/deckhouse/virtualization-controller/pkg/tls/certmanager"
@@ -44,7 +43,6 @@ import (
 type VirtualMachineStorage struct {
 	groupResource schema.GroupResource
 	vmLister      virtlisters.VirtualMachineLister
-	vmIndexer     cache.Indexer
 	console       *vmrest.ConsoleREST
 	vnc           *vmrest.VNCREST
 	portforward   *vmrest.PortForwardREST

--- a/images/virtualization-artifact/pkg/apiserver/server/config.go
+++ b/images/virtualization-artifact/pkg/apiserver/server/config.go
@@ -74,14 +74,11 @@ func (c Config) Validate() error {
 
 func (c Config) Complete() (*Server, error) {
 	proxyCertManager := filesystem.NewFileCertificateManager(c.ProxyClientCertFile, c.ProxyClientKeyFile)
-	informer, err := virtualizationInformerFactory(c.Rest)
+	vmSharedInformerFactory, err := virtualizationInformerFactory(c.Rest)
 	if err != nil {
 		return nil, err
 	}
-	vmInformer, err := informer.ForResource(virtv2.GroupVersionResource(virtv2.VirtualMachineResource))
-	if err != nil {
-		return nil, err
-	}
+	vmInformer := vmSharedInformerFactory.Virtualization().V1alpha2().VirtualMachines()
 
 	genericServer, err := c.Apiserver.Complete(nil).New("virtualziation-api", genericapiserver.NewEmptyDelegate())
 	if err != nil {
@@ -101,7 +98,6 @@ func (c Config) Complete() (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
-	virtclient.VirtualizationV1alpha2()
 	if err = api.Install(vmInformer.Lister(),
 		genericServer,
 		c.Kubevirt,

--- a/images/virtualization-artifact/pkg/apiserver/server/config.go
+++ b/images/virtualization-artifact/pkg/apiserver/server/config.go
@@ -29,6 +29,7 @@ import (
 	"github.com/deckhouse/virtualization-controller/pkg/apiserver/api"
 	vmrest "github.com/deckhouse/virtualization-controller/pkg/apiserver/registry/vm/rest"
 	"github.com/deckhouse/virtualization-controller/pkg/tls/certmanager/filesystem"
+	virtClient "github.com/deckhouse/virtualization/api/client/generated/clientset/versioned"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
@@ -81,10 +82,12 @@ func (c Config) Complete() (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	genericServer, err := c.Apiserver.Complete(nil).New("virtualziation-api", genericapiserver.NewEmptyDelegate())
 	if err != nil {
 		return nil, err
 	}
+
 	kubeclient, err := apiextensionsv1.NewForConfig(c.Rest)
 	if err != nil {
 		return nil, err
@@ -93,7 +96,19 @@ func (c Config) Complete() (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err = api.Install(vmInformer.Lister(), genericServer, c.Kubevirt, proxyCertManager, crd); err != nil {
+
+	virtclient, err := virtClient.NewForConfig(c.Rest)
+	if err != nil {
+		return nil, err
+	}
+	virtclient.VirtualizationV1alpha2()
+	if err = api.Install(vmInformer.Lister(),
+		genericServer,
+		c.Kubevirt,
+		proxyCertManager,
+		crd,
+		virtclient.VirtualizationV1alpha2(),
+	); err != nil {
 		return nil, err
 	}
 

--- a/images/virtualization-artifact/pkg/apiserver/server/informer.go
+++ b/images/virtualization-artifact/pkg/apiserver/server/informer.go
@@ -35,7 +35,7 @@ const (
 func virtualizationInformerFactory(rest *rest.Config) (virtInformers.SharedInformerFactory, error) {
 	client, err := virtClient.NewForConfig(rest)
 	if err != nil {
-		return nil, fmt.Errorf("unable to construct lister client: %w", err)
+		return nil, fmt.Errorf("unable to construct client: %w", err)
 	}
 	return virtInformers.NewSharedInformerFactory(client, defaultResync), nil
 }


### PR DESCRIPTION
## Description
impl delete method for subresource virtualmachine on apiserver

## Why do we need it, and what problem does it solve?
`kubectl delete virtualmachine` causes an error because a subresource with the same name is used

## What is the expected result?
```bash
❯ kubectl get vm 
NAME          PHASE     NODE                   IPADDRESS    AGE
linux-vm-01   Running   dev-rnd-virtlab-yb-1   10.66.10.1   58s

❯ kubectl delete virtualmachine linux-vm-01 
virtualmachine.subresources.virtualization.deckhouse.io "linux-vm-01" deleted

❯ kubectl get vm 
NAME          PHASE         NODE                   IPADDRESS    AGE
linux-vm-01   Terminating   dev-rnd-virtlab-yb-1   10.66.10.1   74s

```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
