### PR TITLE
fix(cvi): fix cleanup for resources

### DIFF
--- a/images/virtualization-artifact/pkg/controller/cvi/cvi_controller.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/cvi_controller.go
@@ -61,12 +61,11 @@ func NewController(
 	protection := service.NewProtectionService(mgr.GetClient(), virtv2.FinalizerCVIProtection)
 	importer := service.NewImporterService(dvcr, mgr.GetClient(), importerImage, requirements, PodPullPolicy, PodVerbose, ControllerName, protection)
 	uploader := service.NewUploaderService(dvcr, mgr.GetClient(), uploaderImage, requirements, PodPullPolicy, PodVerbose, ControllerName, protection)
-	disk := service.NewDiskService(mgr.GetClient(), dvcr, protection)
 
 	sources := source.NewSources()
 	sources.Set(virtv2.DataSourceTypeHTTP, source.NewHTTPDataSource(stat, importer, dvcr, ns))
 	sources.Set(virtv2.DataSourceTypeContainerImage, source.NewRegistryDataSource(stat, importer, dvcr, mgr.GetClient(), ns))
-	sources.Set(virtv2.DataSourceTypeObjectRef, source.NewObjectRefDataSource(stat, importer, disk, dvcr, mgr.GetClient(), ns))
+	sources.Set(virtv2.DataSourceTypeObjectRef, source.NewObjectRefDataSource(stat, importer, dvcr, mgr.GetClient(), ns))
 	sources.Set(virtv2.DataSourceTypeUpload, source.NewUploadDataSource(stat, uploader, dvcr, ns))
 
 	reconciler := NewReconciler(

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/interfaces.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/interfaces.go
@@ -40,6 +40,7 @@ type Importer interface {
 	CleanUp(ctx context.Context, sup *supplements.Generator) (bool, error)
 	CleanUpSupplements(ctx context.Context, sup *supplements.Generator) (bool, error)
 	GetPod(ctx context.Context, sup *supplements.Generator) (*corev1.Pod, error)
+	DeletePod(ctx context.Context, obj service.ObjectKind, controllerName string) (bool, error)
 	Protect(ctx context.Context, pod *corev1.Pod) error
 	Unprotect(ctx context.Context, pod *corev1.Pod) error
 	GetPodSettingsWithPVC(ownerRef *metav1.OwnerReference, sup *supplements.Generator, pvcName, pvcNamespace string) *importer.PodSettings

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/mock.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/mock.go
@@ -34,6 +34,9 @@ var _ Importer = &ImporterMock{}
 //			CleanUpSupplementsFunc: func(ctx context.Context, sup *supplements.Generator) (bool, error) {
 //				panic("mock out the CleanUpSupplements method")
 //			},
+//			DeletePodFunc: func(ctx context.Context, obj service.ObjectKind, controllerName string) (bool, error) {
+//				panic("mock out the DeletePod method")
+//			},
 //			GetPodFunc: func(ctx context.Context, sup *supplements.Generator) (*corev1.Pod, error) {
 //				panic("mock out the GetPod method")
 //			},
@@ -64,6 +67,9 @@ type ImporterMock struct {
 
 	// CleanUpSupplementsFunc mocks the CleanUpSupplements method.
 	CleanUpSupplementsFunc func(ctx context.Context, sup *supplements.Generator) (bool, error)
+
+	// DeletePodFunc mocks the DeletePod method.
+	DeletePodFunc func(ctx context.Context, obj service.ObjectKind, controllerName string) (bool, error)
 
 	// GetPodFunc mocks the GetPod method.
 	GetPodFunc func(ctx context.Context, sup *supplements.Generator) (*corev1.Pod, error)
@@ -98,6 +104,15 @@ type ImporterMock struct {
 			Ctx context.Context
 			// Sup is the sup argument value.
 			Sup *supplements.Generator
+		}
+		// DeletePod holds details about calls to the DeletePod method.
+		DeletePod []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Obj is the obj argument value.
+			Obj service.ObjectKind
+			// ControllerName is the controllerName argument value.
+			ControllerName string
 		}
 		// GetPod holds details about calls to the GetPod method.
 		GetPod []struct {
@@ -160,6 +175,7 @@ type ImporterMock struct {
 	}
 	lockCleanUp               sync.RWMutex
 	lockCleanUpSupplements    sync.RWMutex
+	lockDeletePod             sync.RWMutex
 	lockGetPod                sync.RWMutex
 	lockGetPodSettingsWithPVC sync.RWMutex
 	lockProtect               sync.RWMutex
@@ -237,6 +253,46 @@ func (mock *ImporterMock) CleanUpSupplementsCalls() []struct {
 	mock.lockCleanUpSupplements.RLock()
 	calls = mock.calls.CleanUpSupplements
 	mock.lockCleanUpSupplements.RUnlock()
+	return calls
+}
+
+// DeletePod calls DeletePodFunc.
+func (mock *ImporterMock) DeletePod(ctx context.Context, obj service.ObjectKind, controllerName string) (bool, error) {
+	if mock.DeletePodFunc == nil {
+		panic("ImporterMock.DeletePodFunc: method is nil but Importer.DeletePod was just called")
+	}
+	callInfo := struct {
+		Ctx            context.Context
+		Obj            service.ObjectKind
+		ControllerName string
+	}{
+		Ctx:            ctx,
+		Obj:            obj,
+		ControllerName: controllerName,
+	}
+	mock.lockDeletePod.Lock()
+	mock.calls.DeletePod = append(mock.calls.DeletePod, callInfo)
+	mock.lockDeletePod.Unlock()
+	return mock.DeletePodFunc(ctx, obj, controllerName)
+}
+
+// DeletePodCalls gets all the calls that were made to DeletePod.
+// Check the length with:
+//
+//	len(mockedImporter.DeletePodCalls())
+func (mock *ImporterMock) DeletePodCalls() []struct {
+	Ctx            context.Context
+	Obj            service.ObjectKind
+	ControllerName string
+} {
+	var calls []struct {
+		Ctx            context.Context
+		Obj            service.ObjectKind
+		ControllerName string
+	}
+	mock.lockDeletePod.RLock()
+	calls = mock.calls.DeletePod
+	mock.lockDeletePod.RUnlock()
 	return calls
 }
 

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref.go
@@ -52,7 +52,6 @@ type ObjectRefDataSource struct {
 func NewObjectRefDataSource(
 	statService Stat,
 	importerService Importer,
-	diskService *service.DiskService,
 	dvcrSettings *dvcr.Settings,
 	client client.Client,
 	controllerNamespace string,
@@ -64,8 +63,8 @@ func NewObjectRefDataSource(
 		client:              client,
 		controllerNamespace: controllerNamespace,
 
-		viOnPvcSyncer: NewObjectRefVirtualImageOnPvc(importerService, diskService, controllerNamespace, dvcrSettings, statService),
-		vdSyncer:      NewObjectRefVirtualDisk(importerService, diskService, controllerNamespace, dvcrSettings, statService),
+		viOnPvcSyncer: NewObjectRefVirtualImageOnPvc(importerService, dvcrSettings, statService),
+		vdSyncer:      NewObjectRefVirtualDisk(importerService, client, controllerNamespace, dvcrSettings, statService),
 	}
 }
 

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref.go
@@ -230,24 +230,24 @@ func (ds ObjectRefDataSource) Sync(ctx context.Context, cvi *virtv2.ClusterVirtu
 }
 
 func (ds ObjectRefDataSource) CleanUp(ctx context.Context, cvi *virtv2.ClusterVirtualImage) (bool, error) {
-	viRefCleanUpResult, err := ds.viOnPvcSyncer.CleanUp(ctx, cvi)
+	viRefRequeue, err := ds.viOnPvcSyncer.CleanUp(ctx, cvi)
 	if err != nil {
 		return false, err
 	}
 
-	vdRefCleanUpResult, err := ds.vdSyncer.CleanUp(ctx, cvi)
+	vdRefRequeue, err := ds.vdSyncer.CleanUp(ctx, cvi)
 	if err != nil {
 		return false, err
 	}
 
 	supgen := supplements.NewGenerator(common.CVIShortName, cvi.Name, ds.controllerNamespace, cvi.UID)
 
-	objRefCleanUpResult, err := ds.importerService.CleanUp(ctx, supgen)
+	objRefRequeue, err := ds.importerService.CleanUp(ctx, supgen)
 	if err != nil {
 		return false, err
 	}
 
-	return objRefCleanUpResult || vdRefCleanUpResult || viRefCleanUpResult, nil
+	return objRefRequeue || vdRefRequeue || viRefRequeue, nil
 }
 
 func (ds ObjectRefDataSource) Validate(ctx context.Context, cvi *virtv2.ClusterVirtualImage) error {

--- a/images/virtualization-artifact/pkg/controller/service/disk_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/disk_service.go
@@ -439,14 +439,6 @@ func (s DiskService) GetVirtualDiskSnapshot(ctx context.Context, name, namespace
 	return helper.FetchObject(ctx, types.NamespacedName{Name: name, Namespace: namespace}, s.client, &virtv2.VirtualDiskSnapshot{})
 }
 
-func (s DiskService) GetVirtualDisk(ctx context.Context, name, namespace string) (*virtv2.VirtualDisk, error) {
-	return helper.FetchObject(ctx, types.NamespacedName{Name: name, Namespace: namespace}, s.client, &virtv2.VirtualDisk{})
-}
-
-func (s DiskService) GetVirtualMachine(ctx context.Context, name, namespace string) (*virtv2.VirtualMachine, error) {
-	return helper.FetchObject(ctx, types.NamespacedName{Name: name, Namespace: namespace}, s.client, &virtv2.VirtualMachine{})
-}
-
 func (s DiskService) CheckImportProcess(ctx context.Context, dv *cdiv1.DataVolume, pvc *corev1.PersistentVolumeClaim) error {
 	if dv == nil {
 		return nil

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref.go
@@ -72,7 +72,7 @@ func NewObjectRefDataSource(
 		diskService:        diskService,
 		storageClassForPVC: storageClassForPVC,
 		viObjectRefOnPvc:   NewObjectRefDataVirtualImageOnPVC(statService, importerService, dvcrSettings, client, diskService, storageClassForPVC),
-		vdSyncer:           NewObjectRefVirtualDisk(importerService, diskService, dvcrSettings, statService, storageClassForPVC),
+		vdSyncer:           NewObjectRefVirtualDisk(importerService, client, diskService, dvcrSettings, statService, storageClassForPVC),
 	}
 }
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fixed an error inside the CleanUp call that caused the finalizer not to be removed from ClusterVirtualImage

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
