### PR TITLE
chore(core): add comments to prevent accidental adding status subresource

### DIFF
--- a/crds/embedded/cdi.yaml
+++ b/crds/embedded/cdi.yaml
@@ -2320,3 +2320,8 @@ spec:
       served: true
       storage: true
       subresources: {}
+# IMPORTANT! Do not add status subresource, as it breaks the status update
+# in CDI components.
+# Delete this precaution when future CDI updates add status subresource.
+#      subresources:
+#        status: {}

--- a/crds/embedded/virtualmachineinstances.yaml
+++ b/crds/embedded/virtualmachineinstances.yaml
@@ -4054,3 +4054,8 @@ spec:
         type: object
     served: true
     storage: true
+# IMPORTANT! Do not add status subresource, as it breaks the status update
+# in Kubevirt components.
+# Delete this precaution when future Kubevirt updates add status subresource.
+#      subresources:
+#        status: {}


### PR DESCRIPTION
## Description

- Add comments to prevent accidental adding status subresource in InternalVirtualizationCDI and InternalVirtualizationVirtualMachineInstance.

## Why do we need it, and what problem does it solve?

Some resources for KubeVirt and CDI store status field as "main" fields, not as a subresource. Set status to subresource will break update operation for these resources.


## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
