### PR TITLE
fix(api): wait for uploader to be ready to process user's upload

### DIFF
--- a/images/virtualization-artifact/pkg/controller/common/util.go
+++ b/images/virtualization-artifact/pkg/controller/common/util.go
@@ -374,6 +374,26 @@ func CreateCloneSourcePodName(obj UIDable) string {
 	return string(obj.GetUID()) + common.ClonerSourcePodNameSuffix
 }
 
+// IsPodRunning returns true if a Pod is in 'Running' phase, false if not.
+func IsPodRunning(pod *corev1.Pod) bool {
+	return pod != nil && pod.Status.Phase == corev1.PodRunning
+}
+
+// IsPodStarted returns true if a Pod is in started state, false if not.
+func IsPodStarted(pod *corev1.Pod) bool {
+	if pod == nil || pod.Status.StartTime == nil {
+		return false
+	}
+
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.Started == nil || !*cs.Started {
+			return false
+		}
+	}
+
+	return true
+}
+
 // IsPodComplete returns true if a Pod is in 'Succeeded' phase, false if not.
 func IsPodComplete(pod *corev1.Pod) bool {
 	return pod != nil && pod.Status.Phase == corev1.PodSucceeded

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/interfaces.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/interfaces.go
@@ -63,6 +63,7 @@ type Stat interface {
 	GetDVCRImageName(pod *corev1.Pod) string
 	GetDownloadSpeed(ownerUID types.UID, pod *corev1.Pod) *virtv2.StatusSpeed
 	GetProgress(ownerUID types.UID, pod *corev1.Pod, prevProgress string, opts ...service.GetProgressOption) string
+	IsUploaderReady(pod *corev1.Pod, ing *netv1.Ingress) bool
 	IsUploadStarted(ownerUID types.UID, pod *corev1.Pod) bool
 	CheckPod(pod *corev1.Pod) error
 }

--- a/images/virtualization-artifact/pkg/controller/service/stat_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/stat_service.go
@@ -24,10 +24,12 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/deckhouse/virtualization-controller/pkg/common"
+	cc "github.com/deckhouse/virtualization-controller/pkg/controller/common"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/monitoring"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service/internal"
 	"github.com/deckhouse/virtualization-controller/pkg/imageformat"
@@ -241,6 +243,14 @@ func (s StatService) IsImportStarted(ownerUID types.UID, pod *corev1.Pod) bool {
 	}
 
 	return progress.ProgressRaw() > 0
+}
+
+func (s StatService) IsUploaderReady(pod *corev1.Pod, ing *netv1.Ingress) bool {
+	if pod == nil || ing == nil {
+		return false
+	}
+
+	return cc.IsPodRunning(pod) && cc.IsPodStarted(pod) && ing.Annotations[cc.AnnUploadURL] != ""
 }
 
 func (s StatService) IsUploadStarted(ownerUID types.UID, pod *corev1.Pod) bool {

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/interfaces.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/interfaces.go
@@ -63,6 +63,7 @@ type Stat interface {
 	GetDVCRImageName(pod *corev1.Pod) string
 	GetDownloadSpeed(ownerUID types.UID, pod *corev1.Pod) *virtv2.StatusSpeed
 	GetProgress(ownerUID types.UID, pod *corev1.Pod, prevProgress string, opts ...service.GetProgressOption) string
+	IsUploaderReady(pod *corev1.Pod, ing *netv1.Ingress) bool
 	IsUploadStarted(ownerUID types.UID, pod *corev1.Pod) bool
 	CheckPod(pod *corev1.Pod) error
 }

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/mock.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/mock.go
@@ -986,6 +986,9 @@ var _ Stat = &StatMock{}
 //			IsUploadStartedFunc: func(ownerUID types.UID, pod *corev1.Pod) bool {
 //				panic("mock out the IsUploadStarted method")
 //			},
+//			IsUploaderReadyFunc: func(pod *corev1.Pod, ing *netv1.Ingress) bool {
+//				panic("mock out the IsUploaderReady method")
+//			},
 //		}
 //
 //		// use mockedStat in code that requires Stat
@@ -1016,6 +1019,9 @@ type StatMock struct {
 
 	// IsUploadStartedFunc mocks the IsUploadStarted method.
 	IsUploadStartedFunc func(ownerUID types.UID, pod *corev1.Pod) bool
+
+	// IsUploaderReadyFunc mocks the IsUploaderReady method.
+	IsUploaderReadyFunc func(pod *corev1.Pod, ing *netv1.Ingress) bool
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -1069,6 +1075,13 @@ type StatMock struct {
 			// Pod is the pod argument value.
 			Pod *corev1.Pod
 		}
+		// IsUploaderReady holds details about calls to the IsUploaderReady method.
+		IsUploaderReady []struct {
+			// Pod is the pod argument value.
+			Pod *corev1.Pod
+			// Ing is the ing argument value.
+			Ing *netv1.Ingress
+		}
 	}
 	lockCheckPod         sync.RWMutex
 	lockGetCDROM         sync.RWMutex
@@ -1078,6 +1091,7 @@ type StatMock struct {
 	lockGetProgress      sync.RWMutex
 	lockGetSize          sync.RWMutex
 	lockIsUploadStarted  sync.RWMutex
+	lockIsUploaderReady  sync.RWMutex
 }
 
 // CheckPod calls CheckPodFunc.
@@ -1353,5 +1367,41 @@ func (mock *StatMock) IsUploadStartedCalls() []struct {
 	mock.lockIsUploadStarted.RLock()
 	calls = mock.calls.IsUploadStarted
 	mock.lockIsUploadStarted.RUnlock()
+	return calls
+}
+
+// IsUploaderReady calls IsUploaderReadyFunc.
+func (mock *StatMock) IsUploaderReady(pod *corev1.Pod, ing *netv1.Ingress) bool {
+	if mock.IsUploaderReadyFunc == nil {
+		panic("StatMock.IsUploaderReadyFunc: method is nil but Stat.IsUploaderReady was just called")
+	}
+	callInfo := struct {
+		Pod *corev1.Pod
+		Ing *netv1.Ingress
+	}{
+		Pod: pod,
+		Ing: ing,
+	}
+	mock.lockIsUploaderReady.Lock()
+	mock.calls.IsUploaderReady = append(mock.calls.IsUploaderReady, callInfo)
+	mock.lockIsUploaderReady.Unlock()
+	return mock.IsUploaderReadyFunc(pod, ing)
+}
+
+// IsUploaderReadyCalls gets all the calls that were made to IsUploaderReady.
+// Check the length with:
+//
+//	len(mockedStat.IsUploaderReadyCalls())
+func (mock *StatMock) IsUploaderReadyCalls() []struct {
+	Pod *corev1.Pod
+	Ing *netv1.Ingress
+} {
+	var calls []struct {
+		Pod *corev1.Pod
+		Ing *netv1.Ingress
+	}
+	mock.lockIsUploaderReady.RLock()
+	calls = mock.calls.IsUploaderReady
+	mock.lockIsUploaderReady.RUnlock()
 	return calls
 }

--- a/images/virtualization-artifact/pkg/controller/vm/internal/lifecycle.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/lifecycle.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/deckhouse/virtualization-controller/pkg/controller/common"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vm/internal/state"
@@ -175,7 +176,7 @@ func (h *LifeCycleHandler) syncPodStarted(vm *virtv2.VirtualMachine, kvvm *virtv
 	mgr := conditions.NewManager(vm.Status.Conditions)
 	cb := conditions.NewConditionBuilder(vmcondition.TypePodStarted).Generation(vm.GetGeneration())
 
-	if isPodStarted(pod) {
+	if common.IsPodStarted(pod) {
 		mgr.Update(cb.Status(metav1.ConditionTrue).
 			Reason(vmcondition.ReasonPodStarted).
 			Condition())

--- a/images/virtualization-artifact/pkg/controller/vm/internal/util.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/util.go
@@ -134,20 +134,6 @@ var mapPhases = map[virtv1.VirtualMachinePrintableStatus]virtv2.MachinePhase{
 
 const kvvmEmptyPhase virtv1.VirtualMachinePrintableStatus = ""
 
-func isPodStarted(pod *corev1.Pod) bool {
-	if pod == nil || pod.Status.StartTime == nil {
-		return false
-	}
-
-	for _, cs := range pod.Status.ContainerStatuses {
-		if cs.Started == nil || !*cs.Started {
-			return false
-		}
-	}
-
-	return true
-}
-
 func isPodStartedError(phase virtv1.VirtualMachinePrintableStatus) bool {
 	return slices.Contains([]virtv1.VirtualMachinePrintableStatus{
 		virtv1.VirtualMachineStatusErrImagePull,


### PR DESCRIPTION
## Description

Wait for uploader to be ready to process user's upload

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
