### PR TITLE
chore(module): remove builders and artifacts from images_digests.json

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,9 +35,15 @@ The first thing we recommend is to check the existing [issues](https://github.co
    - Follow [the commit message convention](#commit-message).
    - Sign off every commit you contributed as an acknowledgment of the [DCO](https://developercertificate.org/).
 
-7. Push commits. 
+7. Push commits.
 
 8. Create a pull request following the [pull request name convention](#pull-request-name).
+
+## Images
+
+The module images are located in the ./images directory.
+
+Images, such as build images or images with binary artifacts, should not be included in the module. To do so, they must be labeled as follows in the `werf.inc.yaml` file: `final: false`.
 
 ## Conventions
 
@@ -112,7 +118,7 @@ Supported scopes are the following:
   # User metrics, alerts, dashboards, and logs that provide insights into system performance and health.
   - observability
 
-  # Maintaining, improving code quality and development workflow. 
+  # Maintaining, improving code quality and development workflow.
   - ci
   - lint
   - format

--- a/images/base-alt-p10/werf.inc.yaml
+++ b/images/base-alt-p10/werf.inc.yaml
@@ -1,5 +1,6 @@
 ---
 image: {{ $.ImageName }}
+final: false
 from: {{ $.Images.BASE_ALT_P10 }}
 shell:
   setup:

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -201,6 +201,7 @@ shell:
     gcc-c++==10-alt1:sisyphus+263054.200.3.1
 ---
 image: {{ $.ImageName }}-libxcrypt-builder
+final: false
 fromImage: {{ $.ImageName }}-lib-builder
 shell:
   beforeInstall:
@@ -214,6 +215,7 @@ shell:
   - make && make install
 ---
 image: {{ $.ImageName }}-openssl-builder
+final: false
 fromImage: {{ $.ImageName }}-lib-builder
 shell:
   beforeInstall:
@@ -226,6 +228,7 @@ shell:
   - make && make install
 ---
 image: {{ $.ImageName }}-pcre-builder
+final: false
 fromImage: {{ $.ImageName }}-lib-builder
 shell:
   beforeInstall:
@@ -239,6 +242,7 @@ shell:
   - make && make install
 ---
 image: {{ $.ImageName }}-liboverride-builder
+final: false
 fromImage: {{ $.ImageName }}-lib-builder
 git:
   - add: /images/{{ $.ImageName }}/liboverride
@@ -257,6 +261,7 @@ shell:
 ---
 # Note: edk2-ovmf==20231115 requires p11 AltLinux to build.
 image: {{ $.ImageName }}-edk2-builder
+final: false
 from: {{ $.Images.BASE_ALT_P11 }}
 git:
 - add: /images/{{ $.ImageName }}/edk2

--- a/images/virtualization-artifact/werf.inc.yaml
+++ b/images/virtualization-artifact/werf.inc.yaml
@@ -1,5 +1,6 @@
 ---
 image: {{ $.ImageName }}
+final: false
 from: {{ .Images.BASE_GOLANG_21_BOOKWORM }}
 git:
 - add: /api
@@ -33,6 +34,3 @@ shell:
   - export GOARCH=amd64
   - go build -v -a -o virtualization-controller ./cmd/virtualization-controller
   - go build -v -a -o virtualization-api ./cmd/virtualization-api
-
-
-

--- a/werf.yaml
+++ b/werf.yaml
@@ -60,8 +60,10 @@ dockerfile: Dockerfile
   {{- range $ImageYamlMainfest := regexSplit "\n?---[ \t]*\n" (include "module_image_template" $ctx) -1 }}
 
     {{- $ImageManifest := $ImageYamlMainfest | fromYaml }}
-    {{- if $ImageManifest.image }}
-      {{- $ImagesIDList = append $ImagesIDList $ImageManifest.image }}
+    {{- if $ImageManifest | dig "final" true }}
+      {{- if $ImageManifest.image }}
+        {{- $ImagesIDList = append $ImagesIDList $ImageManifest.image }}
+      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}
@@ -106,7 +108,7 @@ shell:
 ---
 image: bundle
 from: {{ .Images.BASE_SCRATCH }}
-fromCacheVersion: "2024-02-15.1"
+fromCacheVersion: "2024-09-17.0"
 import:
   - image: images-digests
     add: /images_digests.json


### PR DESCRIPTION
## Description
We don't need base images, builder and artifacts in images_digests.json

## Why do we need it, and what problem does it solve?
Reduce the size of transferred data to the customer's container registry

## What is the expected result?
Example:

```
kubectl -n d8-system exec -ti -c deckhouse deploy/deckhouse -- deckhouse-controller global values -o json | jq .modulesImages.digests.virtualization -r           
{
  "cdiApiserver": "sha256:90f7f47801ebe97a8cdf6b147c490c739f04a80a64dbad6def99361e58395101",
  "cdiCloner": "sha256:64bf203e560e4eb0f9a6cd40226131bf15fac98673ddd9521f6ebe24de570378",
  "cdiController": "sha256:6373e5c470f7fd24918ed2aee976c35ea79ec10864ee9be10ee931f605ccdaf6",
  "cdiImporter": "sha256:956132fffe289407cdbb48cbe5c87bbf1474b54a77d5668dfc1b8d43635e61b9",
  "cdiOperator": "sha256:f82083faf236e2a0d8b8c777d3aedaabdc7634a643bf44077ba54a7ba19e36ee",
  "cdiUploadproxy": "sha256:d1b2a6f534c3dd3151dfd2c94172a778a65a70cd8d715f5483f0eb2caf2c6549",
  "cdiUploadserver": "sha256:1266830d2e0f985e75a51628d061bb726e0f58c8b26ba85ed9c9b883129c8cd8",
  "dvcr": "sha256:607b137c0ad48b6eb8cca415601ad5c4a86eb8037fa2e3eed98a27f32d4b3e2d",
  "dvcrArtifact": "sha256:a198ddc15e0a406757df8d6ab3751b5d2d22ccb7c4bdf44ed53ebf6dddfaac4d",
  "dvcrImporter": "sha256:f308b5a6ebdaef58bc87075950b123c0b80f88da5df535c9a498cc992dffc2f2",
  "dvcrUploader": "sha256:019a7d6c7b0e75ccc192e28d6efb06ccc0a952bd844319344d1698aafe92d127",
  "kubeApiProxy": "sha256:816bfc142ada3dcc4bb5a11379caa8cb6ada002ea6a19dd5af56e625943fff8d",
  "libguestfs": "sha256:763a72a6a121a57444798a6eb493e651956de6b95a4ca7c73ef01b0bec0fd7a8",
  "preDeleteHook": "sha256:568bb70a6d1dfae014d972d41b3ab7cc300324e667bffc0a1eab3e2ed20b2d11",
  "virtApi": "sha256:2b351147488f16e1a71473eff5ecb32e1e2c8c152923964e6bb016cfeb8708ad",
  "virtController": "sha256:272bcc05bc2c951d484872378ef710d06e2de15b56d9b04097d7cd68117f7c3c",
  "virtExportproxy": "sha256:a7c77fdd9087bcc7e207562e1163a883aa3ab50997ae2adb69414c7e755c5d97",
  "virtExportserver": "sha256:9214502ceccef14d8e193c6a4d4b3631f4b7a4a257b3e8d5af021b7abb476794",
  "virtHandler": "sha256:9103fdf680524a3b3e41f8906bafd483fb6fc1e0a14b09bfbf76ee16c7d2fa77",
  "virtLauncher": "sha256:56fb378b3d0b16daa1f2202f8ff0da4e6236d79827994e4ad6e7cf4d002c64fd",
  "virtOperator": "sha256:42bbd431fed5e00b18af6b83a742f9e7f86c64d13fa690edec48cc982422c7b1",
  "virtualizationApi": "sha256:80a872c96aa377605622a3ce09ec3bae8961d916f86179b68d56681edfced4e1",
  "virtualizationController": "sha256:da1eba637345d71602f84d83fe2306f053568462f16a72dadb51cdfc9415878f",
  "vmRouteForge": "sha256:261fe34e18debc540ef1748d3aabeffcca8bc8b398cefffe673690d6ce8a3e92"
}
```


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
