### PR TITLE
fix(vm-route-forge): add check to ensure VM host node is identified

### DIFF
--- a/images/vm-route-forge/Taskfile.yaml
+++ b/images/vm-route-forge/Taskfile.yaml
@@ -3,7 +3,8 @@
 version: "3"
 
 vars:
-  DLV_IMAGE_ENV: "DLV_IMAGE"
+  DLV_IMAGE:
+    sh:  if [ -z $DLV_IMAGE ]; then echo "ttl.sh/$(uuidgen | awk '{print tolower($0)}'):10m" ; else echo $DLV_IMAGE ; fi
 
 tasks:
   lint:
@@ -16,20 +17,33 @@ tasks:
 
   dlv:build:
     desc: "Build image vm-route-forge with dlv"
-    preconditions:
-      - sh: if [ -z ${{ .DLV_IMAGE_ENV }}]; then exit 1 ; fi
-        msg: "export env {{ .DLV_IMAGE_ENV }}"
-    cmd: cd ../../ && docker build -f ./images/vm-route-forge/dlv.Dockerfile -t "${{ .DLV_IMAGE_ENV }}" .
-
-  dlv:push:
-    desc: "Push image vm-route-forge with dlv"
-    preconditions:
-      - sh: if [ -z ${{ .DLV_IMAGE_ENV }}]; then exit 1 ; fi
-        msg: "export env {{ .DLV_IMAGE_ENV }}"
-    cmd: docker push "${{ .DLV_IMAGE_ENV }}"
+    cmd: cd ../../ && docker build -f ./images/vm-route-forge/dlv.Dockerfile -t "{{ .DLV_IMAGE }}" .
 
   dlv:build-push:
     desc: "Build and Push image vm-route-forge with dlv"
     cmds:
-      - task: build
-      - task: push
+      - task: dlv:build
+      - docker push "{{ .DLV_IMAGE }}"
+      - task: dlv:print
+
+  dlv:print:
+    desc: "Print subcommands for debug"
+    env:
+      IMAGE: "{{ .DLV_IMAGE }}"
+    cmd: |
+      cat <<EOF
+      kubectl -n d8-virtualization patch ds vm-route-forge --type='strategic' -p '{
+        "spec": {
+          "template": {
+            "spec": {
+              "containers": [ {
+                "name": "vm-route-forge",
+                "image": "${IMAGE}",
+                "ports": [ { "containerPort": 2345, "name": "dlv" } ]
+              }]
+            }
+          }
+        }
+      }'
+      kubectl -n d8-virtualization port-forward $(kubectl -n d8-virtualization get pod -l app=vm-route-forge -oname | head -1) 2345:2345
+      EOF

--- a/images/vm-route-forge/Taskfile.yaml
+++ b/images/vm-route-forge/Taskfile.yaml
@@ -4,7 +4,7 @@ version: "3"
 
 vars:
   DLV_IMAGE:
-    sh:  if [ -z $DLV_IMAGE ]; then echo "ttl.sh/$(uuidgen | awk '{print tolower($0)}'):10m" ; else echo $DLV_IMAGE ; fi
+    sh: if [ -z $DLV_IMAGE ]; then echo "ttl.sh/$(uuidgen | awk '{print tolower($0)}'):10m" ; else echo $DLV_IMAGE ; fi
 
 tasks:
   lint:


### PR DESCRIPTION
## Description
Add a check that the node on which the VM will be running has been identified

## Why do we need it, and what problem does it solve?
We have too many logs when there is no node defined for the VM to run.
```
vm-route-forge-dfw4s vm-route-forge 2024-09-09T16:14:36Z    ERROR    vm-route-forge    re-enqueuing VirtualMachine console-review/cooing-wildfowl-erinn    {"controller": "routeController", "error": "ciliumNode has no CiliumInternalIP specified"}
vm-route-forge-dfw4s vm-route-forge vm-route-forge/internal/controller/route.(*Controller).worker.func1
vm-route-forge-dfw4s vm-route-forge     /app/images/vm-route-forge/internal/controller/route/route_controller.go:252
vm-route-forge-dfw4s vm-route-forge vm-route-forge/internal/controller/route.(*Controller).worker
vm-route-forge-dfw4s vm-route-forge     /app/images/vm-route-forge/internal/controller/route/route_controller.go:261
vm-route-forge-dfw4s vm-route-forge k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext.func1
vm-route-forge-dfw4s vm-route-forge     

```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
