### PR TITLE
feat(vd): override virtualdisk's pvc parameters via StorageClass annotations

### DIFF
--- a/images/virtualization-artifact/pkg/controller/common/util.go
+++ b/images/virtualization-artifact/pkg/controller/common/util.go
@@ -177,6 +177,12 @@ const (
 	// AnnImmediateBinding provides a const to indicate whether immediate binding should be performed on the PV (overrides global config)
 	AnnImmediateBinding = AnnAPIGroup + "/storage.bind.immediate.requested"
 
+	AnnAPIGroupV              = "virtualization.deckhouse.io"
+	AnnVirtualDisk            = "virtualdisk." + AnnAPIGroupV
+	AnnVirtualDiskVolumeMode  = AnnVirtualDisk + "/volume-mode"
+	AnnVirtualDiskAccessMode  = AnnVirtualDisk + "/access-mode"
+	AnnVirtualDiskBindingMode = AnnVirtualDisk + "/binding-mode"
+
 	// AnnSelectedNode annotation is added to a PVC that has been triggered by scheduler to
 	// be dynamically provisioned. Its value is the name of the selected node.
 	AnnSelectedNode = "volume.kubernetes.io/selected-node"

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/dv.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/dv.go
@@ -68,6 +68,10 @@ func (b *DV) SetPVC(storageClassName *string,
 	)
 }
 
+func (b *DV) SetImmediate() {
+	b.AddAnnotation("cdi.kubevirt.io/storage.bind.immediate.requested", "true")
+}
+
 func (b *DV) SetDataSource(source *cdiv1.DataVolumeSource) {
 	b.Resource.Spec.Source = source
 }


### PR DESCRIPTION
## Description
override pvc parameters using annotations in StorageClass

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
