### PR TITLE
fix(vi): fix panic when creating vi from vd

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_vi_on_pvc.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_vi_on_pvc.go
@@ -102,15 +102,7 @@ func (ds ObjectRefVirtualImageOnPvc) Sync(ctx context.Context, vd *virtv2.Virtua
 		}
 
 		err = ds.diskService.Start(ctx, size, vd.Spec.PersistentVolumeClaim.StorageClass, source, vd, supgen)
-		if err != nil {
-			if errors.Is(err, service.ErrStorageClassNotFound) {
-				vd.Status.Phase = virtv2.DiskProvisioning
-				condition.Status = metav1.ConditionFalse
-				condition.Reason = vdcondition.ProvisioningFailed
-				condition.Message = "Provided StorageClass not found in the cluster."
-				return false, nil
-			}
-
+		if updated, err := setPhaseConditionFromStorageError(err, vd, condition); err != nil || updated {
 			return false, err
 		}
 

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/http.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/http.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"k8s.io/utils/ptr"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	"github.com/deckhouse/virtualization-controller/pkg/common"

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"k8s.io/utils/ptr"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -177,14 +178,16 @@ func (ds ObjectRefDataSource) StoreToPVC(ctx context.Context, vi *virtv2.Virtual
 			return false, err
 		}
 
-		sc, err := ds.diskService.GetStorageClass(ctx, &ds.storageClassForPVC)
+		err = ds.diskService.StartImmediate(ctx, diskSize, ptr.To(ds.storageClassForPVC), source, vi, supgen)
 		if err != nil {
-			setPhaseConditionToFailed(&condition, &vi.Status.Phase, err)
-			return false, err
-		}
+			if errors.Is(err, service.ErrStorageClassNotFound) {
+				vi.Status.Phase = virtv2.ImageProvisioning
+				condition.Status = metav1.ConditionFalse
+				condition.Reason = vicondition.ProvisioningFailed
+				condition.Message = "Provided StorageClass not found in the cluster."
+				return false, nil
+			}
 
-		err = ds.diskService.StartImmediate(ctx, diskSize, sc.GetName(), source, vi, supgen)
-		if err != nil {
 			return false, err
 		}
 

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"k8s.io/utils/ptr"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref.go
@@ -179,15 +179,7 @@ func (ds ObjectRefDataSource) StoreToPVC(ctx context.Context, vi *virtv2.Virtual
 		}
 
 		err = ds.diskService.StartImmediate(ctx, diskSize, ptr.To(ds.storageClassForPVC), source, vi, supgen)
-		if err != nil {
-			if errors.Is(err, service.ErrStorageClassNotFound) {
-				vi.Status.Phase = virtv2.ImageProvisioning
-				condition.Status = metav1.ConditionFalse
-				condition.Reason = vicondition.ProvisioningFailed
-				condition.Message = "Provided StorageClass not found in the cluster."
-				return false, nil
-			}
-
+		if updated, err := setPhaseConditionFromStorageError(err, vi, &condition); err != nil || updated {
 			return false, err
 		}
 

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vd.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vd.go
@@ -230,6 +230,7 @@ func (ds ObjectRefVirtualDisk) StoreToPVC(ctx context.Context, vi *virtv2.Virtua
 		fmt.Println("vd", vdRef)
 		fmt.Println("vdSpec", vdRef.Spec)
 		fmt.Println("vdStatus", vdRef.Status)
+		fmt.Println("vdStatusCap", vdRef.Status.Capacity)
 		fmt.Println("")
 		fmt.Println("")
 

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vd.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vd.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/utils/ptr"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vd.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vd.go
@@ -231,15 +231,7 @@ func (ds ObjectRefVirtualDisk) StoreToPVC(ctx context.Context, vi *virtv2.Virtua
 		}
 
 		err = ds.diskService.StartImmediate(ctx, size, ptr.To(ds.storageClassForPVC), source, vi, supgen)
-		if err != nil {
-			if errors.Is(err, service.ErrStorageClassNotFound) {
-				vi.Status.Phase = virtv2.ImageProvisioning
-				condition.Status = metav1.ConditionFalse
-				condition.Reason = vicondition.ProvisioningFailed
-				condition.Message = "Provided StorageClass not found in the cluster."
-				return false, nil
-			}
-
+		if updated, err := setPhaseConditionFromStorageError(err, vi, condition); err != nil || updated {
 			return false, err
 		}
 

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vd.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vd.go
@@ -225,15 +225,6 @@ func (ds ObjectRefVirtualDisk) StoreToPVC(ctx context.Context, vi *virtv2.Virtua
 			},
 		}
 
-		fmt.Println("")
-		fmt.Println("")
-		fmt.Println("vd", vdRef)
-		fmt.Println("vdSpec", vdRef.Spec)
-		fmt.Println("vdStatus", vdRef.Status)
-		fmt.Println("vdStatusCap", vdRef.Status.Capacity)
-		fmt.Println("")
-		fmt.Println("")
-
 		size, err := resource.ParseQuantity(vdRef.Status.Capacity)
 		if err != nil {
 			return false, err
@@ -273,8 +264,8 @@ func (ds ObjectRefVirtualDisk) StoreToPVC(ctx context.Context, vi *virtv2.Virtua
 		condition.Message = ""
 
 		var imageStatus virtv2.ImageStatusSize
-		imageStatus.Stored = vdRef.Spec.PersistentVolumeClaim.Size.String()
-		imageStatus.Unpacked = vdRef.Spec.PersistentVolumeClaim.Size.String()
+		imageStatus.Stored = vdRef.Status.Capacity
+		imageStatus.Unpacked = vdRef.Status.Capacity
 		vi.Status.Size = imageStatus
 
 		vi.Status.Format = imageformat.FormatRAW

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vi_on_pvc.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vi_on_pvc.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"k8s.io/utils/ptr"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -223,14 +224,16 @@ func (ds ObjectRefDataVirtualImageOnPVC) StoreToPVC(ctx context.Context, vi, viR
 			},
 		}
 
-		sc, err := ds.diskService.GetStorageClass(ctx, &ds.storageClassForPVC)
+		err = ds.diskService.StartImmediate(ctx, size, ptr.To(ds.storageClassForPVC), source, vi, supgen)
 		if err != nil {
-			setPhaseConditionToFailed(condition, &vi.Status.Phase, err)
-			return false, err
-		}
+			if errors.Is(err, service.ErrStorageClassNotFound) {
+				vi.Status.Phase = virtv2.ImageProvisioning
+				condition.Status = metav1.ConditionFalse
+				condition.Reason = vicondition.ProvisioningFailed
+				condition.Message = "Provided StorageClass not found in the cluster."
+				return false, nil
+			}
 
-		err = ds.diskService.StartImmediate(ctx, size, sc.GetName(), source, vi, supgen)
-		if err != nil {
 			return false, err
 		}
 

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vi_on_pvc.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vi_on_pvc.go
@@ -225,15 +225,7 @@ func (ds ObjectRefDataVirtualImageOnPVC) StoreToPVC(ctx context.Context, vi, viR
 		}
 
 		err = ds.diskService.StartImmediate(ctx, size, ptr.To(ds.storageClassForPVC), source, vi, supgen)
-		if err != nil {
-			if errors.Is(err, service.ErrStorageClassNotFound) {
-				vi.Status.Phase = virtv2.ImageProvisioning
-				condition.Status = metav1.ConditionFalse
-				condition.Reason = vicondition.ProvisioningFailed
-				condition.Message = "Provided StorageClass not found in the cluster."
-				return false, nil
-			}
-
+		if updated, err := setPhaseConditionFromStorageError(err, vi, condition); err != nil || updated {
 			return false, err
 		}
 

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vi_on_pvc.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vi_on_pvc.go
@@ -20,10 +20,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"k8s.io/utils/ptr"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/registry.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/registry.go
@@ -20,12 +20,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"k8s.io/utils/ptr"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/registry.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/registry.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"k8s.io/utils/ptr"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -182,14 +183,17 @@ func (ds RegistryDataSource) StoreToPVC(ctx context.Context, vi *virtv2.VirtualI
 		}
 
 		source := ds.getSource(supgen, ds.statService.GetDVCRImageName(pod))
-		sc, err := ds.diskService.GetStorageClass(ctx, &ds.storageClassForPVC)
-		if err != nil {
-			setPhaseConditionToFailed(&condition, &vi.Status.Phase, err)
-			return false, err
-		}
 
-		err = ds.diskService.StartImmediate(ctx, diskSize, sc.GetName(), source, vi, supgen)
+		err = ds.diskService.StartImmediate(ctx, diskSize, ptr.To(ds.storageClassForPVC), source, vi, supgen)
 		if err != nil {
+			if errors.Is(err, service.ErrStorageClassNotFound) {
+				vi.Status.Phase = virtv2.ImageProvisioning
+				condition.Status = metav1.ConditionFalse
+				condition.Reason = vicondition.ProvisioningFailed
+				condition.Message = "Provided StorageClass not found in the cluster."
+				return false, nil
+			}
+
 			return false, err
 		}
 

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/registry.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/registry.go
@@ -185,15 +185,7 @@ func (ds RegistryDataSource) StoreToPVC(ctx context.Context, vi *virtv2.VirtualI
 		source := ds.getSource(supgen, ds.statService.GetDVCRImageName(pod))
 
 		err = ds.diskService.StartImmediate(ctx, diskSize, ptr.To(ds.storageClassForPVC), source, vi, supgen)
-		if err != nil {
-			if errors.Is(err, service.ErrStorageClassNotFound) {
-				vi.Status.Phase = virtv2.ImageProvisioning
-				condition.Status = metav1.ConditionFalse
-				condition.Reason = vicondition.ProvisioningFailed
-				condition.Message = "Provided StorageClass not found in the cluster."
-				return false, nil
-			}
-
+		if updated, err := setPhaseConditionFromStorageError(err, vi, &condition); err != nil || updated {
 			return false, err
 		}
 

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/upload.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/upload.go
@@ -206,15 +206,7 @@ func (ds UploadDataSource) StoreToPVC(ctx context.Context, vi *virtv2.VirtualIma
 		source := ds.getSource(supgen, ds.statService.GetDVCRImageName(pod))
 
 		err = ds.diskService.StartImmediate(ctx, diskSize, ptr.To(ds.storageClassForPVC), source, vi, supgen)
-		if err != nil {
-			if errors.Is(err, service.ErrStorageClassNotFound) {
-				vi.Status.Phase = virtv2.ImageProvisioning
-				condition.Status = metav1.ConditionFalse
-				condition.Reason = vicondition.ProvisioningFailed
-				condition.Message = "Provided StorageClass not found in the cluster."
-				return false, nil
-			}
-
+		if updated, err := setPhaseConditionFromStorageError(err, vi, &condition); err != nil || updated {
 			return false, err
 		}
 

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/upload.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/upload.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"k8s.io/utils/ptr"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	cc "github.com/deckhouse/virtualization-controller/pkg/common"

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/upload.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/upload.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"k8s.io/utils/ptr"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -203,14 +204,17 @@ func (ds UploadDataSource) StoreToPVC(ctx context.Context, vi *virtv2.VirtualIma
 		}
 
 		source := ds.getSource(supgen, ds.statService.GetDVCRImageName(pod))
-		sc, err := ds.diskService.GetStorageClass(ctx, &ds.storageClassForPVC)
-		if err != nil {
-			setPhaseConditionToFailed(&condition, &vi.Status.Phase, err)
-			return false, err
-		}
 
-		err = ds.diskService.StartImmediate(ctx, diskSize, sc.GetName(), source, vi, supgen)
+		err = ds.diskService.StartImmediate(ctx, diskSize, ptr.To(ds.storageClassForPVC), source, vi, supgen)
 		if err != nil {
+			if errors.Is(err, service.ErrStorageClassNotFound) {
+				vi.Status.Phase = virtv2.ImageProvisioning
+				condition.Status = metav1.ConditionFalse
+				condition.Reason = vicondition.ProvisioningFailed
+				condition.Message = "Provided StorageClass not found in the cluster."
+				return false, nil
+			}
+
 			return false, err
 		}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This PR fixes the problem where creating a VirtualImage (VI) from a VirtualDisk (VD) caused the application to panic.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
