### PR TITLE
feat(vmop): add metrics

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vmop/vmop_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/vmop_controller.go
@@ -26,10 +26,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vmop/internal"
 	"github.com/deckhouse/virtualization-controller/pkg/logger"
+	vmopcolelctor "github.com/deckhouse/virtualization-controller/pkg/monitoring/metrics/vmop"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
@@ -40,9 +42,9 @@ const (
 func SetupController(
 	ctx context.Context,
 	mgr manager.Manager,
-	log *slog.Logger,
+	lg *slog.Logger,
 ) error {
-	log = log.With(logger.SlogController(controllerName))
+	log := lg.With(logger.SlogController(controllerName))
 
 	recorder := mgr.GetEventRecorderFor(controllerName)
 	client := mgr.GetClient()
@@ -77,6 +79,8 @@ func SetupController(
 		Complete(); err != nil {
 		return err
 	}
+
+	vmopcolelctor.SetupCollector(mgr.GetCache(), metrics.Registry, lg)
 
 	log.Info("Initialized VirtualMachineOperation controller")
 	return nil

--- a/images/virtualization-artifact/pkg/monitoring/metrics/vmop/collector.go
+++ b/images/virtualization-artifact/pkg/monitoring/metrics/vmop/collector.go
@@ -66,7 +66,7 @@ func (c Collector) Collect(ch chan<- prometheus.Metric) {
 		s.Report(m)
 		return
 	}); err != nil {
-		c.log.Error("Failed to iterate of VMOPs", logger.SlogErr(err))
+		c.log.Error("Failed to iterate over VMOPs", logger.SlogErr(err))
 		return
 	}
 }

--- a/images/virtualization-artifact/pkg/monitoring/metrics/vmop/collector.go
+++ b/images/virtualization-artifact/pkg/monitoring/metrics/vmop/collector.go
@@ -1,0 +1,56 @@
+package vmop
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/deckhouse/virtualization-controller/pkg/logger"
+)
+
+const collectorName = "vmop-collector"
+
+func SetupCollector(reader client.Reader,
+	registerer prometheus.Registerer,
+	log *slog.Logger,
+) *Collector {
+	c := &Collector{
+		iterator: newUnsafeIterator(reader),
+		log:      log.With(logger.SlogCollector(collectorName)),
+	}
+	registerer.MustRegister(c)
+	return c
+}
+
+type handler func(m *dataMetric) (stop bool)
+
+type Iterator interface {
+	Iter(ctx context.Context, h handler) error
+}
+
+type Collector struct {
+	iterator Iterator
+	log      *slog.Logger
+}
+
+func (c Collector) Describe(ch chan<- *prometheus.Desc) {
+	for _, v := range vmopMetrics {
+		ch <- v
+	}
+}
+
+func (c Collector) Collect(ch chan<- prometheus.Metric) {
+	s := newScraper(ch, c.log)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	if err := c.iterator.Iter(ctx, func(m *dataMetric) (stop bool) {
+		s.Report(m)
+		return
+	}); err != nil {
+		c.log.Error("Failed to iterate of VMOPs", logger.SlogErr(err))
+		return
+	}
+}

--- a/images/virtualization-artifact/pkg/monitoring/metrics/vmop/collector.go
+++ b/images/virtualization-artifact/pkg/monitoring/metrics/vmop/collector.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package vmop
 
 import (

--- a/images/virtualization-artifact/pkg/monitoring/metrics/vmop/data_metric.go
+++ b/images/virtualization-artifact/pkg/monitoring/metrics/vmop/data_metric.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package vmop
 
 import virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"

--- a/images/virtualization-artifact/pkg/monitoring/metrics/vmop/data_metric.go
+++ b/images/virtualization-artifact/pkg/monitoring/metrics/vmop/data_metric.go
@@ -1,0 +1,24 @@
+package vmop
+
+import virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+
+type dataMetric struct {
+	Name      string
+	Namespace string
+	UID       string
+	Phase     virtv2.VMOPPhase
+}
+
+// DO NOT mutate VirtualMachineOperation!
+func newDataMetric(vmop *virtv2.VirtualMachineOperation) *dataMetric {
+	if vmop == nil {
+		return nil
+	}
+
+	return &dataMetric{
+		Name:      vmop.Name,
+		Namespace: vmop.Namespace,
+		UID:       string(vmop.UID),
+		Phase:     vmop.Status.Phase,
+	}
+}

--- a/images/virtualization-artifact/pkg/monitoring/metrics/vmop/metrics.go
+++ b/images/virtualization-artifact/pkg/monitoring/metrics/vmop/metrics.go
@@ -1,0 +1,36 @@
+package vmop
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/deckhouse/virtualization-controller/pkg/monitoring/metrics"
+)
+
+const (
+	MetricVMOPStatusPhase = "virtualmachineoperation_status_phase"
+)
+
+var baseLabels = []string{"name", "namespace", "uid"}
+
+func WithBaseLabels(labels ...string) []string {
+	return append(baseLabels, labels...)
+}
+
+func WithBaseLabelsByMetric(m *dataMetric, labels ...string) []string {
+	var base []string
+	if m != nil {
+		base = []string{
+			m.Name,
+			m.Namespace,
+			m.UID,
+		}
+	}
+	return append(base, labels...)
+}
+
+var vmopMetrics = map[string]*prometheus.Desc{
+	MetricVMOPStatusPhase: prometheus.NewDesc(prometheus.BuildFQName(metrics.MetricNamespace, "", MetricVMOPStatusPhase),
+		"The virtualmachineoperation current phase.",
+		WithBaseLabels("phase"),
+		nil),
+}

