### PR TITLE
feat(gc): leave only last 10 resources

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm/gc.go
+++ b/images/virtualization-artifact/pkg/controller/vm/gc.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/deckhouse/virtualization-controller/pkg/config"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/gc"
-	"github.com/deckhouse/virtualization-controller/pkg/sdk/framework/helper"
 )
 
 const gcVMMigrationControllerName = "vmi-migration-gc-controller"
@@ -57,10 +56,7 @@ func SetupGC(
 			if !ok {
 				return false
 			}
-			if vmiMigrationIsFinal(migration) && helper.GetAge(migration) > ttl {
-				return true
-			}
-			return false
+			return vmiMigrationIsFinal(migration)
 		},
 	)
 }

--- a/images/virtualization-artifact/pkg/controller/vmop/gc.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/gc.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/deckhouse/virtualization-controller/pkg/config"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/gc"
-	"github.com/deckhouse/virtualization-controller/pkg/sdk/framework/helper"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
@@ -57,10 +56,7 @@ func SetupGC(
 			if !ok {
 				return false
 			}
-			if vmopIsFinal(vmop) && helper.GetAge(vmop) > ttl {
-				return true
-			}
-			return false
+			return vmopIsFinal(vmop)
 		},
 	)
 }

--- a/templates/virtualization-controller/_helpers.tpl
+++ b/templates/virtualization-controller/_helpers.tpl
@@ -49,13 +49,13 @@
 - name: PROVISIONING_POD_REQUESTS
   value: '{"cpu":"100m","memory":"60M"}'
 - name: GC_VMOP_TTL
-  value: "1h"
+  value: "24h"
 - name: GC_VMOP_SCHEDULE
-  value: "*/30 * * * *"
+  value: "0 * * * *"
 - name: GC_VMI_MIGRATION_TTL
-  value: "1h"
+  value: "24h"
 - name: GC_VMI_MIGRATION_SCHEDULE
-  value: "*/30 * * * *"
+  value: "0 * * * *"
 
 {{- if eq .Values.virtualization.logLevel "debug" }}
 - name: PPROF_BIND_ADDRESS


### PR DESCRIPTION
## Description
* leave only last 10 resources
* replace ttl for vmop with 24h
* replace ttl for vmi migration with 24h
* replace schedule for vmop with every hour
* replace schedule for vmi migration with every hour

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
