### PR TITLE
feat(vm-route-forge): add routes for subnets in blackhole

### DIFF
--- a/images/vm-route-forge/internal/controller/route/route_controller.go
+++ b/images/vm-route-forge/internal/controller/route/route_controller.go
@@ -226,7 +226,7 @@ func (c *Controller) Run(ctx context.Context, workers int) error {
 	go func() {
 		wait.UntilWithContext(newCtx, func(_ context.Context) {
 			if err := c.netlinkMgr.AddSubnetsRoutesToBlackHole(); err != nil {
-				c.log.Error(err, "Failed to add routes for subnets in blackhole.")
+				c.log.Error(err, "Failed to add blackhole routes for subnets.")
 			}
 		}, time.Minute)
 	}()

--- a/images/vm-route-forge/internal/controller/route/route_controller.go
+++ b/images/vm-route-forge/internal/controller/route/route_controller.go
@@ -223,6 +223,14 @@ func (c *Controller) Run(ctx context.Context, workers int) error {
 		return fmt.Errorf("failed to synchronize routing rules at start: %w", err)
 	}
 
+	go func() {
+		wait.UntilWithContext(newCtx, func(_ context.Context) {
+			if err := c.netlinkMgr.AddSubnetsRoutesToBlackHole(); err != nil {
+				c.log.Error(err, "Failed to add routes for subnets in blackhole.")
+			}
+		}, time.Minute)
+	}()
+
 	c.log.Info("Starting workers of route controller")
 	for i := 0; i < workers; i++ {
 		go wait.UntilWithContext(newCtx, c.worker, time.Second)

--- a/images/vm-route-forge/internal/controller/route/route_controller.go
+++ b/images/vm-route-forge/internal/controller/route/route_controller.go
@@ -224,6 +224,7 @@ func (c *Controller) Run(ctx context.Context, workers int) error {
 	}
 
 	go func() {
+		// AddSubnetRoutesToBlackHole will be executed every minute until context canceled.
 		wait.UntilWithContext(newCtx, func(_ context.Context) {
 			if err := c.netlinkMgr.AddSubnetsRoutesToBlackHole(); err != nil {
 				c.log.Error(err, "Failed to add blackhole routes for subnets.")

--- a/images/vm-route-forge/internal/netlinkmanager/manager.go
+++ b/images/vm-route-forge/internal/netlinkmanager/manager.go
@@ -67,6 +67,22 @@ func New(cache vmipcache.Cache,
 	}
 }
 
+func (m *Manager) AddSubnetsRoutesToBlackHole() error {
+	for _, cidr := range m.cidrs {
+		route := &netlink.Route{
+			Scope: netlink.SCOPE_UNIVERSE,
+			Dst:   cidr,
+			Table: m.routeTableID,
+			Type:  unix.RTN_BLACKHOLE,
+		}
+		if err := m.nlWrapper.RouteReplace(route); err != nil {
+			return fmt.Errorf("failed to update route: %w", err)
+		}
+	}
+
+	return nil
+}
+
 // SyncRules adds rules for configured CIDRS into the Cilium table.
 // Also, it removes existing rules for previously configured CIDRs.
 func (m *Manager) SyncRules() error {

--- a/images/vm-route-forge/internal/netlinkmanager/manager.go
+++ b/images/vm-route-forge/internal/netlinkmanager/manager.go
@@ -41,6 +41,8 @@ const (
 	DefaultCiliumRouteTable = 1490
 	LocalRouteTable         = 255
 	netlinkManager          = "netlinkManager"
+	routePriority           = 0
+	blackHoleRoutePriority  = 100
 )
 
 type Manager struct {
@@ -70,10 +72,11 @@ func New(cache vmipcache.Cache,
 func (m *Manager) AddSubnetsRoutesToBlackHole() error {
 	for _, cidr := range m.cidrs {
 		route := &netlink.Route{
-			Scope: netlink.SCOPE_UNIVERSE,
-			Dst:   cidr,
-			Table: m.routeTableID,
-			Type:  unix.RTN_BLACKHOLE,
+			Scope:    netlink.SCOPE_UNIVERSE,
+			Dst:      cidr,
+			Table:    m.routeTableID,
+			Type:     unix.RTN_BLACKHOLE,
+			Priority: blackHoleRoutePriority,
 		}
 		if err := m.nlWrapper.RouteReplace(route); err != nil {
 			return fmt.Errorf("failed to update route: %w", err)
@@ -209,6 +212,7 @@ func (m *Manager) UpdateRoute(vm *virtv2.VirtualMachine, ciliumNode *ciliumv2.Ci
 	route.Dst = vmRouteDst
 	route.Table = m.routeTableID
 	route.Type = 1
+	route.Priority = routePriority
 
 	if err = m.nlWrapper.RouteReplace(&route); err != nil {
 		m.log.Error(err, fmt.Sprintf("failed to update route %q to %q for VM %s/%s", fmtRoute(origRoute), fmtRoute(route), vm.GetNamespace(), vm.GetName()))


### PR DESCRIPTION
## Description
add routes for subnets in blackhole

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