--- a/images/virtualization-artifact/pkg/monitoring/metrics/vmop/metrics.go
+++ b/images/virtualization-artifact/pkg/monitoring/metrics/vmop/metrics.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package vmop
 
 import (

--- a/images/virtualization-artifact/pkg/monitoring/metrics/vmop/scraper.go
+++ b/images/virtualization-artifact/pkg/monitoring/metrics/vmop/scraper.go
@@ -1,0 +1,61 @@
+package vmop
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/deckhouse/virtualization-controller/pkg/util"
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+)
+
+func newScraper(ch chan<- prometheus.Metric, log *slog.Logger) *scraper {
+	return &scraper{ch: ch, log: log}
+}
+
+type scraper struct {
+	ch  chan<- prometheus.Metric
+	log *slog.Logger
+}
+
+func (s *scraper) Report(m *dataMetric) {
+	s.updateDiskStatusPhaseMetrics(m)
+}
+
+func (s *scraper) updateDiskStatusPhaseMetrics(m *dataMetric) {
+	phase := m.Phase
+	if phase == "" {
+		phase = virtv2.VMOPPhasePending
+	}
+	phases := []struct {
+		value bool
+		name  string
+	}{
+		{phase == virtv2.VMOPPhasePending, string(virtv2.VMOPPhasePending)},
+		{phase == virtv2.VMOPPhaseInProgress, string(virtv2.VMOPPhaseInProgress)},
+		{phase == virtv2.VMOPPhaseCompleted, string(virtv2.VMOPPhaseCompleted)},
+		{phase == virtv2.VMOPPhaseFailed, string(virtv2.VMOPPhaseFailed)},
+		{phase == virtv2.VMOPPhaseTerminating, string(virtv2.VMOPPhaseTerminating)},
+	}
+
+	for _, p := range phases {
+		s.defaultUpdate(MetricVMOPStatusPhase,
+			util.BoolFloat64(p.value), m, p.name)
+	}
+}
+
+func (s *scraper) defaultUpdate(descName string, value float64, m *dataMetric, labels ...string) {
+	desc := vmopMetrics[descName]
+	metric, err := prometheus.NewConstMetric(
+		desc,
+		prometheus.GaugeValue,
+		value,
+		WithBaseLabelsByMetric(m, labels...)...,
+	)
+	if err != nil {
+		s.log.Warn(fmt.Sprintf("Error creating the new const dataMetric for %s: %s", desc, err))
+		return
+	}
+	s.ch <- metric
+}

--- a/images/virtualization-artifact/pkg/monitoring/metrics/vmop/scraper.go
+++ b/images/virtualization-artifact/pkg/monitoring/metrics/vmop/scraper.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package vmop
 
 import (

--- a/images/virtualization-artifact/pkg/monitoring/metrics/vmop/unsafe.go
+++ b/images/virtualization-artifact/pkg/monitoring/metrics/vmop/unsafe.go
@@ -1,0 +1,41 @@
+package vmop
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+)
+
+func newUnsafeIterator(reader client.Reader) *iterator {
+	return &iterator{
+		reader: reader,
+	}
+}
+
+type iterator struct {
+	reader client.Reader
+}
+
+// Iter implements iteration on objects VirtualMachineOperation and create new DTO.
+// DO NOT mutate VirtualMachineOperation!
+func (l *iterator) Iter(ctx context.Context, h handler) error {
+	vmops := virtv2.VirtualMachineOperationList{}
+	if err := l.reader.List(ctx, &vmops, client.UnsafeDisableDeepCopy); err != nil {
+		return err
+	}
+	for _, vmop := range vmops.Items {
+		m := newDataMetric(&vmop)
+		if stop := h(m); stop {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			continue
+		}
+	}
+	return nil
+}

