### PR TITLE
chore(lint): add doc-ru linter

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -87,6 +87,16 @@ tasks:
           go run tools/addlicense/{main,variables,msg,utils}.go -directory ./
         {{end}}
 
+  lint:doc-ru:
+    desc: "Check the correspondence between description fields in the original crd and the Russian language version"
+    cmds:
+    - |
+        docker run \
+          --rm -it -v "$PWD:/src" docker.io/fl64/d8-doc-ru-linter:v0.0.1-dev0 \
+          sh -c \
+            'for crd in /src/crds/*.yaml; do [[ "$(basename "$crd")" =~ ^doc-ru ]] || /d8-doc-ru-linter -s "$crd" -d "/src/crds/doc-ru-$(basename "$crd")" -n /dev/null; done'
+
+
   lint:prettier:yaml:
     desc: "Check if yaml files are prettier-formatted."
     cmds:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -91,11 +91,8 @@ tasks:
     cmds:
       - task: lint:doc-ru
       - task: lint:prettier:yaml
-      - task: virtualization-controller:dvcr:_ensure:golangci-lint
       - task: virtualization-controller:dvcr:lint
-      - task: virtualization-controller:dvcr:lint:go
       - task: virtualization-controller:lint
-      - task: virtualization-controller:lint:go
 
   lint:doc-ru:
     desc: "Check the correspondence between description fields in the original crd and the Russian language version"

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -87,6 +87,17 @@ tasks:
           go run tools/addlicense/{main,variables,msg,utils}.go -directory ./
         {{end}}
 
+  lint:
+    cmds:
+    - task: lint:doc-ru
+    - task: lint:prettier:yaml
+    - task: virtualization-controller:dvcr:_ensure:golangci-lint
+    - task: virtualization-controller:dvcr:lint
+    - task: virtualization-controller:dvcr:lint:go
+    - task: virtualization-controller:lint
+    - task: virtualization-controller:lint:go
+
+
   lint:doc-ru:
     desc: "Check the correspondence between description fields in the original crd and the Russian language version"
     cmds:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -89,24 +89,22 @@ tasks:
 
   lint:
     cmds:
-    - task: lint:doc-ru
-    - task: lint:prettier:yaml
-    - task: virtualization-controller:dvcr:_ensure:golangci-lint
-    - task: virtualization-controller:dvcr:lint
-    - task: virtualization-controller:dvcr:lint:go
-    - task: virtualization-controller:lint
-    - task: virtualization-controller:lint:go
-
+      - task: lint:doc-ru
+      - task: lint:prettier:yaml
+      - task: virtualization-controller:dvcr:_ensure:golangci-lint
+      - task: virtualization-controller:dvcr:lint
+      - task: virtualization-controller:dvcr:lint:go
+      - task: virtualization-controller:lint
+      - task: virtualization-controller:lint:go
 
   lint:doc-ru:
     desc: "Check the correspondence between description fields in the original crd and the Russian language version"
     cmds:
-    - |
+      - |
         docker run \
           --rm -it -v "$PWD:/src" docker.io/fl64/d8-doc-ru-linter:v0.0.1-dev0 \
           sh -c \
             'for crd in /src/crds/*.yaml; do [[ "$(basename "$crd")" =~ ^doc-ru ]] || /d8-doc-ru-linter -s "$crd" -d "/src/crds/doc-ru-$(basename "$crd")" -n /dev/null; done'
-
 
   lint:prettier:yaml:
     desc: "Check if yaml files are prettier-formatted."


### PR DESCRIPTION
## Description
- add doc-ru linter to check the differences between crd and the RU version of crd
- add task `lint` to run all linters

## Why do we need it, and what problem does it solve?
We need to make sure that all changes are reflected in all language versions of crd

## What is the expected result?
A tool that allows you to display the difference in crd

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
