### PR TITLE
fix(vm,vmip): improve VMIP management

### DIFF
--- a/api/core/v1alpha2/virtual_machine_ip_address.go
+++ b/api/core/v1alpha2/virtual_machine_ip_address.go
@@ -80,6 +80,7 @@ type VirtualMachineIPAddressStatus struct {
 type VirtualMachineIPAddressPhase string
 
 const (
-	VirtualMachineIPAddressPhasePending VirtualMachineIPAddressPhase = "Pending"
-	VirtualMachineIPAddressPhaseBound   VirtualMachineIPAddressPhase = "Bound"
+	VirtualMachineIPAddressPhasePending  VirtualMachineIPAddressPhase = "Pending"
+	VirtualMachineIPAddressPhaseBound    VirtualMachineIPAddressPhase = "Bound"
+	VirtualMachineIPAddressPhaseAttached VirtualMachineIPAddressPhase = "Attached"
 )

--- a/crds/doc-ru-virtualmachineipaddresses.yaml
+++ b/crds/doc-ru-virtualmachineipaddresses.yaml
@@ -46,7 +46,7 @@ spec:
 
                     * Pending - создание ресурса находится в процессе выполнения.
                     * Bound - ресурс `VirtualMachineIPAddress` привязан к ресурсу `VirtualMachineIPAddressLease`.
-                    * Attached - ресурс `VirtualMachineIPAddress` подсключен к ресурсу `VirtualMachine`.
+                    * Attached - ресурс `VirtualMachineIPAddress` подключен к ресурсу `VirtualMachine`.
                 virtualMachineName:
                   description: |
                     Имя виртуальной машины, которая в настоящее время использует этот IP-адрес.

--- a/crds/doc-ru-virtualmachineipaddresses.yaml
+++ b/crds/doc-ru-virtualmachineipaddresses.yaml
@@ -46,6 +46,7 @@ spec:
 
                     * Pending - создание ресурса находится в процессе выполнения.
                     * Bound - ресурс `VirtualMachineIPAddress` привязан к ресурсу `VirtualMachineIPAddressLease`.
+                    * Attached - ресурс `VirtualMachineIPAddress` подсключен к ресурсу `VirtualMachine`.
                 virtualMachineName:
                   description: |
                     Имя виртуальной машины, которая в настоящее время использует этот IP-адрес.

--- a/crds/virtualmachineipaddresses.yaml
+++ b/crds/virtualmachineipaddresses.yaml
@@ -96,11 +96,13 @@ spec:
                   enum:
                     - "Pending"
                     - "Bound"
+                    - "Attached"
                   description: |
                     Represents the current state of IP address.
 
                     * Pending - the process of creating is in progress.
                     * Bound - the IP address is bound to IP address lease.
+                    * Attached - the IP address is attached to VirtualMachine.
                 observedGeneration:
                   type: integer
                   description: |

--- a/images/virtualization-artifact/pkg/controller/common/util.go
+++ b/images/virtualization-artifact/pkg/controller/common/util.go
@@ -246,7 +246,7 @@ const (
 	// LabelsPrefix is a prefix for virtualization-controller labels.
 	LabelsPrefix = "virtualization.deckhouse.io"
 
-	// LabelVirtualMachineName is a label to link ip address back to virtual machine.
+	// LabelVirtualMachineName is a label to link VirtualMachineOperation to VirtualMachine.
 	LabelVirtualMachineName = LabelsPrefix + "/virtual-machine-name"
 
 	UploaderServiceLabel = "service"

--- a/images/virtualization-artifact/pkg/controller/indexer/indexer.go
+++ b/images/virtualization-artifact/pkg/controller/indexer/indexer.go
@@ -34,6 +34,8 @@ const (
 	IndexFieldVMIPLeaseByVMIP = "spec.virtualMachineIPAddressRef.Name"
 
 	IndexFieldVDByVDSnapshot = "spec.DataSource.ObjectRef.Name,.Kind=VirtualDiskSnapshot"
+
+	IndexFieldVMIPByVM = "status.virtualMachine"
 )
 
 type indexFunc func(ctx context.Context, mgr manager.Manager) error
@@ -46,6 +48,7 @@ func IndexALL(ctx context.Context, mgr manager.Manager) error {
 		IndexVMByCVI,
 		IndexVMIPLeaseByVMIP,
 		IndexVDByVDSnapshot,
+		IndexVMIPByVM,
 	} {
 		if err := fn(ctx, mgr); err != nil {
 			return err
@@ -104,5 +107,15 @@ func IndexVMIPLeaseByVMIP(ctx context.Context, mgr manager.Manager) error {
 			return nil
 		}
 		return []string{lease.Spec.VirtualMachineIPAddressRef.Name}
+	})
+}
+
+func IndexVMIPByVM(ctx context.Context, mgr manager.Manager) error {
+	return mgr.GetFieldIndexer().IndexField(ctx, &virtv2.VirtualMachineIPAddress{}, IndexFieldVMIPByVM, func(object client.Object) []string {
+		vmip, ok := object.(*virtv2.VirtualMachineIPAddress)
+		if !ok || vmip == nil {
+			return nil
+		}
+		return []string{vmip.Status.VirtualMachine}
 	})
 }

--- a/images/virtualization-artifact/pkg/controller/ipam/ipam.go
+++ b/images/virtualization-artifact/pkg/controller/ipam/ipam.go
@@ -24,7 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/deckhouse/virtualization-controller/pkg/controller/common"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
@@ -54,25 +53,12 @@ func (m IPAM) CheckIpAddressAvailableForBinding(vmName string, vmip *virtv2.Virt
 	}
 
 	return nil
-	//boundVMName := vmip.Status.VirtualMachine
-	//if boundVMName == "" || boundVMName == vmName {
-	//	return nil
-	//}
-	//
-	//return fmt.Errorf(
-	//	"unable to bind the ip address (%s) to the virtual machine (%s): the ip address has already been linked to another one",
-	//	vmip.Name,
-	//	vmName,
-	//)
 }
 
 func (m IPAM) CreateIPAddress(ctx context.Context, vm *virtv2.VirtualMachine, client client.Client) error {
 	ownerRef := metav1.NewControllerRef(vm, vm.GroupVersionKind())
 	return client.Create(ctx, &virtv2.VirtualMachineIPAddress{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{
-				common.LabelVirtualMachineName: vm.Name,
-			},
 			GenerateName:    GenerateName(vm),
 			Namespace:       vm.Namespace,
 			OwnerReferences: []metav1.OwnerReference{*ownerRef},
@@ -99,9 +85,7 @@ func GetVirtualMachineName(vmip *virtv2.VirtualMachineIPAddress) string {
 	if gn := vmip.GenerateName; gn != "" {
 		return strings.TrimSuffix(vmip.GenerateName, generateNameSuffix)
 	}
-	if name := vmip.GetLabels()[common.LabelVirtualMachineName]; name != "" {
-		return name
-	}
+
 	name := vmip.GetName()
 	for _, ow := range vmip.GetOwnerReferences() {
 		if ow.Kind == virtv2.VirtualMachineKind {

--- a/images/virtualization-artifact/pkg/controller/ipam/ipam.go
+++ b/images/virtualization-artifact/pkg/controller/ipam/ipam.go
@@ -42,7 +42,7 @@ func (m IPAM) IsBound(vmName string, vmip *virtv2.VirtualMachineIPAddress) bool 
 		return false
 	}
 
-	if vmip.Status.Phase != virtv2.VirtualMachineIPAddressPhaseBound {
+	if vmip.Status.Phase != virtv2.VirtualMachineIPAddressPhaseBound && vmip.Status.Phase != virtv2.VirtualMachineIPAddressPhaseAttached {
 		return false
 	}
 

--- a/images/virtualization-artifact/pkg/controller/ipam/ipam.go
+++ b/images/virtualization-artifact/pkg/controller/ipam/ipam.go
@@ -19,7 +19,6 @@ package ipam
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -54,16 +53,17 @@ func (m IPAM) CheckIpAddressAvailableForBinding(vmName string, vmip *virtv2.Virt
 		return errors.New("cannot to bind with empty ip address")
 	}
 
-	boundVMName := vmip.Status.VirtualMachine
-	if boundVMName == "" || boundVMName == vmName {
-		return nil
-	}
-
-	return fmt.Errorf(
-		"unable to bind the ip address (%s) to the virtual machine (%s): the ip address has already been linked to another one",
-		vmip.Name,
-		vmName,
-	)
+	return nil
+	//boundVMName := vmip.Status.VirtualMachine
+	//if boundVMName == "" || boundVMName == vmName {
+	//	return nil
+	//}
+	//
+	//return fmt.Errorf(
+	//	"unable to bind the ip address (%s) to the virtual machine (%s): the ip address has already been linked to another one",
+	//	vmip.Name,
+	//	vmName,
+	//)
 }
 
 func (m IPAM) CreateIPAddress(ctx context.Context, vm *virtv2.VirtualMachine, client client.Client) error {

--- a/images/virtualization-artifact/pkg/controller/vm/internal/ipam.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/ipam.go
@@ -120,7 +120,6 @@ func (h *IPAMHandler) Handle(ctx context.Context, s state.VirtualMachineState) (
 							Reason(vmcondition.ReasonIPAddressNotAssigned).
 							Message(msg).
 							Condition())
-						h.recorder.Event(changed, corev1.EventTypeWarning, vmcondition.ReasonIPAddressNotAssigned.String(), msg)
 						log.Error(msg)
 					}
 					break

--- a/images/virtualization-artifact/pkg/controller/vm/internal/ipam.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/ipam.go
@@ -100,7 +100,6 @@ func (h *IPAMHandler) Handle(ctx context.Context, s state.VirtualMachineState) (
 			Reason(vmcondition.ReasonIPAddressReady).
 			Condition())
 		changed.Status.VirtualMachineIPAddress = ipAddress.GetName()
-		changed.Status.IPAddress = ipAddress.Status.Address
 		kvvmi, err := s.KVVMI(ctx)
 		if err != nil {
 			return reconcile.Result{}, err
@@ -111,6 +110,7 @@ func (h *IPAMHandler) Handle(ctx context.Context, s state.VirtualMachineState) (
 					hasClaimedIP := false
 					for _, ip := range iface.IPs {
 						if ip == ipAddress.Status.Address {
+							changed.Status.IPAddress = ipAddress.Status.Address
 							hasClaimedIP = true
 						}
 					}

--- a/images/virtualization-artifact/pkg/controller/vm/internal/ipam.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/ipam.go
@@ -100,7 +100,7 @@ func (h *IPAMHandler) Handle(ctx context.Context, s state.VirtualMachineState) (
 			Reason(vmcondition.ReasonIPAddressReady).
 			Condition())
 		changed.Status.VirtualMachineIPAddress = ipAddress.GetName()
-		if changed.Status.Phase != virtv2.MachineRunning {
+		if changed.Status.Phase != virtv2.MachineRunning && changed.Status.Phase != virtv2.MachineStopping {
 			changed.Status.IPAddress = ipAddress.Status.Address
 		}
 		kvvmi, err := s.KVVMI(ctx)

--- a/images/virtualization-artifact/pkg/controller/vm/internal/ipam.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/ipam.go
@@ -100,7 +100,9 @@ func (h *IPAMHandler) Handle(ctx context.Context, s state.VirtualMachineState) (
 			Reason(vmcondition.ReasonIPAddressReady).
 			Condition())
 		changed.Status.VirtualMachineIPAddress = ipAddress.GetName()
-		changed.Status.IPAddress = ipAddress.Status.Address
+		if changed.Status.Phase != virtv2.MachineRunning {
+			changed.Status.IPAddress = ipAddress.Status.Address
+		}
 		kvvmi, err := s.KVVMI(ctx)
 		if err != nil {
 			return reconcile.Result{}, err

--- a/images/virtualization-artifact/pkg/controller/vm/internal/ipam.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/ipam.go
@@ -100,6 +100,7 @@ func (h *IPAMHandler) Handle(ctx context.Context, s state.VirtualMachineState) (
 			Reason(vmcondition.ReasonIPAddressReady).
 			Condition())
 		changed.Status.VirtualMachineIPAddress = ipAddress.GetName()
+		changed.Status.IPAddress = ipAddress.Status.Address
 		kvvmi, err := s.KVVMI(ctx)
 		if err != nil {
 			return reconcile.Result{}, err
@@ -110,7 +111,6 @@ func (h *IPAMHandler) Handle(ctx context.Context, s state.VirtualMachineState) (
 					hasClaimedIP := false
 					for _, ip := range iface.IPs {
 						if ip == ipAddress.Status.Address {
-							changed.Status.IPAddress = ipAddress.Status.Address
 							hasClaimedIP = true
 						}
 					}

--- a/images/virtualization-artifact/pkg/controller/vm/internal/ipam.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/ipam.go
@@ -140,6 +140,8 @@ func (h *IPAMHandler) Handle(ctx context.Context, s state.VirtualMachineState) (
 		if current.Spec.VirtualMachineIPAddress != "" {
 			log.Info(fmt.Sprintf("The requested ip address (%s) for the virtual machine not found: waiting for the ip address", current.Spec.VirtualMachineIPAddress))
 			cb.Message(fmt.Sprintf("The requested ip address (%s) for the virtual machine not found: waiting for the ip address", current.Spec.VirtualMachineIPAddress))
+			mgr.Update(cb.Condition())
+			changed.Status.Conditions = mgr.Generate()
 			return reconcile.Result{RequeueAfter: 2 * time.Second}, nil
 		}
 		log.Info("VirtualMachineIPAddress not found: create the new one", slog.String("vmipName", current.GetName()))

--- a/images/virtualization-artifact/pkg/controller/vm/internal/state/state.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/state/state.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kvvmutil "github.com/deckhouse/virtualization-controller/pkg/common/kvvm"
-	"github.com/deckhouse/virtualization-controller/pkg/controller/common"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/indexer"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/powerstate"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization-controller/pkg/sdk/framework/helper"
@@ -303,10 +303,12 @@ func (s *state) IPAddress(ctx context.Context) (*virtv2.VirtualMachineIPAddress,
 	vmipName := s.vm.Current().Spec.VirtualMachineIPAddress
 	if vmipName == "" {
 		vmipList := &virtv2.VirtualMachineIPAddressList{}
-		err := s.client.List(ctx, vmipList, &client.ListOptions{
-			Namespace:     s.vm.Current().GetNamespace(),
-			LabelSelector: labels.SelectorFromSet(map[string]string{common.LabelVirtualMachineName: s.vm.Current().GetName()}),
-		})
+
+		err := s.client.List(ctx, vmipList, client.InNamespace(s.vm.Current().GetNamespace()),
+			&client.MatchingFields{
+				indexer.IndexFieldVMIPByVM: s.vm.Current().GetName(),
+			})
+
 		if err != nil {
 			return nil, fmt.Errorf("failed to list VirtualMachineIPAddress: %w", err)
 		}

--- a/images/virtualization-artifact/pkg/controller/vm/internal/state/state.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/state/state.go
@@ -304,11 +304,12 @@ func (s *state) IPAddress(ctx context.Context) (*virtv2.VirtualMachineIPAddress,
 	if vmipName == "" {
 		vmipList := &virtv2.VirtualMachineIPAddressList{}
 
-		err := s.client.List(ctx, vmipList, client.InNamespace(s.vm.Current().GetNamespace()),
+		err := s.client.List(ctx, vmipList,
+			client.InNamespace(s.vm.Current().GetNamespace()),
 			&client.MatchingFields{
 				indexer.IndexFieldVMIPByVM: s.vm.Current().GetName(),
-			})
-
+			},
+		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to list VirtualMachineIPAddress: %w", err)
 		}

--- a/images/virtualization-artifact/pkg/controller/vm/internal/validators/ipam_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/validators/ipam_validator.go
@@ -69,7 +69,6 @@ func (v *IPAMValidator) ValidateUpdate(ctx context.Context, oldVM, newVM *v1alph
 	}
 
 	if newVM.Spec.VirtualMachineIPAddress == "" {
-		//return nil, fmt.Errorf("spec.virtualMachineIPAddress cannot be changed to an empty value once set")
 		return nil, nil
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vm/internal/validators/ipam_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/validators/ipam_validator.go
@@ -69,7 +69,8 @@ func (v *IPAMValidator) ValidateUpdate(ctx context.Context, oldVM, newVM *v1alph
 	}
 
 	if newVM.Spec.VirtualMachineIPAddress == "" {
-		return nil, fmt.Errorf("spec.virtualMachineIPAddress cannot be changed to an empty value once set")
+		//return nil, fmt.Errorf("spec.virtualMachineIPAddress cannot be changed to an empty value once set")
+		return nil, nil
 	}
 
 	vmipKey := types.NamespacedName{Name: newVM.Spec.VirtualMachineIPAddress, Namespace: newVM.Namespace}

--- a/images/virtualization-artifact/pkg/controller/vmchange/comparators.go
+++ b/images/virtualization-artifact/pkg/controller/vmchange/comparators.go
@@ -58,7 +58,7 @@ func compareVirtualMachineIPAddress(current, desired *v1alpha2.VirtualMachineSpe
 		current.VirtualMachineIPAddress,
 		desired.VirtualMachineIPAddress,
 		"",
-		ActionNone,
+		ActionRestart,
 	)
 }
 

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/lifecycle_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/lifecycle_handler.go
@@ -94,7 +94,7 @@ func (h *LifecycleHandler) Handle(ctx context.Context, state state.VMIPState) (r
 				Condition())
 		}
 
-	case vm != nil && vm.DeletionTimestamp == nil:
+	case vm != nil && vm.GetDeletionTimestamp().IsZero():
 		if vmipStatus.Phase != virtv2.VirtualMachineIPAddressPhaseAttached {
 			vmipStatus.Phase = virtv2.VirtualMachineIPAddressPhaseAttached
 			vmipStatus.VirtualMachine = vm.Name

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/protection_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/protection_handler.go
@@ -29,8 +29,7 @@ import (
 
 const ProtectionHandlerName = "ProtectionHandler"
 
-type ProtectionHandler struct {
-}
+type ProtectionHandler struct{}
 
 func NewProtectionHandler() *ProtectionHandler {
 	return &ProtectionHandler{}

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/protection_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/protection_handler.go
@@ -48,6 +48,7 @@ func (h *ProtectionHandler) Handle(ctx context.Context, state state.VMIPState) (
 	if vm == nil || vm.DeletionTimestamp != nil {
 		log.Info("VirtualMachineIP is no longer attached to any VM, proceeding with detachment", "VirtualMachineIPName", vmip.Name)
 		controllerutil.RemoveFinalizer(vmip, virtv2.FinalizerIPAddressCleanup)
+		// TODO: add list all vms with this vmip. And remove finalizer if list == 0. Or add if > 0 (vd -> attache.go)
 		controllerutil.RemoveFinalizer(vmip, virtv2.FinalizerIPAddressProtection)
 	} else if vmip.GetDeletionTimestamp() == nil {
 		controllerutil.AddFinalizer(vmip, virtv2.FinalizerIPAddressCleanup)

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/protection_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/protection_handler.go
@@ -19,7 +19,6 @@ package internal
 import (
 	"context"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -31,13 +30,10 @@ import (
 const ProtectionHandlerName = "ProtectionHandler"
 
 type ProtectionHandler struct {
-	client client.Client
 }
 
-func NewProtectionHandler(client client.Client) *ProtectionHandler {
-	return &ProtectionHandler{
-		client: client,
-	}
+func NewProtectionHandler() *ProtectionHandler {
+	return &ProtectionHandler{}
 }
 
 func (h *ProtectionHandler) Handle(ctx context.Context, state state.VMIPState) (reconcile.Result, error) {

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/protection_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/protection_handler.go
@@ -23,7 +23,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/deckhouse/virtualization-controller/pkg/controller/ipam"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vmip/internal/state"
 	"github.com/deckhouse/virtualization-controller/pkg/logger"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
@@ -51,25 +50,10 @@ func (h *ProtectionHandler) Handle(ctx context.Context, state state.VMIPState) (
 		return reconcile.Result{}, err
 	}
 
-	attachedVMs, err := h.getAttachedVM(ctx, vmip)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
-	switch {
-	case len(attachedVMs) == 0:
-		log.Debug("Allow VirtualMachineIPAddress deletion")
-		controllerutil.RemoveFinalizer(vmip, virtv2.FinalizerIPAddressProtection)
-	case vmip.DeletionTimestamp == nil:
-		log.Debug("Protect VirtualMachineIPAddress from deletion")
-		controllerutil.AddFinalizer(vmip, virtv2.FinalizerIPAddressProtection)
-	default:
-		log.Debug("VirtualMachineIPAddress deletion is delayed: it's protected by virtual machines")
-	}
-
 	if vm == nil || vm.DeletionTimestamp != nil {
 		log.Info("VirtualMachineIP is no longer attached to any VM, proceeding with detachment", "VirtualMachineIPName", vmip.Name)
 		controllerutil.RemoveFinalizer(vmip, virtv2.FinalizerIPAddressCleanup)
+		controllerutil.RemoveFinalizer(vmip, virtv2.FinalizerIPAddressProtection)
 	} else if vmip.GetDeletionTimestamp() == nil {
 		controllerutil.AddFinalizer(vmip, virtv2.FinalizerIPAddressCleanup)
 		log.Info("VirtualMachineIP is still attached, finalizer added", "VirtualMachineIPName", vmip.Name)
@@ -80,23 +64,4 @@ func (h *ProtectionHandler) Handle(ctx context.Context, state state.VMIPState) (
 
 func (h *ProtectionHandler) Name() string {
 	return ProtectionHandlerName
-}
-
-func (h *ProtectionHandler) getAttachedVM(ctx context.Context, vmip *virtv2.VirtualMachineIPAddress) ([]virtv2.VirtualMachine, error) {
-	var vms virtv2.VirtualMachineList
-	err := h.client.List(ctx, &vms, &client.ListOptions{
-		Namespace: vmip.Namespace,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	var attachedVMs []virtv2.VirtualMachine
-	for _, vm := range vms.Items { //FIXME
-		if vm.Spec.VirtualMachineIPAddress == vmip.Name || vm.Spec.VirtualMachineIPAddress == "" && vm.Name == ipam.GetVirtualMachineName(vmip) {
-			attachedVMs = append(attachedVMs, vm)
-		}
-	}
-
-	return attachedVMs, nil
 }

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/state/state.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/state/state.go
@@ -118,7 +118,7 @@ func (s *state) VirtualMachine(ctx context.Context) (*virtv2.VirtualMachine, err
 			return nil, fmt.Errorf("unable to get VM %s: %w", vmKey, err)
 		}
 
-		if vm.Status.VirtualMachineIPAddress == s.vmip.Name {
+		if vm.Status.VirtualMachineIPAddress == s.vmip.Name && vm.Status.IPAddress == s.vmip.Status.Address {
 			s.vm = vm
 		}
 	}

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/state/state.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/state/state.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/deckhouse/virtualization-controller/pkg/controller/common"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/indexer"
-	"github.com/deckhouse/virtualization-controller/pkg/controller/ipam"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vmip/internal/util"
 	"github.com/deckhouse/virtualization-controller/pkg/sdk/framework/helper"
@@ -132,8 +131,8 @@ func (s *state) VirtualMachine(ctx context.Context) (*virtv2.VirtualMachine, err
 			return nil, err
 		}
 
-		for i, vm := range vms.Items { //FIXME
-			if vm.Spec.VirtualMachineIPAddress == s.vmip.Name || vm.Spec.VirtualMachineIPAddress == "" && vm.Name == ipam.GetVirtualMachineName(s.vmip) {
+		for i, vm := range vms.Items {
+			if vm.Spec.VirtualMachineIPAddress == s.vmip.Name {
 				s.vm = &vms.Items[i]
 				break
 			}

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/state/state.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/state/state.go
@@ -118,8 +118,6 @@ func (s *state) VirtualMachine(ctx context.Context) (*virtv2.VirtualMachine, err
 			return nil, fmt.Errorf("unable to get VM %s: %w", vmKey, err)
 		}
 
-		fmt.Println(vm.Status.VirtualMachineIPAddress, s.vmip.Name, vm.Status.IPAddress, s.vmip.Status.Address)
-
 		if vm.Status.VirtualMachineIPAddress == s.vmip.Name && vm.Status.IPAddress == s.vmip.Status.Address {
 			s.vm = vm
 		}

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/state/state.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/state/state.go
@@ -113,9 +113,13 @@ func (s *state) VirtualMachine(ctx context.Context) (*virtv2.VirtualMachine, err
 	var err error
 	if s.vmip.Status.VirtualMachine != "" {
 		vmKey := types.NamespacedName{Name: s.vmip.Status.VirtualMachine, Namespace: s.vmip.Namespace}
-		s.vm, err = helper.FetchObject(ctx, vmKey, s.client, &virtv2.VirtualMachine{})
+		vm, err := helper.FetchObject(ctx, vmKey, s.client, &virtv2.VirtualMachine{})
 		if err != nil {
 			return nil, fmt.Errorf("unable to get VM %s: %w", vmKey, err)
+		}
+
+		if vm.Status.VirtualMachineIPAddress == s.vmip.Name {
+			s.vm = vm
 		}
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/state/state.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/state/state.go
@@ -132,9 +132,8 @@ func (s *state) VirtualMachine(ctx context.Context) (*virtv2.VirtualMachine, err
 			return nil, err
 		}
 
-		for i, vm := range vms.Items {
-			if vm.Spec.VirtualMachineIPAddress == s.vmip.Name ||
-				vm.Spec.VirtualMachineIPAddress == "" && vm.Name == ipam.GetVirtualMachineName(s.vmip) {
+		for i, vm := range vms.Items { //FIXME
+			if vm.Spec.VirtualMachineIPAddress == s.vmip.Name || vm.Spec.VirtualMachineIPAddress == "" && vm.Name == ipam.GetVirtualMachineName(s.vmip) {
 				s.vm = &vms.Items[i]
 				break
 			}

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/state/state.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/state/state.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/deckhouse/virtualization-controller/pkg/controller/common"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/indexer"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/ipam"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vmip/internal/util"
 	"github.com/deckhouse/virtualization-controller/pkg/sdk/framework/helper"
@@ -132,7 +133,7 @@ func (s *state) VirtualMachine(ctx context.Context) (*virtv2.VirtualMachine, err
 		}
 
 		for i, vm := range vms.Items {
-			if vm.Spec.VirtualMachineIPAddress == s.vmip.Name {
+			if vm.Spec.VirtualMachineIPAddress == s.vmip.Name || vm.Spec.VirtualMachineIPAddress == "" && vm.Name == ipam.GetVirtualMachineName(s.vmip) {
 				s.vm = &vms.Items[i]
 				break
 			}

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/state/state.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/state/state.go
@@ -118,6 +118,10 @@ func (s *state) VirtualMachine(ctx context.Context) (*virtv2.VirtualMachine, err
 			return nil, fmt.Errorf("unable to get VM %s: %w", vmKey, err)
 		}
 
+		if vm == nil {
+			return s.vm, nil
+		}
+
 		if vm.Status.VirtualMachineIPAddress == s.vmip.Name && vm.Status.IPAddress == s.vmip.Status.Address {
 			s.vm = vm
 		}

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/state/state.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/state/state.go
@@ -118,6 +118,8 @@ func (s *state) VirtualMachine(ctx context.Context) (*virtv2.VirtualMachine, err
 			return nil, fmt.Errorf("unable to get VM %s: %w", vmKey, err)
 		}
 
+		fmt.Println(vm.Status.VirtualMachineIPAddress, s.vmip.Name, vm.Status.IPAddress, s.vmip.Status.Address)
+
 		if vm.Status.VirtualMachineIPAddress == s.vmip.Name && vm.Status.IPAddress == s.vmip.Status.Address {
 			s.vm = vm
 		}

--- a/images/virtualization-artifact/pkg/controller/vmip/vmip_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/vmip_controller.go
@@ -47,7 +47,7 @@ func NewController(
 	ipService := service.NewIpAddressService(log, virtualMachineCIDRs)
 
 	handlers := []Handler{
-		internal.NewProtectionHandler(mgr.GetClient()),
+		internal.NewProtectionHandler(),
 		internal.NewIPLeaseHandler(mgr.GetClient(), ipService, recorder),
 		internal.NewLifecycleHandler(),
 	}

--- a/images/virtualization-artifact/pkg/controller/vmip/vmip_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/vmip_controller.go
@@ -47,7 +47,7 @@ func NewController(
 	ipService := service.NewIpAddressService(log, virtualMachineCIDRs)
 
 	handlers := []Handler{
-		internal.NewProtectionHandler(),
+		internal.NewProtectionHandler(mgr.GetClient()),
 		internal.NewIPLeaseHandler(mgr.GetClient(), ipService, recorder),
 		internal.NewLifecycleHandler(),
 	}

--- a/images/virtualization-artifact/pkg/controller/vmip/vmip_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/vmip_reconciler.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -32,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	"github.com/deckhouse/virtualization-controller/pkg/controller/common"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/indexer"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vmip/internal/state"
 	"github.com/deckhouse/virtualization-controller/pkg/logger"
@@ -104,10 +103,10 @@ func (r *Reconciler) enqueueRequestsFromVMs(ctx context.Context, obj client.Obje
 	}
 
 	vmipList := &virtv2.VirtualMachineIPAddressList{}
-	err := r.client.List(ctx, vmipList, &client.ListOptions{
-		Namespace:     vm.GetNamespace(),
-		LabelSelector: labels.SelectorFromSet(map[string]string{common.LabelVirtualMachineName: vm.GetName()}),
-	})
+	err := r.client.List(ctx, vmipList, client.InNamespace(vm.Namespace),
+		&client.MatchingFields{
+			indexer.IndexFieldVMIPByVM: vm.Name,
+		})
 	if err != nil {
 		return nil
 	}

--- a/images/virtualization-artifact/pkg/controller/vmip/vmip_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/vmip_reconciler.go
@@ -108,9 +108,7 @@ func (r *Reconciler) enqueueRequestsFromVMs(ctx context.Context, obj client.Obje
 		Namespace:     vm.GetNamespace(),
 		LabelSelector: labels.SelectorFromSet(map[string]string{common.LabelVirtualMachineName: vm.GetName()}),
 	})
-
 	if err != nil {
-		logger.FromContext(ctx).Error("failed to list VirtualMachineIPAddress: %w", err)
 		return nil
 	}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This PR introduces several critical fixes and enhancements to the VirtualMachine controller and VirtualMachineIPAddress management, including:

- Fix IP address updates for running VirtualMachines.
- Add 'Attached' phase for VirtualMachineIPAddress.
- Enable automatic IP assignment when switching a VirtualMachine from a specified IP to none.
- Allow multiple VirtualMachines to share the same IP address, with the first one occupying it and others in 'Pending' - state until the IP is available.
- Improve condition values in the VirtualMachine controller for more accurate state management.
- Add indexing for VirtualMachineIPAddress resources to improve discovery efficiency.
- Remove VirtualMachine name labels from VirtualMachineIPAddress resources.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