--- a/images/virtualization-artifact/pkg/monitoring/metrics/vmop/unsafe.go
+++ b/images/virtualization-artifact/pkg/monitoring/metrics/vmop/unsafe.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package vmop
 
 import (

--- a/monitoring/prometheus-rules/internal-virtualization-virt-hander.yaml
+++ b/monitoring/prometheus-rules/internal-virtualization-virt-hander.yaml
@@ -1,6 +1,6 @@
 - name: kubernetes.internal.virtualization.virt_handler_state
   rules:
-    - alert: D8InternalVirtualizationVirtHandlerlTargetDown
+    - alert: D8InternalVirtualizationVirtHandlerTargetDown
       expr: max by (job) (up{job="internal-virtualization-kubevirt-prometheus-metrics"}) == 0
       for: 1m
       labels:
@@ -9,8 +9,8 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_create_group_if_not_exists__d8_internal_virtulaization_virt_handler_health: "D8InternalVirtualizationVirtHandlerlHealth,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
-        plk_grouped_by__d8_internal_virtulaization_virt_handler_health: "D8InternalVirtualizationVirtHandlerlHealth,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_create_group_if_not_exists__d8_internal_virtualization_virt_handler_health: "D8InternalVirtualizationVirtHandlerlHealth,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_grouped_by__d8_internal_virtualization_virt_handler_health: "D8InternalVirtualizationVirtHandlerlHealth,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
         plk_ignore_labels: "job"
         summary: Prometheus cannot scrape the virtualization-controller metrics.
         description: |
@@ -18,7 +18,7 @@
           1. Check the Pod status: `kubectl -n d8-virtualization get pod -l kubevirt.internal.virtualization.deckhouse.io=virt-handler`
           2. Or check the Pod logs: `kubectl -n d8-virtualization logs daemonsets/virt-handler`
 
-    - alert: D8InternalVirtualizationVirtHandlerlTargetAbsent
+    - alert: D8InternalVirtualizationVirtHandlerTargetAbsent
       expr: absent(up{job="internal-virtualization-kubevirt-prometheus-metrics") == 1
       labels:
         severity_level: "6"
@@ -28,8 +28,8 @@
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
         plk_ignore_labels: "job"
-        plk_create_group_if_not_exists__d8_internal_virtulaization_virt_handler_health: "D8InternalVirtualizationVirtHandlerlHealth,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
-        plk_grouped_by__d8_internal_virtulaization_virt_handler_health: "D8InternalVirtualizationVirtHandlerlHealth,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_create_group_if_not_exists__d8_internal_virtualization_virt_handler_health: "D8InternalVirtualizationVirtHandlerHealth,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_grouped_by__d8_internal_virtualization_virt_handler_health: "D8InternalVirtualizationVirtHandlerHealth,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
         summary: There is no `virtualization-controller` target in Prometheus.
         description: |
           The recommended course of action:
@@ -46,8 +46,8 @@
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
         plk_labels_as_annotations: "pod"
-        plk_create_group_if_not_exists__d8_linstor_node_health: "D8InternalVirtualizationVirtHandlerlHealth,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
-        plk_grouped_by__d8_linstor_node_health: "D8InternalVirtualizationVirtHandlerlHealth,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_create_group_if_not_exists__d8_internal_virtualization_virt_handler_health: "D8InternalVirtualizationVirtHandlerHealth,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_grouped_by__d8_internal_virtualization_virt_handler_health: "D8InternalVirtualizationVirtHandlerHealth,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
         summary: The virt-handler Pod is NOT Ready.
         description: |
           The recommended course of action:
@@ -63,8 +63,8 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
-        plk_create_group_if_not_exists__d8_linstor_node_health: "D8InternalVirtualizationVirtHandlerlHealth,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
-        plk_grouped_by__d8_linstor_node_health: "D8InternalVirtualizationVirtHandlerlHealth,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_create_group_if_not_exists__d8_internal_virtualization_virt_handler_health: "D8InternalVirtualizationVirtHandlerHealth,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_grouped_by__d8_internal_virtualization_virt_handler_health: "D8InternalVirtualizationVirtHandlerHealth,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
         summary: The virt-handler Pod is NOT Running.
         description: |
           The recommended course of action:

--- a/monitoring/prometheus-rules/vmop.yaml
+++ b/monitoring/prometheus-rules/vmop.yaml
@@ -9,8 +9,8 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
-        plk_create_group_if_not_exists__d8_virtualization_vmop_health: "D8VirtualizationVmopHealth,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
-        plk_grouped_by__d8_virtualization_vmop_health: "D8VirtualizationVmopHealth,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_create_group_if_not_exists__d8_virtualization_vmop_stuck_in_progress_state: "D8VirtualizationVmopStuckInProgressState,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_grouped_by__d8_virtualization_vmop_stuck_in_progress_state: "D8VirtualizationVmopStuckInProgressState,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
         summary: The VMOP with phase InProgress for a long time.
         description: |
           The recommended course of action:

--- a/monitoring/prometheus-rules/vmop.yaml
+++ b/monitoring/prometheus-rules/vmop.yaml
@@ -1,0 +1,17 @@
+- name: kubernetes.virtualization.vmop
+  rules:
+    - alert: D8VirtualizationVmopInProgressForLongTime
+      expr: d8_virtualization_virtualmachineoperation_status_phase{phase="InProgress"} == 1
+      labels:
+        severity_level: "6"
+        tier: cluster
+      for: 30m
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_create_group_if_not_exists__d8_virtualization_vmop_health: "D8VirtualizationVmopHealth,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_grouped_by__d8_virtualization_vmop_health: "D8VirtualizationVmopHealth,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
+        summary: The VMOP with phase InProgress for a long time.
+        description: |
+          The recommended course of action:
+          1. Find VMOPs whose phase is "InProgress" and sort by creation time: `kubectl get vmop -A -o jsonpath="{range .items[?(@.status.phase=='InProgress')].metadata}{.namespace}{'\t'}{.name}{'\t'}{.creationTimestamp}{'\n'}{end}" --sort-by=.metadata.creationTimestamp`

--- a/monitoring/prometheus-rules/vmop.yaml
+++ b/monitoring/prometheus-rules/vmop.yaml
@@ -14,4 +14,4 @@
         summary: The VMOP with phase InProgress for a long time.
         description: |
           The recommended course of action:
-          1. Find VMOPs whose phase is "InProgress" and sort by creation time: `kubectl get vmop -A -o jsonpath="{range .items[?(@.status.phase=='InProgress')].metadata}{.namespace}{'\t'}{.name}{'\t'}{.creationTimestamp}{'\n'}{end}" --sort-by=.metadata.creationTimestamp`
+          Find VMOPs whose phase is "InProgress" and sort by creation time: `kubectl get vmop -A -o jsonpath="{range .items[?(@.status.phase=='InProgress')].metadata}{.namespace}{'\t'}{.name}{'\t'}{.creationTimestamp}{'\n'}{end}" --sort-by=.metadata.creationTimestamp`

--- a/monitoring/prometheus-rules/vmop.yaml
+++ b/monitoring/prometheus-rules/vmop.yaml
@@ -3,7 +3,7 @@
     - alert: D8VirtualizationVmopInProgressForLongTime
       expr: d8_virtualization_virtualmachineoperation_status_phase{phase="InProgress"} == 1
       labels:
-        severity_level: "6"
+        severity_level: "9"
         tier: cluster
       for: 30m
       annotations:

--- a/monitoring/prometheus-rules/vmop.yaml
+++ b/monitoring/prometheus-rules/vmop.yaml
@@ -1,6 +1,6 @@
 - name: kubernetes.virtualization.vmop
   rules:
-    - alert: D8VirtualizationVmopInProgressForLongTime
+    - alert: D8VirtualizationVMOPStuckInPorgressState
       expr: d8_virtualization_virtualmachineoperation_status_phase{phase="InProgress"} == 1
       labels:
         severity_level: "9"


### PR DESCRIPTION
## Description
Add metrics for VMOP
`d8_virtualization_virtualmachineoperation_status_phase`
With base labels` ["name", "namespace", "uid"]`

![Screenshot from 2024-09-17 11-58-47](https://github.com/user-attachments/assets/c0aa72a2-ee84-4e10-9cf6-c54554ed6ecc)

## Why do we need it, and what problem does it solve?
we need more metrics

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
