### PR TITLE
feat(vm): round the runtimeOverhead to Mi

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm/internal/statistic.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/statistic.go
@@ -18,6 +18,7 @@ package internal
 
 import (
 	"context"
+	"math"
 	"sort"
 	"strconv"
 	"time"
@@ -138,6 +139,7 @@ func (h *StatisticHandler) syncResources(changed *virtv2.VirtualMachine,
 
 		memoryOverhead := memoryPodRequest.DeepCopy()
 		memoryOverhead.Sub(memoryKVVMIRequest)
+		memoryOverhead = *resource.NewQuantity(int64(math.Ceil(float64(memoryOverhead.Value())/1024))*1024, resource.BinarySI)
 
 		resources = virtv2.ResourcesStatus{
 			CPU: virtv2.CPUStatus{

--- a/images/virtualization-artifact/pkg/controller/vm/internal/statistic.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/statistic.go
@@ -139,7 +139,8 @@ func (h *StatisticHandler) syncResources(changed *virtv2.VirtualMachine,
 
 		memoryOverhead := memoryPodRequest.DeepCopy()
 		memoryOverhead.Sub(memoryKVVMIRequest)
-		memoryOverhead = *resource.NewQuantity(int64(math.Ceil(float64(memoryOverhead.Value())/1024))*1024, resource.BinarySI)
+		mi := int64(1024 * 1024)
+		memoryOverhead = *resource.NewQuantity(int64(math.Ceil(float64(memoryOverhead.Value()/mi)))*mi, resource.BinarySI)
 
 		resources = virtv2.ResourcesStatus{
 			CPU: virtv2.CPUStatus{

--- a/images/virtualization-artifact/pkg/controller/vm/internal/statistic.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/statistic.go
@@ -140,7 +140,7 @@ func (h *StatisticHandler) syncResources(changed *virtv2.VirtualMachine,
 		memoryOverhead := memoryPodRequest.DeepCopy()
 		memoryOverhead.Sub(memoryKVVMIRequest)
 		mi := int64(1024 * 1024)
-		memoryOverhead = *resource.NewQuantity(int64(math.Ceil(float64(memoryOverhead.Value()/mi)))*mi, resource.BinarySI)
+		memoryOverhead = *resource.NewQuantity(int64(math.Ceil(float64(memoryOverhead.Value())/float64(mi)))*mi, resource.BinarySI)
 
 		resources = virtv2.ResourcesStatus{
 			CPU: virtv2.CPUStatus{


### PR DESCRIPTION
## Description
round the runtimeOverhead to Mi

## Why do we need it, and what problem does it solve?
Displaying the parameter in bytes is not human readable

## Checklist
- [X] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
