### PR TITLE
chore(crds): reformat yaml to kubectl style, ignore prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,7 @@
 **/werf*.yml
 **/templates
 **/ISSUE_TEMPLATE
+crds/embedded
 images/cdi-artifact/__containerized-data-importer*
 images/virt-artifact/__kubevirt*
 .gitlab-ci.yml

--- a/crds/embedded/cdi.yaml
+++ b/crds/embedded/cdi.yaml
@@ -1,12 +1,14 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: internalvirtualizationcdis.cdi.internal.virtualization.deckhouse.io
   labels:
+    app.kubernetes.io/component: cdi
     heritage: deckhouse
     module: virtualization
-    app.kubernetes.io/component: cdi
+  name: internalvirtualizationcdis.cdi.internal.virtualization.deckhouse.io
 spec:
+  conversion:
+    strategy: None
   group: cdi.internal.virtualization.deckhouse.io
   names:
     categories:
@@ -33,10 +35,14 @@ spec:
           description: CDI is the CDI Operator CRD
           properties:
             apiVersion:
-              description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
@@ -47,28 +53,36 @@ spec:
                   description: certificate configuration
                   properties:
                     ca:
-                      description: CA configuration CA certs are kept in the CA bundle as long as they are valid
+                      description: CA configuration CA certs are kept in the CA bundle
+                        as long as they are valid
                       properties:
                         duration:
-                          description: The requested 'duration' (i.e. lifetime) of the Certificate.
+                          description: The requested 'duration' (i.e. lifetime) of the
+                            Certificate.
                           type: string
                         renewBefore:
-                          description: The amount of time before the currently issued certificate's `notAfter` time that we will begin to attempt to renew the certificate.
+                          description: The amount of time before the currently issued
+                            certificate's `notAfter` time that we will begin to attempt
+                            to renew the certificate.
                           type: string
                       type: object
                     server:
                       description: Server configuration Certs are rotated and discarded
                       properties:
                         duration:
-                          description: The requested 'duration' (i.e. lifetime) of the Certificate.
+                          description: The requested 'duration' (i.e. lifetime) of the
+                            Certificate.
                           type: string
                         renewBefore:
-                          description: The amount of time before the currently issued certificate's `notAfter` time that we will begin to attempt to renew the certificate.
+                          description: The amount of time before the currently issued
+                            certificate's `notAfter` time that we will begin to attempt
+                            to renew the certificate.
                           type: string
                       type: object
                   type: object
                 cloneStrategyOverride:
-                  description: "Clone strategy override: should we use a host-assisted copy even if snapshots are available?"
+                  description: 'Clone strategy override: should we use a host-assisted
+                  copy even if snapshots are available?'
                   enum:
                     - copy
                     - snapshot
@@ -78,36 +92,50 @@ spec:
                   description: CDIConfig at CDI level
                   properties:
                     dataVolumeTTLSeconds:
-                      description: DataVolumeTTLSeconds is the time in seconds after DataVolume completion it can be garbage collected. Disabled by default.
+                      description: DataVolumeTTLSeconds is the time in seconds after
+                        DataVolume completion it can be garbage collected. Disabled
+                        by default.
                       format: int32
                       type: integer
                     featureGates:
-                      description: FeatureGates are a list of specific enabled feature gates
+                      description: FeatureGates are a list of specific enabled feature
+                        gates
                       items:
                         type: string
                       type: array
                     filesystemOverhead:
-                      description: FilesystemOverhead describes the space reserved for overhead when using Filesystem volumes. A value is between 0 and 1, if not defined it is 0.055 (5.5% overhead)
+                      description: FilesystemOverhead describes the space reserved for
+                        overhead when using Filesystem volumes. A value is between 0
+                        and 1, if not defined it is 0.055 (5.5% overhead)
                       properties:
                         global:
-                          description: Global is how much space of a Filesystem volume should be reserved for overhead. This value is used unless overridden by a more specific value (per storageClass)
+                          description: Global is how much space of a Filesystem volume
+                            should be reserved for overhead. This value is used unless
+                            overridden by a more specific value (per storageClass)
                           pattern: ^(0(?:\.\d{1,3})?|1)$
                           type: string
                         storageClass:
                           additionalProperties:
-                            description: "Percent is a string that can only be a value between [0,1) (Note: we actually rely on reconcile to reject invalid values)"
+                            description: 'Percent is a string that can only be a value
+                            between [0,1) (Note: we actually rely on reconcile to
+                            reject invalid values)'
                             pattern: ^(0(?:\.\d{1,3})?|1)$
                             type: string
-                          description: StorageClass specifies how much space of a Filesystem volume should be reserved for safety. The keys are the storageClass and the values are the overhead. This value overrides the global value
+                          description: StorageClass specifies how much space of a Filesystem
+                            volume should be reserved for safety. The keys are the storageClass
+                            and the values are the overhead. This value overrides the
+                            global value
                           type: object
                       type: object
                     imagePullSecrets:
                       description: The imagePullSecrets used to pull the container images
                       items:
-                        description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same namespace.
                         properties:
                           name:
-                            description: "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?"
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
@@ -116,16 +144,31 @@ spec:
                       description: ImportProxy contains importer pod proxy configuration.
                       properties:
                         HTTPProxy:
-                          description: HTTPProxy is the URL http://<username>:<pswd>@<ip>:<port> of the import proxy for HTTP requests.  Empty means unset and will not result in the import pod env var.
+                          description: HTTPProxy is the URL http://<username>:<pswd>@<ip>:<port>
+                            of the import proxy for HTTP requests.  Empty means unset
+                            and will not result in the import pod env var.
                           type: string
                         HTTPSProxy:
-                          description: HTTPSProxy is the URL https://<username>:<pswd>@<ip>:<port> of the import proxy for HTTPS requests.  Empty means unset and will not result in the import pod env var.
+                          description: HTTPSProxy is the URL https://<username>:<pswd>@<ip>:<port>
+                            of the import proxy for HTTPS requests.  Empty means unset
+                            and will not result in the import pod env var.
                           type: string
                         noProxy:
-                          description: NoProxy is a comma-separated list of hostnames and/or CIDRs for which the proxy should not be used. Empty means unset and will not result in the import pod env var.
+                          description: NoProxy is a comma-separated list of hostnames
+                            and/or CIDRs for which the proxy should not be used. Empty
+                            means unset and will not result in the import pod env var.
                           type: string
                         trustedCAProxy:
-                          description: "TrustedCAProxy is the name of a ConfigMap in the cdi namespace that contains a user-provided trusted certificate authority (CA) bundle. The TrustedCAProxy ConfigMap is consumed by the DataImportCron controller for creating cronjobs, and by the import controller referring a copy of the ConfigMap in the import namespace. Here is an example of the ConfigMap (in yaml): \n apiVersion: v1 kind: ConfigMap metadata: name: my-ca-proxy-cm namespace: cdi data: ca.pem: | -----BEGIN CERTIFICATE----- ... <base64 encoded cert> ... -----END CERTIFICATE-----"
+                          description: "TrustedCAProxy is the name of a ConfigMap in
+                          the cdi namespace that contains a user-provided trusted
+                          certificate authority (CA) bundle. The TrustedCAProxy ConfigMap
+                          is consumed by the DataImportCron controller for creating
+                          cronjobs, and by the import controller referring a copy
+                          of the ConfigMap in the import namespace. Here is an example
+                          of the ConfigMap (in yaml): \n apiVersion: v1 kind: ConfigMap
+                          metadata: name: my-ca-proxy-cm namespace: cdi data: ca.pem:
+                          | -----BEGIN CERTIFICATE----- ... <base64 encoded cert>
+                          ... -----END CERTIFICATE-----"
                           type: string
                       type: object
                     insecureRegistries:
@@ -134,19 +177,27 @@ spec:
                         type: string
                       type: array
                     logVerbosity:
-                      description: LogVerbosity overrides the default verbosity level used to initialize loggers
+                      description: LogVerbosity overrides the default verbosity level
+                        used to initialize loggers
                       format: int32
                       type: integer
                     podResourceRequirements:
-                      description: ResourceRequirements describes the compute resource requirements.
+                      description: ResourceRequirements describes the compute resource
+                        requirements.
                       properties:
                         claims:
-                          description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable."
+                          description: "Claims lists the names of resources, defined
+                          in spec.resourceClaims, that are used by this container.
+                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                          feature gate. \n This field is immutable."
                           items:
                             description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                             properties:
                               name:
-                                description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                                description: Name must match the name of one entry in
+                                  pod.spec.resourceClaims of the Pod where this field
+                                  is used. It makes that resource available inside a
+                                  container.
                                 type: string
                             required:
                               - name
@@ -162,7 +213,8 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
+                          description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                         requests:
                           additionalProperties:
@@ -171,29 +223,54 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
+                          description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                       type: object
                     preallocation:
-                      description: Preallocation controls whether storage for DataVolumes should be allocated in advance.
+                      description: Preallocation controls whether storage for DataVolumes
+                        should be allocated in advance.
                       type: boolean
                     scratchSpaceStorageClass:
-                      description: "Override the storage class to used for scratch space during transfer operations. The scratch space storage class is determined in the following order: 1. value of scratchSpaceStorageClass, if that doesn't exist, use the default storage class, if there is no default storage class, use the storage class of the DataVolume, if no storage class specified, use no storage class for scratch space"
+                      description: 'Override the storage class to used for scratch space
+                      during transfer operations. The scratch space storage class
+                      is determined in the following order: 1. value of scratchSpaceStorageClass,
+                      if that doesn''t exist, use the default storage class, if there
+                      is no default storage class, use the storage class of the DataVolume,
+                      if no storage class specified, use no storage class for scratch
+                      space'
                       type: string
                     tlsSecurityProfile:
-                      description: TLSSecurityProfile is used by operators to apply cluster-wide TLS security settings to operands.
+                      description: TLSSecurityProfile is used by operators to apply
+                        cluster-wide TLS security settings to operands.
                       properties:
                         custom:
-                          description: "custom is a user-defined TLS security profile. Be extremely careful using a custom profile as invalid configurations can be catastrophic. An example custom profile looks like this: \n ciphers: - ECDHE-ECDSA-CHACHA20-POLY1305 - ECDHE-RSA-CHACHA20-POLY1305 - ECDHE-RSA-AES128-GCM-SHA256 - ECDHE-ECDSA-AES128-GCM-SHA256 minTLSVersion: TLSv1.1"
+                          description: "custom is a user-defined TLS security profile.
+                          Be extremely careful using a custom profile as invalid configurations
+                          can be catastrophic. An example custom profile looks like
+                          this: \n ciphers: - ECDHE-ECDSA-CHACHA20-POLY1305 - ECDHE-RSA-CHACHA20-POLY1305
+                          - ECDHE-RSA-AES128-GCM-SHA256 - ECDHE-ECDSA-AES128-GCM-SHA256
+                          minTLSVersion: TLSv1.1"
                           nullable: true
                           properties:
                             ciphers:
-                              description: "ciphers is used to specify the cipher algorithms that are negotiated during the TLS handshake.  Operators may remove entries their operands do not support.  For example, to use DES-CBC3-SHA  (yaml): \n ciphers: - DES-CBC3-SHA"
+                              description: "ciphers is used to specify the cipher algorithms
+                              that are negotiated during the TLS handshake.  Operators
+                              may remove entries their operands do not support.  For
+                              example, to use DES-CBC3-SHA  (yaml): \n ciphers: -
+                              DES-CBC3-SHA"
                               items:
                                 type: string
                               type: array
                             minTLSVersion:
-                              description: "minTLSVersion is used to specify the minimal version of the TLS protocol that is negotiated during the TLS handshake. For example, to use TLS versions 1.1, 1.2 and 1.3 (yaml): \n minTLSVersion: TLSv1.1 \n NOTE: currently the highest minTLSVersion allowed is VersionTLS12"
+                              description: "minTLSVersion is used to specify the minimal
+                              version of the TLS protocol that is negotiated during
+                              the TLS handshake. For example, to use TLS versions
+                              1.1, 1.2 and 1.3 (yaml): \n minTLSVersion: TLSv1.1 \n
+                              NOTE: currently the highest minTLSVersion allowed is
+                              VersionTLS12"
                               enum:
                                 - VersionTLS10
                                 - VersionTLS11
@@ -202,19 +279,53 @@ spec:
                               type: string
                           type: object
                         intermediate:
-                          description: "intermediate is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29 \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256 - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256 - ECDHE-ECDSA-AES128-GCM-SHA256 - ECDHE-RSA-AES128-GCM-SHA256 - ECDHE-ECDSA-AES256-GCM-SHA384 - ECDHE-RSA-AES256-GCM-SHA384 - ECDHE-ECDSA-CHACHA20-POLY1305 - ECDHE-RSA-CHACHA20-POLY1305 - DHE-RSA-AES128-GCM-SHA256 - DHE-RSA-AES256-GCM-SHA384 minTLSVersion: TLSv1.2"
+                          description: "intermediate is a TLS security profile based
+                          on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
+                          \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256
+                          - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256
+                          - ECDHE-ECDSA-AES128-GCM-SHA256 - ECDHE-RSA-AES128-GCM-SHA256
+                          - ECDHE-ECDSA-AES256-GCM-SHA384 - ECDHE-RSA-AES256-GCM-SHA384
+                          - ECDHE-ECDSA-CHACHA20-POLY1305 - ECDHE-RSA-CHACHA20-POLY1305
+                          - DHE-RSA-AES128-GCM-SHA256 - DHE-RSA-AES256-GCM-SHA384
+                          minTLSVersion: TLSv1.2"
                           nullable: true
                           type: object
                         modern:
-                          description: "modern is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256 - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256 minTLSVersion: TLSv1.3 \n NOTE: Currently unsupported."
+                          description: "modern is a TLS security profile based on: \n
+                          https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
+                          \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256
+                          - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256
+                          minTLSVersion: TLSv1.3 \n NOTE: Currently unsupported."
                           nullable: true
                           type: object
                         old:
-                          description: "old is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256 - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256 - ECDHE-ECDSA-AES128-GCM-SHA256 - ECDHE-RSA-AES128-GCM-SHA256 - ECDHE-ECDSA-AES256-GCM-SHA384 - ECDHE-RSA-AES256-GCM-SHA384 - ECDHE-ECDSA-CHACHA20-POLY1305 - ECDHE-RSA-CHACHA20-POLY1305 - DHE-RSA-AES128-GCM-SHA256 - DHE-RSA-AES256-GCM-SHA384 - DHE-RSA-CHACHA20-POLY1305 - ECDHE-ECDSA-AES128-SHA256 - ECDHE-RSA-AES128-SHA256 - ECDHE-ECDSA-AES128-SHA - ECDHE-RSA-AES128-SHA - ECDHE-ECDSA-AES256-SHA384 - ECDHE-RSA-AES256-SHA384 - ECDHE-ECDSA-AES256-SHA - ECDHE-RSA-AES256-SHA - DHE-RSA-AES128-SHA256 - DHE-RSA-AES256-SHA256 - AES128-GCM-SHA256 - AES256-GCM-SHA384 - AES128-SHA256 - AES256-SHA256 - AES128-SHA - AES256-SHA - DES-CBC3-SHA minTLSVersion: TLSv1.0"
+                          description: "old is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility
+                          \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256
+                          - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256
+                          - ECDHE-ECDSA-AES128-GCM-SHA256 - ECDHE-RSA-AES128-GCM-SHA256
+                          - ECDHE-ECDSA-AES256-GCM-SHA384 - ECDHE-RSA-AES256-GCM-SHA384
+                          - ECDHE-ECDSA-CHACHA20-POLY1305 - ECDHE-RSA-CHACHA20-POLY1305
+                          - DHE-RSA-AES128-GCM-SHA256 - DHE-RSA-AES256-GCM-SHA384
+                          - DHE-RSA-CHACHA20-POLY1305 - ECDHE-ECDSA-AES128-SHA256
+                          - ECDHE-RSA-AES128-SHA256 - ECDHE-ECDSA-AES128-SHA - ECDHE-RSA-AES128-SHA
+                          - ECDHE-ECDSA-AES256-SHA384 - ECDHE-RSA-AES256-SHA384 -
+                          ECDHE-ECDSA-AES256-SHA - ECDHE-RSA-AES256-SHA - DHE-RSA-AES128-SHA256
+                          - DHE-RSA-AES256-SHA256 - AES128-GCM-SHA256 - AES256-GCM-SHA384
+                          - AES128-SHA256 - AES256-SHA256 - AES128-SHA - AES256-SHA
+                          - DES-CBC3-SHA minTLSVersion: TLSv1.0"
                           nullable: true
                           type: object
                         type:
-                          description: "type is one of Old, Intermediate, Modern or Custom. Custom provides the ability to specify individual TLS security profile parameters. Old, Intermediate and Modern are TLS security profiles based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations \n The profiles are intent based, so they may change over time as new ciphers are developed and existing ciphers are found to be insecure.  Depending on precisely which ciphers are available to a process, the list may be reduced. \n Note that the Modern profile is currently not supported because it is not yet well adopted by common software libraries."
+                          description: "type is one of Old, Intermediate, Modern or
+                          Custom. Custom provides the ability to specify individual
+                          TLS security profile parameters. Old, Intermediate and Modern
+                          are TLS security profiles based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations
+                          \n The profiles are intent based, so they may change over
+                          time as new ciphers are developed and existing ciphers are
+                          found to be insecure.  Depending on precisely which ciphers
+                          are available to a process, the list may be reduced. \n
+                          Note that the Modern profile is currently not supported
+                          because it is not yet well adopted by common software libraries."
                           enum:
                             - Old
                             - Intermediate
@@ -229,7 +340,8 @@ spec:
                 customizeComponents:
                   properties:
                     flags:
-                      description: Configure the value used for deployment and daemonset resources
+                      description: Configure the value used for deployment and daemonset
+                        resources
                       properties:
                         api:
                           additionalProperties:
@@ -267,42 +379,79 @@ spec:
                       x-kubernetes-list-type: atomic
                   type: object
                 imagePullPolicy:
-                  description: PullPolicy describes a policy for if/when to pull a container image
+                  description: PullPolicy describes a policy for if/when to pull a container
+                    image
                   enum:
                     - Always
                     - IfNotPresent
                     - Never
                   type: string
                 infra:
-                  description: Rules on which nodes CDI infrastructure pods will be scheduled
+                  description: Rules on which nodes CDI infrastructure pods will be
+                    scheduled
                   properties:
                     affinity:
-                      description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                      description: affinity enables pod affinity/anti-affinity placement
+                        expanding the types of constraints that can be expressed with
+                        nodeSelector. affinity is going to be applied to the relevant
+                        kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
                       properties:
                         nodeAffinity:
-                          description: Describes node affinity scheduling rules for the pod.
+                          description: Describes node affinity scheduling rules for
+                            the pod.
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node matches the corresponding matchExpressions;
+                                the node(s) with the highest sum are the most preferred.
                               items:
-                                description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                description: An empty preferred scheduling term matches
+                                  all objects with implicit weight 0 (i.e. it's a no-op).
+                                  A null preferred scheduling term matches no objects
+                                  (i.e. is also a no-op).
                                 properties:
                                   preference:
-                                    description: A node selector term, associated with the corresponding weight.
+                                    description: A node selector term, associated with
+                                      the corresponding weight.
                                     properties:
                                       matchExpressions:
-                                        description: A list of node selector requirements by node's labels.
+                                        description: A list of node selector requirements
+                                          by node's labels.
                                         items:
-                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
+                                              description: The label key that the selector
+                                                applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -312,18 +461,35 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
-                                        description: A list of node selector requirements by node's fields.
+                                        description: A list of node selector requirements
+                                          by node's fields.
                                         items:
-                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
+                                              description: The label key that the selector
+                                                applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -335,7 +501,8 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   weight:
-                                    description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                    description: Weight associated with matching the
+                                      corresponding nodeSelectorTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -344,26 +511,53 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                              description: If the affinity requirements specified by
+                                this field are not met at scheduling time, the pod will
+                                not be scheduled onto the node. If the affinity requirements
+                                specified by this field cease to be met at some point
+                                during pod execution (e.g. due to an update), the system
+                                may or may not try to eventually evict the pod from
+                                its node.
                               properties:
                                 nodeSelectorTerms:
-                                  description: Required. A list of node selector terms. The terms are ORed.
+                                  description: Required. A list of node selector terms.
+                                    The terms are ORed.
                                   items:
-                                    description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                    description: A null or empty node selector term
+                                      matches no objects. The requirements of them are
+                                      ANDed. The TopologySelectorTerm type implements
+                                      a subset of the NodeSelectorTerm.
                                     properties:
                                       matchExpressions:
-                                        description: A list of node selector requirements by node's labels.
+                                        description: A list of node selector requirements
+                                          by node's labels.
                                         items:
-                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
+                                              description: The label key that the selector
+                                                applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -373,18 +567,35 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
-                                        description: A list of node selector requirements by node's fields.
+                                        description: A list of node selector requirements
+                                          by node's fields.
                                         items:
-                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
+                                              description: The label key that the selector
+                                                applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -402,32 +613,65 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         podAffinity:
-                          description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                          description: Describes pod affinity scheduling rules (e.g.
+                            co-locate this pod in the same node, zone, etc. as some
+                            other pod(s)).
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node has pods which matches the corresponding
+                                podAffinityTerm; the node(s) with the highest sum are
+                                the most preferred.
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
                                 properties:
                                   podAffinityTerm:
-                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
                                     properties:
                                       labelSelector:
-                                        description: A label query over a set of resources, in this case pods.
+                                        description: A label query over a set of resources,
+                                          in this case pods.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -439,26 +683,53 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaceSelector:
-                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                        description: A label query over the set of namespaces
+                                          that the term applies to. The term is applied
+                                          to the union of the namespaces selected by
+                                          this field and the ones listed in the namespaces
+                                          field. null selector and null or empty namespaces
+                                          list means "this pod's namespace". An empty
+                                          selector ({}) matches all namespaces.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -470,23 +741,42 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        description: namespaces specifies a static list
+                                          of namespace names that the term applies to.
+                                          The term is applied to the union of the namespaces
+                                          listed in this field and the ones selected
+                                          by namespaceSelector. null or empty namespaces
+                                          list and null namespaceSelector means "this
+                                          pod's namespace".
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                        description: This pod should be co-located (affinity)
+                                          or not co-located (anti-affinity) with the
+                                          pods matching the labelSelector in the specified
+                                          namespaces, where co-located is defined as
+                                          running on a node whose value of the label
+                                          with key topologyKey matches that of any node
+                                          on which any of the selected pods is running.
+                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
-                                    description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -495,26 +785,56 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              description: If the affinity requirements specified by
+                                this field are not met at scheduling time, the pod will
+                                not be scheduled onto the node. If the affinity requirements
+                                specified by this field cease to be met at some point
+                                during pod execution (e.g. due to a pod label update),
+                                the system may or may not try to eventually evict the
+                                pod from its node. When there are multiple elements,
+                                the lists of nodes corresponding to each podAffinityTerm
+                                are intersected, i.e. all terms must be satisfied.
                               items:
-                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or not
+                                  co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any node
+                                  on which a pod of the set of pods is running
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources, in this case pods.
+                                    description: A label query over a set of resources,
+                                      in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -526,26 +846,52 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                    description: A label query over the set of namespaces
+                                      that the term applies to. The term is applied
+                                      to the union of the namespaces selected by this
+                                      field and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list
+                                      means "this pod's namespace". An empty selector
+                                      ({}) matches all namespaces.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -557,17 +903,33 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    description: namespaces specifies a static list
+                                      of namespace names that the term applies to. The
+                                      term is applied to the union of the namespaces
+                                      listed in this field and the ones selected by
+                                      namespaceSelector. null or empty namespaces list
+                                      and null namespaceSelector means "this pod's namespace".
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified namespaces,
+                                      where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey
+                                      matches that of any node on which any of the selected
+                                      pods is running. Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                   - topologyKey
@@ -575,32 +937,65 @@ spec:
                               type: array
                           type: object
                         podAntiAffinity:
-                          description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                          description: Describes pod anti-affinity scheduling rules
+                            (e.g. avoid putting this pod in the same node, zone, etc.
+                            as some other pod(s)).
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the anti-affinity expressions
+                                specified by this field, but it may choose a node that
+                                violates one or more of the expressions. The node that
+                                is most preferred is the one with the greatest sum of
+                                weights, i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                anti-affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node has pods which matches the corresponding
+                                podAffinityTerm; the node(s) with the highest sum are
+                                the most preferred.
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
                                 properties:
                                   podAffinityTerm:
-                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
                                     properties:
                                       labelSelector:
-                                        description: A label query over a set of resources, in this case pods.
+                                        description: A label query over a set of resources,
+                                          in this case pods.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -612,26 +1007,53 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaceSelector:
-                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                        description: A label query over the set of namespaces
+                                          that the term applies to. The term is applied
+                                          to the union of the namespaces selected by
+                                          this field and the ones listed in the namespaces
+                                          field. null selector and null or empty namespaces
+                                          list means "this pod's namespace". An empty
+                                          selector ({}) matches all namespaces.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -643,23 +1065,42 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        description: namespaces specifies a static list
+                                          of namespace names that the term applies to.
+                                          The term is applied to the union of the namespaces
+                                          listed in this field and the ones selected
+                                          by namespaceSelector. null or empty namespaces
+                                          list and null namespaceSelector means "this
+                                          pod's namespace".
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                        description: This pod should be co-located (affinity)
+                                          or not co-located (anti-affinity) with the
+                                          pods matching the labelSelector in the specified
+                                          namespaces, where co-located is defined as
+                                          running on a node whose value of the label
+                                          with key topologyKey matches that of any node
+                                          on which any of the selected pods is running.
+                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
-                                    description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -668,26 +1109,56 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              description: If the anti-affinity requirements specified
+                                by this field are not met at scheduling time, the pod
+                                will not be scheduled onto the node. If the anti-affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a pod
+                                label update), the system may or may not try to eventually
+                                evict the pod from its node. When there are multiple
+                                elements, the lists of nodes corresponding to each podAffinityTerm
+                                are intersected, i.e. all terms must be satisfied.
                               items:
-                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or not
+                                  co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any node
+                                  on which a pod of the set of pods is running
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources, in this case pods.
+                                    description: A label query over a set of resources,
+                                      in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -699,26 +1170,52 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                    description: A label query over the set of namespaces
+                                      that the term applies to. The term is applied
+                                      to the union of the namespaces selected by this
+                                      field and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list
+                                      means "this pod's namespace". An empty selector
+                                      ({}) matches all namespaces.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -730,17 +1227,33 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    description: namespaces specifies a static list
+                                      of namespace names that the term applies to. The
+                                      term is applied to the union of the namespaces
+                                      listed in this field and the ones selected by
+                                      namespaceSelector. null or empty namespaces list
+                                      and null namespaceSelector means "this pod's namespace".
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified namespaces,
+                                      where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey
+                                      matches that of any node on which any of the selected
+                                      pods is running. Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                   - topologyKey
@@ -751,28 +1264,53 @@ spec:
                     nodeSelector:
                       additionalProperties:
                         type: string
-                      description: "nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector"
+                      description: 'nodeSelector is the node selector applied to the
+                      relevant kind of pods It specifies a map of key-value pairs:
+                      for the pod to be eligible to run on a node, the node must have
+                      each of the indicated key-value pairs as labels (it can have
+                      additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
                       type: object
                     tolerations:
-                      description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                      description: tolerations is a list of tolerations applied to the
+                        relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+                        for more info. These are additional tolerations other than default
+                        ones.
                       items:
-                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                        description: The pod this Toleration is attached to tolerates
+                          any taint that matches the triple <key,value,effect> using
+                          the matching operator <operator>.
                         properties:
                           effect:
-                            description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            description: Effect indicates the taint effect to match.
+                              Empty means match all taint effects. When specified, allowed
+                              values are NoSchedule, PreferNoSchedule and NoExecute.
                             type: string
                           key:
-                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            description: Key is the taint key that the toleration applies
+                              to. Empty means match all taint keys. If the key is empty,
+                              operator must be Exists; this combination means to match
+                              all values and all keys.
                             type: string
                           operator:
-                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                            description: Operator represents a key's relationship to
+                              the value. Valid operators are Exists and Equal. Defaults
+                              to Equal. Exists is equivalent to wildcard for value,
+                              so that a pod can tolerate all taints of a particular
+                              category.
                             type: string
                           tolerationSeconds:
-                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                            description: TolerationSeconds represents the period of
+                              time the toleration (which must be of effect NoExecute,
+                              otherwise this field is ignored) tolerates the taint.
+                              By default, it is not set, which means tolerate the taint
+                              forever (do not evict). Zero and negative values will
+                              be treated as 0 (evict immediately) by the system.
                             format: int64
                             type: integer
                           value:
-                            description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            description: Value is the taint value the toleration matches
+                              to. If the operator is Exists, the value should be empty,
+                              otherwise just a regular string.
                             type: string
                         type: object
                       type: array
@@ -781,7 +1319,8 @@ spec:
                   description: PriorityClass of the CDI control plane
                   type: string
                 uninstallStrategy:
-                  description: CDIUninstallStrategy defines the state to leave CDI on uninstall
+                  description: CDIUninstallStrategy defines the state to leave CDI on
+                    uninstall
                   enum:
                     - RemoveWorkloads
                     - BlockUninstallIfWorkloadsExist
@@ -790,32 +1329,67 @@ spec:
                   description: Restrict on which nodes CDI workload pods will be scheduled
                   properties:
                     affinity:
-                      description: affinity enables pod affinity/anti-affinity placement expanding the types of constraints that can be expressed with nodeSelector. affinity is going to be applied to the relevant kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                      description: affinity enables pod affinity/anti-affinity placement
+                        expanding the types of constraints that can be expressed with
+                        nodeSelector. affinity is going to be applied to the relevant
+                        kind of pods in parallel with nodeSelector See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
                       properties:
                         nodeAffinity:
-                          description: Describes node affinity scheduling rules for the pod.
+                          description: Describes node affinity scheduling rules for
+                            the pod.
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node matches the corresponding matchExpressions;
+                                the node(s) with the highest sum are the most preferred.
                               items:
-                                description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                description: An empty preferred scheduling term matches
+                                  all objects with implicit weight 0 (i.e. it's a no-op).
+                                  A null preferred scheduling term matches no objects
+                                  (i.e. is also a no-op).
                                 properties:
                                   preference:
-                                    description: A node selector term, associated with the corresponding weight.
+                                    description: A node selector term, associated with
+                                      the corresponding weight.
                                     properties:
                                       matchExpressions:
-                                        description: A list of node selector requirements by node's labels.
+                                        description: A list of node selector requirements
+                                          by node's labels.
                                         items:
-                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
+                                              description: The label key that the selector
+                                                applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -825,18 +1399,35 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
-                                        description: A list of node selector requirements by node's fields.
+                                        description: A list of node selector requirements
+                                          by node's fields.
                                         items:
-                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
+                                              description: The label key that the selector
+                                                applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -848,7 +1439,8 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   weight:
-                                    description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                    description: Weight associated with matching the
+                                      corresponding nodeSelectorTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -857,26 +1449,53 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                              description: If the affinity requirements specified by
+                                this field are not met at scheduling time, the pod will
+                                not be scheduled onto the node. If the affinity requirements
+                                specified by this field cease to be met at some point
+                                during pod execution (e.g. due to an update), the system
+                                may or may not try to eventually evict the pod from
+                                its node.
                               properties:
                                 nodeSelectorTerms:
-                                  description: Required. A list of node selector terms. The terms are ORed.
+                                  description: Required. A list of node selector terms.
+                                    The terms are ORed.
                                   items:
-                                    description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                    description: A null or empty node selector term
+                                      matches no objects. The requirements of them are
+                                      ANDed. The TopologySelectorTerm type implements
+                                      a subset of the NodeSelectorTerm.
                                     properties:
                                       matchExpressions:
-                                        description: A list of node selector requirements by node's labels.
+                                        description: A list of node selector requirements
+                                          by node's labels.
                                         items:
-                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
+                                              description: The label key that the selector
+                                                applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -886,18 +1505,35 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
-                                        description: A list of node selector requirements by node's fields.
+                                        description: A list of node selector requirements
+                                          by node's fields.
                                         items:
-                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
+                                              description: The label key that the selector
+                                                applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -915,32 +1551,65 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         podAffinity:
-                          description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                          description: Describes pod affinity scheduling rules (e.g.
+                            co-locate this pod in the same node, zone, etc. as some
+                            other pod(s)).
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node has pods which matches the corresponding
+                                podAffinityTerm; the node(s) with the highest sum are
+                                the most preferred.
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
                                 properties:
                                   podAffinityTerm:
-                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
                                     properties:
                                       labelSelector:
-                                        description: A label query over a set of resources, in this case pods.
+                                        description: A label query over a set of resources,
+                                          in this case pods.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -952,26 +1621,53 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaceSelector:
-                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                        description: A label query over the set of namespaces
+                                          that the term applies to. The term is applied
+                                          to the union of the namespaces selected by
+                                          this field and the ones listed in the namespaces
+                                          field. null selector and null or empty namespaces
+                                          list means "this pod's namespace". An empty
+                                          selector ({}) matches all namespaces.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -983,23 +1679,42 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        description: namespaces specifies a static list
+                                          of namespace names that the term applies to.
+                                          The term is applied to the union of the namespaces
+                                          listed in this field and the ones selected
+                                          by namespaceSelector. null or empty namespaces
+                                          list and null namespaceSelector means "this
+                                          pod's namespace".
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                        description: This pod should be co-located (affinity)
+                                          or not co-located (anti-affinity) with the
+                                          pods matching the labelSelector in the specified
+                                          namespaces, where co-located is defined as
+                                          running on a node whose value of the label
+                                          with key topologyKey matches that of any node
+                                          on which any of the selected pods is running.
+                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
-                                    description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -1008,26 +1723,56 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              description: If the affinity requirements specified by
+                                this field are not met at scheduling time, the pod will
+                                not be scheduled onto the node. If the affinity requirements
+                                specified by this field cease to be met at some point
+                                during pod execution (e.g. due to a pod label update),
+                                the system may or may not try to eventually evict the
+                                pod from its node. When there are multiple elements,
+                                the lists of nodes corresponding to each podAffinityTerm
+                                are intersected, i.e. all terms must be satisfied.
                               items:
-                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or not
+                                  co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any node
+                                  on which a pod of the set of pods is running
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources, in this case pods.
+                                    description: A label query over a set of resources,
+                                      in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -1039,26 +1784,52 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                    description: A label query over the set of namespaces
+                                      that the term applies to. The term is applied
+                                      to the union of the namespaces selected by this
+                                      field and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list
+                                      means "this pod's namespace". An empty selector
+                                      ({}) matches all namespaces.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -1070,17 +1841,33 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    description: namespaces specifies a static list
+                                      of namespace names that the term applies to. The
+                                      term is applied to the union of the namespaces
+                                      listed in this field and the ones selected by
+                                      namespaceSelector. null or empty namespaces list
+                                      and null namespaceSelector means "this pod's namespace".
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified namespaces,
+                                      where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey
+                                      matches that of any node on which any of the selected
+                                      pods is running. Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                   - topologyKey
@@ -1088,32 +1875,65 @@ spec:
                               type: array
                           type: object
                         podAntiAffinity:
-                          description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                          description: Describes pod anti-affinity scheduling rules
+                            (e.g. avoid putting this pod in the same node, zone, etc.
+                            as some other pod(s)).
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the anti-affinity expressions
+                                specified by this field, but it may choose a node that
+                                violates one or more of the expressions. The node that
+                                is most preferred is the one with the greatest sum of
+                                weights, i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                anti-affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node has pods which matches the corresponding
+                                podAffinityTerm; the node(s) with the highest sum are
+                                the most preferred.
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
                                 properties:
                                   podAffinityTerm:
-                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
                                     properties:
                                       labelSelector:
-                                        description: A label query over a set of resources, in this case pods.
+                                        description: A label query over a set of resources,
+                                          in this case pods.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1125,26 +1945,53 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaceSelector:
-                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                        description: A label query over the set of namespaces
+                                          that the term applies to. The term is applied
+                                          to the union of the namespaces selected by
+                                          this field and the ones listed in the namespaces
+                                          field. null selector and null or empty namespaces
+                                          list means "this pod's namespace". An empty
+                                          selector ({}) matches all namespaces.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1156,23 +2003,42 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        description: namespaces specifies a static list
+                                          of namespace names that the term applies to.
+                                          The term is applied to the union of the namespaces
+                                          listed in this field and the ones selected
+                                          by namespaceSelector. null or empty namespaces
+                                          list and null namespaceSelector means "this
+                                          pod's namespace".
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                        description: This pod should be co-located (affinity)
+                                          or not co-located (anti-affinity) with the
+                                          pods matching the labelSelector in the specified
+                                          namespaces, where co-located is defined as
+                                          running on a node whose value of the label
+                                          with key topologyKey matches that of any node
+                                          on which any of the selected pods is running.
+                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
-                                    description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -1181,26 +2047,56 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              description: If the anti-affinity requirements specified
+                                by this field are not met at scheduling time, the pod
+                                will not be scheduled onto the node. If the anti-affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a pod
+                                label update), the system may or may not try to eventually
+                                evict the pod from its node. When there are multiple
+                                elements, the lists of nodes corresponding to each podAffinityTerm
+                                are intersected, i.e. all terms must be satisfied.
                               items:
-                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or not
+                                  co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any node
+                                  on which a pod of the set of pods is running
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources, in this case pods.
+                                    description: A label query over a set of resources,
+                                      in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -1212,26 +2108,52 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                    description: A label query over the set of namespaces
+                                      that the term applies to. The term is applied
+                                      to the union of the namespaces selected by this
+                                      field and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list
+                                      means "this pod's namespace". An empty selector
+                                      ({}) matches all namespaces.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -1243,17 +2165,33 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    description: namespaces specifies a static list
+                                      of namespace names that the term applies to. The
+                                      term is applied to the union of the namespaces
+                                      listed in this field and the ones selected by
+                                      namespaceSelector. null or empty namespaces list
+                                      and null namespaceSelector means "this pod's namespace".
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified namespaces,
+                                      where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey
+                                      matches that of any node on which any of the selected
+                                      pods is running. Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                   - topologyKey
@@ -1264,28 +2202,53 @@ spec:
                     nodeSelector:
                       additionalProperties:
                         type: string
-                      description: "nodeSelector is the node selector applied to the relevant kind of pods It specifies a map of key-value pairs: for the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector"
+                      description: 'nodeSelector is the node selector applied to the
+                      relevant kind of pods It specifies a map of key-value pairs:
+                      for the pod to be eligible to run on a node, the node must have
+                      each of the indicated key-value pairs as labels (it can have
+                      additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
                       type: object
                     tolerations:
-                      description: tolerations is a list of tolerations applied to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more info. These are additional tolerations other than default ones.
+                      description: tolerations is a list of tolerations applied to the
+                        relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+                        for more info. These are additional tolerations other than default
+                        ones.
                       items:
-                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                        description: The pod this Toleration is attached to tolerates
+                          any taint that matches the triple <key,value,effect> using
+                          the matching operator <operator>.
                         properties:
                           effect:
-                            description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            description: Effect indicates the taint effect to match.
+                              Empty means match all taint effects. When specified, allowed
+                              values are NoSchedule, PreferNoSchedule and NoExecute.
                             type: string
                           key:
-                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            description: Key is the taint key that the toleration applies
+                              to. Empty means match all taint keys. If the key is empty,
+                              operator must be Exists; this combination means to match
+                              all values and all keys.
                             type: string
                           operator:
-                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                            description: Operator represents a key's relationship to
+                              the value. Valid operators are Exists and Equal. Defaults
+                              to Equal. Exists is equivalent to wildcard for value,
+                              so that a pod can tolerate all taints of a particular
+                              category.
                             type: string
                           tolerationSeconds:
-                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                            description: TolerationSeconds represents the period of
+                              time the toleration (which must be of effect NoExecute,
+                              otherwise this field is ignored) tolerates the taint.
+                              By default, it is not set, which means tolerate the taint
+                              forever (do not evict). Zero and negative values will
+                              be treated as 0 (evict immediately) by the system.
                             format: int64
                             type: integer
                           value:
-                            description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            description: Value is the taint value the toleration matches
+                              to. If the operator is Exists, the value should be empty,
+                              otherwise just a regular string.
                             type: string
                         type: object
                       type: array
@@ -1297,7 +2260,8 @@ spec:
                 conditions:
                   description: A list of current conditions of the resource
                   items:
-                    description: Condition represents the state of the operator's reconciliation functionality.
+                    description: Condition represents the state of the operator's reconciliation
+                      functionality.
                     properties:
                       lastHeartbeatTime:
                         format: date-time
@@ -1312,7 +2276,8 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType is the state of the operator's reconciliation functionality.
+                        description: ConditionType is the state of the operator's reconciliation
+                          functionality.
                         type: string
                     required:
                       - status

--- a/crds/embedded/datavolumes.yaml
+++ b/crds/embedded/datavolumes.yaml
@@ -1,11 +1,11 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: internalvirtualizationdatavolumes.cdi.internal.virtualization.deckhouse.io
   labels:
+    app.kubernetes.io/component: cdi
     heritage: deckhouse
     module: virtualization
-    app.kubernetes.io/component: cdi
+  name: internalvirtualizationdatavolumes.cdi.internal.virtualization.deckhouse.io
 spec:
   conversion:
     strategy: None
@@ -41,22 +41,19 @@ spec:
       name: v1beta1
       schema:
         openAPIV3Schema:
-          description:
-            DataVolume is an abstraction on top of PersistentVolumeClaims
+          description: DataVolume is an abstraction on top of PersistentVolumeClaims
             to allow easy population of those PersistentVolumeClaims with relation to
             VirtualMachines
           properties:
             apiVersion:
-              description:
-                "APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description:
-                "Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
@@ -64,20 +61,17 @@ spec:
               description: DataVolumeSpec defines the DataVolume type specification
               properties:
                 checkpoints:
-                  description:
-                    Checkpoints is a list of DataVolumeCheckpoints, representing
+                  description: Checkpoints is a list of DataVolumeCheckpoints, representing
                     stages in a multistage import.
                   items:
                     description: DataVolumeCheckpoint defines a stage in a warm migration.
                     properties:
                       current:
-                        description:
-                          Current is the identifier of the snapshot created
+                        description: Current is the identifier of the snapshot created
                           for this checkpoint.
                         type: string
                       previous:
-                        description:
-                          Previous is the identifier of the snapshot from
+                        description: Previous is the identifier of the snapshot from
                           the previous checkpoint.
                         type: string
                     required:
@@ -92,13 +86,11 @@ spec:
                     - archive
                   type: string
                 finalCheckpoint:
-                  description:
-                    FinalCheckpoint indicates whether the current DataVolumeCheckpoint
+                  description: FinalCheckpoint indicates whether the current DataVolumeCheckpoint
                     is the final checkpoint.
                   type: boolean
                 preallocation:
-                  description:
-                    Preallocation controls whether storage for DataVolumes
+                  description: Preallocation controls whether storage for DataVolumes
                     should be allocated in advance.
                   type: boolean
                 priorityClassName:
@@ -108,28 +100,25 @@ spec:
                   description: PVC is the PVC specification
                   properties:
                     accessModes:
-                      description:
-                        "accessModes contains the desired access modes the
-                        volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1"
+                      description: 'accessModes contains the desired access modes the
+                      volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                       items:
                         type: string
                       type: array
                     dataSource:
-                      description:
-                        "dataSource field can be used to specify either:
-                        * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                        * An existing PVC (PersistentVolumeClaim) If the provisioner
-                        or an external controller can support the specified data source,
-                        it will create a new volume based on the contents of the specified
-                        data source. When the AnyVolumeDataSource feature gate is enabled,
-                        dataSource contents will be copied to dataSourceRef, and dataSourceRef
-                        contents will be copied to dataSource when dataSourceRef.namespace
-                        is not specified. If the namespace is specified, then dataSourceRef
-                        will not be copied to dataSource."
+                      description: 'dataSource field can be used to specify either:
+                      * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                      * An existing PVC (PersistentVolumeClaim) If the provisioner
+                      or an external controller can support the specified data source,
+                      it will create a new volume based on the contents of the specified
+                      data source. When the AnyVolumeDataSource feature gate is enabled,
+                      dataSource contents will be copied to dataSourceRef, and dataSourceRef
+                      contents will be copied to dataSource when dataSourceRef.namespace
+                      is not specified. If the namespace is specified, then dataSourceRef
+                      will not be copied to dataSource.'
                       properties:
                         apiGroup:
-                          description:
-                            APIGroup is the group for the resource being
+                          description: APIGroup is the group for the resource being
                             referenced. If APIGroup is not specified, the specified
                             Kind must be in the core API group. For any other third-party
                             types, APIGroup is required.
@@ -146,36 +135,34 @@ spec:
                       type: object
                       x-kubernetes-map-type: atomic
                     dataSourceRef:
-                      description:
-                        "dataSourceRef specifies the object from which to
-                        populate the volume with data, if a non-empty volume is desired.
-                        This may be any object from a non-empty API group (non core
-                        object) or a PersistentVolumeClaim object. When this field is
-                        specified, volume binding will only succeed if the type of the
-                        specified object matches some installed volume populator or
-                        dynamic provisioner. This field will replace the functionality
-                        of the dataSource field and as such if both fields are non-empty,
-                        they must have the same value. For backwards compatibility,
-                        when namespace isn't specified in dataSourceRef, both fields
-                        (dataSource and dataSourceRef) will be set to the same value
-                        automatically if one of them is empty and the other is non-empty.
-                        When namespace is specified in dataSourceRef, dataSource isn't
-                        set to the same value and must be empty. There are three important
-                        differences between dataSource and dataSourceRef: * While dataSource
-                        only allows two specific types of objects, dataSourceRef allows
-                        any non-core object, as well as PersistentVolumeClaim objects.
-                        * While dataSource ignores disallowed values (dropping them),
-                        dataSourceRef preserves all values, and generates an error if
-                        a disallowed value is specified. * While dataSource only allows
-                        local objects, dataSourceRef allows objects in any namespaces.
-                        (Beta) Using this field requires the AnyVolumeDataSource feature
-                        gate to be enabled. (Alpha) Using the namespace field of dataSourceRef
-                        requires the CrossNamespaceVolumeDataSource feature gate to
-                        be enabled."
+                      description: 'dataSourceRef specifies the object from which to
+                      populate the volume with data, if a non-empty volume is desired.
+                      This may be any object from a non-empty API group (non core
+                      object) or a PersistentVolumeClaim object. When this field is
+                      specified, volume binding will only succeed if the type of the
+                      specified object matches some installed volume populator or
+                      dynamic provisioner. This field will replace the functionality
+                      of the dataSource field and as such if both fields are non-empty,
+                      they must have the same value. For backwards compatibility,
+                      when namespace isn''t specified in dataSourceRef, both fields
+                      (dataSource and dataSourceRef) will be set to the same value
+                      automatically if one of them is empty and the other is non-empty.
+                      When namespace is specified in dataSourceRef, dataSource isn''t
+                      set to the same value and must be empty. There are three important
+                      differences between dataSource and dataSourceRef: * While dataSource
+                      only allows two specific types of objects, dataSourceRef allows
+                      any non-core object, as well as PersistentVolumeClaim objects.
+                      * While dataSource ignores disallowed values (dropping them),
+                      dataSourceRef preserves all values, and generates an error if
+                      a disallowed value is specified. * While dataSource only allows
+                      local objects, dataSourceRef allows objects in any namespaces.
+                      (Beta) Using this field requires the AnyVolumeDataSource feature
+                      gate to be enabled. (Alpha) Using the namespace field of dataSourceRef
+                      requires the CrossNamespaceVolumeDataSource feature gate to
+                      be enabled.'
                       properties:
                         apiGroup:
-                          description:
-                            APIGroup is the group for the resource being
+                          description: APIGroup is the group for the resource being
                             referenced. If APIGroup is not specified, the specified
                             Kind must be in the core API group. For any other third-party
                             types, APIGroup is required.
@@ -187,8 +174,7 @@ spec:
                           description: Name is the name of resource being referenced
                           type: string
                         namespace:
-                          description:
-                            Namespace is the namespace of resource being
+                          description: Namespace is the namespace of resource being
                             referenced Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant
                             object is required in the referent namespace to allow that
                             namespace's owner to accept the reference. See the ReferenceGrant
@@ -200,25 +186,22 @@ spec:
                         - name
                       type: object
                     resources:
-                      description:
-                        "resources represents the minimum resources the volume
-                        should have. If RecoverVolumeExpansionFailure feature is enabled
-                        users are allowed to specify resource requirements that are
-                        lower than previous value but must still be higher than capacity
-                        recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources"
+                      description: 'resources represents the minimum resources the volume
+                      should have. If RecoverVolumeExpansionFailure feature is enabled
+                      users are allowed to specify resource requirements that are
+                      lower than previous value but must still be higher than capacity
+                      recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                       properties:
                         claims:
-                          description:
-                            "Claims lists the names of resources, defined
-                            in spec.resourceClaims, that are used by this container.
-                            \n This is an alpha field and requires enabling the DynamicResourceAllocation
-                            feature gate. \n This field is immutable."
+                          description: "Claims lists the names of resources, defined
+                          in spec.resourceClaims, that are used by this container.
+                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                          feature gate. \n This field is immutable."
                           items:
                             description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                             properties:
                               name:
-                                description:
-                                  Name must match the name of one entry in
+                                description: Name must match the name of one entry in
                                   pod.spec.resourceClaims of the Pod where this field
                                   is used. It makes that resource available inside a
                                   container.
@@ -237,9 +220,8 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description:
-                            "Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
+                          description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                         requests:
                           additionalProperties:
@@ -248,42 +230,35 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description:
-                            "Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified, otherwise
-                            to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
+                          description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                       type: object
                     selector:
-                      description:
-                        selector is a label query over volumes to consider
+                      description: selector is a label query over volumes to consider
                         for binding.
                       properties:
                         matchExpressions:
-                          description:
-                            matchExpressions is a list of label selector
+                          description: matchExpressions is a list of label selector
                             requirements. The requirements are ANDed.
                           items:
-                            description:
-                              A label selector requirement is a selector
+                            description: A label selector requirement is a selector
                               that contains values, a key, and an operator that relates
                               the key and values.
                             properties:
                               key:
-                                description:
-                                  key is the label key that the selector
+                                description: key is the label key that the selector
                                   applies to.
                                 type: string
                               operator:
-                                description:
-                                  operator represents a key's relationship
+                                description: operator represents a key's relationship
                                   to a set of values. Valid operators are In, NotIn,
                                   Exists and DoesNotExist.
                                 type: string
                               values:
-                                description:
-                                  values is an array of string values. If
+                                description: values is an array of string values. If
                                   the operator is In or NotIn, the values array must
                                   be non-empty. If the operator is Exists or DoesNotExist,
                                   the values array must be empty. This array is replaced
@@ -299,8 +274,7 @@ spec:
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description:
-                            matchLabels is a map of {key,value} pairs. A
+                          description: matchLabels is a map of {key,value} pairs. A
                             single {key,value} in the matchLabels map is equivalent
                             to an element of matchExpressions, whose key field is "key",
                             the operator is "In", and the values array contains only
@@ -309,19 +283,16 @@ spec:
                       type: object
                       x-kubernetes-map-type: atomic
                     storageClassName:
-                      description:
-                        "storageClassName is the name of the StorageClass
-                        required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1"
+                      description: 'storageClassName is the name of the StorageClass
+                      required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                       type: string
                     volumeMode:
-                      description:
-                        volumeMode defines what type of volume is required
+                      description: volumeMode defines what type of volume is required
                         by the claim. Value of Filesystem is implied when not included
                         in claim spec.
                       type: string
                     volumeName:
-                      description:
-                        volumeName is the binding reference to the PersistentVolume
+                      description: volumeName is the binding reference to the PersistentVolume
                         backing this claim.
                       type: string
                   type: object
@@ -329,18 +300,15 @@ spec:
                   description: Source is the src of the data for the requested DataVolume
                   properties:
                     blank:
-                      description:
-                        DataVolumeBlankImage provides the parameters to create
+                      description: DataVolumeBlankImage provides the parameters to create
                         a new raw blank image for the PVC
                       type: object
                     gcs:
-                      description:
-                        DataVolumeSourceGCS provides the parameters to create
+                      description: DataVolumeSourceGCS provides the parameters to create
                         a Data Volume from an GCS source
                       properties:
                         secretRef:
-                          description:
-                            SecretRef provides the secret reference needed
+                          description: SecretRef provides the secret reference needed
                             to access the GCS source
                           type: string
                         url:
@@ -350,35 +318,30 @@ spec:
                         - url
                       type: object
                     http:
-                      description:
-                        DataVolumeSourceHTTP can be either an http or https
+                      description: DataVolumeSourceHTTP can be either an http or https
                         endpoint, with an optional basic auth user name and password,
                         and an optional configmap containing additional CAs
                       properties:
                         certConfigMap:
-                          description:
-                            CertConfigMap is a configmap reference, containing
+                          description: CertConfigMap is a configmap reference, containing
                             a Certificate Authority(CA) public key, and a base64 encoded
                             pem certificate
                           type: string
                         extraHeaders:
-                          description:
-                            ExtraHeaders is a list of strings containing
+                          description: ExtraHeaders is a list of strings containing
                             extra headers to include with HTTP transfer requests
                           items:
                             type: string
                           type: array
                         secretExtraHeaders:
-                          description:
-                            SecretExtraHeaders is a list of Secret references,
+                          description: SecretExtraHeaders is a list of Secret references,
                             each containing an extra HTTP header that may include sensitive
                             information
                           items:
                             type: string
                           type: array
                         secretRef:
-                          description:
-                            SecretRef A Secret reference, the secret should
+                          description: SecretRef A Secret reference, the secret should
                             contain accessKeyId (user name) base64 encoded, and secretKey
                             (password) also base64 encoded
                           type: string
@@ -389,21 +352,18 @@ spec:
                         - url
                       type: object
                     imageio:
-                      description:
-                        DataVolumeSourceImageIO provides the parameters to
+                      description: DataVolumeSourceImageIO provides the parameters to
                         create a Data Volume from an imageio source
                       properties:
                         certConfigMap:
-                          description:
-                            CertConfigMap provides a reference to the CA
+                          description: CertConfigMap provides a reference to the CA
                             cert
                           type: string
                         diskId:
                           description: DiskID provides id of a disk to be imported
                           type: string
                         secretRef:
-                          description:
-                            SecretRef provides the secret reference needed
+                          description: SecretRef provides the secret reference needed
                             to access the ovirt-engine
                           type: string
                         url:
@@ -414,8 +374,7 @@ spec:
                         - url
                       type: object
                     pvc:
-                      description:
-                        DataVolumeSourcePVC provides the parameters to create
+                      description: DataVolumeSourcePVC provides the parameters to create
                         a Data Volume from an existing PVC
                       properties:
                         name:
@@ -429,48 +388,40 @@ spec:
                         - namespace
                       type: object
                     registry:
-                      description:
-                        DataVolumeSourceRegistry provides the parameters
+                      description: DataVolumeSourceRegistry provides the parameters
                         to create a Data Volume from an registry source
                       properties:
                         certConfigMap:
-                          description:
-                            CertConfigMap provides a reference to the Registry
+                          description: CertConfigMap provides a reference to the Registry
                             certs
                           type: string
                         imageStream:
                           description: ImageStream is the name of image stream for import
                           type: string
                         pullMethod:
-                          description:
-                            PullMethod can be either "pod" (default import),
+                          description: PullMethod can be either "pod" (default import),
                             or "node" (node docker cache based import)
                           type: string
                         secretRef:
-                          description:
-                            SecretRef provides the secret reference needed
+                          description: SecretRef provides the secret reference needed
                             to access the Registry source
                           type: string
                         url:
-                          description:
-                            "URL is the url of the registry source (starting
-                            with the scheme: docker, oci-archive)"
+                          description: 'URL is the url of the registry source (starting
+                          with the scheme: docker, oci-archive)'
                           type: string
                       type: object
                     s3:
-                      description:
-                        DataVolumeSourceS3 provides the parameters to create
+                      description: DataVolumeSourceS3 provides the parameters to create
                         a Data Volume from an S3 source
                       properties:
                         certConfigMap:
-                          description:
-                            CertConfigMap is a configmap reference, containing
+                          description: CertConfigMap is a configmap reference, containing
                             a Certificate Authority(CA) public key, and a base64 encoded
                             pem certificate
                           type: string
                         secretRef:
-                          description:
-                            SecretRef provides the secret reference needed
+                          description: SecretRef provides the secret reference needed
                             to access the S3 source
                           type: string
                         url:
@@ -480,8 +431,7 @@ spec:
                         - url
                       type: object
                     snapshot:
-                      description:
-                        DataVolumeSourceSnapshot provides the parameters
+                      description: DataVolumeSourceSnapshot provides the parameters
                         to create a Data Volume from an existing VolumeSnapshot
                       properties:
                         name:
@@ -495,64 +445,53 @@ spec:
                         - namespace
                       type: object
                     upload:
-                      description:
-                        DataVolumeSourceUpload provides the parameters to
+                      description: DataVolumeSourceUpload provides the parameters to
                         create a Data Volume by uploading the source
                       type: object
                     vddk:
-                      description:
-                        DataVolumeSourceVDDK provides the parameters to create
+                      description: DataVolumeSourceVDDK provides the parameters to create
                         a Data Volume from a Vmware source
                       properties:
                         backingFile:
-                          description:
-                            BackingFile is the path to the virtual hard disk
+                          description: BackingFile is the path to the virtual hard disk
                             to migrate from vCenter/ESXi
                           type: string
                         initImageURL:
-                          description:
-                            InitImageURL is an optional URL to an image containing
+                          description: InitImageURL is an optional URL to an image containing
                             an extracted VDDK library, overrides v2v-vmware config map
                           type: string
                         secretRef:
-                          description:
-                            SecretRef provides a reference to a secret containing
+                          description: SecretRef provides a reference to a secret containing
                             the username and password needed to access the vCenter or
                             ESXi host
                           type: string
                         thumbprint:
-                          description:
-                            Thumbprint is the certificate thumbprint of the
+                          description: Thumbprint is the certificate thumbprint of the
                             vCenter or ESXi host
                           type: string
                         url:
-                          description:
-                            URL is the URL of the vCenter or ESXi host with
+                          description: URL is the URL of the vCenter or ESXi host with
                             the VM to migrate
                           type: string
                         uuid:
-                          description:
-                            UUID is the UUID of the virtual machine that
+                          description: UUID is the UUID of the virtual machine that
                             the backing file is attached to in vCenter/ESXi
                           type: string
                       type: object
                   type: object
                 sourceRef:
-                  description:
-                    SourceRef is an indirect reference to the source of data
+                  description: SourceRef is an indirect reference to the source of data
                     for the requested DataVolume
                   properties:
                     kind:
-                      description:
-                        The kind of the source reference, currently only
+                      description: The kind of the source reference, currently only
                         "DataSource" is supported
                       type: string
                     name:
                       description: The name of the source reference
                       type: string
                     namespace:
-                      description:
-                        The namespace of the source reference, defaults to
+                      description: The namespace of the source reference, defaults to
                         the DataVolume namespace
                       type: string
                   required:
@@ -563,29 +502,26 @@ spec:
                   description: Storage is the requested storage specification
                   properties:
                     accessModes:
-                      description:
-                        "AccessModes contains the desired access modes the
-                        volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1"
+                      description: 'AccessModes contains the desired access modes the
+                      volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                       items:
                         type: string
                       type: array
                     dataSource:
-                      description:
-                        "This field can be used to specify either: * An existing
-                        VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                        * An existing PVC (PersistentVolumeClaim) * An existing custom
-                        resource that implements data population (Alpha) In order to
-                        use custom resource types that implement data population, the
-                        AnyVolumeDataSource feature gate must be enabled. If the provisioner
-                        or an external controller can support the specified data source,
-                        it will create a new volume based on the contents of the specified
-                        data source. If the AnyVolumeDataSource feature gate is enabled,
-                        this field will always have the same contents as the DataSourceRef
-                        field."
+                      description: 'This field can be used to specify either: * An existing
+                      VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                      * An existing PVC (PersistentVolumeClaim) * An existing custom
+                      resource that implements data population (Alpha) In order to
+                      use custom resource types that implement data population, the
+                      AnyVolumeDataSource feature gate must be enabled. If the provisioner
+                      or an external controller can support the specified data source,
+                      it will create a new volume based on the contents of the specified
+                      data source. If the AnyVolumeDataSource feature gate is enabled,
+                      this field will always have the same contents as the DataSourceRef
+                      field.'
                       properties:
                         apiGroup:
-                          description:
-                            APIGroup is the group for the resource being
+                          description: APIGroup is the group for the resource being
                             referenced. If APIGroup is not specified, the specified
                             Kind must be in the core API group. For any other third-party
                             types, APIGroup is required.
@@ -602,29 +538,27 @@ spec:
                       type: object
                       x-kubernetes-map-type: atomic
                     dataSourceRef:
-                      description:
-                        "Specifies the object from which to populate the
-                        volume with data, if a non-empty volume is desired. This may
-                        be any local object from a non-empty API group (non core object)
-                        or a PersistentVolumeClaim object. When this field is specified,
-                        volume binding will only succeed if the type of the specified
-                        object matches some installed volume populator or dynamic provisioner.
-                        This field will replace the functionality of the DataSource
-                        field and as such if both fields are non-empty, they must have
-                        the same value. For backwards compatibility, both fields (DataSource
-                        and DataSourceRef) will be set to the same value automatically
-                        if one of them is empty and the other is non-empty. There are
-                        two important differences between DataSource and DataSourceRef:
-                        * While DataSource only allows two specific types of objects,
-                        DataSourceRef allows any non-core object, as well as PersistentVolumeClaim
-                        objects. * While DataSource ignores disallowed values (dropping
-                        them), DataSourceRef preserves all values, and generates an
-                        error if a disallowed value is specified. (Beta) Using this
-                        field requires the AnyVolumeDataSource feature gate to be enabled."
+                      description: 'Specifies the object from which to populate the
+                      volume with data, if a non-empty volume is desired. This may
+                      be any local object from a non-empty API group (non core object)
+                      or a PersistentVolumeClaim object. When this field is specified,
+                      volume binding will only succeed if the type of the specified
+                      object matches some installed volume populator or dynamic provisioner.
+                      This field will replace the functionality of the DataSource
+                      field and as such if both fields are non-empty, they must have
+                      the same value. For backwards compatibility, both fields (DataSource
+                      and DataSourceRef) will be set to the same value automatically
+                      if one of them is empty and the other is non-empty. There are
+                      two important differences between DataSource and DataSourceRef:
+                      * While DataSource only allows two specific types of objects,
+                      DataSourceRef allows any non-core object, as well as PersistentVolumeClaim
+                      objects. * While DataSource ignores disallowed values (dropping
+                      them), DataSourceRef preserves all values, and generates an
+                      error if a disallowed value is specified. (Beta) Using this
+                      field requires the AnyVolumeDataSource feature gate to be enabled.'
                       properties:
                         apiGroup:
-                          description:
-                            APIGroup is the group for the resource being
+                          description: APIGroup is the group for the resource being
                             referenced. If APIGroup is not specified, the specified
                             Kind must be in the core API group. For any other third-party
                             types, APIGroup is required.
@@ -636,8 +570,7 @@ spec:
                           description: Name is the name of resource being referenced
                           type: string
                         namespace:
-                          description:
-                            Namespace is the namespace of resource being
+                          description: Namespace is the namespace of resource being
                             referenced Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant
                             object is required in the referent namespace to allow that
                             namespace's owner to accept the reference. See the ReferenceGrant
@@ -649,22 +582,19 @@ spec:
                         - name
                       type: object
                     resources:
-                      description:
-                        "Resources represents the minimum resources the volume
-                        should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources"
+                      description: 'Resources represents the minimum resources the volume
+                      should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                       properties:
                         claims:
-                          description:
-                            "Claims lists the names of resources, defined
-                            in spec.resourceClaims, that are used by this container.
-                            \n This is an alpha field and requires enabling the DynamicResourceAllocation
-                            feature gate. \n This field is immutable."
+                          description: "Claims lists the names of resources, defined
+                          in spec.resourceClaims, that are used by this container.
+                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                          feature gate. \n This field is immutable."
                           items:
                             description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                             properties:
                               name:
-                                description:
-                                  Name must match the name of one entry in
+                                description: Name must match the name of one entry in
                                   pod.spec.resourceClaims of the Pod where this field
                                   is used. It makes that resource available inside a
                                   container.
@@ -683,9 +613,8 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description:
-                            "Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
+                          description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                         requests:
                           additionalProperties:
@@ -694,40 +623,34 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description:
-                            "Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified, otherwise
-                            to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
+                          description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                       type: object
                     selector:
                       description: A label query over volumes to consider for binding.
                       properties:
                         matchExpressions:
-                          description:
-                            matchExpressions is a list of label selector
+                          description: matchExpressions is a list of label selector
                             requirements. The requirements are ANDed.
                           items:
-                            description:
-                              A label selector requirement is a selector
+                            description: A label selector requirement is a selector
                               that contains values, a key, and an operator that relates
                               the key and values.
                             properties:
                               key:
-                                description:
-                                  key is the label key that the selector
+                                description: key is the label key that the selector
                                   applies to.
                                 type: string
                               operator:
-                                description:
-                                  operator represents a key's relationship
+                                description: operator represents a key's relationship
                                   to a set of values. Valid operators are In, NotIn,
                                   Exists and DoesNotExist.
                                 type: string
                               values:
-                                description:
-                                  values is an array of string values. If
+                                description: values is an array of string values. If
                                   the operator is In or NotIn, the values array must
                                   be non-empty. If the operator is Exists or DoesNotExist,
                                   the values array must be empty. This array is replaced
@@ -743,8 +666,7 @@ spec:
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description:
-                            matchLabels is a map of {key,value} pairs. A
+                          description: matchLabels is a map of {key,value} pairs. A
                             single {key,value} in the matchLabels map is equivalent
                             to an element of matchExpressions, whose key field is "key",
                             the operator is "In", and the values array contains only
@@ -753,19 +675,16 @@ spec:
                       type: object
                       x-kubernetes-map-type: atomic
                     storageClassName:
-                      description:
-                        "Name of the StorageClass required by the claim.
-                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1"
+                      description: 'Name of the StorageClass required by the claim.
+                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                       type: string
                     volumeMode:
-                      description:
-                        volumeMode defines what type of volume is required
+                      description: volumeMode defines what type of volume is required
                         by the claim. Value of Filesystem is implied when not included
                         in claim spec.
                       type: string
                     volumeName:
-                      description:
-                        VolumeName is the binding reference to the PersistentVolume
+                      description: VolumeName is the binding reference to the PersistentVolume
                         backing this claim.
                       type: string
                   type: object
@@ -774,14 +693,12 @@ spec:
               description: DataVolumeStatus contains the current status of the DataVolume
               properties:
                 claimName:
-                  description:
-                    ClaimName is the name of the underlying PVC used by the
+                  description: ClaimName is the name of the underlying PVC used by the
                     DataVolume.
                   type: string
                 conditions:
                   items:
-                    description:
-                      DataVolumeCondition represents the state of a data
+                    description: DataVolumeCondition represents the state of a data
                       volume condition.
                     properties:
                       lastHeartbeatTime:
@@ -797,8 +714,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description:
-                          DataVolumeConditionType is the string representation
+                        description: DataVolumeConditionType is the string representation
                           of known condition types
                         type: string
                     required:
@@ -810,14 +726,12 @@ spec:
                   description: Phase is the current phase of the data volume
                   type: string
                 progress:
-                  description:
-                    DataVolumeProgress is the current progress of the DataVolume
+                  description: DataVolumeProgress is the current progress of the DataVolume
                     transfer operation. Value between 0 and 100 inclusive, N/A if not
                     available
                   type: string
                 restartCount:
-                  description:
-                    RestartCount is the number of times the pod populating
+                  description: RestartCount is the number of times the pod populating
                     the DataVolume has restarted
                   format: int32
                   type: integer

--- a/crds/embedded/kubevirt.yaml
+++ b/crds/embedded/kubevirt.yaml
@@ -19,17 +19,20 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: internalvirtualizationkubevirts.internal.virtualization.deckhouse.io
   labels:
+    app.kubernetes.io/component: kubevirt
     heritage: deckhouse
     module: virtualization
-    app.kubernetes.io/component: kubevirt
+  name: internalvirtualizationkubevirts.internal.virtualization.deckhouse.io
 spec:
+  conversion:
+    strategy: None
   group: internal.virtualization.deckhouse.io
   names:
     categories:
       - intvirt
     kind: InternalVirtualizationKubeVirt
+    listKind: InternalVirtualizationKubeVirtList
     plural: internalvirtualizationkubevirts
     singular: internalvirtualizationkubevirt
   scope: Namespaced
@@ -47,16 +50,14 @@ spec:
           description: KubeVirt represents the object deploying all KubeVirt resources
           properties:
             apiVersion:
-              description:
-                "APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description:
-                "Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
@@ -67,25 +68,21 @@ spec:
                     selfSigned:
                       properties:
                         ca:
-                          description:
-                            CA configuration CA certs are kept in the CA
+                          description: CA configuration CA certs are kept in the CA
                             bundle as long as they are valid
                           properties:
                             duration:
-                              description:
-                                The requested 'duration' (i.e. lifetime)
+                              description: The requested 'duration' (i.e. lifetime)
                                 of the Certificate.
                               type: string
                             renewBefore:
-                              description:
-                                The amount of time before the currently issued
+                              description: The amount of time before the currently issued
                                 certificate's "notAfter" time that we will begin to
                                 attempt to renew the certificate.
                               type: string
                           type: object
                         caOverlapInterval:
-                          description:
-                            Deprecated. Use CA.Duration and CA.RenewBefore
+                          description: Deprecated. Use CA.Duration and CA.RenewBefore
                             instead
                           type: string
                         caRotateInterval:
@@ -98,13 +95,11 @@ spec:
                           description: Server configuration Certs are rotated and discarded
                           properties:
                             duration:
-                              description:
-                                The requested 'duration' (i.e. lifetime)
+                              description: The requested 'duration' (i.e. lifetime)
                                 of the Certificate.
                               type: string
                             renewBefore:
-                              description:
-                                The amount of time before the currently issued
+                              description: The amount of time before the currently issued
                                 certificate's "notAfter" time that we will begin to
                                 attempt to renew the certificate.
                               type: string
@@ -115,8 +110,7 @@ spec:
                   description: holds kubevirt configurations. same as the virt-configMap
                   properties:
                     additionalGuestMemoryOverheadRatio:
-                      description:
-                        AdditionalGuestMemoryOverheadRatio can be used to
+                      description: AdditionalGuestMemoryOverheadRatio can be used to
                         increase the virtualization infrastructure overhead. This is
                         useful, since the calculation of this overhead is not accurate
                         and cannot be entirely known in advance. The ratio that is being
@@ -126,31 +120,26 @@ spec:
                         could be scheduled to a node. If not set, the default is 1.
                       type: string
                     apiConfiguration:
-                      description:
-                        ReloadableComponentConfiguration holds all generic
+                      description: ReloadableComponentConfiguration holds all generic
                         k8s configuration options which can be reloaded by components
                         without requiring a restart.
                       properties:
                         restClient:
-                          description:
-                            RestClient can be used to tune certain aspects
+                          description: RestClient can be used to tune certain aspects
                             of the k8s client in use.
                           properties:
                             rateLimiter:
-                              description:
-                                RateLimiter allows selecting and configuring
+                              description: RateLimiter allows selecting and configuring
                                 different rate limiters for the k8s client.
                               properties:
                                 tokenBucketRateLimiter:
                                   properties:
                                     burst:
-                                      description:
-                                        Maximum burst for throttle. If it's
+                                      description: Maximum burst for throttle. If it's
                                         zero, the component default will be used
                                       type: integer
                                     qps:
-                                      description:
-                                        QPS indicates the maximum QPS to
+                                      description: QPS indicates the maximum QPS to
                                         the apiserver from this client. If it's zero,
                                         the component default will be used
                                       type: number
@@ -203,37 +192,31 @@ spec:
                           type: object
                       type: object
                     autoCPULimitNamespaceLabelSelector:
-                      description:
-                        When set, AutoCPULimitNamespaceLabelSelector will
+                      description: When set, AutoCPULimitNamespaceLabelSelector will
                         set a CPU limit on virt-launcher for VMIs running inside namespaces
                         that match the label selector. The CPU limit will equal the
                         number of requested vCPUs. This setting does not apply to VMIs
                         with dedicated CPUs.
                       properties:
                         matchExpressions:
-                          description:
-                            matchExpressions is a list of label selector
+                          description: matchExpressions is a list of label selector
                             requirements. The requirements are ANDed.
                           items:
-                            description:
-                              A label selector requirement is a selector
+                            description: A label selector requirement is a selector
                               that contains values, a key, and an operator that relates
                               the key and values.
                             properties:
                               key:
-                                description:
-                                  key is the label key that the selector
+                                description: key is the label key that the selector
                                   applies to.
                                 type: string
                               operator:
-                                description:
-                                  operator represents a key's relationship
+                                description: operator represents a key's relationship
                                   to a set of values. Valid operators are In, NotIn,
                                   Exists and DoesNotExist.
                                 type: string
                               values:
-                                description:
-                                  values is an array of string values. If
+                                description: values is an array of string values. If
                                   the operator is In or NotIn, the values array must
                                   be non-empty. If the operator is Exists or DoesNotExist,
                                   the values array must be empty. This array is replaced
@@ -249,8 +232,7 @@ spec:
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description:
-                            matchLabels is a map of {key,value} pairs. A
+                          description: matchLabels is a map of {key,value} pairs. A
                             single {key,value} in the matchLabels map is equivalent
                             to an element of matchExpressions, whose key field is "key",
                             the operator is "In", and the values array contains only
@@ -258,31 +240,26 @@ spec:
                           type: object
                       type: object
                     controllerConfiguration:
-                      description:
-                        ReloadableComponentConfiguration holds all generic
+                      description: ReloadableComponentConfiguration holds all generic
                         k8s configuration options which can be reloaded by components
                         without requiring a restart.
                       properties:
                         restClient:
-                          description:
-                            RestClient can be used to tune certain aspects
+                          description: RestClient can be used to tune certain aspects
                             of the k8s client in use.
                           properties:
                             rateLimiter:
-                              description:
-                                RateLimiter allows selecting and configuring
+                              description: RateLimiter allows selecting and configuring
                                 different rate limiters for the k8s client.
                               properties:
                                 tokenBucketRateLimiter:
                                   properties:
                                     burst:
-                                      description:
-                                        Maximum burst for throttle. If it's
+                                      description: Maximum burst for throttle. If it's
                                         zero, the component default will be used
                                       type: integer
                                     qps:
-                                      description:
-                                        QPS indicates the maximum QPS to
+                                      description: QPS indicates the maximum QPS to
                                         the apiserver from this client. If it's zero,
                                         the component default will be used
                                       type: number
@@ -307,20 +284,18 @@ spec:
                       description: DeveloperConfiguration holds developer options
                       properties:
                         cpuAllocationRatio:
-                          description:
-                            "For each requested virtual CPU, CPUAllocationRatio
-                            defines how much physical CPU to request per VMI from the
-                            hosting node. The value is in fraction of a CPU thread (or
-                            core on non-hyperthreaded nodes). For example, a value of
-                            1 means 1 physical CPU thread per VMI CPU thread. A value
-                            of 100 would be 1% of a physical thread allocated for each
-                            requested VMI thread. This option has no effect on VMIs
-                            that request dedicated CPUs. More information at: https://kubevirt.io/user-guide/operations/node_overcommit/#node-cpu-allocation-ratio
-                            Defaults to 10"
+                          description: 'For each requested virtual CPU, CPUAllocationRatio
+                          defines how much physical CPU to request per VMI from the
+                          hosting node. The value is in fraction of a CPU thread (or
+                          core on non-hyperthreaded nodes). For example, a value of
+                          1 means 1 physical CPU thread per VMI CPU thread. A value
+                          of 100 would be 1% of a physical thread allocated for each
+                          requested VMI thread. This option has no effect on VMIs
+                          that request dedicated CPUs. More information at: https://kubevirt.io/user-guide/operations/node_overcommit/#node-cpu-allocation-ratio
+                          Defaults to 10'
                           type: integer
                         diskVerification:
-                          description:
-                            DiskVerification holds container disks verification
+                          description: DiskVerification holds container disks verification
                             limits
                           properties:
                             memoryLimit:
@@ -333,22 +308,19 @@ spec:
                             - memoryLimit
                           type: object
                         featureGates:
-                          description:
-                            FeatureGates is the list of experimental features
+                          description: FeatureGates is the list of experimental features
                             to enable. Defaults to none
                           items:
                             type: string
                           type: array
                         logVerbosity:
-                          description:
-                            LogVerbosity sets log verbosity level of  various
+                          description: LogVerbosity sets log verbosity level of  various
                             components
                           properties:
                             nodeVerbosity:
                               additionalProperties:
                                 type: integer
-                              description:
-                                NodeVerbosity represents a map of nodes with
+                              description: NodeVerbosity represents a map of nodes with
                                 a specific verbosity level
                               type: object
                             virtAPI:
@@ -363,8 +335,7 @@ spec:
                               type: integer
                           type: object
                         memoryOvercommit:
-                          description:
-                            MemoryOvercommit is the percentage of memory
+                          description: MemoryOvercommit is the percentage of memory
                             we want to give VMIs compared to the amount given to its
                             parent pod (virt-launcher). For example, a value of 102
                             means the VMI will "see" 2% more memory than its parent
@@ -373,76 +344,66 @@ spec:
                             crashes. Use carefully. Defaults to 100
                           type: integer
                         minimumClusterTSCFrequency:
-                          description:
-                            Allow overriding the automatically determined
+                          description: Allow overriding the automatically determined
                             minimum TSC frequency of the cluster and fixate the minimum
                             to this frequency.
                           format: int64
                           type: integer
                         minimumReservePVCBytes:
-                          description:
-                            MinimumReservePVCBytes is the amount of space,
+                          description: MinimumReservePVCBytes is the amount of space,
                             in bytes, to leave unused on disks. Defaults to 131072 (128KiB)
                           format: int64
                           type: integer
                         nodeSelectors:
                           additionalProperties:
                             type: string
-                          description:
-                            NodeSelectors allows restricting VMI creation
+                          description: NodeSelectors allows restricting VMI creation
                             to nodes that match a set of labels. Defaults to none
                           type: object
                         pvcTolerateLessSpaceUpToPercent:
-                          description:
-                            LessPVCSpaceToleration determines how much smaller,
+                          description: LessPVCSpaceToleration determines how much smaller,
                             in percentage, disk PVCs are allowed to be compared to the
                             requested size (to account for various overheads). Defaults
                             to 10
                           type: integer
                         useEmulation:
-                          description:
-                            UseEmulation can be set to true to allow fallback
+                          description: UseEmulation can be set to true to allow fallback
                             to software emulation in case hardware-assisted emulation
                             is not available. Defaults to false
                           type: boolean
                       type: object
                     emulatedMachines:
+                      description: Deprecated. Use architectureConfiguration instead.
                       items:
                         type: string
                       type: array
                     evictionStrategy:
-                      description:
-                        EvictionStrategy defines at the cluster level if
+                      description: EvictionStrategy defines at the cluster level if
                         the VirtualMachineInstance should be migrated instead of shut-off
                         in case of a node drain. If the VirtualMachineInstance specific
                         field is set it overrides the cluster level one.
                       type: string
                     handlerConfiguration:
-                      description:
-                        ReloadableComponentConfiguration holds all generic
+                      description: ReloadableComponentConfiguration holds all generic
                         k8s configuration options which can be reloaded by components
                         without requiring a restart.
                       properties:
                         restClient:
-                          description:
-                            RestClient can be used to tune certain aspects
+                          description: RestClient can be used to tune certain aspects
                             of the k8s client in use.
                           properties:
                             rateLimiter:
-                              description:
-                                RateLimiter allows selecting and configuring
+                              description: RateLimiter allows selecting and configuring
                                 different rate limiters for the k8s client.
                               properties:
                                 tokenBucketRateLimiter:
                                   properties:
                                     burst:
-                                      description:
-                                        Maximum burst for throttle. If it's
+                                      description: Maximum burst for throttle. If it's
                                         zero, the component default will be used
                                       type: integer
                                     qps:
-                                      description:
-                                        QPS indicates the maximum QPS to
+                                      description: QPS indicates the maximum QPS to
                                         the apiserver from this client. If it's zero,
                                         the component default will be used
                                       type: number
@@ -454,45 +415,37 @@ spec:
                           type: object
                       type: object
                     imagePullPolicy:
-                      description:
-                        PullPolicy describes a policy for if/when to pull
+                      description: PullPolicy describes a policy for if/when to pull
                         a container image
                       type: string
                     ksmConfiguration:
-                      description:
-                        KSMConfiguration holds the information regarding
+                      description: KSMConfiguration holds the information regarding
                         the enabling the KSM in the nodes (if available).
                       properties:
                         nodeLabelSelector:
-                          description:
-                            NodeLabelSelector is a selector that filters
+                          description: NodeLabelSelector is a selector that filters
                             in which nodes the KSM will be enabled. Empty NodeLabelSelector
                             will enable ksm for every node.
                           properties:
                             matchExpressions:
-                              description:
-                                matchExpressions is a list of label selector
+                              description: matchExpressions is a list of label selector
                                 requirements. The requirements are ANDed.
                               items:
-                                description:
-                                  A label selector requirement is a selector
+                                description: A label selector requirement is a selector
                                   that contains values, a key, and an operator that
                                   relates the key and values.
                                 properties:
                                   key:
-                                    description:
-                                      key is the label key that the selector
+                                    description: key is the label key that the selector
                                       applies to.
                                     type: string
                                   operator:
-                                    description:
-                                      operator represents a key's relationship
+                                    description: operator represents a key's relationship
                                       to a set of values. Valid operators are In, NotIn,
                                       Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description:
-                                      values is an array of string values.
+                                    description: values is an array of string values.
                                       If the operator is In or NotIn, the values array
                                       must be non-empty. If the operator is Exists or
                                       DoesNotExist, the values array must be empty.
@@ -509,8 +462,7 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description:
-                                matchLabels is a map of {key,value} pairs.
+                              description: matchLabels is a map of {key,value} pairs.
                                 A single {key,value} in the matchLabels map is equivalent
                                 to an element of matchExpressions, whose key field is
                                 "key", the operator is "In", and the values array contains
@@ -519,22 +471,37 @@ spec:
                           type: object
                       type: object
                     liveUpdateConfiguration:
-                      description:
-                        LiveUpdateConfiguration holds defaults for live update
+                      description: LiveUpdateConfiguration holds defaults for live update
                         features
                       properties:
                         maxCpuSockets:
-                          description:
-                            MaxCpuSockets holds the maximum amount of sockets
+                          description: MaxCpuSockets holds the maximum amount of sockets
                             that can be hotplugged
+                          format: int32
+                          type: integer
+                        maxGuest:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: MaxGuest defines the maximum amount memory that
+                            can be allocated to the guest using hotplug.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        maxHotplugRatio:
+                          description: 'MaxHotplugRatio is the ratio used to define
+                          the max amount of a hotplug resource that can be made available
+                          to a VM when the specific Max* setting is not defined (MaxCpuSockets,
+                          MaxGuest) Example: VM is configured with 512Mi of guest
+                          memory, if MaxGuest is not defined and MaxHotplugRatio is
+                          2 then MaxGuest = 1Gi defaults to 4'
                           format: int32
                           type: integer
                       type: object
                     machineType:
+                      description: Deprecated. Use architectureConfiguration instead.
                       type: string
                     mediatedDevicesConfiguration:
-                      description:
-                        MediatedDevicesConfiguration holds information about
+                      description: MediatedDevicesConfiguration holds information about
                         MDEV types to be defined, if available
                       properties:
                         mediatedDeviceTypes:
@@ -550,8 +517,7 @@ spec:
                           x-kubernetes-list-type: atomic
                         nodeMediatedDeviceTypes:
                           items:
-                            description:
-                              NodeMediatedDeviceTypesConfig holds information
+                            description: NodeMediatedDeviceTypesConfig holds information
                               about MDEV types to be defined in a specific node that
                               matches the NodeSelector field.
                             properties:
@@ -569,11 +535,10 @@ spec:
                               nodeSelector:
                                 additionalProperties:
                                   type: string
-                                description:
-                                  "NodeSelector is a selector which must
-                                  be true for the vmi to fit on a node. Selector which
-                                  must match a node's labels for the vmi to be scheduled
-                                  on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/"
+                                description: 'NodeSelector is a selector which must
+                                be true for the vmi to fit on a node. Selector which
+                                must match a node''s labels for the vmi to be scheduled
+                                on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                                 type: object
                             required:
                               - nodeSelector
@@ -585,21 +550,18 @@ spec:
                       format: int32
                       type: integer
                     migrations:
-                      description:
-                        MigrationConfiguration holds migration options. Can
+                      description: MigrationConfiguration holds migration options. Can
                         be overridden for specific groups of VMs though migration policies.
                         Visit https://kubevirt.io/user-guide/operations/migration_policies/
                         for more information.
                       properties:
                         allowAutoConverge:
-                          description:
-                            AllowAutoConverge allows the platform to compromise
+                          description: AllowAutoConverge allows the platform to compromise
                             performance/availability of VMIs to guarantee successful
                             VMI live migrations. Defaults to false
                           type: boolean
                         allowPostCopy:
-                          description:
-                            AllowPostCopy enables post-copy live migrations.
+                          description: AllowPostCopy enables post-copy live migrations.
                             Such migrations allow even the busiest VMIs to successfully
                             live-migrate. However, events like a network failure can
                             cause a VMI crash. If set to true, migrations will still
@@ -610,15 +572,13 @@ spec:
                           anyOf:
                             - type: integer
                             - type: string
-                          description:
-                            BandwidthPerMigration limits the amount of network
+                          description: BandwidthPerMigration limits the amount of network
                             bandwidth live migrations are allowed to use. The value
                             is in quantity per second. Defaults to 0 (no limit)
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         completionTimeoutPerGiB:
-                          description:
-                            CompletionTimeoutPerGiB is the maximum number
+                          description: CompletionTimeoutPerGiB is the maximum number
                             of seconds per GiB a migration is allowed to take. If a
                             live-migration takes longer to migrate than this value multiplied
                             by the size of the VMI, the migration will be cancelled,
@@ -626,14 +586,12 @@ spec:
                           format: int64
                           type: integer
                         disableTLS:
-                          description:
-                            When set to true, DisableTLS will disable the
+                          description: When set to true, DisableTLS will disable the
                             additional layer of live migration encryption provided by
                             KubeVirt. This is usually a bad idea. Defaults to false
                           type: boolean
                         matchSELinuxLevelOnMigration:
-                          description:
-                            By default, the SELinux level of target virt-launcher
+                          description: By default, the SELinux level of target virt-launcher
                             pods is forced to the level of the source virt-launcher.
                             When set to true, MatchSELinuxLevelOnMigration lets the
                             CRI auto-assign a random level to the target. That will
@@ -643,34 +601,29 @@ spec:
                             SELinux levels.
                           type: boolean
                         network:
-                          description:
-                            Network is the name of the CNI network to use
+                          description: Network is the name of the CNI network to use
                             for live migrations. By default, migrations go through the
                             pod network.
                           type: string
                         nodeDrainTaintKey:
-                          description:
-                            "NodeDrainTaintKey defines the taint key that
-                            indicates a node should be drained. Note: this option relies
-                            on the deprecated node taint feature. Default: kubevirt.io/drain"
+                          description: 'NodeDrainTaintKey defines the taint key that
+                          indicates a node should be drained. Note: this option relies
+                          on the deprecated node taint feature. Default: kubevirt.io/drain'
                           type: string
                         parallelMigrationsPerCluster:
-                          description:
-                            ParallelMigrationsPerCluster is the total number
+                          description: ParallelMigrationsPerCluster is the total number
                             of concurrent live migrations allowed cluster-wide. Defaults
                             to 5
                           format: int32
                           type: integer
                         parallelOutboundMigrationsPerNode:
-                          description:
-                            ParallelOutboundMigrationsPerNode is the maximum
+                          description: ParallelOutboundMigrationsPerNode is the maximum
                             number of concurrent outgoing live migrations allowed per
                             node. Defaults to 2
                           format: int32
                           type: integer
                         progressTimeout:
-                          description:
-                            ProgressTimeout is the maximum number of seconds
+                          description: ProgressTimeout is the maximum number of seconds
                             a live migration is allowed to make no progress. Hitting
                             this timeout means a migration transferred 0 data for that
                             many seconds. The migration is then considered stuck and
@@ -678,8 +631,7 @@ spec:
                           format: int64
                           type: integer
                         unsafeMigrationOverride:
-                          description:
-                            UnsafeMigrationOverride allows live migrations
+                          description: UnsafeMigrationOverride allows live migrations
                             to occur even if the compatibility check indicates the migration
                             will be unsafe to the guest. Defaults to false
                           type: boolean
@@ -689,6 +641,39 @@ spec:
                     network:
                       description: NetworkConfiguration holds network options
                       properties:
+                        binding:
+                          additionalProperties:
+                            properties:
+                              domainAttachmentType:
+                                description: 'DomainAttachmentType is a standard domain
+                                network attachment method kubevirt supports. Supported
+                                values: "tap". The standard domain attachment can
+                                be used instead or in addition to the sidecarImage.
+                                version: 1alphav1'
+                                type: string
+                              migration:
+                                description: 'Migration means the VM using the plugin
+                                can be safely migrated version: 1alphav1'
+                                properties:
+                                  method:
+                                    description: 'Method defines a pre-defined migration
+                                    methodology version: 1alphav1'
+                                    type: string
+                                type: object
+                              networkAttachmentDefinition:
+                                description: 'NetworkAttachmentDefinition references
+                                to a NetworkAttachmentDefinition CR object. Format:
+                                <name>, <namespace>/<name>. If namespace is not specified,
+                                VMI namespace is assumed. version: 1alphav1'
+                                type: string
+                              sidecarImage:
+                                description: 'SidecarImage references a container image
+                                that runs in the virt-launcher pod. The sidecar handles
+                                (libvirt) domain configuration and optional services.
+                                version: 1alphav1'
+                                type: string
+                            type: object
+                          type: object
                         defaultNetworkInterface:
                           type: string
                         permitBridgeInterfaceOnPodNetwork:
@@ -701,16 +686,15 @@ spec:
                         type: boolean
                       type: object
                     ovmfPath:
+                      description: Deprecated. Use architectureConfiguration instead.
                       type: string
                     permittedHostDevices:
-                      description:
-                        PermittedHostDevices holds information about devices
+                      description: PermittedHostDevices holds information about devices
                         allowed for passthrough
                       properties:
                         mediatedDevices:
                           items:
-                            description:
-                              MediatedHostDevice represents a host mediated
+                            description: MediatedHostDevice represents a host mediated
                               device allowed for passthrough
                             properties:
                               externalResourceProvider:
@@ -727,28 +711,21 @@ spec:
                           x-kubernetes-list-type: atomic
                         pciHostDevices:
                           items:
-                            description:
-                              PciHostDevice represents a host PCI device
+                            description: PciHostDevice represents a host PCI device
                               allowed for passthrough
                             properties:
                               externalResourceProvider:
-                                description:
-                                  If true, KubeVirt will leave the allocation
+                                description: If true, KubeVirt will leave the allocation
                                   and monitoring to an external device plugin
                                 type: boolean
                               pciVendorSelector:
-                                description:
-                                  The vendor_id:product_id tuple of the PCI
+                                description: The vendor_id:product_id tuple of the PCI
                                   device
                                 type: string
                               resourceName:
-                                description:
-                                  The name of the resource that is representing
+                                description: The name of the resource that is representing
                                   the device. Exposed by a device plugin and requested
-                                  by VMs. Typically of the form vendor.com/product_nameThe
-                                  name of the resource that is representing the device.
-                                  Exposed by a device plugin and requested by VMs. Typically
-                                  of the form vendor.com/product_name
+                                  by VMs. Typically of the form vendor.com/product_name
                                 type: string
                             required:
                               - pciVendorSelector
@@ -756,20 +733,47 @@ spec:
                             type: object
                           type: array
                           x-kubernetes-list-type: atomic
+                        usb:
+                          items:
+                            properties:
+                              externalResourceProvider:
+                                description: If true, KubeVirt will leave the allocation
+                                  and monitoring to an external device plugin
+                                type: boolean
+                              resourceName:
+                                description: 'Identifies the list of USB host devices.
+                                e.g: kubevirt.io/storage, kubevirt.io/bootable-usb,
+                                etc'
+                                type: string
+                              selectors:
+                                items:
+                                  properties:
+                                    product:
+                                      type: string
+                                    vendor:
+                                      type: string
+                                  required:
+                                    - product
+                                    - vendor
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                              - resourceName
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                       type: object
                     seccompConfiguration:
-                      description:
-                        SeccompConfiguration holds Seccomp configuration
+                      description: SeccompConfiguration holds Seccomp configuration
                         for Kubevirt components
                       properties:
                         virtualMachineInstanceProfile:
-                          description:
-                            VirtualMachineInstanceProfile defines what profile
+                          description: VirtualMachineInstanceProfile defines what profile
                             should be used with virt-launcher. Defaults to none
                           properties:
                             customProfile:
-                              description:
-                                CustomProfile allows to request arbitrary
+                              description: CustomProfile allows to request arbitrary
                                 profile for virt-launcher
                               properties:
                                 localhostProfile:
@@ -795,38 +799,32 @@ spec:
                           type: string
                       type: object
                     supportContainerResources:
-                      description:
-                        SupportContainerResources specifies the resource
+                      description: SupportContainerResources specifies the resource
                         requirements for various types of supporting containers such
                         as container disks/virtiofs/sidecars and hotplug attachment
                         pods. If omitted a sensible default will be supplied.
                       items:
-                        description:
-                          SupportContainerResources are used to specify the
+                        description: SupportContainerResources are used to specify the
                           cpu/memory request and limits for the containers that support
                           various features of Virtual Machines. These containers are
                           usually idle and don't require a lot of memory or cpu.
                         properties:
                           resources:
-                            description:
-                              ResourceRequirements describes the compute
+                            description: ResourceRequirements describes the compute
                               resource requirements.
                             properties:
                               claims:
-                                description:
-                                  "Claims lists the names of resources, defined
-                                  in spec.resourceClaims, that are used by this container.
-                                  \n This is an alpha field and requires enabling the
-                                  DynamicResourceAllocation feature gate. \n This field
-                                  is immutable. It can only be set for containers."
+                                description: "Claims lists the names of resources, defined
+                                in spec.resourceClaims, that are used by this container.
+                                \n This is an alpha field and requires enabling the
+                                DynamicResourceAllocation feature gate. \n This field
+                                is immutable. It can only be set for containers."
                                 items:
-                                  description:
-                                    ResourceClaim references one entry in
+                                  description: ResourceClaim references one entry in
                                     PodSpec.ResourceClaims.
                                   properties:
                                     name:
-                                      description:
-                                        Name must match the name of one entry
+                                      description: Name must match the name of one entry
                                         in pod.spec.resourceClaims of the Pod where
                                         this field is used. It makes that resource available
                                         inside a container.
@@ -845,9 +843,8 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description:
-                                  "Limits describes the maximum amount of
-                                  compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
+                                description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -856,12 +853,11 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description:
-                                  "Requests describes the minimum amount
-                                  of compute resources required. If Requests is omitted
-                                  for a container, it defaults to Limits if that is
-                                  explicitly specified, otherwise to an implementation-defined
-                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
+                                description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                 type: object
                             type: object
                           type:
@@ -888,13 +884,12 @@ spec:
                           type: array
                           x-kubernetes-list-type: set
                         minTLSVersion:
-                          description:
-                            "MinTLSVersion is a way to specify the minimum
-                            protocol version that is acceptable for TLS connections.
-                            Protocol versions are based on the following most common
-                            TLS configurations: \n   https://ssl-config.mozilla.org/
-                            \n Note that SSLv3.0 is not a supported protocol version
-                            due to well known vulnerabilities such as POODLE: https://en.wikipedia.org/wiki/POODLE"
+                          description: "MinTLSVersion is a way to specify the minimum
+                          protocol version that is acceptable for TLS connections.
+                          Protocol versions are based on the following most common
+                          TLS configurations: \n   https://ssl-config.mozilla.org/
+                          \n Note that SSLv3.0 is not a supported protocol version
+                          due to well known vulnerabilities such as POODLE: https://en.wikipedia.org/wiki/POODLE"
                           enum:
                             - VersionTLS10
                             - VersionTLS11
@@ -905,52 +900,60 @@ spec:
                     virtualMachineInstancesPerNode:
                       type: integer
                     virtualMachineOptions:
-                      description:
-                        VirtualMachineOptions holds the cluster level information
+                      description: VirtualMachineOptions holds the cluster level information
                         regarding the virtual machine.
                       properties:
                         disableFreePageReporting:
-                          description:
-                            DisableFreePageReporting disable the free page
+                          description: DisableFreePageReporting disable the free page
                             reporting of memory balloon device https://libvirt.org/formatdomain.html#memory-balloon-device.
                             This will have effect only if AutoattachMemBalloon is not
                             false and the vmi is not requesting any high performance
                             feature (dedicatedCPU/realtime/hugePages), in which free
                             page reporting is always disabled.
                           type: object
+                        disableSerialConsoleLog:
+                          description: DisableSerialConsoleLog disables logging the
+                            auto-attached default serial console. If not set, serial
+                            console logs will be written to a file and then streamed
+                            from a container named 'guest-console-log'. The value can
+                            be individually overridden for each VM, not relevant if
+                            AutoattachSerialConsole is disabled.
+                          type: object
                       type: object
+                    vmRolloutStrategy:
+                      description: VMRolloutStrategy defines how changes to a VM object
+                        propagate to its VMI
+                      enum:
+                        - Stage
+                        - LiveUpdate
+                      nullable: true
+                      type: string
                     vmStateStorageClass:
-                      description:
-                        VMStateStorageClass is the name of the storage class
+                      description: VMStateStorageClass is the name of the storage class
                         to use for the PVCs created to preserve VM state, like TPM.
                         The storage class must support RWX in filesystem mode.
                       type: string
                     webhookConfiguration:
-                      description:
-                        ReloadableComponentConfiguration holds all generic
+                      description: ReloadableComponentConfiguration holds all generic
                         k8s configuration options which can be reloaded by components
                         without requiring a restart.
                       properties:
                         restClient:
-                          description:
-                            RestClient can be used to tune certain aspects
+                          description: RestClient can be used to tune certain aspects
                             of the k8s client in use.
                           properties:
                             rateLimiter:
-                              description:
-                                RateLimiter allows selecting and configuring
+                              description: RateLimiter allows selecting and configuring
                                 different rate limiters for the k8s client.
                               properties:
                                 tokenBucketRateLimiter:
                                   properties:
                                     burst:
-                                      description:
-                                        Maximum burst for throttle. If it's
+                                      description: Maximum burst for throttle. If it's
                                         zero, the component default will be used
                                       type: integer
                                     qps:
-                                      description:
-                                        QPS indicates the maximum QPS to
+                                      description: QPS indicates the maximum QPS to
                                         the apiserver from this client. If it's zero,
                                         the component default will be used
                                       type: number
@@ -965,8 +968,7 @@ spec:
                 customizeComponents:
                   properties:
                     flags:
-                      description:
-                        Configure the value used for deployment and daemonset
+                      description: Configure the value used for deployment and daemonset
                         resources
                       properties:
                         api:
@@ -1008,59 +1010,49 @@ spec:
                   description: The ImagePullPolicy to use.
                   type: string
                 imagePullSecrets:
-                  description:
-                    The imagePullSecrets to pull the container images from
+                  description: The imagePullSecrets to pull the container images from
                     Defaults to none
                   items:
-                    description:
-                      LocalObjectReference contains enough information to
+                    description: LocalObjectReference contains enough information to
                       let you locate the referenced object inside the same namespace.
                     properties:
                       name:
-                        description:
-                          "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?"
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
                   type: array
                   x-kubernetes-list-type: atomic
                 imageRegistry:
-                  description:
-                    The image registry to pull the container images from
+                  description: The image registry to pull the container images from
                     Defaults to the same registry the operator's container image is
                     pulled from.
                   type: string
                 imageTag:
-                  description:
-                    The image tag to use for the continer images installed.
+                  description: The image tag to use for the continer images installed.
                     Defaults to the same tag as the operator's container image.
                   type: string
                 infra:
-                  description:
-                    selectors and tolerations that should apply to KubeVirt
+                  description: selectors and tolerations that should apply to KubeVirt
                     infrastructure components
                   properties:
                     nodePlacement:
-                      description:
-                        nodePlacement describes scheduling configuration
+                      description: nodePlacement describes scheduling configuration
                         for specific KubeVirt components
                       properties:
                         affinity:
-                          description:
-                            affinity enables pod affinity/anti-affinity placement
+                          description: affinity enables pod affinity/anti-affinity placement
                             expanding the types of constraints that can be expressed
                             with nodeSelector. affinity is going to be applied to the
                             relevant kind of pods in parallel with nodeSelector See
                             https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
                           properties:
                             nodeAffinity:
-                              description:
-                                Describes node affinity scheduling rules
+                              description: Describes node affinity scheduling rules
                                 for the pod.
                               properties:
                                 preferredDuringSchedulingIgnoredDuringExecution:
-                                  description:
-                                    The scheduler will prefer to schedule
+                                  description: The scheduler will prefer to schedule
                                     pods to nodes that satisfy the affinity expressions
                                     specified by this field, but it may choose a node
                                     that violates one or more of the expressions. The
@@ -1073,43 +1065,36 @@ spec:
                                     the node matches the corresponding matchExpressions;
                                     the node(s) with the highest sum are the most preferred.
                                   items:
-                                    description:
-                                      An empty preferred scheduling term
+                                    description: An empty preferred scheduling term
                                       matches all objects with implicit weight 0 (i.e.
                                       it's a no-op). A null preferred scheduling term
                                       matches no objects (i.e. is also a no-op).
                                     properties:
                                       preference:
-                                        description:
-                                          A node selector term, associated
+                                        description: A node selector term, associated
                                           with the corresponding weight.
                                         properties:
                                           matchExpressions:
-                                            description:
-                                              A list of node selector requirements
+                                            description: A list of node selector requirements
                                               by node's labels.
                                             items:
-                                              description:
-                                                A node selector requirement
+                                              description: A node selector requirement
                                                 is a selector that contains values,
                                                 a key, and an operator that relates
                                                 the key and values.
                                               properties:
                                                 key:
-                                                  description:
-                                                    The label key that the
+                                                  description: The label key that the
                                                     selector applies to.
                                                   type: string
                                                 operator:
-                                                  description:
-                                                    Represents a key's relationship
+                                                  description: Represents a key's relationship
                                                     to a set of values. Valid operators
                                                     are In, NotIn, Exists, DoesNotExist.
                                                     Gt, and Lt.
                                                   type: string
                                                 values:
-                                                  description:
-                                                    An array of string values.
+                                                  description: An array of string values.
                                                     If the operator is In or NotIn,
                                                     the values array must be non-empty.
                                                     If the operator is Exists or DoesNotExist,
@@ -1128,31 +1113,26 @@ spec:
                                               type: object
                                             type: array
                                           matchFields:
-                                            description:
-                                              A list of node selector requirements
+                                            description: A list of node selector requirements
                                               by node's fields.
                                             items:
-                                              description:
-                                                A node selector requirement
+                                              description: A node selector requirement
                                                 is a selector that contains values,
                                                 a key, and an operator that relates
                                                 the key and values.
                                               properties:
                                                 key:
-                                                  description:
-                                                    The label key that the
+                                                  description: The label key that the
                                                     selector applies to.
                                                   type: string
                                                 operator:
-                                                  description:
-                                                    Represents a key's relationship
+                                                  description: Represents a key's relationship
                                                     to a set of values. Valid operators
                                                     are In, NotIn, Exists, DoesNotExist.
                                                     Gt, and Lt.
                                                   type: string
                                                 values:
-                                                  description:
-                                                    An array of string values.
+                                                  description: An array of string values.
                                                     If the operator is In or NotIn,
                                                     the values array must be non-empty.
                                                     If the operator is Exists or DoesNotExist,
@@ -1172,8 +1152,7 @@ spec:
                                             type: array
                                         type: object
                                       weight:
-                                        description:
-                                          Weight associated with matching
+                                        description: Weight associated with matching
                                           the corresponding nodeSelectorTerm, in the
                                           range 1-100.
                                         format: int32
@@ -1184,8 +1163,7 @@ spec:
                                     type: object
                                   type: array
                                 requiredDuringSchedulingIgnoredDuringExecution:
-                                  description:
-                                    If the affinity requirements specified
+                                  description: If the affinity requirements specified
                                     by this field are not met at scheduling time, the
                                     pod will not be scheduled onto the node. If the
                                     affinity requirements specified by this field cease
@@ -1194,42 +1172,35 @@ spec:
                                     to eventually evict the pod from its node.
                                   properties:
                                     nodeSelectorTerms:
-                                      description:
-                                        Required. A list of node selector
+                                      description: Required. A list of node selector
                                         terms. The terms are ORed.
                                       items:
-                                        description:
-                                          A null or empty node selector term
+                                        description: A null or empty node selector term
                                           matches no objects. The requirements of them
                                           are ANDed. The TopologySelectorTerm type implements
                                           a subset of the NodeSelectorTerm.
                                         properties:
                                           matchExpressions:
-                                            description:
-                                              A list of node selector requirements
+                                            description: A list of node selector requirements
                                               by node's labels.
                                             items:
-                                              description:
-                                                A node selector requirement
+                                              description: A node selector requirement
                                                 is a selector that contains values,
                                                 a key, and an operator that relates
                                                 the key and values.
                                               properties:
                                                 key:
-                                                  description:
-                                                    The label key that the
+                                                  description: The label key that the
                                                     selector applies to.
                                                   type: string
                                                 operator:
-                                                  description:
-                                                    Represents a key's relationship
+                                                  description: Represents a key's relationship
                                                     to a set of values. Valid operators
                                                     are In, NotIn, Exists, DoesNotExist.
                                                     Gt, and Lt.
                                                   type: string
                                                 values:
-                                                  description:
-                                                    An array of string values.
+                                                  description: An array of string values.
                                                     If the operator is In or NotIn,
                                                     the values array must be non-empty.
                                                     If the operator is Exists or DoesNotExist,
@@ -1248,31 +1219,26 @@ spec:
                                               type: object
                                             type: array
                                           matchFields:
-                                            description:
-                                              A list of node selector requirements
+                                            description: A list of node selector requirements
                                               by node's fields.
                                             items:
-                                              description:
-                                                A node selector requirement
+                                              description: A node selector requirement
                                                 is a selector that contains values,
                                                 a key, and an operator that relates
                                                 the key and values.
                                               properties:
                                                 key:
-                                                  description:
-                                                    The label key that the
+                                                  description: The label key that the
                                                     selector applies to.
                                                   type: string
                                                 operator:
-                                                  description:
-                                                    Represents a key's relationship
+                                                  description: Represents a key's relationship
                                                     to a set of values. Valid operators
                                                     are In, NotIn, Exists, DoesNotExist.
                                                     Gt, and Lt.
                                                   type: string
                                                 values:
-                                                  description:
-                                                    An array of string values.
+                                                  description: An array of string values.
                                                     If the operator is In or NotIn,
                                                     the values array must be non-empty.
                                                     If the operator is Exists or DoesNotExist,
@@ -1297,14 +1263,12 @@ spec:
                                   type: object
                               type: object
                             podAffinity:
-                              description:
-                                Describes pod affinity scheduling rules (e.g.
+                              description: Describes pod affinity scheduling rules (e.g.
                                 co-locate this pod in the same node, zone, etc. as some
                                 other pod(s)).
                               properties:
                                 preferredDuringSchedulingIgnoredDuringExecution:
-                                  description:
-                                    The scheduler will prefer to schedule
+                                  description: The scheduler will prefer to schedule
                                     pods to nodes that satisfy the affinity expressions
                                     specified by this field, but it may choose a node
                                     that violates one or more of the expressions. The
@@ -1318,49 +1282,41 @@ spec:
                                     podAffinityTerm; the node(s) with the highest sum
                                     are the most preferred.
                                   items:
-                                    description:
-                                      The weights of all of the matched WeightedPodAffinityTerm
+                                    description: The weights of all of the matched WeightedPodAffinityTerm
                                       fields are added per-node to find the most preferred
                                       node(s)
                                     properties:
                                       podAffinityTerm:
-                                        description:
-                                          Required. A pod affinity term,
+                                        description: Required. A pod affinity term,
                                           associated with the corresponding weight.
                                         properties:
                                           labelSelector:
-                                            description:
-                                              A label query over a set of
+                                            description: A label query over a set of
                                               resources, in this case pods.
                                             properties:
                                               matchExpressions:
-                                                description:
-                                                  matchExpressions is a list
+                                                description: matchExpressions is a list
                                                   of label selector requirements. The
                                                   requirements are ANDed.
                                                 items:
-                                                  description:
-                                                    A label selector requirement
+                                                  description: A label selector requirement
                                                     is a selector that contains values,
                                                     a key, and an operator that relates
                                                     the key and values.
                                                   properties:
                                                     key:
-                                                      description:
-                                                        key is the label
+                                                      description: key is the label
                                                         key that the selector applies
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description:
-                                                        operator represents
+                                                      description: operator represents
                                                         a key's relationship to a set
                                                         of values. Valid operators are
                                                         In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description:
-                                                        values is an array
+                                                      description: values is an array
                                                         of string values. If the operator
                                                         is In or NotIn, the values array
                                                         must be non-empty. If the operator
@@ -1379,8 +1335,7 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description:
-                                                  matchLabels is a map of
+                                                description: matchLabels is a map of
                                                   {key,value} pairs. A single {key,value}
                                                   in the matchLabels map is equivalent
                                                   to an element of matchExpressions,
@@ -1391,8 +1346,7 @@ spec:
                                                 type: object
                                             type: object
                                           namespaceSelector:
-                                            description:
-                                              A label query over the set
+                                            description: A label query over the set
                                               of namespaces that the term applies to.
                                               The term is applied to the union of the
                                               namespaces selected by this field and
@@ -1402,33 +1356,28 @@ spec:
                                               empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
-                                                description:
-                                                  matchExpressions is a list
+                                                description: matchExpressions is a list
                                                   of label selector requirements. The
                                                   requirements are ANDed.
                                                 items:
-                                                  description:
-                                                    A label selector requirement
+                                                  description: A label selector requirement
                                                     is a selector that contains values,
                                                     a key, and an operator that relates
                                                     the key and values.
                                                   properties:
                                                     key:
-                                                      description:
-                                                        key is the label
+                                                      description: key is the label
                                                         key that the selector applies
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description:
-                                                        operator represents
+                                                      description: operator represents
                                                         a key's relationship to a set
                                                         of values. Valid operators are
                                                         In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description:
-                                                        values is an array
+                                                      description: values is an array
                                                         of string values. If the operator
                                                         is In or NotIn, the values array
                                                         must be non-empty. If the operator
@@ -1447,8 +1396,7 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description:
-                                                  matchLabels is a map of
+                                                description: matchLabels is a map of
                                                   {key,value} pairs. A single {key,value}
                                                   in the matchLabels map is equivalent
                                                   to an element of matchExpressions,
@@ -1459,8 +1407,7 @@ spec:
                                                 type: object
                                             type: object
                                           namespaces:
-                                            description:
-                                              namespaces specifies a static
+                                            description: namespaces specifies a static
                                               list of namespace names that the term
                                               applies to. The term is applied to the
                                               union of the namespaces listed in this
@@ -1471,8 +1418,7 @@ spec:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description:
-                                              This pod should be co-located
+                                            description: This pod should be co-located
                                               (affinity) or not co-located (anti-affinity)
                                               with the pods matching the labelSelector
                                               in the specified namespaces, where co-located
@@ -1486,8 +1432,7 @@ spec:
                                           - topologyKey
                                         type: object
                                       weight:
-                                        description:
-                                          weight associated with matching
+                                        description: weight associated with matching
                                           the corresponding podAffinityTerm, in the
                                           range 1-100.
                                         format: int32
@@ -1498,8 +1443,7 @@ spec:
                                     type: object
                                   type: array
                                 requiredDuringSchedulingIgnoredDuringExecution:
-                                  description:
-                                    If the affinity requirements specified
+                                  description: If the affinity requirements specified
                                     by this field are not met at scheduling time, the
                                     pod will not be scheduled onto the node. If the
                                     affinity requirements specified by this field cease
@@ -1510,8 +1454,7 @@ spec:
                                     corresponding to each podAffinityTerm are intersected,
                                     i.e. all terms must be satisfied.
                                   items:
-                                    description:
-                                      Defines a set of pods (namely those
+                                    description: Defines a set of pods (namely those
                                       matching the labelSelector relative to the given
                                       namespace(s)) that this pod should be co-located
                                       (affinity) or not co-located (anti-affinity) with,
@@ -1521,37 +1464,31 @@ spec:
                                       set of pods is running
                                     properties:
                                       labelSelector:
-                                        description:
-                                          A label query over a set of resources,
+                                        description: A label query over a set of resources,
                                           in this case pods.
                                         properties:
                                           matchExpressions:
-                                            description:
-                                              matchExpressions is a list
+                                            description: matchExpressions is a list
                                               of label selector requirements. The requirements
                                               are ANDed.
                                             items:
-                                              description:
-                                                A label selector requirement
+                                              description: A label selector requirement
                                                 is a selector that contains values,
                                                 a key, and an operator that relates
                                                 the key and values.
                                               properties:
                                                 key:
-                                                  description:
-                                                    key is the label key
+                                                  description: key is the label key
                                                     that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description:
-                                                    operator represents a
+                                                  description: operator represents a
                                                     key's relationship to a set of values.
                                                     Valid operators are In, NotIn, Exists
                                                     and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description:
-                                                    values is an array of
+                                                  description: values is an array of
                                                     string values. If the operator is
                                                     In or NotIn, the values array must
                                                     be non-empty. If the operator is
@@ -1570,8 +1507,7 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description:
-                                              matchLabels is a map of {key,value}
+                                            description: matchLabels is a map of {key,value}
                                               pairs. A single {key,value} in the matchLabels
                                               map is equivalent to an element of matchExpressions,
                                               whose key field is "key", the operator
@@ -1580,8 +1516,7 @@ spec:
                                             type: object
                                         type: object
                                       namespaceSelector:
-                                        description:
-                                          A label query over the set of namespaces
+                                        description: A label query over the set of namespaces
                                           that the term applies to. The term is applied
                                           to the union of the namespaces selected by
                                           this field and the ones listed in the namespaces
@@ -1590,32 +1525,27 @@ spec:
                                           selector ({}) matches all namespaces.
                                         properties:
                                           matchExpressions:
-                                            description:
-                                              matchExpressions is a list
+                                            description: matchExpressions is a list
                                               of label selector requirements. The requirements
                                               are ANDed.
                                             items:
-                                              description:
-                                                A label selector requirement
+                                              description: A label selector requirement
                                                 is a selector that contains values,
                                                 a key, and an operator that relates
                                                 the key and values.
                                               properties:
                                                 key:
-                                                  description:
-                                                    key is the label key
+                                                  description: key is the label key
                                                     that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description:
-                                                    operator represents a
+                                                  description: operator represents a
                                                     key's relationship to a set of values.
                                                     Valid operators are In, NotIn, Exists
                                                     and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description:
-                                                    values is an array of
+                                                  description: values is an array of
                                                     string values. If the operator is
                                                     In or NotIn, the values array must
                                                     be non-empty. If the operator is
@@ -1634,8 +1564,7 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description:
-                                              matchLabels is a map of {key,value}
+                                            description: matchLabels is a map of {key,value}
                                               pairs. A single {key,value} in the matchLabels
                                               map is equivalent to an element of matchExpressions,
                                               whose key field is "key", the operator
@@ -1644,8 +1573,7 @@ spec:
                                             type: object
                                         type: object
                                       namespaces:
-                                        description:
-                                          namespaces specifies a static list
+                                        description: namespaces specifies a static list
                                           of namespace names that the term applies to.
                                           The term is applied to the union of the namespaces
                                           listed in this field and the ones selected
@@ -1656,8 +1584,7 @@ spec:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description:
-                                          This pod should be co-located (affinity)
+                                        description: This pod should be co-located (affinity)
                                           or not co-located (anti-affinity) with the
                                           pods matching the labelSelector in the specified
                                           namespaces, where co-located is defined as
@@ -1672,14 +1599,12 @@ spec:
                                   type: array
                               type: object
                             podAntiAffinity:
-                              description:
-                                Describes pod anti-affinity scheduling rules
+                              description: Describes pod anti-affinity scheduling rules
                                 (e.g. avoid putting this pod in the same node, zone,
                                 etc. as some other pod(s)).
                               properties:
                                 preferredDuringSchedulingIgnoredDuringExecution:
-                                  description:
-                                    The scheduler will prefer to schedule
+                                  description: The scheduler will prefer to schedule
                                     pods to nodes that satisfy the anti-affinity expressions
                                     specified by this field, but it may choose a node
                                     that violates one or more of the expressions. The
@@ -1693,49 +1618,41 @@ spec:
                                     podAffinityTerm; the node(s) with the highest sum
                                     are the most preferred.
                                   items:
-                                    description:
-                                      The weights of all of the matched WeightedPodAffinityTerm
+                                    description: The weights of all of the matched WeightedPodAffinityTerm
                                       fields are added per-node to find the most preferred
                                       node(s)
                                     properties:
                                       podAffinityTerm:
-                                        description:
-                                          Required. A pod affinity term,
+                                        description: Required. A pod affinity term,
                                           associated with the corresponding weight.
                                         properties:
                                           labelSelector:
-                                            description:
-                                              A label query over a set of
+                                            description: A label query over a set of
                                               resources, in this case pods.
                                             properties:
                                               matchExpressions:
-                                                description:
-                                                  matchExpressions is a list
+                                                description: matchExpressions is a list
                                                   of label selector requirements. The
                                                   requirements are ANDed.
                                                 items:
-                                                  description:
-                                                    A label selector requirement
+                                                  description: A label selector requirement
                                                     is a selector that contains values,
                                                     a key, and an operator that relates
                                                     the key and values.
                                                   properties:
                                                     key:
-                                                      description:
-                                                        key is the label
+                                                      description: key is the label
                                                         key that the selector applies
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description:
-                                                        operator represents
+                                                      description: operator represents
                                                         a key's relationship to a set
                                                         of values. Valid operators are
                                                         In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description:
-                                                        values is an array
+                                                      description: values is an array
                                                         of string values. If the operator
                                                         is In or NotIn, the values array
                                                         must be non-empty. If the operator
@@ -1754,8 +1671,7 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description:
-                                                  matchLabels is a map of
+                                                description: matchLabels is a map of
                                                   {key,value} pairs. A single {key,value}
                                                   in the matchLabels map is equivalent
                                                   to an element of matchExpressions,
@@ -1766,8 +1682,7 @@ spec:
                                                 type: object
                                             type: object
                                           namespaceSelector:
-                                            description:
-                                              A label query over the set
+                                            description: A label query over the set
                                               of namespaces that the term applies to.
                                               The term is applied to the union of the
                                               namespaces selected by this field and
@@ -1777,33 +1692,28 @@ spec:
                                               empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
-                                                description:
-                                                  matchExpressions is a list
+                                                description: matchExpressions is a list
                                                   of label selector requirements. The
                                                   requirements are ANDed.
                                                 items:
-                                                  description:
-                                                    A label selector requirement
+                                                  description: A label selector requirement
                                                     is a selector that contains values,
                                                     a key, and an operator that relates
                                                     the key and values.
                                                   properties:
                                                     key:
-                                                      description:
-                                                        key is the label
+                                                      description: key is the label
                                                         key that the selector applies
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description:
-                                                        operator represents
+                                                      description: operator represents
                                                         a key's relationship to a set
                                                         of values. Valid operators are
                                                         In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description:
-                                                        values is an array
+                                                      description: values is an array
                                                         of string values. If the operator
                                                         is In or NotIn, the values array
                                                         must be non-empty. If the operator
@@ -1822,8 +1732,7 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description:
-                                                  matchLabels is a map of
+                                                description: matchLabels is a map of
                                                   {key,value} pairs. A single {key,value}
                                                   in the matchLabels map is equivalent
                                                   to an element of matchExpressions,
@@ -1834,8 +1743,7 @@ spec:
                                                 type: object
                                             type: object
                                           namespaces:
-                                            description:
-                                              namespaces specifies a static
+                                            description: namespaces specifies a static
                                               list of namespace names that the term
                                               applies to. The term is applied to the
                                               union of the namespaces listed in this
@@ -1846,8 +1754,7 @@ spec:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description:
-                                              This pod should be co-located
+                                            description: This pod should be co-located
                                               (affinity) or not co-located (anti-affinity)
                                               with the pods matching the labelSelector
                                               in the specified namespaces, where co-located
@@ -1861,8 +1768,7 @@ spec:
                                           - topologyKey
                                         type: object
                                       weight:
-                                        description:
-                                          weight associated with matching
+                                        description: weight associated with matching
                                           the corresponding podAffinityTerm, in the
                                           range 1-100.
                                         format: int32
@@ -1873,8 +1779,7 @@ spec:
                                     type: object
                                   type: array
                                 requiredDuringSchedulingIgnoredDuringExecution:
-                                  description:
-                                    If the anti-affinity requirements specified
+                                  description: If the anti-affinity requirements specified
                                     by this field are not met at scheduling time, the
                                     pod will not be scheduled onto the node. If the
                                     anti-affinity requirements specified by this field
@@ -1885,8 +1790,7 @@ spec:
                                     lists of nodes corresponding to each podAffinityTerm
                                     are intersected, i.e. all terms must be satisfied.
                                   items:
-                                    description:
-                                      Defines a set of pods (namely those
+                                    description: Defines a set of pods (namely those
                                       matching the labelSelector relative to the given
                                       namespace(s)) that this pod should be co-located
                                       (affinity) or not co-located (anti-affinity) with,
@@ -1896,37 +1800,31 @@ spec:
                                       set of pods is running
                                     properties:
                                       labelSelector:
-                                        description:
-                                          A label query over a set of resources,
+                                        description: A label query over a set of resources,
                                           in this case pods.
                                         properties:
                                           matchExpressions:
-                                            description:
-                                              matchExpressions is a list
+                                            description: matchExpressions is a list
                                               of label selector requirements. The requirements
                                               are ANDed.
                                             items:
-                                              description:
-                                                A label selector requirement
+                                              description: A label selector requirement
                                                 is a selector that contains values,
                                                 a key, and an operator that relates
                                                 the key and values.
                                               properties:
                                                 key:
-                                                  description:
-                                                    key is the label key
+                                                  description: key is the label key
                                                     that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description:
-                                                    operator represents a
+                                                  description: operator represents a
                                                     key's relationship to a set of values.
                                                     Valid operators are In, NotIn, Exists
                                                     and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description:
-                                                    values is an array of
+                                                  description: values is an array of
                                                     string values. If the operator is
                                                     In or NotIn, the values array must
                                                     be non-empty. If the operator is
@@ -1945,8 +1843,7 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description:
-                                              matchLabels is a map of {key,value}
+                                            description: matchLabels is a map of {key,value}
                                               pairs. A single {key,value} in the matchLabels
                                               map is equivalent to an element of matchExpressions,
                                               whose key field is "key", the operator
@@ -1955,8 +1852,7 @@ spec:
                                             type: object
                                         type: object
                                       namespaceSelector:
-                                        description:
-                                          A label query over the set of namespaces
+                                        description: A label query over the set of namespaces
                                           that the term applies to. The term is applied
                                           to the union of the namespaces selected by
                                           this field and the ones listed in the namespaces
@@ -1965,32 +1861,27 @@ spec:
                                           selector ({}) matches all namespaces.
                                         properties:
                                           matchExpressions:
-                                            description:
-                                              matchExpressions is a list
+                                            description: matchExpressions is a list
                                               of label selector requirements. The requirements
                                               are ANDed.
                                             items:
-                                              description:
-                                                A label selector requirement
+                                              description: A label selector requirement
                                                 is a selector that contains values,
                                                 a key, and an operator that relates
                                                 the key and values.
                                               properties:
                                                 key:
-                                                  description:
-                                                    key is the label key
+                                                  description: key is the label key
                                                     that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description:
-                                                    operator represents a
+                                                  description: operator represents a
                                                     key's relationship to a set of values.
                                                     Valid operators are In, NotIn, Exists
                                                     and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description:
-                                                    values is an array of
+                                                  description: values is an array of
                                                     string values. If the operator is
                                                     In or NotIn, the values array must
                                                     be non-empty. If the operator is
@@ -2009,8 +1900,7 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description:
-                                              matchLabels is a map of {key,value}
+                                            description: matchLabels is a map of {key,value}
                                               pairs. A single {key,value} in the matchLabels
                                               map is equivalent to an element of matchExpressions,
                                               whose key field is "key", the operator
@@ -2019,8 +1909,7 @@ spec:
                                             type: object
                                         type: object
                                       namespaces:
-                                        description:
-                                          namespaces specifies a static list
+                                        description: namespaces specifies a static list
                                           of namespace names that the term applies to.
                                           The term is applied to the union of the namespaces
                                           listed in this field and the ones selected
@@ -2031,8 +1920,7 @@ spec:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description:
-                                          This pod should be co-located (affinity)
+                                        description: This pod should be co-located (affinity)
                                           or not co-located (anti-affinity) with the
                                           pods matching the labelSelector in the specified
                                           namespaces, where co-located is defined as
@@ -2050,50 +1938,43 @@ spec:
                         nodeSelector:
                           additionalProperties:
                             type: string
-                          description:
-                            "nodeSelector is the node selector applied to
-                            the relevant kind of pods It specifies a map of key-value
-                            pairs: for the pod to be eligible to run on a node, the
-                            node must have each of the indicated key-value pairs as
-                            labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector"
+                          description: 'nodeSelector is the node selector applied to
+                          the relevant kind of pods It specifies a map of key-value
+                          pairs: for the pod to be eligible to run on a node, the
+                          node must have each of the indicated key-value pairs as
+                          labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
                           type: object
                         tolerations:
-                          description:
-                            tolerations is a list of tolerations applied
+                          description: tolerations is a list of tolerations applied
                             to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
                             for more info. These are additional tolerations other than
                             default ones.
                           items:
-                            description:
-                              The pod this Toleration is attached to tolerates
+                            description: The pod this Toleration is attached to tolerates
                               any taint that matches the triple <key,value,effect> using
                               the matching operator <operator>.
                             properties:
                               effect:
-                                description:
-                                  Effect indicates the taint effect to match.
+                                description: Effect indicates the taint effect to match.
                                   Empty means match all taint effects. When specified,
                                   allowed values are NoSchedule, PreferNoSchedule and
                                   NoExecute.
                                 type: string
                               key:
-                                description:
-                                  Key is the taint key that the toleration
+                                description: Key is the taint key that the toleration
                                   applies to. Empty means match all taint keys. If the
                                   key is empty, operator must be Exists; this combination
                                   means to match all values and all keys.
                                 type: string
                               operator:
-                                description:
-                                  Operator represents a key's relationship
+                                description: Operator represents a key's relationship
                                   to the value. Valid operators are Exists and Equal.
                                   Defaults to Equal. Exists is equivalent to wildcard
                                   for value, so that a pod can tolerate all taints of
                                   a particular category.
                                 type: string
                               tolerationSeconds:
-                                description:
-                                  TolerationSeconds represents the period
+                                description: TolerationSeconds represents the period
                                   of time the toleration (which must be of effect NoExecute,
                                   otherwise this field is ignored) tolerates the taint.
                                   By default, it is not set, which means tolerate the
@@ -2102,8 +1983,7 @@ spec:
                                 format: int64
                                 type: integer
                               value:
-                                description:
-                                  Value is the taint value the toleration
+                                description: Value is the taint value the toleration
                                   matches to. If the operator is Exists, the value should
                                   be empty, otherwise just a regular string.
                                 type: string
@@ -2111,110 +1991,94 @@ spec:
                           type: array
                       type: object
                     replicas:
-                      description:
-                        "replicas indicates how many replicas should be created
-                        for each KubeVirt infrastructure component (like virt-api or
-                        virt-controller). Defaults to 2. WARNING: this is an advanced
-                        feature that prevents auto-scaling for core kubevirt components.
-                        Please use with caution!"
+                      description: 'replicas indicates how many replicas should be created
+                      for each KubeVirt infrastructure component (like virt-api or
+                      virt-controller). Defaults to 2. WARNING: this is an advanced
+                      feature that prevents auto-scaling for core kubevirt components.
+                      Please use with caution!'
                       type: integer
                   type: object
                 monitorAccount:
-                  description:
-                    The name of the Prometheus service account that needs
+                  description: The name of the Prometheus service account that needs
                     read-access to KubeVirt endpoints Defaults to prometheus-k8s
                   type: string
                 monitorNamespace:
                   description: The namespace Prometheus is deployed in Defaults to openshift-monitor
                   type: string
                 productComponent:
-                  description:
-                    Designate the apps.kubevirt.io/component label for KubeVirt
+                  description: Designate the apps.kubevirt.io/component label for KubeVirt
                     components. Useful if KubeVirt is included as part of a product.
                     If ProductComponent is not specified, the component label default
                     value is kubevirt.
                   type: string
                 productName:
-                  description:
-                    Designate the apps.kubevirt.io/part-of label for KubeVirt
+                  description: Designate the apps.kubevirt.io/part-of label for KubeVirt
                     components. Useful if KubeVirt is included as part of a product.
                     If ProductName is not specified, the part-of label will be omitted.
                   type: string
                 productVersion:
-                  description:
-                    Designate the apps.kubevirt.io/version label for KubeVirt
+                  description: Designate the apps.kubevirt.io/version label for KubeVirt
                     components. Useful if KubeVirt is included as part of a product.
                     If ProductVersion is not specified, KubeVirt's version will be used.
                   type: string
                 serviceMonitorNamespace:
-                  description:
-                    The namespace the service monitor will be deployed  When
+                  description: The namespace the service monitor will be deployed  When
                     ServiceMonitorNamespace is set, then we'll install the service monitor
                     object in that namespace otherwise we will use the monitoring namespace.
                   type: string
                 uninstallStrategy:
-                  description:
-                    Specifies if kubevirt can be deleted if workloads are
+                  description: Specifies if kubevirt can be deleted if workloads are
                     still present. This is mainly a precaution to avoid accidental data
                     loss
                   type: string
                 workloadUpdateStrategy:
-                  description:
-                    WorkloadUpdateStrategy defines at the cluster level how
+                  description: WorkloadUpdateStrategy defines at the cluster level how
                     to handle automated workload updates
                   properties:
                     batchEvictionInterval:
-                      description:
-                        "BatchEvictionInterval Represents the interval to
-                        wait before issuing the next batch of shutdowns \n Defaults
-                        to 1 minute"
+                      description: "BatchEvictionInterval Represents the interval to
+                      wait before issuing the next batch of shutdowns \n Defaults
+                      to 1 minute"
                       type: string
                     batchEvictionSize:
-                      description:
-                        "BatchEvictionSize Represents the number of VMIs
-                        that can be forced updated per the BatchShutdownInteral interval
-                        \n Defaults to 10"
+                      description: "BatchEvictionSize Represents the number of VMIs
+                      that can be forced updated per the BatchShutdownInteral interval
+                      \n Defaults to 10"
                       type: integer
                     workloadUpdateMethods:
-                      description:
-                        "WorkloadUpdateMethods defines the methods that can
-                        be used to disrupt workloads during automated workload updates.
-                        When multiple methods are present, the least disruptive method
-                        takes precedence over more disruptive methods. For example if
-                        both LiveMigrate and Shutdown methods are listed, only VMs which
-                        are not live migratable will be restarted/shutdown \n An empty
-                        list defaults to no automated workload updating"
+                      description: "WorkloadUpdateMethods defines the methods that can
+                      be used to disrupt workloads during automated workload updates.
+                      When multiple methods are present, the least disruptive method
+                      takes precedence over more disruptive methods. For example if
+                      both LiveMigrate and Shutdown methods are listed, only VMs which
+                      are not live migratable will be restarted/shutdown \n An empty
+                      list defaults to no automated workload updating"
                       items:
                         type: string
                       type: array
                       x-kubernetes-list-type: atomic
                   type: object
                 workloads:
-                  description:
-                    selectors and tolerations that should apply to KubeVirt
+                  description: selectors and tolerations that should apply to KubeVirt
                     workloads
                   properties:
                     nodePlacement:
-                      description:
-                        nodePlacement describes scheduling configuration
+                      description: nodePlacement describes scheduling configuration
                         for specific KubeVirt components
                       properties:
                         affinity:
-                          description:
-                            affinity enables pod affinity/anti-affinity placement
+                          description: affinity enables pod affinity/anti-affinity placement
                             expanding the types of constraints that can be expressed
                             with nodeSelector. affinity is going to be applied to the
                             relevant kind of pods in parallel with nodeSelector See
                             https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
                           properties:
                             nodeAffinity:
-                              description:
-                                Describes node affinity scheduling rules
+                              description: Describes node affinity scheduling rules
                                 for the pod.
                               properties:
                                 preferredDuringSchedulingIgnoredDuringExecution:
-                                  description:
-                                    The scheduler will prefer to schedule
+                                  description: The scheduler will prefer to schedule
                                     pods to nodes that satisfy the affinity expressions
                                     specified by this field, but it may choose a node
                                     that violates one or more of the expressions. The
@@ -2227,43 +2091,36 @@ spec:
                                     the node matches the corresponding matchExpressions;
                                     the node(s) with the highest sum are the most preferred.
                                   items:
-                                    description:
-                                      An empty preferred scheduling term
+                                    description: An empty preferred scheduling term
                                       matches all objects with implicit weight 0 (i.e.
                                       it's a no-op). A null preferred scheduling term
                                       matches no objects (i.e. is also a no-op).
                                     properties:
                                       preference:
-                                        description:
-                                          A node selector term, associated
+                                        description: A node selector term, associated
                                           with the corresponding weight.
                                         properties:
                                           matchExpressions:
-                                            description:
-                                              A list of node selector requirements
+                                            description: A list of node selector requirements
                                               by node's labels.
                                             items:
-                                              description:
-                                                A node selector requirement
+                                              description: A node selector requirement
                                                 is a selector that contains values,
                                                 a key, and an operator that relates
                                                 the key and values.
                                               properties:
                                                 key:
-                                                  description:
-                                                    The label key that the
+                                                  description: The label key that the
                                                     selector applies to.
                                                   type: string
                                                 operator:
-                                                  description:
-                                                    Represents a key's relationship
+                                                  description: Represents a key's relationship
                                                     to a set of values. Valid operators
                                                     are In, NotIn, Exists, DoesNotExist.
                                                     Gt, and Lt.
                                                   type: string
                                                 values:
-                                                  description:
-                                                    An array of string values.
+                                                  description: An array of string values.
                                                     If the operator is In or NotIn,
                                                     the values array must be non-empty.
                                                     If the operator is Exists or DoesNotExist,
@@ -2282,31 +2139,26 @@ spec:
                                               type: object
                                             type: array
                                           matchFields:
-                                            description:
-                                              A list of node selector requirements
+                                            description: A list of node selector requirements
                                               by node's fields.
                                             items:
-                                              description:
-                                                A node selector requirement
+                                              description: A node selector requirement
                                                 is a selector that contains values,
                                                 a key, and an operator that relates
                                                 the key and values.
                                               properties:
                                                 key:
-                                                  description:
-                                                    The label key that the
+                                                  description: The label key that the
                                                     selector applies to.
                                                   type: string
                                                 operator:
-                                                  description:
-                                                    Represents a key's relationship
+                                                  description: Represents a key's relationship
                                                     to a set of values. Valid operators
                                                     are In, NotIn, Exists, DoesNotExist.
                                                     Gt, and Lt.
                                                   type: string
                                                 values:
-                                                  description:
-                                                    An array of string values.
+                                                  description: An array of string values.
                                                     If the operator is In or NotIn,
                                                     the values array must be non-empty.
                                                     If the operator is Exists or DoesNotExist,
@@ -2326,8 +2178,7 @@ spec:
                                             type: array
                                         type: object
                                       weight:
-                                        description:
-                                          Weight associated with matching
+                                        description: Weight associated with matching
                                           the corresponding nodeSelectorTerm, in the
                                           range 1-100.
                                         format: int32
@@ -2338,8 +2189,7 @@ spec:
                                     type: object
                                   type: array
                                 requiredDuringSchedulingIgnoredDuringExecution:
-                                  description:
-                                    If the affinity requirements specified
+                                  description: If the affinity requirements specified
                                     by this field are not met at scheduling time, the
                                     pod will not be scheduled onto the node. If the
                                     affinity requirements specified by this field cease
@@ -2348,42 +2198,35 @@ spec:
                                     to eventually evict the pod from its node.
                                   properties:
                                     nodeSelectorTerms:
-                                      description:
-                                        Required. A list of node selector
+                                      description: Required. A list of node selector
                                         terms. The terms are ORed.
                                       items:
-                                        description:
-                                          A null or empty node selector term
+                                        description: A null or empty node selector term
                                           matches no objects. The requirements of them
                                           are ANDed. The TopologySelectorTerm type implements
                                           a subset of the NodeSelectorTerm.
                                         properties:
                                           matchExpressions:
-                                            description:
-                                              A list of node selector requirements
+                                            description: A list of node selector requirements
                                               by node's labels.
                                             items:
-                                              description:
-                                                A node selector requirement
+                                              description: A node selector requirement
                                                 is a selector that contains values,
                                                 a key, and an operator that relates
                                                 the key and values.
                                               properties:
                                                 key:
-                                                  description:
-                                                    The label key that the
+                                                  description: The label key that the
                                                     selector applies to.
                                                   type: string
                                                 operator:
-                                                  description:
-                                                    Represents a key's relationship
+                                                  description: Represents a key's relationship
                                                     to a set of values. Valid operators
                                                     are In, NotIn, Exists, DoesNotExist.
                                                     Gt, and Lt.
                                                   type: string
                                                 values:
-                                                  description:
-                                                    An array of string values.
+                                                  description: An array of string values.
                                                     If the operator is In or NotIn,
                                                     the values array must be non-empty.
                                                     If the operator is Exists or DoesNotExist,
@@ -2402,31 +2245,26 @@ spec:
                                               type: object
                                             type: array
                                           matchFields:
-                                            description:
-                                              A list of node selector requirements
+                                            description: A list of node selector requirements
                                               by node's fields.
                                             items:
-                                              description:
-                                                A node selector requirement
+                                              description: A node selector requirement
                                                 is a selector that contains values,
                                                 a key, and an operator that relates
                                                 the key and values.
                                               properties:
                                                 key:
-                                                  description:
-                                                    The label key that the
+                                                  description: The label key that the
                                                     selector applies to.
                                                   type: string
                                                 operator:
-                                                  description:
-                                                    Represents a key's relationship
+                                                  description: Represents a key's relationship
                                                     to a set of values. Valid operators
                                                     are In, NotIn, Exists, DoesNotExist.
                                                     Gt, and Lt.
                                                   type: string
                                                 values:
-                                                  description:
-                                                    An array of string values.
+                                                  description: An array of string values.
                                                     If the operator is In or NotIn,
                                                     the values array must be non-empty.
                                                     If the operator is Exists or DoesNotExist,
@@ -2451,14 +2289,12 @@ spec:
                                   type: object
                               type: object
                             podAffinity:
-                              description:
-                                Describes pod affinity scheduling rules (e.g.
+                              description: Describes pod affinity scheduling rules (e.g.
                                 co-locate this pod in the same node, zone, etc. as some
                                 other pod(s)).
                               properties:
                                 preferredDuringSchedulingIgnoredDuringExecution:
-                                  description:
-                                    The scheduler will prefer to schedule
+                                  description: The scheduler will prefer to schedule
                                     pods to nodes that satisfy the affinity expressions
                                     specified by this field, but it may choose a node
                                     that violates one or more of the expressions. The
@@ -2472,49 +2308,41 @@ spec:
                                     podAffinityTerm; the node(s) with the highest sum
                                     are the most preferred.
                                   items:
-                                    description:
-                                      The weights of all of the matched WeightedPodAffinityTerm
+                                    description: The weights of all of the matched WeightedPodAffinityTerm
                                       fields are added per-node to find the most preferred
                                       node(s)
                                     properties:
                                       podAffinityTerm:
-                                        description:
-                                          Required. A pod affinity term,
+                                        description: Required. A pod affinity term,
                                           associated with the corresponding weight.
                                         properties:
                                           labelSelector:
-                                            description:
-                                              A label query over a set of
+                                            description: A label query over a set of
                                               resources, in this case pods.
                                             properties:
                                               matchExpressions:
-                                                description:
-                                                  matchExpressions is a list
+                                                description: matchExpressions is a list
                                                   of label selector requirements. The
                                                   requirements are ANDed.
                                                 items:
-                                                  description:
-                                                    A label selector requirement
+                                                  description: A label selector requirement
                                                     is a selector that contains values,
                                                     a key, and an operator that relates
                                                     the key and values.
                                                   properties:
                                                     key:
-                                                      description:
-                                                        key is the label
+                                                      description: key is the label
                                                         key that the selector applies
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description:
-                                                        operator represents
+                                                      description: operator represents
                                                         a key's relationship to a set
                                                         of values. Valid operators are
                                                         In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description:
-                                                        values is an array
+                                                      description: values is an array
                                                         of string values. If the operator
                                                         is In or NotIn, the values array
                                                         must be non-empty. If the operator
@@ -2533,8 +2361,7 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description:
-                                                  matchLabels is a map of
+                                                description: matchLabels is a map of
                                                   {key,value} pairs. A single {key,value}
                                                   in the matchLabels map is equivalent
                                                   to an element of matchExpressions,
@@ -2545,8 +2372,7 @@ spec:
                                                 type: object
                                             type: object
                                           namespaceSelector:
-                                            description:
-                                              A label query over the set
+                                            description: A label query over the set
                                               of namespaces that the term applies to.
                                               The term is applied to the union of the
                                               namespaces selected by this field and
@@ -2556,33 +2382,28 @@ spec:
                                               empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
-                                                description:
-                                                  matchExpressions is a list
+                                                description: matchExpressions is a list
                                                   of label selector requirements. The
                                                   requirements are ANDed.
                                                 items:
-                                                  description:
-                                                    A label selector requirement
+                                                  description: A label selector requirement
                                                     is a selector that contains values,
                                                     a key, and an operator that relates
                                                     the key and values.
                                                   properties:
                                                     key:
-                                                      description:
-                                                        key is the label
+                                                      description: key is the label
                                                         key that the selector applies
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description:
-                                                        operator represents
+                                                      description: operator represents
                                                         a key's relationship to a set
                                                         of values. Valid operators are
                                                         In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description:
-                                                        values is an array
+                                                      description: values is an array
                                                         of string values. If the operator
                                                         is In or NotIn, the values array
                                                         must be non-empty. If the operator
@@ -2601,8 +2422,7 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description:
-                                                  matchLabels is a map of
+                                                description: matchLabels is a map of
                                                   {key,value} pairs. A single {key,value}
                                                   in the matchLabels map is equivalent
                                                   to an element of matchExpressions,
@@ -2613,8 +2433,7 @@ spec:
                                                 type: object
                                             type: object
                                           namespaces:
-                                            description:
-                                              namespaces specifies a static
+                                            description: namespaces specifies a static
                                               list of namespace names that the term
                                               applies to. The term is applied to the
                                               union of the namespaces listed in this
@@ -2625,8 +2444,7 @@ spec:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description:
-                                              This pod should be co-located
+                                            description: This pod should be co-located
                                               (affinity) or not co-located (anti-affinity)
                                               with the pods matching the labelSelector
                                               in the specified namespaces, where co-located
@@ -2640,8 +2458,7 @@ spec:
                                           - topologyKey
                                         type: object
                                       weight:
-                                        description:
-                                          weight associated with matching
+                                        description: weight associated with matching
                                           the corresponding podAffinityTerm, in the
                                           range 1-100.
                                         format: int32
@@ -2652,8 +2469,7 @@ spec:
                                     type: object
                                   type: array
                                 requiredDuringSchedulingIgnoredDuringExecution:
-                                  description:
-                                    If the affinity requirements specified
+                                  description: If the affinity requirements specified
                                     by this field are not met at scheduling time, the
                                     pod will not be scheduled onto the node. If the
                                     affinity requirements specified by this field cease
@@ -2664,8 +2480,7 @@ spec:
                                     corresponding to each podAffinityTerm are intersected,
                                     i.e. all terms must be satisfied.
                                   items:
-                                    description:
-                                      Defines a set of pods (namely those
+                                    description: Defines a set of pods (namely those
                                       matching the labelSelector relative to the given
                                       namespace(s)) that this pod should be co-located
                                       (affinity) or not co-located (anti-affinity) with,
@@ -2675,37 +2490,31 @@ spec:
                                       set of pods is running
                                     properties:
                                       labelSelector:
-                                        description:
-                                          A label query over a set of resources,
+                                        description: A label query over a set of resources,
                                           in this case pods.
                                         properties:
                                           matchExpressions:
-                                            description:
-                                              matchExpressions is a list
+                                            description: matchExpressions is a list
                                               of label selector requirements. The requirements
                                               are ANDed.
                                             items:
-                                              description:
-                                                A label selector requirement
+                                              description: A label selector requirement
                                                 is a selector that contains values,
                                                 a key, and an operator that relates
                                                 the key and values.
                                               properties:
                                                 key:
-                                                  description:
-                                                    key is the label key
+                                                  description: key is the label key
                                                     that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description:
-                                                    operator represents a
+                                                  description: operator represents a
                                                     key's relationship to a set of values.
                                                     Valid operators are In, NotIn, Exists
                                                     and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description:
-                                                    values is an array of
+                                                  description: values is an array of
                                                     string values. If the operator is
                                                     In or NotIn, the values array must
                                                     be non-empty. If the operator is
@@ -2724,8 +2533,7 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description:
-                                              matchLabels is a map of {key,value}
+                                            description: matchLabels is a map of {key,value}
                                               pairs. A single {key,value} in the matchLabels
                                               map is equivalent to an element of matchExpressions,
                                               whose key field is "key", the operator
@@ -2734,8 +2542,7 @@ spec:
                                             type: object
                                         type: object
                                       namespaceSelector:
-                                        description:
-                                          A label query over the set of namespaces
+                                        description: A label query over the set of namespaces
                                           that the term applies to. The term is applied
                                           to the union of the namespaces selected by
                                           this field and the ones listed in the namespaces
@@ -2744,32 +2551,27 @@ spec:
                                           selector ({}) matches all namespaces.
                                         properties:
                                           matchExpressions:
-                                            description:
-                                              matchExpressions is a list
+                                            description: matchExpressions is a list
                                               of label selector requirements. The requirements
                                               are ANDed.
                                             items:
-                                              description:
-                                                A label selector requirement
+                                              description: A label selector requirement
                                                 is a selector that contains values,
                                                 a key, and an operator that relates
                                                 the key and values.
                                               properties:
                                                 key:
-                                                  description:
-                                                    key is the label key
+                                                  description: key is the label key
                                                     that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description:
-                                                    operator represents a
+                                                  description: operator represents a
                                                     key's relationship to a set of values.
                                                     Valid operators are In, NotIn, Exists
                                                     and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description:
-                                                    values is an array of
+                                                  description: values is an array of
                                                     string values. If the operator is
                                                     In or NotIn, the values array must
                                                     be non-empty. If the operator is
@@ -2788,8 +2590,7 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description:
-                                              matchLabels is a map of {key,value}
+                                            description: matchLabels is a map of {key,value}
                                               pairs. A single {key,value} in the matchLabels
                                               map is equivalent to an element of matchExpressions,
                                               whose key field is "key", the operator
@@ -2798,8 +2599,7 @@ spec:
                                             type: object
                                         type: object
                                       namespaces:
-                                        description:
-                                          namespaces specifies a static list
+                                        description: namespaces specifies a static list
                                           of namespace names that the term applies to.
                                           The term is applied to the union of the namespaces
                                           listed in this field and the ones selected
@@ -2810,8 +2610,7 @@ spec:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description:
-                                          This pod should be co-located (affinity)
+                                        description: This pod should be co-located (affinity)
                                           or not co-located (anti-affinity) with the
                                           pods matching the labelSelector in the specified
                                           namespaces, where co-located is defined as
@@ -2826,14 +2625,12 @@ spec:
                                   type: array
                               type: object
                             podAntiAffinity:
-                              description:
-                                Describes pod anti-affinity scheduling rules
+                              description: Describes pod anti-affinity scheduling rules
                                 (e.g. avoid putting this pod in the same node, zone,
                                 etc. as some other pod(s)).
                               properties:
                                 preferredDuringSchedulingIgnoredDuringExecution:
-                                  description:
-                                    The scheduler will prefer to schedule
+                                  description: The scheduler will prefer to schedule
                                     pods to nodes that satisfy the anti-affinity expressions
                                     specified by this field, but it may choose a node
                                     that violates one or more of the expressions. The
@@ -2847,49 +2644,41 @@ spec:
                                     podAffinityTerm; the node(s) with the highest sum
                                     are the most preferred.
                                   items:
-                                    description:
-                                      The weights of all of the matched WeightedPodAffinityTerm
+                                    description: The weights of all of the matched WeightedPodAffinityTerm
                                       fields are added per-node to find the most preferred
                                       node(s)
                                     properties:
                                       podAffinityTerm:
-                                        description:
-                                          Required. A pod affinity term,
+                                        description: Required. A pod affinity term,
                                           associated with the corresponding weight.
                                         properties:
                                           labelSelector:
-                                            description:
-                                              A label query over a set of
+                                            description: A label query over a set of
                                               resources, in this case pods.
                                             properties:
                                               matchExpressions:
-                                                description:
-                                                  matchExpressions is a list
+                                                description: matchExpressions is a list
                                                   of label selector requirements. The
                                                   requirements are ANDed.
                                                 items:
-                                                  description:
-                                                    A label selector requirement
+                                                  description: A label selector requirement
                                                     is a selector that contains values,
                                                     a key, and an operator that relates
                                                     the key and values.
                                                   properties:
                                                     key:
-                                                      description:
-                                                        key is the label
+                                                      description: key is the label
                                                         key that the selector applies
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description:
-                                                        operator represents
+                                                      description: operator represents
                                                         a key's relationship to a set
                                                         of values. Valid operators are
                                                         In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description:
-                                                        values is an array
+                                                      description: values is an array
                                                         of string values. If the operator
                                                         is In or NotIn, the values array
                                                         must be non-empty. If the operator
@@ -2908,8 +2697,7 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description:
-                                                  matchLabels is a map of
+                                                description: matchLabels is a map of
                                                   {key,value} pairs. A single {key,value}
                                                   in the matchLabels map is equivalent
                                                   to an element of matchExpressions,
@@ -2920,8 +2708,7 @@ spec:
                                                 type: object
                                             type: object
                                           namespaceSelector:
-                                            description:
-                                              A label query over the set
+                                            description: A label query over the set
                                               of namespaces that the term applies to.
                                               The term is applied to the union of the
                                               namespaces selected by this field and
@@ -2931,33 +2718,28 @@ spec:
                                               empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
-                                                description:
-                                                  matchExpressions is a list
+                                                description: matchExpressions is a list
                                                   of label selector requirements. The
                                                   requirements are ANDed.
                                                 items:
-                                                  description:
-                                                    A label selector requirement
+                                                  description: A label selector requirement
                                                     is a selector that contains values,
                                                     a key, and an operator that relates
                                                     the key and values.
                                                   properties:
                                                     key:
-                                                      description:
-                                                        key is the label
+                                                      description: key is the label
                                                         key that the selector applies
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description:
-                                                        operator represents
+                                                      description: operator represents
                                                         a key's relationship to a set
                                                         of values. Valid operators are
                                                         In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description:
-                                                        values is an array
+                                                      description: values is an array
                                                         of string values. If the operator
                                                         is In or NotIn, the values array
                                                         must be non-empty. If the operator
@@ -2976,8 +2758,7 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description:
-                                                  matchLabels is a map of
+                                                description: matchLabels is a map of
                                                   {key,value} pairs. A single {key,value}
                                                   in the matchLabels map is equivalent
                                                   to an element of matchExpressions,
@@ -2988,8 +2769,7 @@ spec:
                                                 type: object
                                             type: object
                                           namespaces:
-                                            description:
-                                              namespaces specifies a static
+                                            description: namespaces specifies a static
                                               list of namespace names that the term
                                               applies to. The term is applied to the
                                               union of the namespaces listed in this
@@ -3000,8 +2780,7 @@ spec:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description:
-                                              This pod should be co-located
+                                            description: This pod should be co-located
                                               (affinity) or not co-located (anti-affinity)
                                               with the pods matching the labelSelector
                                               in the specified namespaces, where co-located
@@ -3015,8 +2794,7 @@ spec:
                                           - topologyKey
                                         type: object
                                       weight:
-                                        description:
-                                          weight associated with matching
+                                        description: weight associated with matching
                                           the corresponding podAffinityTerm, in the
                                           range 1-100.
                                         format: int32
@@ -3027,8 +2805,7 @@ spec:
                                     type: object
                                   type: array
                                 requiredDuringSchedulingIgnoredDuringExecution:
-                                  description:
-                                    If the anti-affinity requirements specified
+                                  description: If the anti-affinity requirements specified
                                     by this field are not met at scheduling time, the
                                     pod will not be scheduled onto the node. If the
                                     anti-affinity requirements specified by this field
@@ -3039,8 +2816,7 @@ spec:
                                     lists of nodes corresponding to each podAffinityTerm
                                     are intersected, i.e. all terms must be satisfied.
                                   items:
-                                    description:
-                                      Defines a set of pods (namely those
+                                    description: Defines a set of pods (namely those
                                       matching the labelSelector relative to the given
                                       namespace(s)) that this pod should be co-located
                                       (affinity) or not co-located (anti-affinity) with,
@@ -3050,37 +2826,31 @@ spec:
                                       set of pods is running
                                     properties:
                                       labelSelector:
-                                        description:
-                                          A label query over a set of resources,
+                                        description: A label query over a set of resources,
                                           in this case pods.
                                         properties:
                                           matchExpressions:
-                                            description:
-                                              matchExpressions is a list
+                                            description: matchExpressions is a list
                                               of label selector requirements. The requirements
                                               are ANDed.
                                             items:
-                                              description:
-                                                A label selector requirement
+                                              description: A label selector requirement
                                                 is a selector that contains values,
                                                 a key, and an operator that relates
                                                 the key and values.
                                               properties:
                                                 key:
-                                                  description:
-                                                    key is the label key
+                                                  description: key is the label key
                                                     that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description:
-                                                    operator represents a
+                                                  description: operator represents a
                                                     key's relationship to a set of values.
                                                     Valid operators are In, NotIn, Exists
                                                     and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description:
-                                                    values is an array of
+                                                  description: values is an array of
                                                     string values. If the operator is
                                                     In or NotIn, the values array must
                                                     be non-empty. If the operator is
@@ -3099,8 +2869,7 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description:
-                                              matchLabels is a map of {key,value}
+                                            description: matchLabels is a map of {key,value}
                                               pairs. A single {key,value} in the matchLabels
                                               map is equivalent to an element of matchExpressions,
                                               whose key field is "key", the operator
@@ -3109,8 +2878,7 @@ spec:
                                             type: object
                                         type: object
                                       namespaceSelector:
-                                        description:
-                                          A label query over the set of namespaces
+                                        description: A label query over the set of namespaces
                                           that the term applies to. The term is applied
                                           to the union of the namespaces selected by
                                           this field and the ones listed in the namespaces
@@ -3119,32 +2887,27 @@ spec:
                                           selector ({}) matches all namespaces.
                                         properties:
                                           matchExpressions:
-                                            description:
-                                              matchExpressions is a list
+                                            description: matchExpressions is a list
                                               of label selector requirements. The requirements
                                               are ANDed.
                                             items:
-                                              description:
-                                                A label selector requirement
+                                              description: A label selector requirement
                                                 is a selector that contains values,
                                                 a key, and an operator that relates
                                                 the key and values.
                                               properties:
                                                 key:
-                                                  description:
-                                                    key is the label key
+                                                  description: key is the label key
                                                     that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description:
-                                                    operator represents a
+                                                  description: operator represents a
                                                     key's relationship to a set of values.
                                                     Valid operators are In, NotIn, Exists
                                                     and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description:
-                                                    values is an array of
+                                                  description: values is an array of
                                                     string values. If the operator is
                                                     In or NotIn, the values array must
                                                     be non-empty. If the operator is
@@ -3163,8 +2926,7 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description:
-                                              matchLabels is a map of {key,value}
+                                            description: matchLabels is a map of {key,value}
                                               pairs. A single {key,value} in the matchLabels
                                               map is equivalent to an element of matchExpressions,
                                               whose key field is "key", the operator
@@ -3173,8 +2935,7 @@ spec:
                                             type: object
                                         type: object
                                       namespaces:
-                                        description:
-                                          namespaces specifies a static list
+                                        description: namespaces specifies a static list
                                           of namespace names that the term applies to.
                                           The term is applied to the union of the namespaces
                                           listed in this field and the ones selected
@@ -3185,8 +2946,7 @@ spec:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description:
-                                          This pod should be co-located (affinity)
+                                        description: This pod should be co-located (affinity)
                                           or not co-located (anti-affinity) with the
                                           pods matching the labelSelector in the specified
                                           namespaces, where co-located is defined as
@@ -3204,50 +2964,43 @@ spec:
                         nodeSelector:
                           additionalProperties:
                             type: string
-                          description:
-                            "nodeSelector is the node selector applied to
-                            the relevant kind of pods It specifies a map of key-value
-                            pairs: for the pod to be eligible to run on a node, the
-                            node must have each of the indicated key-value pairs as
-                            labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector"
+                          description: 'nodeSelector is the node selector applied to
+                          the relevant kind of pods It specifies a map of key-value
+                          pairs: for the pod to be eligible to run on a node, the
+                          node must have each of the indicated key-value pairs as
+                          labels (it can have additional labels as well). See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector'
                           type: object
                         tolerations:
-                          description:
-                            tolerations is a list of tolerations applied
+                          description: tolerations is a list of tolerations applied
                             to the relevant kind of pods See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
                             for more info. These are additional tolerations other than
                             default ones.
                           items:
-                            description:
-                              The pod this Toleration is attached to tolerates
+                            description: The pod this Toleration is attached to tolerates
                               any taint that matches the triple <key,value,effect> using
                               the matching operator <operator>.
                             properties:
                               effect:
-                                description:
-                                  Effect indicates the taint effect to match.
+                                description: Effect indicates the taint effect to match.
                                   Empty means match all taint effects. When specified,
                                   allowed values are NoSchedule, PreferNoSchedule and
                                   NoExecute.
                                 type: string
                               key:
-                                description:
-                                  Key is the taint key that the toleration
+                                description: Key is the taint key that the toleration
                                   applies to. Empty means match all taint keys. If the
                                   key is empty, operator must be Exists; this combination
                                   means to match all values and all keys.
                                 type: string
                               operator:
-                                description:
-                                  Operator represents a key's relationship
+                                description: Operator represents a key's relationship
                                   to the value. Valid operators are Exists and Equal.
                                   Defaults to Equal. Exists is equivalent to wildcard
                                   for value, so that a pod can tolerate all taints of
                                   a particular category.
                                 type: string
                               tolerationSeconds:
-                                description:
-                                  TolerationSeconds represents the period
+                                description: TolerationSeconds represents the period
                                   of time the toleration (which must be of effect NoExecute,
                                   otherwise this field is ignored) tolerates the taint.
                                   By default, it is not set, which means tolerate the
@@ -3256,8 +3009,7 @@ spec:
                                 format: int64
                                 type: integer
                               value:
-                                description:
-                                  Value is the taint value the toleration
+                                description: Value is the taint value the toleration
                                   matches to. If the operator is Exists, the value should
                                   be empty, otherwise just a regular string.
                                 type: string
@@ -3265,24 +3017,21 @@ spec:
                           type: array
                       type: object
                     replicas:
-                      description:
-                        "replicas indicates how many replicas should be created
-                        for each KubeVirt infrastructure component (like virt-api or
-                        virt-controller). Defaults to 2. WARNING: this is an advanced
-                        feature that prevents auto-scaling for core kubevirt components.
-                        Please use with caution!"
+                      description: 'replicas indicates how many replicas should be created
+                      for each KubeVirt infrastructure component (like virt-api or
+                      virt-controller). Defaults to 2. WARNING: this is an advanced
+                      feature that prevents auto-scaling for core kubevirt components.
+                      Please use with caution!'
                       type: integer
                   type: object
               type: object
             status:
-              description:
-                KubeVirtStatus represents information pertaining to a KubeVirt
+              description: KubeVirtStatus represents information pertaining to a KubeVirt
                 deployment.
               properties:
                 conditions:
                   items:
-                    description:
-                      KubeVirtCondition represents a condition of a KubeVirt
+                    description: KubeVirtCondition represents a condition of a KubeVirt
                       deployment
                     properties:
                       lastProbeTime:
@@ -3310,8 +3059,7 @@ spec:
                   type: string
                 generations:
                   items:
-                    description:
-                      GenerationStatus keeps track of the generation for
+                    description: GenerationStatus keeps track of the generation for
                       a given resource so that decisions about forced updates can be
                       made.
                     properties:
@@ -3319,13 +3067,11 @@ spec:
                         description: group is the group of the thing you're tracking
                         type: string
                       hash:
-                        description:
-                          hash is an optional field set for resources without
+                        description: hash is an optional field set for resources without
                           generation that are content sensitive like secrets and configmaps
                         type: string
                       lastGeneration:
-                        description:
-                          lastGeneration is the last generation of the workload
+                        description: lastGeneration is the last generation of the workload
                           controller involved
                         format: int64
                         type: integer
@@ -3336,8 +3082,7 @@ spec:
                         description: namespace is where the thing you're tracking is
                         type: string
                       resource:
-                        description:
-                          resource is the resource type of the thing you're
+                        description: resource is the resource type of the thing you're
                           tracking
                         type: string
                     required:
@@ -3364,8 +3109,7 @@ spec:
                 outdatedVirtualMachineInstanceWorkloads:
                   type: integer
                 phase:
-                  description:
-                    KubeVirtPhase is a label for the phase of a KubeVirt
+                  description: KubeVirtPhase is a label for the phase of a KubeVirt
                     deployment at the current time.
                   type: string
                 targetDeploymentConfig:

--- a/crds/embedded/virtualmachineinstances.yaml
+++ b/crds/embedded/virtualmachineinstances.yaml
@@ -1,11 +1,11 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: internalvirtualizationvirtualmachineinstances.internal.virtualization.deckhouse.io
   labels:
+    app.kubernetes.io/component: kubevirt
     heritage: deckhouse
     module: virtualization
-    app.kubernetes.io/component: kubevirt
+  name: internalvirtualizationvirtualmachineinstances.internal.virtualization.deckhouse.io
 spec:
   conversion:
     strategy: None
@@ -49,66 +49,60 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description:
-            VirtualMachineInstance is *the* VirtualMachineInstance Definition.
+          description: VirtualMachineInstance is *the* VirtualMachineInstance Definition.
             It represents a virtual machine in the runtime environment of kubernetes.
           properties:
             apiVersion:
-              description:
-                "APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description:
-                "Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
             spec:
-              description:
-                VirtualMachineInstance Spec contains the VirtualMachineInstance
+              description: VirtualMachineInstance Spec contains the VirtualMachineInstance
                 specification.
               properties:
                 accessCredentials:
-                  description:
-                    Specifies a set of public keys to inject into the vm
+                  description: Specifies a set of public keys to inject into the vm
                     guest
                   items:
-                    description:
-                      AccessCredential represents a credential source that
+                    description: AccessCredential represents a credential source that
                       can be used to authorize remote access to the vm guest Only one
                       of its members may be specified.
                     properties:
                       sshPublicKey:
-                        description:
-                          SSHPublicKey represents the source and method of
+                        description: SSHPublicKey represents the source and method of
                           applying a ssh public key into a guest virtual machine.
                         properties:
                           propagationMethod:
-                            description:
-                              PropagationMethod represents how the public
+                            description: PropagationMethod represents how the public
                               key is injected into the vm guest.
                             properties:
                               configDrive:
-                                description:
-                                  ConfigDrivePropagation means that the ssh
+                                description: ConfigDrivePropagation means that the ssh
                                   public keys are injected into the VM using metadata
                                   using the configDrive cloud-init provider
                                 type: object
+                              noCloud:
+                                description: NoCloudPropagation means that the ssh public
+                                  keys are injected into the VM using metadata using
+                                  the noCloud cloud-init provider
+                                type: object
                               qemuGuestAgent:
-                                description:
-                                  QemuGuestAgentAccessCredentailPropagation
+                                description: QemuGuestAgentAccessCredentailPropagation
                                   means ssh public keys are dynamically injected into
                                   the vm at runtime via the qemu guest agent. This feature
                                   requires the qemu guest agent to be running within
                                   the guest.
                                 properties:
                                   users:
-                                    description:
-                                      Users represents a list of guest users
+                                    description: Users represents a list of guest users
                                       that should have the ssh public keys added to
                                       their authorized_keys file.
                                     items:
@@ -120,18 +114,15 @@ spec:
                                 type: object
                             type: object
                           source:
-                            description:
-                              Source represents where the public keys are
+                            description: Source represents where the public keys are
                               pulled from
                             properties:
                               secret:
-                                description:
-                                  Secret means that the access credential
+                                description: Secret means that the access credential
                                   is pulled from a kubernetes secret
                                 properties:
                                   secretName:
-                                    description:
-                                      SecretName represents the name of the
+                                    description: SecretName represents the name of the
                                       secret in the VMI's namespace
                                     type: string
                                 required:
@@ -143,18 +134,15 @@ spec:
                           - source
                         type: object
                       userPassword:
-                        description:
-                          UserPassword represents the source and method for
+                        description: UserPassword represents the source and method for
                           applying a guest user's password
                         properties:
                           propagationMethod:
-                            description:
-                              propagationMethod represents how the user passwords
+                            description: propagationMethod represents how the user passwords
                               are injected into the vm guest.
                             properties:
                               qemuGuestAgent:
-                                description:
-                                  QemuGuestAgentAccessCredentailPropagation
+                                description: QemuGuestAgentAccessCredentailPropagation
                                   means passwords are dynamically injected into the
                                   vm at runtime via the qemu guest agent. This feature
                                   requires the qemu guest agent to be running within
@@ -162,18 +150,15 @@ spec:
                                 type: object
                             type: object
                           source:
-                            description:
-                              Source represents where the user passwords
+                            description: Source represents where the user passwords
                               are pulled from
                             properties:
                               secret:
-                                description:
-                                  Secret means that the access credential
+                                description: Secret means that the access credential
                                   is pulled from a kubernetes secret
                                 properties:
                                   secretName:
-                                    description:
-                                      SecretName represents the name of the
+                                    description: SecretName represents the name of the
                                       secret in the VMI's namespace
                                     type: string
                                 required:
@@ -191,13 +176,11 @@ spec:
                   description: If affinity is specifies, obey all the affinity rules
                   properties:
                     nodeAffinity:
-                      description:
-                        Describes node affinity scheduling rules for the
+                      description: Describes node affinity scheduling rules for the
                         pod.
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description:
-                            The scheduler will prefer to schedule pods to
+                          description: The scheduler will prefer to schedule pods to
                             nodes that satisfy the affinity expressions specified by
                             this field, but it may choose a node that violates one or
                             more of the expressions. The node that is most preferred
@@ -209,42 +192,35 @@ spec:
                             the corresponding matchExpressions; the node(s) with the
                             highest sum are the most preferred.
                           items:
-                            description:
-                              An empty preferred scheduling term matches
+                            description: An empty preferred scheduling term matches
                               all objects with implicit weight 0 (i.e. it's a no-op).
                               A null preferred scheduling term matches no objects (i.e.
                               is also a no-op).
                             properties:
                               preference:
-                                description:
-                                  A node selector term, associated with the
+                                description: A node selector term, associated with the
                                   corresponding weight.
                                 properties:
                                   matchExpressions:
-                                    description:
-                                      A list of node selector requirements
+                                    description: A list of node selector requirements
                                       by node's labels.
                                     items:
-                                      description:
-                                        A node selector requirement is a
+                                      description: A node selector requirement is a
                                         selector that contains values, a key, and an
                                         operator that relates the key and values.
                                       properties:
                                         key:
-                                          description:
-                                            The label key that the selector
+                                          description: The label key that the selector
                                             applies to.
                                           type: string
                                         operator:
-                                          description:
-                                            Represents a key's relationship
+                                          description: Represents a key's relationship
                                             to a set of values. Valid operators are
                                             In, NotIn, Exists, DoesNotExist. Gt, and
                                             Lt.
                                           type: string
                                         values:
-                                          description:
-                                            An array of string values. If
+                                          description: An array of string values. If
                                             the operator is In or NotIn, the values
                                             array must be non-empty. If the operator
                                             is Exists or DoesNotExist, the values array
@@ -262,30 +238,25 @@ spec:
                                       type: object
                                     type: array
                                   matchFields:
-                                    description:
-                                      A list of node selector requirements
+                                    description: A list of node selector requirements
                                       by node's fields.
                                     items:
-                                      description:
-                                        A node selector requirement is a
+                                      description: A node selector requirement is a
                                         selector that contains values, a key, and an
                                         operator that relates the key and values.
                                       properties:
                                         key:
-                                          description:
-                                            The label key that the selector
+                                          description: The label key that the selector
                                             applies to.
                                           type: string
                                         operator:
-                                          description:
-                                            Represents a key's relationship
+                                          description: Represents a key's relationship
                                             to a set of values. Valid operators are
                                             In, NotIn, Exists, DoesNotExist. Gt, and
                                             Lt.
                                           type: string
                                         values:
-                                          description:
-                                            An array of string values. If
+                                          description: An array of string values. If
                                             the operator is In or NotIn, the values
                                             array must be non-empty. If the operator
                                             is Exists or DoesNotExist, the values array
@@ -304,8 +275,7 @@ spec:
                                     type: array
                                 type: object
                               weight:
-                                description:
-                                  Weight associated with matching the corresponding
+                                description: Weight associated with matching the corresponding
                                   nodeSelectorTerm, in the range 1-100.
                                 format: int32
                                 type: integer
@@ -315,8 +285,7 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description:
-                            If the affinity requirements specified by this
+                          description: If the affinity requirements specified by this
                             field are not met at scheduling time, the pod will not be
                             scheduled onto the node. If the affinity requirements specified
                             by this field cease to be met at some point during pod execution
@@ -324,41 +293,34 @@ spec:
                             eventually evict the pod from its node.
                           properties:
                             nodeSelectorTerms:
-                              description:
-                                Required. A list of node selector terms.
+                              description: Required. A list of node selector terms.
                                 The terms are ORed.
                               items:
-                                description:
-                                  A null or empty node selector term matches
+                                description: A null or empty node selector term matches
                                   no objects. The requirements of them are ANDed. The
                                   TopologySelectorTerm type implements a subset of the
                                   NodeSelectorTerm.
                                 properties:
                                   matchExpressions:
-                                    description:
-                                      A list of node selector requirements
+                                    description: A list of node selector requirements
                                       by node's labels.
                                     items:
-                                      description:
-                                        A node selector requirement is a
+                                      description: A node selector requirement is a
                                         selector that contains values, a key, and an
                                         operator that relates the key and values.
                                       properties:
                                         key:
-                                          description:
-                                            The label key that the selector
+                                          description: The label key that the selector
                                             applies to.
                                           type: string
                                         operator:
-                                          description:
-                                            Represents a key's relationship
+                                          description: Represents a key's relationship
                                             to a set of values. Valid operators are
                                             In, NotIn, Exists, DoesNotExist. Gt, and
                                             Lt.
                                           type: string
                                         values:
-                                          description:
-                                            An array of string values. If
+                                          description: An array of string values. If
                                             the operator is In or NotIn, the values
                                             array must be non-empty. If the operator
                                             is Exists or DoesNotExist, the values array
@@ -376,30 +338,25 @@ spec:
                                       type: object
                                     type: array
                                   matchFields:
-                                    description:
-                                      A list of node selector requirements
+                                    description: A list of node selector requirements
                                       by node's fields.
                                     items:
-                                      description:
-                                        A node selector requirement is a
+                                      description: A node selector requirement is a
                                         selector that contains values, a key, and an
                                         operator that relates the key and values.
                                       properties:
                                         key:
-                                          description:
-                                            The label key that the selector
+                                          description: The label key that the selector
                                             applies to.
                                           type: string
                                         operator:
-                                          description:
-                                            Represents a key's relationship
+                                          description: Represents a key's relationship
                                             to a set of values. Valid operators are
                                             In, NotIn, Exists, DoesNotExist. Gt, and
                                             Lt.
                                           type: string
                                         values:
-                                          description:
-                                            An array of string values. If
+                                          description: An array of string values. If
                                             the operator is In or NotIn, the values
                                             array must be non-empty. If the operator
                                             is Exists or DoesNotExist, the values array
@@ -423,13 +380,11 @@ spec:
                           type: object
                       type: object
                     podAffinity:
-                      description:
-                        Describes pod affinity scheduling rules (e.g. co-locate
+                      description: Describes pod affinity scheduling rules (e.g. co-locate
                         this pod in the same node, zone, etc. as some other pod(s)).
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description:
-                            The scheduler will prefer to schedule pods to
+                          description: The scheduler will prefer to schedule pods to
                             nodes that satisfy the affinity expressions specified by
                             this field, but it may choose a node that violates one or
                             more of the expressions. The node that is most preferred
@@ -441,47 +396,39 @@ spec:
                             pods which matches the corresponding podAffinityTerm; the
                             node(s) with the highest sum are the most preferred.
                           items:
-                            description:
-                              The weights of all of the matched WeightedPodAffinityTerm
+                            description: The weights of all of the matched WeightedPodAffinityTerm
                               fields are added per-node to find the most preferred node(s)
                             properties:
                               podAffinityTerm:
-                                description:
-                                  Required. A pod affinity term, associated
+                                description: Required. A pod affinity term, associated
                                   with the corresponding weight.
                                 properties:
                                   labelSelector:
-                                    description:
-                                      A label query over a set of resources,
+                                    description: A label query over a set of resources,
                                       in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description:
-                                          matchExpressions is a list of label
+                                        description: matchExpressions is a list of label
                                           selector requirements. The requirements are
                                           ANDed.
                                         items:
-                                          description:
-                                            A label selector requirement
+                                          description: A label selector requirement
                                             is a selector that contains values, a key,
                                             and an operator that relates the key and
                                             values.
                                           properties:
                                             key:
-                                              description:
-                                                key is the label key that
+                                              description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description:
-                                                operator represents a key's
+                                              description: operator represents a key's
                                                 relationship to a set of values. Valid
                                                 operators are In, NotIn, Exists and
                                                 DoesNotExist.
                                               type: string
                                             values:
-                                              description:
-                                                values is an array of string
+                                              description: values is an array of string
                                                 values. If the operator is In or NotIn,
                                                 the values array must be non-empty.
                                                 If the operator is Exists or DoesNotExist,
@@ -499,8 +446,7 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description:
-                                          matchLabels is a map of {key,value}
+                                        description: matchLabels is a map of {key,value}
                                           pairs. A single {key,value} in the matchLabels
                                           map is equivalent to an element of matchExpressions,
                                           whose key field is "key", the operator is
@@ -509,8 +455,7 @@ spec:
                                         type: object
                                     type: object
                                   namespaceSelector:
-                                    description:
-                                      A label query over the set of namespaces
+                                    description: A label query over the set of namespaces
                                       that the term applies to. The term is applied
                                       to the union of the namespaces selected by this
                                       field and the ones listed in the namespaces field.
@@ -519,32 +464,27 @@ spec:
                                       ({}) matches all namespaces.
                                     properties:
                                       matchExpressions:
-                                        description:
-                                          matchExpressions is a list of label
+                                        description: matchExpressions is a list of label
                                           selector requirements. The requirements are
                                           ANDed.
                                         items:
-                                          description:
-                                            A label selector requirement
+                                          description: A label selector requirement
                                             is a selector that contains values, a key,
                                             and an operator that relates the key and
                                             values.
                                           properties:
                                             key:
-                                              description:
-                                                key is the label key that
+                                              description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description:
-                                                operator represents a key's
+                                              description: operator represents a key's
                                                 relationship to a set of values. Valid
                                                 operators are In, NotIn, Exists and
                                                 DoesNotExist.
                                               type: string
                                             values:
-                                              description:
-                                                values is an array of string
+                                              description: values is an array of string
                                                 values. If the operator is In or NotIn,
                                                 the values array must be non-empty.
                                                 If the operator is Exists or DoesNotExist,
@@ -562,8 +502,7 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description:
-                                          matchLabels is a map of {key,value}
+                                        description: matchLabels is a map of {key,value}
                                           pairs. A single {key,value} in the matchLabels
                                           map is equivalent to an element of matchExpressions,
                                           whose key field is "key", the operator is
@@ -572,8 +511,7 @@ spec:
                                         type: object
                                     type: object
                                   namespaces:
-                                    description:
-                                      namespaces specifies a static list
+                                    description: namespaces specifies a static list
                                       of namespace names that the term applies to. The
                                       term is applied to the union of the namespaces
                                       listed in this field and the ones selected by
@@ -583,8 +521,7 @@ spec:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description:
-                                      This pod should be co-located (affinity)
+                                    description: This pod should be co-located (affinity)
                                       or not co-located (anti-affinity) with the pods
                                       matching the labelSelector in the specified namespaces,
                                       where co-located is defined as running on a node
@@ -596,8 +533,7 @@ spec:
                                   - topologyKey
                                 type: object
                               weight:
-                                description:
-                                  weight associated with matching the corresponding
+                                description: weight associated with matching the corresponding
                                   podAffinityTerm, in the range 1-100.
                                 format: int32
                                 type: integer
@@ -607,8 +543,7 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description:
-                            If the affinity requirements specified by this
+                          description: If the affinity requirements specified by this
                             field are not met at scheduling time, the pod will not be
                             scheduled onto the node. If the affinity requirements specified
                             by this field cease to be met at some point during pod execution
@@ -618,8 +553,7 @@ spec:
                             to each podAffinityTerm are intersected, i.e. all terms
                             must be satisfied.
                           items:
-                            description:
-                              Defines a set of pods (namely those matching
+                            description: Defines a set of pods (namely those matching
                               the labelSelector relative to the given namespace(s))
                               that this pod should be co-located (affinity) or not co-located
                               (anti-affinity) with, where co-located is defined as running
@@ -628,34 +562,28 @@ spec:
                               pods is running
                             properties:
                               labelSelector:
-                                description:
-                                  A label query over a set of resources,
+                                description: A label query over a set of resources,
                                   in this case pods.
                                 properties:
                                   matchExpressions:
-                                    description:
-                                      matchExpressions is a list of label
+                                    description: matchExpressions is a list of label
                                       selector requirements. The requirements are ANDed.
                                     items:
-                                      description:
-                                        A label selector requirement is a
+                                      description: A label selector requirement is a
                                         selector that contains values, a key, and an
                                         operator that relates the key and values.
                                       properties:
                                         key:
-                                          description:
-                                            key is the label key that the
+                                          description: key is the label key that the
                                             selector applies to.
                                           type: string
                                         operator:
-                                          description:
-                                            operator represents a key's relationship
+                                          description: operator represents a key's relationship
                                             to a set of values. Valid operators are
                                             In, NotIn, Exists and DoesNotExist.
                                           type: string
                                         values:
-                                          description:
-                                            values is an array of string
+                                          description: values is an array of string
                                             values. If the operator is In or NotIn,
                                             the values array must be non-empty. If the
                                             operator is Exists or DoesNotExist, the
@@ -672,8 +600,7 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description:
-                                      matchLabels is a map of {key,value}
+                                    description: matchLabels is a map of {key,value}
                                       pairs. A single {key,value} in the matchLabels
                                       map is equivalent to an element of matchExpressions,
                                       whose key field is "key", the operator is "In",
@@ -682,8 +609,7 @@ spec:
                                     type: object
                                 type: object
                               namespaceSelector:
-                                description:
-                                  A label query over the set of namespaces
+                                description: A label query over the set of namespaces
                                   that the term applies to. The term is applied to the
                                   union of the namespaces selected by this field and
                                   the ones listed in the namespaces field. null selector
@@ -691,29 +617,24 @@ spec:
                                   namespace". An empty selector ({}) matches all namespaces.
                                 properties:
                                   matchExpressions:
-                                    description:
-                                      matchExpressions is a list of label
+                                    description: matchExpressions is a list of label
                                       selector requirements. The requirements are ANDed.
                                     items:
-                                      description:
-                                        A label selector requirement is a
+                                      description: A label selector requirement is a
                                         selector that contains values, a key, and an
                                         operator that relates the key and values.
                                       properties:
                                         key:
-                                          description:
-                                            key is the label key that the
+                                          description: key is the label key that the
                                             selector applies to.
                                           type: string
                                         operator:
-                                          description:
-                                            operator represents a key's relationship
+                                          description: operator represents a key's relationship
                                             to a set of values. Valid operators are
                                             In, NotIn, Exists and DoesNotExist.
                                           type: string
                                         values:
-                                          description:
-                                            values is an array of string
+                                          description: values is an array of string
                                             values. If the operator is In or NotIn,
                                             the values array must be non-empty. If the
                                             operator is Exists or DoesNotExist, the
@@ -730,8 +651,7 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description:
-                                      matchLabels is a map of {key,value}
+                                    description: matchLabels is a map of {key,value}
                                       pairs. A single {key,value} in the matchLabels
                                       map is equivalent to an element of matchExpressions,
                                       whose key field is "key", the operator is "In",
@@ -740,8 +660,7 @@ spec:
                                     type: object
                                 type: object
                               namespaces:
-                                description:
-                                  namespaces specifies a static list of namespace
+                                description: namespaces specifies a static list of namespace
                                   names that the term applies to. The term is applied
                                   to the union of the namespaces listed in this field
                                   and the ones selected by namespaceSelector. null or
@@ -751,8 +670,7 @@ spec:
                                   type: string
                                 type: array
                               topologyKey:
-                                description:
-                                  This pod should be co-located (affinity)
+                                description: This pod should be co-located (affinity)
                                   or not co-located (anti-affinity) with the pods matching
                                   the labelSelector in the specified namespaces, where
                                   co-located is defined as running on a node whose value
@@ -766,14 +684,12 @@ spec:
                           type: array
                       type: object
                     podAntiAffinity:
-                      description:
-                        Describes pod anti-affinity scheduling rules (e.g.
+                      description: Describes pod anti-affinity scheduling rules (e.g.
                         avoid putting this pod in the same node, zone, etc. as some
                         other pod(s)).
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description:
-                            The scheduler will prefer to schedule pods to
+                          description: The scheduler will prefer to schedule pods to
                             nodes that satisfy the anti-affinity expressions specified
                             by this field, but it may choose a node that violates one
                             or more of the expressions. The node that is most preferred
@@ -785,47 +701,39 @@ spec:
                             pods which matches the corresponding podAffinityTerm; the
                             node(s) with the highest sum are the most preferred.
                           items:
-                            description:
-                              The weights of all of the matched WeightedPodAffinityTerm
+                            description: The weights of all of the matched WeightedPodAffinityTerm
                               fields are added per-node to find the most preferred node(s)
                             properties:
                               podAffinityTerm:
-                                description:
-                                  Required. A pod affinity term, associated
+                                description: Required. A pod affinity term, associated
                                   with the corresponding weight.
                                 properties:
                                   labelSelector:
-                                    description:
-                                      A label query over a set of resources,
+                                    description: A label query over a set of resources,
                                       in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description:
-                                          matchExpressions is a list of label
+                                        description: matchExpressions is a list of label
                                           selector requirements. The requirements are
                                           ANDed.
                                         items:
-                                          description:
-                                            A label selector requirement
+                                          description: A label selector requirement
                                             is a selector that contains values, a key,
                                             and an operator that relates the key and
                                             values.
                                           properties:
                                             key:
-                                              description:
-                                                key is the label key that
+                                              description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description:
-                                                operator represents a key's
+                                              description: operator represents a key's
                                                 relationship to a set of values. Valid
                                                 operators are In, NotIn, Exists and
                                                 DoesNotExist.
                                               type: string
                                             values:
-                                              description:
-                                                values is an array of string
+                                              description: values is an array of string
                                                 values. If the operator is In or NotIn,
                                                 the values array must be non-empty.
                                                 If the operator is Exists or DoesNotExist,
@@ -843,8 +751,7 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description:
-                                          matchLabels is a map of {key,value}
+                                        description: matchLabels is a map of {key,value}
                                           pairs. A single {key,value} in the matchLabels
                                           map is equivalent to an element of matchExpressions,
                                           whose key field is "key", the operator is
@@ -853,8 +760,7 @@ spec:
                                         type: object
                                     type: object
                                   namespaceSelector:
-                                    description:
-                                      A label query over the set of namespaces
+                                    description: A label query over the set of namespaces
                                       that the term applies to. The term is applied
                                       to the union of the namespaces selected by this
                                       field and the ones listed in the namespaces field.
@@ -863,32 +769,27 @@ spec:
                                       ({}) matches all namespaces.
                                     properties:
                                       matchExpressions:
-                                        description:
-                                          matchExpressions is a list of label
+                                        description: matchExpressions is a list of label
                                           selector requirements. The requirements are
                                           ANDed.
                                         items:
-                                          description:
-                                            A label selector requirement
+                                          description: A label selector requirement
                                             is a selector that contains values, a key,
                                             and an operator that relates the key and
                                             values.
                                           properties:
                                             key:
-                                              description:
-                                                key is the label key that
+                                              description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description:
-                                                operator represents a key's
+                                              description: operator represents a key's
                                                 relationship to a set of values. Valid
                                                 operators are In, NotIn, Exists and
                                                 DoesNotExist.
                                               type: string
                                             values:
-                                              description:
-                                                values is an array of string
+                                              description: values is an array of string
                                                 values. If the operator is In or NotIn,
                                                 the values array must be non-empty.
                                                 If the operator is Exists or DoesNotExist,
@@ -906,8 +807,7 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description:
-                                          matchLabels is a map of {key,value}
+                                        description: matchLabels is a map of {key,value}
                                           pairs. A single {key,value} in the matchLabels
                                           map is equivalent to an element of matchExpressions,
                                           whose key field is "key", the operator is
@@ -916,8 +816,7 @@ spec:
                                         type: object
                                     type: object
                                   namespaces:
-                                    description:
-                                      namespaces specifies a static list
+                                    description: namespaces specifies a static list
                                       of namespace names that the term applies to. The
                                       term is applied to the union of the namespaces
                                       listed in this field and the ones selected by
@@ -927,8 +826,7 @@ spec:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description:
-                                      This pod should be co-located (affinity)
+                                    description: This pod should be co-located (affinity)
                                       or not co-located (anti-affinity) with the pods
                                       matching the labelSelector in the specified namespaces,
                                       where co-located is defined as running on a node
@@ -940,8 +838,7 @@ spec:
                                   - topologyKey
                                 type: object
                               weight:
-                                description:
-                                  weight associated with matching the corresponding
+                                description: weight associated with matching the corresponding
                                   podAffinityTerm, in the range 1-100.
                                 format: int32
                                 type: integer
@@ -951,8 +848,7 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description:
-                            If the anti-affinity requirements specified by
+                          description: If the anti-affinity requirements specified by
                             this field are not met at scheduling time, the pod will
                             not be scheduled onto the node. If the anti-affinity requirements
                             specified by this field cease to be met at some point during
@@ -962,8 +858,7 @@ spec:
                             corresponding to each podAffinityTerm are intersected, i.e.
                             all terms must be satisfied.
                           items:
-                            description:
-                              Defines a set of pods (namely those matching
+                            description: Defines a set of pods (namely those matching
                               the labelSelector relative to the given namespace(s))
                               that this pod should be co-located (affinity) or not co-located
                               (anti-affinity) with, where co-located is defined as running
@@ -972,34 +867,28 @@ spec:
                               pods is running
                             properties:
                               labelSelector:
-                                description:
-                                  A label query over a set of resources,
+                                description: A label query over a set of resources,
                                   in this case pods.
                                 properties:
                                   matchExpressions:
-                                    description:
-                                      matchExpressions is a list of label
+                                    description: matchExpressions is a list of label
                                       selector requirements. The requirements are ANDed.
                                     items:
-                                      description:
-                                        A label selector requirement is a
+                                      description: A label selector requirement is a
                                         selector that contains values, a key, and an
                                         operator that relates the key and values.
                                       properties:
                                         key:
-                                          description:
-                                            key is the label key that the
+                                          description: key is the label key that the
                                             selector applies to.
                                           type: string
                                         operator:
-                                          description:
-                                            operator represents a key's relationship
+                                          description: operator represents a key's relationship
                                             to a set of values. Valid operators are
                                             In, NotIn, Exists and DoesNotExist.
                                           type: string
                                         values:
-                                          description:
-                                            values is an array of string
+                                          description: values is an array of string
                                             values. If the operator is In or NotIn,
                                             the values array must be non-empty. If the
                                             operator is Exists or DoesNotExist, the
@@ -1016,8 +905,7 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description:
-                                      matchLabels is a map of {key,value}
+                                    description: matchLabels is a map of {key,value}
                                       pairs. A single {key,value} in the matchLabels
                                       map is equivalent to an element of matchExpressions,
                                       whose key field is "key", the operator is "In",
@@ -1026,8 +914,7 @@ spec:
                                     type: object
                                 type: object
                               namespaceSelector:
-                                description:
-                                  A label query over the set of namespaces
+                                description: A label query over the set of namespaces
                                   that the term applies to. The term is applied to the
                                   union of the namespaces selected by this field and
                                   the ones listed in the namespaces field. null selector
@@ -1035,29 +922,24 @@ spec:
                                   namespace". An empty selector ({}) matches all namespaces.
                                 properties:
                                   matchExpressions:
-                                    description:
-                                      matchExpressions is a list of label
+                                    description: matchExpressions is a list of label
                                       selector requirements. The requirements are ANDed.
                                     items:
-                                      description:
-                                        A label selector requirement is a
+                                      description: A label selector requirement is a
                                         selector that contains values, a key, and an
                                         operator that relates the key and values.
                                       properties:
                                         key:
-                                          description:
-                                            key is the label key that the
+                                          description: key is the label key that the
                                             selector applies to.
                                           type: string
                                         operator:
-                                          description:
-                                            operator represents a key's relationship
+                                          description: operator represents a key's relationship
                                             to a set of values. Valid operators are
                                             In, NotIn, Exists and DoesNotExist.
                                           type: string
                                         values:
-                                          description:
-                                            values is an array of string
+                                          description: values is an array of string
                                             values. If the operator is In or NotIn,
                                             the values array must be non-empty. If the
                                             operator is Exists or DoesNotExist, the
@@ -1074,8 +956,7 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description:
-                                      matchLabels is a map of {key,value}
+                                    description: matchLabels is a map of {key,value}
                                       pairs. A single {key,value} in the matchLabels
                                       map is equivalent to an element of matchExpressions,
                                       whose key field is "key", the operator is "In",
@@ -1084,8 +965,7 @@ spec:
                                     type: object
                                 type: object
                               namespaces:
-                                description:
-                                  namespaces specifies a static list of namespace
+                                description: namespaces specifies a static list of namespace
                                   names that the term applies to. The term is applied
                                   to the union of the namespaces listed in this field
                                   and the ones selected by namespaceSelector. null or
@@ -1095,8 +975,7 @@ spec:
                                   type: string
                                 type: array
                               topologyKey:
-                                description:
-                                  This pod should be co-located (affinity)
+                                description: This pod should be co-located (affinity)
                                   or not co-located (anti-affinity) with the pods matching
                                   the labelSelector in the specified namespaces, where
                                   co-located is defined as running on a node whose value
@@ -1111,33 +990,28 @@ spec:
                       type: object
                   type: object
                 architecture:
-                  description:
-                    Specifies the architecture of the vm guest you are attempting
+                  description: Specifies the architecture of the vm guest you are attempting
                     to run. Defaults to the compiled architecture of the KubeVirt components
                   type: string
                 dnsConfig:
-                  description:
-                    Specifies the DNS parameters of a pod. Parameters specified
+                  description: Specifies the DNS parameters of a pod. Parameters specified
                     here will be merged to the generated DNS configuration based on
                     DNSPolicy.
                   properties:
                     nameservers:
-                      description:
-                        A list of DNS name server IP addresses. This will
+                      description: A list of DNS name server IP addresses. This will
                         be appended to the base nameservers generated from DNSPolicy.
                         Duplicated nameservers will be removed.
                       items:
                         type: string
                       type: array
                     options:
-                      description:
-                        A list of DNS resolver options. This will be merged
+                      description: A list of DNS resolver options. This will be merged
                         with the base options generated from DNSPolicy. Duplicated entries
                         will be removed. Resolution options given in Options will override
                         those that appear in the base DNSPolicy.
                       items:
-                        description:
-                          PodDNSConfigOption defines DNS resolver options
+                        description: PodDNSConfigOption defines DNS resolver options
                           of a pod.
                         properties:
                           name:
@@ -1148,8 +1022,7 @@ spec:
                         type: object
                       type: array
                     searches:
-                      description:
-                        A list of DNS search domains for host-name lookup.
+                      description: A list of DNS search domains for host-name lookup.
                         This will be appended to the base search paths generated from
                         DNSPolicy. Duplicated search paths will be removed.
                       items:
@@ -1157,21 +1030,18 @@ spec:
                       type: array
                   type: object
                 dnsPolicy:
-                  description:
-                    Set DNS policy for the pod. Defaults to "ClusterFirst".
+                  description: Set DNS policy for the pod. Defaults to "ClusterFirst".
                     Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default'
                     or 'None'. DNS parameters given in DNSConfig will be merged with
                     the policy selected with DNSPolicy. To have DNS options set along
                     with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
                   type: string
                 domain:
-                  description:
-                    Specification of the desired behavior of the VirtualMachineInstance
+                  description: Specification of the desired behavior of the VirtualMachineInstance
                     on the host.
                   properties:
                     chassis:
-                      description:
-                        Chassis specifies the chassis info passed to the
+                      description: Chassis specifies the chassis info passed to the
                         domain.
                       properties:
                         asset:
@@ -1189,86 +1059,72 @@ spec:
                       description: Clock sets the clock and timers of the vmi.
                       properties:
                         timer:
-                          description:
-                            Timer specifies whih timers are attached to the
+                          description: Timer specifies whih timers are attached to the
                             vmi.
                           properties:
                             hpet:
-                              description:
-                                HPET (High Precision Event Timer) - multiple
+                              description: HPET (High Precision Event Timer) - multiple
                                 timers with periodic interrupts.
                               properties:
                                 present:
-                                  description:
-                                    Enabled set to false makes sure that
+                                  description: Enabled set to false makes sure that
                                     the machine type or a preset can't add the timer.
                                     Defaults to true.
                                   type: boolean
                                 tickPolicy:
-                                  description:
-                                    TickPolicy determines what happens when
+                                  description: TickPolicy determines what happens when
                                     QEMU misses a deadline for injecting a tick to the
                                     guest. One of "delay", "catchup", "merge", "discard".
                                   type: string
                               type: object
                             hyperv:
-                              description:
-                                Hyperv (Hypervclock) - lets guests read the
+                              description: Hyperv (Hypervclock) - lets guests read the
                                 host’s wall clock time (paravirtualized). For windows
                                 guests.
                               properties:
                                 present:
-                                  description:
-                                    Enabled set to false makes sure that
+                                  description: Enabled set to false makes sure that
                                     the machine type or a preset can't add the timer.
                                     Defaults to true.
                                   type: boolean
                               type: object
                             kvm:
-                              description:
-                                "KVM \t(KVM clock) - lets guests read the
-                                host’s wall clock time (paravirtualized). For linux
-                                guests."
+                              description: "KVM \t(KVM clock) - lets guests read the
+                              host’s wall clock time (paravirtualized). For linux
+                              guests."
                               properties:
                                 present:
-                                  description:
-                                    Enabled set to false makes sure that
+                                  description: Enabled set to false makes sure that
                                     the machine type or a preset can't add the timer.
                                     Defaults to true.
                                   type: boolean
                               type: object
                             pit:
-                              description:
-                                PIT (Programmable Interval Timer) - a timer
+                              description: PIT (Programmable Interval Timer) - a timer
                                 with periodic interrupts.
                               properties:
                                 present:
-                                  description:
-                                    Enabled set to false makes sure that
+                                  description: Enabled set to false makes sure that
                                     the machine type or a preset can't add the timer.
                                     Defaults to true.
                                   type: boolean
                                 tickPolicy:
-                                  description:
-                                    TickPolicy determines what happens when
+                                  description: TickPolicy determines what happens when
                                     QEMU misses a deadline for injecting a tick to the
                                     guest. One of "delay", "catchup", "discard".
                                   type: string
                               type: object
                             rtc:
-                              description:
-                                RTC (Real Time Clock) - a continuously running
+                              description: RTC (Real Time Clock) - a continuously running
                                 timer with periodic interrupts.
                               properties:
                                 present:
-                                  description:
-                                    Enabled set to false makes sure that
+                                  description: Enabled set to false makes sure that
                                     the machine type or a preset can't add the timer.
                                     Defaults to true.
                                   type: boolean
                                 tickPolicy:
-                                  description:
-                                    TickPolicy determines what happens when
+                                  description: TickPolicy determines what happens when
                                     QEMU misses a deadline for injecting a tick to the
                                     guest. One of "delay", "catchup".
                                   type: string
@@ -1278,45 +1134,38 @@ spec:
                               type: object
                           type: object
                         timezone:
-                          description:
-                            Timezone sets the guest clock to the specified
+                          description: Timezone sets the guest clock to the specified
                             timezone. Zone name follows the TZ environment variable
                             format (e.g. 'America/New_York').
                           type: string
                         utc:
-                          description:
-                            UTC sets the guest clock to UTC on each boot.
+                          description: UTC sets the guest clock to UTC on each boot.
                             If an offset is specified, guest changes to the clock will
                             be kept during reboots and are not reset.
                           properties:
                             offsetSeconds:
-                              description:
-                                OffsetSeconds specifies an offset in seconds,
+                              description: OffsetSeconds specifies an offset in seconds,
                                 relative to UTC. If set, guest changes to the clock
                                 will be kept during reboots and not reset.
                               type: integer
                           type: object
                       type: object
                     cpu:
-                      description:
-                        CPU allow specified the detailed CPU topology inside
+                      description: CPU allow specified the detailed CPU topology inside
                         the vmi.
                       properties:
                         cores:
-                          description:
-                            Cores specifies the number of cores inside the
+                          description: Cores specifies the number of cores inside the
                             vmi. Must be a value greater or equal 1.
                           format: int32
                           type: integer
                         dedicatedCpuPlacement:
-                          description:
-                            DedicatedCPUPlacement requests the scheduler
+                          description: DedicatedCPUPlacement requests the scheduler
                             to place the VirtualMachineInstance on a node with enough
                             dedicated pCPUs and pin the vCPUs to it.
                           type: boolean
                         features:
-                          description:
-                            Features specifies the CPU features list inside
+                          description: Features specifies the CPU features list inside
                             the VMI.
                           items:
                             description: CPUFeature allows specifying a CPU feature.
@@ -1325,51 +1174,45 @@ spec:
                                 description: Name of the CPU feature
                                 type: string
                               policy:
-                                description:
-                                  "Policy is the CPU feature attribute which
-                                  can have the following attributes: force    - The
-                                  virtual CPU will claim the feature is supported regardless
-                                  of it being supported by host CPU. require  - Guest
-                                  creation will fail unless the feature is supported
-                                  by the host CPU or the hypervisor is able to emulate
-                                  it. optional - The feature will be supported by virtual
-                                  CPU if and only if it is supported by host CPU. disable  -
-                                  The feature will not be supported by virtual CPU.
-                                  forbid   - Guest creation will fail if the feature
-                                  is supported by host CPU. Defaults to require"
+                                description: 'Policy is the CPU feature attribute which
+                                can have the following attributes: force    - The
+                                virtual CPU will claim the feature is supported regardless
+                                of it being supported by host CPU. require  - Guest
+                                creation will fail unless the feature is supported
+                                by the host CPU or the hypervisor is able to emulate
+                                it. optional - The feature will be supported by virtual
+                                CPU if and only if it is supported by host CPU. disable  -
+                                The feature will not be supported by virtual CPU.
+                                forbid   - Guest creation will fail if the feature
+                                is supported by host CPU. Defaults to require'
                                 type: string
                             required:
                               - name
                             type: object
                           type: array
                         isolateEmulatorThread:
-                          description:
-                            IsolateEmulatorThread requests one more dedicated
+                          description: IsolateEmulatorThread requests one more dedicated
                             pCPU to be allocated for the VMI to place the emulator thread
                             on it.
                           type: boolean
                         maxSockets:
-                          description:
-                            MaxSockets specifies the maximum amount of sockets
+                          description: MaxSockets specifies the maximum amount of sockets
                             that can be hotplugged
                           format: int32
                           type: integer
                         model:
-                          description:
-                            Model specifies the CPU model inside the VMI.
+                          description: Model specifies the CPU model inside the VMI.
                             List of available models https://github.com/libvirt/libvirt/tree/master/src/cpu_map.
                             It is possible to specify special cases like "host-passthrough"
                             to get the same CPU as the node and "host-model" to get
                             CPU closest to the node one. Defaults to host-model.
                           type: string
                         numa:
-                          description:
-                            NUMA allows specifying settings for the guest
+                          description: NUMA allows specifying settings for the guest
                             NUMA topology
                           properties:
                             guestMappingPassthrough:
-                              description:
-                                GuestMappingPassthrough will create an efficient
+                              description: GuestMappingPassthrough will create an efficient
                                 guest topology based on host CPUs exclusively assigned
                                 to a pod. The created topology ensures that memory and
                                 CPUs on the virtual numa nodes never cross boundaries
@@ -1377,98 +1220,81 @@ spec:
                               type: object
                           type: object
                         realtime:
-                          description:
-                            Realtime instructs the virt-launcher to tune
+                          description: Realtime instructs the virt-launcher to tune
                             the VMI for lower latency, optional for real time workloads
                           properties:
                             mask:
-                              description:
-                                'Mask defines the vcpu mask expression that
-                                defines which vcpus are used for realtime. Format matches
-                                libvirt''s expressions. Example: "0-3,^1","0,2,3","2-3"'
+                              description: 'Mask defines the vcpu mask expression that
+                              defines which vcpus are used for realtime. Format matches
+                              libvirt''s expressions. Example: "0-3,^1","0,2,3","2-3"'
                               type: string
                           type: object
                         sockets:
-                          description:
-                            Sockets specifies the number of sockets inside
+                          description: Sockets specifies the number of sockets inside
                             the vmi. Must be a value greater or equal 1.
                           format: int32
                           type: integer
                         threads:
-                          description:
-                            Threads specifies the number of threads inside
+                          description: Threads specifies the number of threads inside
                             the vmi. Must be a value greater or equal 1.
                           format: int32
                           type: integer
                       type: object
                     devices:
-                      description:
-                        Devices allows adding disks, network interfaces,
+                      description: Devices allows adding disks, network interfaces,
                         and others
                       properties:
                         autoattachGraphicsDevice:
-                          description:
-                            Whether to attach the default graphics device
+                          description: Whether to attach the default graphics device
                             or not. VNC will not be available if set to false. Defaults
                             to true.
                           type: boolean
                         autoattachInputDevice:
-                          description:
-                            Whether to attach an Input Device. Defaults to
+                          description: Whether to attach an Input Device. Defaults to
                             false.
                           type: boolean
                         autoattachMemBalloon:
-                          description:
-                            Whether to attach the Memory balloon device with
+                          description: Whether to attach the Memory balloon device with
                             default period. Period can be adjusted in virt-config. Defaults
                             to true.
                           type: boolean
                         autoattachPodInterface:
-                          description:
-                            Whether to attach a pod network interface. Defaults
+                          description: Whether to attach a pod network interface. Defaults
                             to true.
                           type: boolean
                         autoattachSerialConsole:
-                          description:
-                            Whether to attach the default serial console
+                          description: Whether to attach the default virtio-serial console
                             or not. Serial console access will not be available if set
                             to false. Defaults to true.
                           type: boolean
                         autoattachVSOCK:
-                          description:
-                            Whether to attach the VSOCK CID to the VM or
+                          description: Whether to attach the VSOCK CID to the VM or
                             not. VSOCK access will be available if set to true. Defaults
                             to false.
                           type: boolean
                         blockMultiQueue:
-                          description:
-                            Whether or not to enable virtio multi-queue for
+                          description: Whether or not to enable virtio multi-queue for
                             block devices. Defaults to false.
                           type: boolean
                         clientPassthrough:
-                          description:
-                            To configure and access client devices such as
+                          description: To configure and access client devices such as
                             redirecting USB
                           type: object
                         disableHotplug:
-                          description:
-                            DisableHotplug disabled the ability to hotplug
+                          description: DisableHotplug disabled the ability to hotplug
                             disks.
                           type: boolean
                         disks:
-                          description:
-                            Disks describes disks, cdroms and luns which
+                          description: Disks describes disks, cdroms and luns which
                             are connected to the vmi.
                           items:
                             properties:
                               blockSize:
-                                description:
-                                  If specified, the virtual disk will be
+                                description: If specified, the virtual disk will be
                                   presented with the given block sizes.
                                 properties:
                                   custom:
-                                    description:
-                                      CustomBlockSize represents the desired
+                                    description: CustomBlockSize represents the desired
                                       logical and physical block size for a VM disk.
                                     properties:
                                       logical:
@@ -1480,21 +1306,18 @@ spec:
                                       - physical
                                     type: object
                                   matchVolume:
-                                    description:
-                                      Represents if a feature is enabled
+                                    description: Represents if a feature is enabled
                                       or disabled.
                                     properties:
                                       enabled:
-                                        description:
-                                          Enabled determines if the feature
+                                        description: Enabled determines if the feature
                                           should be enabled or disabled on the guest.
                                           Defaults to true.
                                         type: boolean
                                     type: object
                                 type: object
                               bootOrder:
-                                description:
-                                  BootOrder is an integer value > 0, used
+                                description: BootOrder is an integer value > 0, used
                                   to determine ordering of boot devices. Lower values
                                   take precedence. Each disk or interface that has a
                                   boot order must have a unique value. Disks without
@@ -1502,31 +1325,27 @@ spec:
                                   exists.
                                 type: integer
                               cache:
-                                description:
-                                  "Cache specifies which kvm disk cache mode
-                                  should be used. Supported values are: CacheNone, CacheWriteThrough."
+                                description: 'Cache specifies which kvm disk cache mode
+                                should be used. Supported values are: CacheNone, CacheWriteThrough.'
                                 type: string
                               cdrom:
                                 description: Attach a volume as a cdrom to the vmi.
                                 properties:
                                   bus:
-                                    description:
-                                      "Bus indicates the type of disk device
-                                      to emulate. supported values: virtio, sata, scsi."
+                                    description: 'Bus indicates the type of disk device
+                                    to emulate. supported values: virtio, sata, scsi.'
                                     type: string
                                   readonly:
                                     description: ReadOnly. Defaults to true.
                                     type: boolean
                                   tray:
-                                    description:
-                                      Tray indicates if the tray of the device
+                                    description: Tray indicates if the tray of the device
                                       is open or closed. Allowed values are "open" and
                                       "closed". Defaults to closed.
                                     type: string
                                 type: object
                               dedicatedIOThread:
-                                description:
-                                  dedicatedIOThread indicates this disk should
+                                description: dedicatedIOThread indicates this disk should
                                   have an exclusive IO Thread. Enabling this implies
                                   useIOThreads = true. Defaults to false.
                                 type: boolean
@@ -1534,40 +1353,39 @@ spec:
                                 description: Attach a volume as a disk to the vmi.
                                 properties:
                                   bus:
-                                    description:
-                                      "Bus indicates the type of disk device
-                                      to emulate. supported values: virtio, sata, scsi,
-                                      usb."
+                                    description: 'Bus indicates the type of disk device
+                                    to emulate. supported values: virtio, sata, scsi,
+                                    usb.'
                                     type: string
                                   pciAddress:
-                                    description:
-                                      "If specified, the virtual disk will
-                                      be placed on the guests pci address with the specified
-                                      PCI address. For example: 0000:81:01.10"
+                                    description: 'If specified, the virtual disk will
+                                    be placed on the guests pci address with the specified
+                                    PCI address. For example: 0000:81:01.10'
                                     type: string
                                   readonly:
                                     description: ReadOnly. Defaults to false.
                                     type: boolean
                                 type: object
+                              errorPolicy:
+                                description: If specified, it can change the default
+                                  error policy (stop) for the disk
+                                type: string
                               io:
-                                description:
-                                  "IO specifies which QEMU disk IO mode should
-                                  be used. Supported values are: native, default, threads."
+                                description: 'IO specifies which QEMU disk IO mode should
+                                be used. Supported values are: native, default, threads.'
                                 type: string
                               lun:
                                 description: Attach a volume as a LUN to the vmi.
                                 properties:
                                   bus:
-                                    description:
-                                      "Bus indicates the type of disk device
-                                      to emulate. supported values: virtio, sata, scsi."
+                                    description: 'Bus indicates the type of disk device
+                                    to emulate. supported values: virtio, sata, scsi.'
                                     type: string
                                   readonly:
                                     description: ReadOnly. Defaults to false.
                                     type: boolean
                                   reservation:
-                                    description:
-                                      Reservation indicates if the disk needs
+                                    description: Reservation indicates if the disk needs
                                       to support the persistent reservation for the
                                       SCSI disk
                                     type: boolean
@@ -1576,27 +1394,27 @@ spec:
                                 description: Name is the device name
                                 type: string
                               serial:
-                                description:
-                                  Serial provides the ability to specify
+                                description: Serial provides the ability to specify
                                   a serial number for the disk device.
                                 type: string
                               shareable:
-                                description:
-                                  If specified the disk is made sharable
+                                description: If specified the disk is made sharable
                                   and multiple write from different VMs are permitted
                                 type: boolean
                               tag:
-                                description:
-                                  If specified, disk address and its tag
+                                description: If specified, disk address and its tag
                                   will be provided to the guest via config drive metadata
                                 type: string
                             required:
                               - name
                             type: object
                           type: array
+                        downwardMetrics:
+                          description: DownwardMetrics creates a virtio serials for
+                            exposing the downward metrics to the vmi.
+                          type: object
                         filesystems:
-                          description:
-                            Filesystems describes filesystem which is connected
+                          description: Filesystems describes filesystem which is connected
                             to the vmi.
                           items:
                             properties:
@@ -1619,13 +1437,11 @@ spec:
                               deviceName:
                                 type: string
                               name:
-                                description:
-                                  Name of the GPU device as exposed by a
+                                description: Name of the GPU device as exposed by a
                                   device plugin
                                 type: string
                               tag:
-                                description:
-                                  If specified, the virtual network interface
+                                description: If specified, the virtual network interface
                                   address and its tag will be provided to the guest
                                   via config drive
                                 type: string
@@ -1634,20 +1450,17 @@ spec:
                                   display:
                                     properties:
                                       enabled:
-                                        description:
-                                          Enabled determines if a display
+                                        description: Enabled determines if a display
                                           addapter backed by a vGPU should be enabled
                                           or disabled on the guest. Defaults to true.
                                         type: boolean
                                       ramFB:
-                                        description:
-                                          Enables a boot framebuffer, until
+                                        description: Enables a boot framebuffer, until
                                           the guest OS loads a real GPU driver Defaults
                                           to true.
                                         properties:
                                           enabled:
-                                            description:
-                                              Enabled determines if the feature
+                                            description: Enabled determines if the feature
                                               should be enabled or disabled on the guest.
                                               Defaults to true.
                                             type: boolean
@@ -1665,15 +1478,13 @@ spec:
                           items:
                             properties:
                               deviceName:
-                                description:
-                                  DeviceName is the resource name of the
+                                description: DeviceName is the resource name of the
                                   host device exposed by a device plugin
                                 type: string
                               name:
                                 type: string
                               tag:
-                                description:
-                                  If specified, the virtual network interface
+                                description: If specified, the virtual network interface
                                   address and its tag will be provided to the guest
                                   via config drive
                                 type: string
@@ -1688,17 +1499,15 @@ spec:
                           items:
                             properties:
                               bus:
-                                description:
-                                  "Bus indicates the bus of input device
-                                  to emulate. Supported values: virtio, usb."
+                                description: 'Bus indicates the bus of input device
+                                to emulate. Supported values: virtio, usb.'
                                 type: string
                               name:
                                 description: Name is the device name
                                 type: string
                               type:
-                                description:
-                                  "Type indicated the type of input device.
-                                  Supported values: tablet."
+                                description: 'Type indicated the type of input device.
+                                Supported values: tablet.'
                                 type: string
                             required:
                               - name
@@ -1706,66 +1515,68 @@ spec:
                             type: object
                           type: array
                         interfaces:
-                          description:
-                            Interfaces describe network interfaces which
+                          description: Interfaces describe network interfaces which
                             are added to the vmi.
                           items:
                             properties:
                               acpiIndex:
-                                description:
-                                  If specified, the ACPI index is used to
+                                description: If specified, the ACPI index is used to
                                   provide network interface device naming, that is stable
                                   across changes in PCI addresses assigned to the device.
                                   This value is required to be unique across all devices
                                   and be between 1 and (16*1024-1).
                                 type: integer
+                              binding:
+                                description: 'Binding specifies the binding plugin that
+                                will be used to connect the interface to the guest.
+                                It provides an alternative to InterfaceBindingMethod.
+                                version: 1alphav1'
+                                properties:
+                                  name:
+                                    description: 'Name references to the binding name
+                                    as denined in the kubevirt CR. version: 1alphav1'
+                                    type: string
+                                required:
+                                  - name
+                                type: object
                               bootOrder:
-                                description:
-                                  BootOrder is an integer value > 0, used
+                                description: BootOrder is an integer value > 0, used
                                   to determine ordering of boot devices. Lower values
                                   take precedence. Each interface or disk that has a
                                   boot order must have a unique value. Interfaces without
                                   a boot order are not tried.
                                 type: integer
                               bridge:
-                                description:
-                                  InterfaceBridge connects to a given network
+                                description: InterfaceBridge connects to a given network
                                   via a linux bridge.
                                 type: object
                               dhcpOptions:
-                                description:
-                                  If specified the network interface will
+                                description: If specified the network interface will
                                   pass additional DHCP options to the VMI
                                 properties:
                                   bootFileName:
-                                    description:
-                                      If specified will pass option 67 to
+                                    description: If specified will pass option 67 to
                                       interface's DHCP server
                                     type: string
                                   ntpServers:
-                                    description:
-                                      If specified will pass the configured
+                                    description: If specified will pass the configured
                                       NTP server to the VM via DHCP option 042.
                                     items:
                                       type: string
                                     type: array
                                   privateOptions:
-                                    description:
-                                      "If specified will pass extra DHCP
-                                      options for private use, range: 224-254"
+                                    description: 'If specified will pass extra DHCP
+                                    options for private use, range: 224-254'
                                     items:
-                                      description:
-                                        DHCPExtraOptions defines Extra DHCP
+                                      description: DHCPExtraOptions defines Extra DHCP
                                         options for a VM.
                                       properties:
                                         option:
-                                          description:
-                                            Option is an Integer value from
+                                          description: Option is an Integer value from
                                             224-254 Required.
                                           type: integer
                                         value:
-                                          description:
-                                            Value is a String value for the
+                                          description: Value is a String value for the
                                             Option provided Required.
                                           type: string
                                       required:
@@ -1774,76 +1585,64 @@ spec:
                                       type: object
                                     type: array
                                   tftpServerName:
-                                    description:
-                                      If specified will pass option 66 to
+                                    description: If specified will pass option 66 to
                                       interface's DHCP server
                                     type: string
                                 type: object
                               macAddress:
-                                description:
-                                  "Interface MAC address. For example: de:ad:00:00:be:af
-                                  or DE-AD-00-00-BE-AF."
+                                description: 'Interface MAC address. For example: de:ad:00:00:be:af
+                                or DE-AD-00-00-BE-AF.'
                                 type: string
                               macvtap:
-                                description:
-                                  InterfaceMacvtap connects to a given network
-                                  by extending the Kubernetes node's L2 networks via
-                                  a macvtap interface.
+                                description: Deprecated, please refer to Kubevirt user
+                                  guide for alternatives.
                                 type: object
                               masquerade:
-                                description:
-                                  InterfaceMasquerade connects to a given
+                                description: InterfaceMasquerade connects to a given
                                   network using netfilter rules to nat the traffic.
                                 type: object
                               model:
-                                description:
-                                  "Interface model. One of: e1000, e1000e,
-                                  ne2k_pci, pcnet, rtl8139, virtio. Defaults to virtio.
-                                  TODO:(ihar) switch to enums once opengen-api supports
-                                  them. See: https://github.com/kubernetes/kube-openapi/issues/51"
+                                description: 'Interface model. One of: e1000, e1000e,
+                                ne2k_pci, pcnet, rtl8139, virtio. Defaults to virtio.
+                                TODO:(ihar) switch to enums once opengen-api supports
+                                them. See: https://github.com/kubernetes/kube-openapi/issues/51'
                                 type: string
                               name:
-                                description:
-                                  Logical name of the interface as well as
+                                description: Logical name of the interface as well as
                                   a reference to the associated networks. Must match
                                   the Name of a Network.
                                 type: string
                               passt:
-                                description: InterfacePasst connects to a given network.
+                                description: Deprecated, please refer to Kubevirt user
+                                  guide for alternatives.
                                 type: object
                               pciAddress:
-                                description:
-                                  "If specified, the virtual network interface
-                                  will be placed on the guests pci address with the
-                                  specified PCI address. For example: 0000:81:01.10"
+                                description: 'If specified, the virtual network interface
+                                will be placed on the guests pci address with the
+                                specified PCI address. For example: 0000:81:01.10'
                                 type: string
                               ports:
-                                description:
-                                  List of ports to be forwarded to the virtual
+                                description: List of ports to be forwarded to the virtual
                                   machine.
                                 items:
-                                  description:
-                                    Port represents a port to expose from
+                                  description: Port represents a port to expose from
                                     the virtual machine. Default protocol TCP. The port
                                     field is mandatory
                                   properties:
                                     name:
-                                      description:
-                                        If specified, this must be an IANA_SVC_NAME
+                                      description: If specified, this must be an IANA_SVC_NAME
                                         and unique within the pod. Each named port in
                                         a pod must have a unique name. Name for the
                                         port that can be referred to by services.
                                       type: string
                                     port:
-                                      description:
-                                        Number of port to expose for the
+                                      description: Number of port to expose for the
                                         virtual machine. This must be a valid port number,
                                         0 < x < 65536.
                                       format: int32
                                       type: integer
                                     protocol:
-                                      description:
-                                        Protocol for port. Must be UDP or
+                                      description: Protocol for port. Must be UDP or
                                         TCP. Defaults to "TCP".
                                       type: string
                                   required:
@@ -1851,24 +1650,20 @@ spec:
                                   type: object
                                 type: array
                               slirp:
-                                description:
-                                  InterfaceSlirp connects to a given network
+                                description: InterfaceSlirp connects to a given network
                                   using QEMU user networking mode.
                                 type: object
                               sriov:
-                                description:
-                                  InterfaceSRIOV connects to a given network
+                                description: InterfaceSRIOV connects to a given network
                                   by passing-through an SR-IOV PCI device via vfio.
                                 type: object
                               state:
-                                description:
-                                  State represents the requested operational
+                                description: State represents the requested operational
                                   state of the interface. The (only) value supported
                                   is 'absent', expressing a request to remove the interface.
                                 type: string
                               tag:
-                                description:
-                                  If specified, the virtual network interface
+                                description: If specified, the virtual network interface
                                   address and its tag will be provided to the guest
                                   via config drive
                                 type: string
@@ -1876,27 +1671,31 @@ spec:
                               - name
                             type: object
                           type: array
+                        logSerialConsole:
+                          description: Whether to log the auto-attached default serial
+                            console or not. Serial console logs will be collect to a
+                            file and then streamed from a named 'guest-console-log'.
+                            Not relevant if autoattachSerialConsole is disabled. Defaults
+                            to cluster wide setting on VirtualMachineOptions.
+                          type: boolean
                         networkInterfaceMultiqueue:
-                          description:
-                            If specified, virtual network interfaces configured
+                          description: If specified, virtual network interfaces configured
                             with a virtio bus will also enable the vhost multiqueue
                             feature for network devices. The number of queues created
                             depends on additional factors of the VirtualMachineInstance,
                             like the number of guest CPUs.
                           type: boolean
                         rng:
-                          description:
-                            Whether to have random number generator from
+                          description: Whether to have random number generator from
                             host
                           type: object
                         sound:
                           description: Whether to emulate a sound device.
                           properties:
                             model:
-                              description:
-                                "We only support ich9 or ac97. If SoundDevice
-                                is not set: No sound card is emulated. If SoundDevice
-                                is set but Model is not: ich9"
+                              description: 'We only support ich9 or ac97. If SoundDevice
+                              is not set: No sound card is emulated. If SoundDevice
+                              is set but Model is not: ich9'
                               type: string
                             name:
                               description: User's defined name for this sound device
@@ -1908,29 +1707,25 @@ spec:
                           description: Whether to emulate a TPM device.
                           properties:
                             persistent:
-                              description:
-                                Persistent indicates the state of the TPM
+                              description: Persistent indicates the state of the TPM
                                 device should be kept accross reboots Defaults to false
                               type: boolean
                           type: object
                         useVirtioTransitional:
-                          description:
-                            Fall back to legacy virtio 0.9 support if virtio
+                          description: Fall back to legacy virtio 0.9 support if virtio
                             bus is selected on devices. This is helpful for old machines
                             like CentOS6 or RHEL6 which do not understand virtio_non_transitional
                             (virtio 1.0).
                           type: boolean
                         watchdog:
-                          description:
-                            Watchdog describes a watchdog device which can
+                          description: Watchdog describes a watchdog device which can
                             be added to the vmi.
                           properties:
                             i6300esb:
                               description: i6300esb watchdog device.
                               properties:
                                 action:
-                                  description:
-                                    The action to take. Valid values are
+                                  description: The action to take. Valid values are
                                     poweroff, reset, shutdown. Defaults to reset.
                                   type: string
                               type: object
@@ -1945,13 +1740,11 @@ spec:
                       description: Features like acpi, apic, hyperv, smm.
                       properties:
                         acpi:
-                          description:
-                            ACPI enables/disables ACPI inside the guest.
+                          description: ACPI enables/disables ACPI inside the guest.
                             Defaults to enabled.
                           properties:
                             enabled:
-                              description:
-                                Enabled determines if the feature should
+                              description: Enabled determines if the feature should
                                 be enabled or disabled on the guest. Defaults to true.
                               type: boolean
                           type: object
@@ -1959,13 +1752,11 @@ spec:
                           description: Defaults to the machine type setting.
                           properties:
                             enabled:
-                              description:
-                                Enabled determines if the feature should
+                              description: Enabled determines if the feature should
                                 be enabled or disabled on the guest. Defaults to true.
                               type: boolean
                             endOfInterrupt:
-                              description:
-                                EndOfInterrupt enables the end of interrupt
+                              description: EndOfInterrupt enables the end of interrupt
                                 notification in the guest. Defaults to false.
                               type: boolean
                           type: object
@@ -1973,139 +1764,117 @@ spec:
                           description: Defaults to the machine type setting.
                           properties:
                             evmcs:
-                              description:
-                                EVMCS Speeds up L2 vmexits, but disables
+                              description: EVMCS Speeds up L2 vmexits, but disables
                                 other virtualization features. Requires vapic. Defaults
                                 to the machine type setting.
                               properties:
                                 enabled:
-                                  description:
-                                    Enabled determines if the feature should
+                                  description: Enabled determines if the feature should
                                     be enabled or disabled on the guest. Defaults to
                                     true.
                                   type: boolean
                               type: object
                             frequencies:
-                              description:
-                                Frequencies improves the TSC clock source
+                              description: Frequencies improves the TSC clock source
                                 handling for Hyper-V on KVM. Defaults to the machine
                                 type setting.
                               properties:
                                 enabled:
-                                  description:
-                                    Enabled determines if the feature should
+                                  description: Enabled determines if the feature should
                                     be enabled or disabled on the guest. Defaults to
                                     true.
                                   type: boolean
                               type: object
                             ipi:
-                              description:
-                                IPI improves performances in overcommited
+                              description: IPI improves performances in overcommited
                                 environments. Requires vpindex. Defaults to the machine
                                 type setting.
                               properties:
                                 enabled:
-                                  description:
-                                    Enabled determines if the feature should
+                                  description: Enabled determines if the feature should
                                     be enabled or disabled on the guest. Defaults to
                                     true.
                                   type: boolean
                               type: object
                             reenlightenment:
-                              description:
-                                Reenlightenment enables the notifications
+                              description: Reenlightenment enables the notifications
                                 on TSC frequency changes. Defaults to the machine type
                                 setting.
                               properties:
                                 enabled:
-                                  description:
-                                    Enabled determines if the feature should
+                                  description: Enabled determines if the feature should
                                     be enabled or disabled on the guest. Defaults to
                                     true.
                                   type: boolean
                               type: object
                             relaxed:
-                              description:
-                                Relaxed instructs the guest OS to disable
+                              description: Relaxed instructs the guest OS to disable
                                 watchdog timeouts. Defaults to the machine type setting.
                               properties:
                                 enabled:
-                                  description:
-                                    Enabled determines if the feature should
+                                  description: Enabled determines if the feature should
                                     be enabled or disabled on the guest. Defaults to
                                     true.
                                   type: boolean
                               type: object
                             reset:
-                              description:
-                                Reset enables Hyperv reboot/reset for the
+                              description: Reset enables Hyperv reboot/reset for the
                                 vmi. Requires synic. Defaults to the machine type setting.
                               properties:
                                 enabled:
-                                  description:
-                                    Enabled determines if the feature should
+                                  description: Enabled determines if the feature should
                                     be enabled or disabled on the guest. Defaults to
                                     true.
                                   type: boolean
                               type: object
                             runtime:
-                              description:
-                                Runtime improves the time accounting to improve
+                              description: Runtime improves the time accounting to improve
                                 scheduling in the guest. Defaults to the machine type
                                 setting.
                               properties:
                                 enabled:
-                                  description:
-                                    Enabled determines if the feature should
+                                  description: Enabled determines if the feature should
                                     be enabled or disabled on the guest. Defaults to
                                     true.
                                   type: boolean
                               type: object
                             spinlocks:
-                              description:
-                                Spinlocks allows to configure the spinlock
+                              description: Spinlocks allows to configure the spinlock
                                 retry attempts.
                               properties:
                                 enabled:
-                                  description:
-                                    Enabled determines if the feature should
+                                  description: Enabled determines if the feature should
                                     be enabled or disabled on the guest. Defaults to
                                     true.
                                   type: boolean
                                 spinlocks:
-                                  description:
-                                    Retries indicates the number of retries.
+                                  description: Retries indicates the number of retries.
                                     Must be a value greater or equal 4096. Defaults
                                     to 4096.
                                   format: int32
                                   type: integer
                               type: object
                             synic:
-                              description:
-                                SyNIC enables the Synthetic Interrupt Controller.
+                              description: SyNIC enables the Synthetic Interrupt Controller.
                                 Defaults to the machine type setting.
                               properties:
                                 enabled:
-                                  description:
-                                    Enabled determines if the feature should
+                                  description: Enabled determines if the feature should
                                     be enabled or disabled on the guest. Defaults to
                                     true.
                                   type: boolean
                               type: object
                             synictimer:
-                              description:
-                                SyNICTimer enables Synthetic Interrupt Controller
+                              description: SyNICTimer enables Synthetic Interrupt Controller
                                 Timers, reducing CPU load. Defaults to the machine type
                                 setting.
                               properties:
                                 direct:
-                                  description:
-                                    Represents if a feature is enabled or
+                                  description: Represents if a feature is enabled or
                                     disabled.
                                   properties:
                                     enabled:
-                                      description:
-                                        Enabled determines if the feature
+                                      description: Enabled determines if the feature
                                         should be enabled or disabled on the guest.
                                         Defaults to true.
                                       type: boolean
@@ -2114,92 +1883,77 @@ spec:
                                   type: boolean
                               type: object
                             tlbflush:
-                              description:
-                                TLBFlush improves performances in overcommited
+                              description: TLBFlush improves performances in overcommited
                                 environments. Requires vpindex. Defaults to the machine
                                 type setting.
                               properties:
                                 enabled:
-                                  description:
-                                    Enabled determines if the feature should
+                                  description: Enabled determines if the feature should
                                     be enabled or disabled on the guest. Defaults to
                                     true.
                                   type: boolean
                               type: object
                             vapic:
-                              description:
-                                VAPIC improves the paravirtualized handling
+                              description: VAPIC improves the paravirtualized handling
                                 of interrupts. Defaults to the machine type setting.
                               properties:
                                 enabled:
-                                  description:
-                                    Enabled determines if the feature should
+                                  description: Enabled determines if the feature should
                                     be enabled or disabled on the guest. Defaults to
                                     true.
                                   type: boolean
                               type: object
                             vendorid:
-                              description:
-                                VendorID allows setting the hypervisor vendor
+                              description: VendorID allows setting the hypervisor vendor
                                 id. Defaults to the machine type setting.
                               properties:
                                 enabled:
-                                  description:
-                                    Enabled determines if the feature should
+                                  description: Enabled determines if the feature should
                                     be enabled or disabled on the guest. Defaults to
                                     true.
                                   type: boolean
                                 vendorid:
-                                  description:
-                                    VendorID sets the hypervisor vendor id,
+                                  description: VendorID sets the hypervisor vendor id,
                                     visible to the vmi. String up to twelve characters.
                                   type: string
                               type: object
                             vpindex:
-                              description:
-                                VPIndex enables the Virtual Processor Index
+                              description: VPIndex enables the Virtual Processor Index
                                 to help windows identifying virtual processors. Defaults
                                 to the machine type setting.
                               properties:
                                 enabled:
-                                  description:
-                                    Enabled determines if the feature should
+                                  description: Enabled determines if the feature should
                                     be enabled or disabled on the guest. Defaults to
                                     true.
                                   type: boolean
                               type: object
                           type: object
                         kvm:
-                          description:
-                            Configure how KVM presence is exposed to the
+                          description: Configure how KVM presence is exposed to the
                             guest.
                           properties:
                             hidden:
-                              description:
-                                Hide the KVM hypervisor from standard MSR
+                              description: Hide the KVM hypervisor from standard MSR
                                 based discovery. Defaults to false
                               type: boolean
                           type: object
                         pvspinlock:
-                          description:
-                            Notify the guest that the host supports paravirtual
+                          description: Notify the guest that the host supports paravirtual
                             spinlocks. For older kernels this feature should be explicitly
                             disabled.
                           properties:
                             enabled:
-                              description:
-                                Enabled determines if the feature should
+                              description: Enabled determines if the feature should
                                 be enabled or disabled on the guest. Defaults to true.
                               type: boolean
                           type: object
                         smm:
-                          description:
-                            SMM enables/disables System Management Mode.
+                          description: SMM enables/disables System Management Mode.
                             TSEG not yet implemented.
                           properties:
                             enabled:
-                              description:
-                                Enabled determines if the feature should
+                              description: Enabled determines if the feature should
                                 be enabled or disabled on the guest. Defaults to true.
                               type: boolean
                           type: object
@@ -2207,6 +1961,16 @@ spec:
                     firmware:
                       description: Firmware.
                       properties:
+                        acpi:
+                          description: Information that can be set in the ACPI table
+                          properties:
+                            slicNameRef:
+                              description: 'SlicNameRef should match the volume name
+                              of a secret object. The data in the secret should be
+                              a binary blob that follows the ACPI SLIC standard, see:
+                              https://learn.microsoft.com/en-us/previous-versions/windows/hardware/design/dn653305(v=vs.85)'
+                              type: string
+                          type: object
                         bootloader:
                           description: Settings to control the bootloader that is used.
                           properties:
@@ -2214,17 +1978,19 @@ spec:
                               description: If set (default), BIOS will be used.
                               properties:
                                 useSerial:
-                                  description:
-                                    If set, the BIOS output will be transmitted
+                                  description: If set, the BIOS output will be transmitted
                                     over serial
                                   type: boolean
                               type: object
                             efi:
                               description: If set, EFI will be used instead of BIOS.
                               properties:
+                                persistent:
+                                  description: If set to true, Persistent will persist
+                                    the EFI NVRAM across reboots. Defaults to false
+                                  type: boolean
                                 secureBoot:
-                                  description:
-                                    If set, SecureBoot will be enabled and
+                                  description: If set, SecureBoot will be enabled and
                                     the OVMF roms will be swapped for SecureBoot-enabled
                                     ones. Requires SMM to be enabled. Defaults to true
                                   type: boolean
@@ -2234,42 +2000,36 @@ spec:
                           description: Settings to set the kernel for booting.
                           properties:
                             container:
-                              description:
-                                Container defines the container that containes
+                              description: Container defines the container that containes
                                 kernel artifacts
                               properties:
                                 image:
                                   description: Image that contains initrd / kernel files.
                                   type: string
                                 imagePullPolicy:
-                                  description:
-                                    "Image pull policy. One of Always, Never,
-                                    IfNotPresent. Defaults to Always if :latest tag
-                                    is specified, or IfNotPresent otherwise. Cannot
-                                    be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images"
+                                  description: 'Image pull policy. One of Always, Never,
+                                  IfNotPresent. Defaults to Always if :latest tag
+                                  is specified, or IfNotPresent otherwise. Cannot
+                                  be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                                   type: string
                                 imagePullSecret:
-                                  description:
-                                    ImagePullSecret is the name of the Docker
+                                  description: ImagePullSecret is the name of the Docker
                                     registry secret required to pull the image. The
                                     secret must already exist.
                                   type: string
                                 initrdPath:
-                                  description:
-                                    the fully-qualified path to the ramdisk
+                                  description: the fully-qualified path to the ramdisk
                                     image in the host OS
                                   type: string
                                 kernelPath:
-                                  description:
-                                    The fully-qualified path to the kernel
+                                  description: The fully-qualified path to the kernel
                                     image in the host OS
                                   type: string
                               required:
                                 - image
                               type: object
                             kernelArgs:
-                              description:
-                                Arguments to be passed to the kernel at boot
+                              description: Arguments to be passed to the kernel at boot
                                 time
                               type: string
                           type: object
@@ -2277,16 +2037,14 @@ spec:
                           description: The system-serial-number in SMBIOS
                           type: string
                         uuid:
-                          description:
-                            UUID reported by the vmi bios. Defaults to a
+                          description: UUID reported by the vmi bios. Defaults to a
                             random generated uid.
                           type: string
                       type: object
                     ioThreadsPolicy:
-                      description:
-                        "Controls whether or not disks will share IOThreads.
-                        Omitting IOThreadsPolicy disables use of IOThreads. One of:
-                        shared, auto"
+                      description: 'Controls whether or not disks will share IOThreads.
+                      Omitting IOThreadsPolicy disables use of IOThreads. One of:
+                      shared, auto'
                       type: string
                     launchSecurity:
                       description: Launch Security setting of the vmi.
@@ -2294,25 +2052,34 @@ spec:
                         sev:
                           description: AMD Secure Encrypted Virtualization (SEV).
                           properties:
+                            attestation:
+                              description: If specified, run the attestation process
+                                for a vmi.
+                              type: object
+                            dhCert:
+                              description: Base64 encoded guest owner's Diffie-Hellman
+                                key.
+                              type: string
                             policy:
-                              description:
-                                "Guest policy flags as defined in AMD SEV
-                                API specification. Note: due to security reasons it
-                                is not allowed to enable guest debugging. Therefore
-                                NoDebug flag is not exposed to users and is always true."
+                              description: 'Guest policy flags as defined in AMD SEV
+                              API specification. Note: due to security reasons it
+                              is not allowed to enable guest debugging. Therefore
+                              NoDebug flag is not exposed to users and is always true.'
                               properties:
                                 encryptedState:
                                   description: SEV-ES is required. Defaults to false.
                                   type: boolean
                               type: object
+                            session:
+                              description: Base64 encoded session blob.
+                              type: string
                           type: object
                       type: object
                     machine:
                       description: Machine type.
                       properties:
                         type:
-                          description:
-                            QEMU machine type is the actual chipset of the
+                          description: QEMU machine type is the actual chipset of the
                             VirtualMachineInstance.
                           type: string
                       type: object
@@ -2323,8 +2090,7 @@ spec:
                           anyOf:
                             - type: integer
                             - type: string
-                          description:
-                            Guest allows to specifying the amount of memory
+                          description: Guest allows to specifying the amount of memory
                             which is visible inside the Guest OS. The Guest must lie
                             between Requests and Limits from the resources section.
                             Defaults to the requested memory in the resources section
@@ -2332,20 +2098,27 @@ spec:
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         hugepages:
-                          description:
-                            Hugepages allow to use hugepages for the VirtualMachineInstance
+                          description: Hugepages allow to use hugepages for the VirtualMachineInstance
                             instead of regular memory.
                           properties:
                             pageSize:
-                              description:
-                                PageSize specifies the hugepage size, for
+                              description: PageSize specifies the hugepage size, for
                                 x86_64 architecture valid values are 1Gi and 2Mi.
                               type: string
                           type: object
+                        maxGuest:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: MaxGuest allows to specify the maximum amount
+                            of memory which is visible inside the Guest OS. The delta
+                            between MaxGuest and Guest is the amount of memory that
+                            can be hot(un)plugged.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                       type: object
                     resources:
-                      description:
-                        Resources describes the Compute Resources required
+                      description: Resources describes the Compute Resources required
                         by this vmi.
                       properties:
                         limits:
@@ -2355,14 +2128,12 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description:
-                            Limits describes the maximum amount of compute
+                          description: Limits describes the maximum amount of compute
                             resources allowed. Valid resource keys are "memory" and
                             "cpu".
                           type: object
                         overcommitGuestOverhead:
-                          description:
-                            Don't ask the scheduler to take the guest-management
+                          description: Don't ask the scheduler to take the guest-management
                             overhead into account. Instead put the overhead only into
                             the container's memory limit. This can lead to crashes if
                             all memory is in use on a node. Defaults to false.
@@ -2374,8 +2145,7 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description:
-                            Requests is a description of the initial vmi
+                          description: Requests is a description of the initial vmi
                             resources. Valid resource keys are "memory" and "cpu".
                           type: object
                       type: object
@@ -2383,32 +2153,38 @@ spec:
                     - devices
                   type: object
                 evictionStrategy:
-                  description:
-                    EvictionStrategy can be set to "LiveMigrate" if the VirtualMachineInstance
-                    should be migrated instead of shut-off in case of a node drain.
+                  description: 'EvictionStrategy describes the strategy to follow when
+                  a node drain occurs. The possible options are: - "None": No action
+                  will be taken, according to the specified ''RunStrategy'' the VirtualMachine
+                  will be restarted or shutdown. - "LiveMigrate": the VirtualMachineInstance
+                  will be migrated instead of being shutdown. - "LiveMigrateIfPossible":
+                  the same as "LiveMigrate" but only if the VirtualMachine is Live-Migratable,
+                  otherwise it will behave as "None". - "External": the VirtualMachineInstance
+                  will be protected by a PDB and ''vmi.Status.EvacuationNodeName''
+                  will be set on eviction. This is mainly useful for cluster-api-provider-kubevirt
+                  (capk) which needs a way for VMI''s to be blocked from eviction,
+                  yet signal capk that eviction has been called on the VMI so the
+                  capk controller can handle tearing the VMI down. Details can be
+                  found in the commit description https://github.com/kubevirt/kubevirt/commit/c1d77face705c8b126696bac9a3ee3825f27f1fa.'
                   type: string
                 hostname:
-                  description:
-                    Specifies the hostname of the vmi If not specified, the
+                  description: Specifies the hostname of the vmi If not specified, the
                     hostname will be set to the name of the vmi, if dhcp or cloud-init
                     is configured properly.
                   type: string
                 livenessProbe:
-                  description:
-                    "Periodic probe of VirtualMachineInstance liveness. VirtualmachineInstances
-                    will be stopped if the probe fails. Cannot be updated. More info:
-                    https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
+                  description: 'Periodic probe of VirtualMachineInstance liveness. VirtualmachineInstances
+                  will be stopped if the probe fails. Cannot be updated. More info:
+                  https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                   properties:
                     exec:
-                      description:
-                        One and only one of the following should be specified.
+                      description: One and only one of the following should be specified.
                         Exec specifies the action to take, it will be executed on the
                         guest through the qemu-guest-agent. If the guest agent is not
                         available, this probe will fail.
                       properties:
                         command:
-                          description:
-                            Command is the command line to execute inside
+                          description: Command is the command line to execute inside
                             the container, the working directory for the command  is
                             root ('/') in the container's filesystem. The command is
                             simply exec'd, it is not run inside a shell, so traditional
@@ -2420,32 +2196,27 @@ spec:
                           type: array
                       type: object
                     failureThreshold:
-                      description:
-                        Minimum consecutive failures for the probe to be
+                      description: Minimum consecutive failures for the probe to be
                         considered failed after having succeeded. Defaults to 3. Minimum
                         value is 1.
                       format: int32
                       type: integer
                     guestAgentPing:
-                      description:
-                        GuestAgentPing contacts the qemu-guest-agent for
+                      description: GuestAgentPing contacts the qemu-guest-agent for
                         availability checks.
                       type: object
                     httpGet:
                       description: HTTPGet specifies the http request to perform.
                       properties:
                         host:
-                          description:
-                            Host name to connect to, defaults to the pod
+                          description: Host name to connect to, defaults to the pod
                             IP. You probably want to set "Host" in httpHeaders instead.
                           type: string
                         httpHeaders:
-                          description:
-                            Custom headers to set in the request. HTTP allows
+                          description: Custom headers to set in the request. HTTP allows
                             repeated headers.
                           items:
-                            description:
-                              HTTPHeader describes a custom header to be
+                            description: HTTPHeader describes a custom header to be
                               used in HTTP probes
                             properties:
                               name:
@@ -2466,56 +2237,48 @@ spec:
                           anyOf:
                             - type: integer
                             - type: string
-                          description:
-                            Name or number of the port to access on the container.
+                          description: Name or number of the port to access on the container.
                             Number must be in the range 1 to 65535. Name must be an
                             IANA_SVC_NAME.
                           x-kubernetes-int-or-string: true
                         scheme:
-                          description:
-                            Scheme to use for connecting to the host. Defaults
+                          description: Scheme to use for connecting to the host. Defaults
                             to HTTP.
                           type: string
                       required:
                         - port
                       type: object
                     initialDelaySeconds:
-                      description:
-                        "Number of seconds after the VirtualMachineInstance
-                        has started before liveness probes are initiated. More info:
-                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
+                      description: 'Number of seconds after the VirtualMachineInstance
+                      has started before liveness probes are initiated. More info:
+                      https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                       format: int32
                       type: integer
                     periodSeconds:
-                      description:
-                        How often (in seconds) to perform the probe. Default
+                      description: How often (in seconds) to perform the probe. Default
                         to 10 seconds. Minimum value is 1.
                       format: int32
                       type: integer
                     successThreshold:
-                      description:
-                        Minimum consecutive successes for the probe to be
+                      description: Minimum consecutive successes for the probe to be
                         considered successful after having failed. Defaults to 1. Must
                         be 1 for liveness. Minimum value is 1.
                       format: int32
                       type: integer
                     tcpSocket:
-                      description:
-                        "TCPSocket specifies an action involving a TCP port.
-                        TCP hooks not yet supported TODO: implement a realistic TCP
-                        lifecycle hook"
+                      description: 'TCPSocket specifies an action involving a TCP port.
+                      TCP hooks not yet supported TODO: implement a realistic TCP
+                      lifecycle hook'
                       properties:
                         host:
-                          description:
-                            "Optional: Host name to connect to, defaults
-                            to the pod IP."
+                          description: 'Optional: Host name to connect to, defaults
+                          to the pod IP.'
                           type: string
                         port:
                           anyOf:
                             - type: integer
                             - type: string
-                          description:
-                            Number or name of the port to access on the container.
+                          description: Number or name of the port to access on the container.
                             Number must be in the range 1 to 65535. Name must be an
                             IANA_SVC_NAME.
                           x-kubernetes-int-or-string: true
@@ -2523,59 +2286,51 @@ spec:
                         - port
                       type: object
                     timeoutSeconds:
-                      description:
-                        "Number of seconds after which the probe times out.
-                        For exec probes the timeout fails the probe but does not terminate
-                        the command running on the guest. This means a blocking command
-                        can result in an increasing load on the guest. A small buffer
-                        will be added to the resulting workload exec probe to compensate
-                        for delays caused by the qemu guest exec mechanism. Defaults
-                        to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
+                      description: 'Number of seconds after which the probe times out.
+                      For exec probes the timeout fails the probe but does not terminate
+                      the command running on the guest. This means a blocking command
+                      can result in an increasing load on the guest. A small buffer
+                      will be added to the resulting workload exec probe to compensate
+                      for delays caused by the qemu guest exec mechanism. Defaults
+                      to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                       format: int32
                       type: integer
                   type: object
                 networks:
-                  description:
-                    List of networks that can be attached to a vm's virtual
+                  description: List of networks that can be attached to a vm's virtual
                     interface.
                   items:
-                    description:
-                      Network represents a network type and a resource that
+                    description: Network represents a network type and a resource that
                       should be connected to the vm.
                     properties:
                       multus:
                         description: Represents the multus cni network.
                         properties:
                           default:
-                            description:
-                              Select the default network and add it to the
+                            description: Select the default network and add it to the
                               multus-cni.io/default-network annotation.
                             type: boolean
                           networkName:
-                            description:
-                              "References to a NetworkAttachmentDefinition
-                              CRD object. Format: <networkName>, <namespace>/<networkName>.
-                              If namespace is not specified, VMI namespace is assumed."
+                            description: 'References to a NetworkAttachmentDefinition
+                            CRD object. Format: <networkName>, <namespace>/<networkName>.
+                            If namespace is not specified, VMI namespace is assumed.'
                             type: string
                         required:
                           - networkName
                         type: object
                       name:
-                        description:
-                          "Network name. Must be a DNS_LABEL and unique within
-                          the vm. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+                        description: 'Network name. Must be a DNS_LABEL and unique within
+                        the vm. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                         type: string
                       pod:
                         description: Represents the stock pod network interface.
                         properties:
                           vmIPv6NetworkCIDR:
-                            description:
-                              IPv6 CIDR for the vm network. Defaults to fd10:0:2::/120
+                            description: IPv6 CIDR for the vm network. Defaults to fd10:0:2::/120
                               if not specified.
                             type: string
                           vmNetworkCIDR:
-                            description:
-                              CIDR for vm network. Default 10.0.2.0/24 if
+                            description: CIDR for vm network. Default 10.0.2.0/24 if
                               not specified.
                             type: string
                         type: object
@@ -2586,32 +2341,27 @@ spec:
                 nodeSelector:
                   additionalProperties:
                     type: string
-                  description:
-                    "NodeSelector is a selector which must be true for the
-                    vmi to fit on a node. Selector which must match a node's labels
-                    for the vmi to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/"
+                  description: 'NodeSelector is a selector which must be true for the
+                  vmi to fit on a node. Selector which must match a node''s labels
+                  for the vmi to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                   type: object
                 priorityClassName:
-                  description:
-                    If specified, indicates the pod's priority. If not specified,
+                  description: If specified, indicates the pod's priority. If not specified,
                     the pod priority will be default or zero if there is no default.
                   type: string
                 readinessProbe:
-                  description:
-                    "Periodic probe of VirtualMachineInstance service readiness.
-                    VirtualmachineInstances will be removed from service endpoints if
-                    the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
+                  description: 'Periodic probe of VirtualMachineInstance service readiness.
+                  VirtualmachineInstances will be removed from service endpoints if
+                  the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                   properties:
                     exec:
-                      description:
-                        One and only one of the following should be specified.
+                      description: One and only one of the following should be specified.
                         Exec specifies the action to take, it will be executed on the
                         guest through the qemu-guest-agent. If the guest agent is not
                         available, this probe will fail.
                       properties:
                         command:
-                          description:
-                            Command is the command line to execute inside
+                          description: Command is the command line to execute inside
                             the container, the working directory for the command  is
                             root ('/') in the container's filesystem. The command is
                             simply exec'd, it is not run inside a shell, so traditional
@@ -2623,32 +2373,27 @@ spec:
                           type: array
                       type: object
                     failureThreshold:
-                      description:
-                        Minimum consecutive failures for the probe to be
+                      description: Minimum consecutive failures for the probe to be
                         considered failed after having succeeded. Defaults to 3. Minimum
                         value is 1.
                       format: int32
                       type: integer
                     guestAgentPing:
-                      description:
-                        GuestAgentPing contacts the qemu-guest-agent for
+                      description: GuestAgentPing contacts the qemu-guest-agent for
                         availability checks.
                       type: object
                     httpGet:
                       description: HTTPGet specifies the http request to perform.
                       properties:
                         host:
-                          description:
-                            Host name to connect to, defaults to the pod
+                          description: Host name to connect to, defaults to the pod
                             IP. You probably want to set "Host" in httpHeaders instead.
                           type: string
                         httpHeaders:
-                          description:
-                            Custom headers to set in the request. HTTP allows
+                          description: Custom headers to set in the request. HTTP allows
                             repeated headers.
                           items:
-                            description:
-                              HTTPHeader describes a custom header to be
+                            description: HTTPHeader describes a custom header to be
                               used in HTTP probes
                             properties:
                               name:
@@ -2669,56 +2414,48 @@ spec:
                           anyOf:
                             - type: integer
                             - type: string
-                          description:
-                            Name or number of the port to access on the container.
+                          description: Name or number of the port to access on the container.
                             Number must be in the range 1 to 65535. Name must be an
                             IANA_SVC_NAME.
                           x-kubernetes-int-or-string: true
                         scheme:
-                          description:
-                            Scheme to use for connecting to the host. Defaults
+                          description: Scheme to use for connecting to the host. Defaults
                             to HTTP.
                           type: string
                       required:
                         - port
                       type: object
                     initialDelaySeconds:
-                      description:
-                        "Number of seconds after the VirtualMachineInstance
-                        has started before liveness probes are initiated. More info:
-                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
+                      description: 'Number of seconds after the VirtualMachineInstance
+                      has started before liveness probes are initiated. More info:
+                      https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                       format: int32
                       type: integer
                     periodSeconds:
-                      description:
-                        How often (in seconds) to perform the probe. Default
+                      description: How often (in seconds) to perform the probe. Default
                         to 10 seconds. Minimum value is 1.
                       format: int32
                       type: integer
                     successThreshold:
-                      description:
-                        Minimum consecutive successes for the probe to be
+                      description: Minimum consecutive successes for the probe to be
                         considered successful after having failed. Defaults to 1. Must
                         be 1 for liveness. Minimum value is 1.
                       format: int32
                       type: integer
                     tcpSocket:
-                      description:
-                        "TCPSocket specifies an action involving a TCP port.
-                        TCP hooks not yet supported TODO: implement a realistic TCP
-                        lifecycle hook"
+                      description: 'TCPSocket specifies an action involving a TCP port.
+                      TCP hooks not yet supported TODO: implement a realistic TCP
+                      lifecycle hook'
                       properties:
                         host:
-                          description:
-                            "Optional: Host name to connect to, defaults
-                            to the pod IP."
+                          description: 'Optional: Host name to connect to, defaults
+                          to the pod IP.'
                           type: string
                         port:
                           anyOf:
                             - type: integer
                             - type: string
-                          description:
-                            Number or name of the port to access on the container.
+                          description: Number or name of the port to access on the container.
                             Number must be in the range 1 to 65535. Name must be an
                             IANA_SVC_NAME.
                           x-kubernetes-int-or-string: true
@@ -2726,73 +2463,63 @@ spec:
                         - port
                       type: object
                     timeoutSeconds:
-                      description:
-                        "Number of seconds after which the probe times out.
-                        For exec probes the timeout fails the probe but does not terminate
-                        the command running on the guest. This means a blocking command
-                        can result in an increasing load on the guest. A small buffer
-                        will be added to the resulting workload exec probe to compensate
-                        for delays caused by the qemu guest exec mechanism. Defaults
-                        to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
+                      description: 'Number of seconds after which the probe times out.
+                      For exec probes the timeout fails the probe but does not terminate
+                      the command running on the guest. This means a blocking command
+                      can result in an increasing load on the guest. A small buffer
+                      will be added to the resulting workload exec probe to compensate
+                      for delays caused by the qemu guest exec mechanism. Defaults
+                      to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                       format: int32
                       type: integer
                   type: object
                 schedulerName:
-                  description:
-                    If specified, the VMI will be dispatched by specified
+                  description: If specified, the VMI will be dispatched by specified
                     scheduler. If not specified, the VMI will be dispatched by default
                     scheduler.
                   type: string
                 startStrategy:
-                  description:
-                    StartStrategy can be set to "Paused" if Virtual Machine
+                  description: StartStrategy can be set to "Paused" if Virtual Machine
                     should be started in paused state.
                   type: string
                 subdomain:
-                  description:
-                    If specified, the fully qualified vmi hostname will be
+                  description: If specified, the fully qualified vmi hostname will be
                     "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>". If
                     not specified, the vmi will not have a domainname at all. The DNS
                     entry will resolve to the vmi, no matter if the vmi itself can pick
                     up a hostname.
                   type: string
                 terminationGracePeriodSeconds:
-                  description:
-                    Grace period observed after signalling a VirtualMachineInstance
+                  description: Grace period observed after signalling a VirtualMachineInstance
                     to stop after which the VirtualMachineInstance is force terminated.
                   format: int64
                   type: integer
                 tolerations:
                   description: If toleration is specified, obey all the toleration rules.
                   items:
-                    description:
-                      The pod this Toleration is attached to tolerates any
+                    description: The pod this Toleration is attached to tolerates any
                       taint that matches the triple <key,value,effect> using the matching
                       operator <operator>.
                     properties:
                       effect:
-                        description:
-                          Effect indicates the taint effect to match. Empty
+                        description: Effect indicates the taint effect to match. Empty
                           means match all taint effects. When specified, allowed values
                           are NoSchedule, PreferNoSchedule and NoExecute.
                         type: string
                       key:
-                        description:
-                          Key is the taint key that the toleration applies
+                        description: Key is the taint key that the toleration applies
                           to. Empty means match all taint keys. If the key is empty,
                           operator must be Exists; this combination means to match all
                           values and all keys.
                         type: string
                       operator:
-                        description:
-                          Operator represents a key's relationship to the
+                        description: Operator represents a key's relationship to the
                           value. Valid operators are Exists and Equal. Defaults to Equal.
                           Exists is equivalent to wildcard for value, so that a pod
                           can tolerate all taints of a particular category.
                         type: string
                       tolerationSeconds:
-                        description:
-                          TolerationSeconds represents the period of time
+                        description: TolerationSeconds represents the period of time
                           the toleration (which must be of effect NoExecute, otherwise
                           this field is ignored) tolerates the taint. By default, it
                           is not set, which means tolerate the taint forever (do not
@@ -2801,53 +2528,44 @@ spec:
                         format: int64
                         type: integer
                       value:
-                        description:
-                          Value is the taint value the toleration matches
+                        description: Value is the taint value the toleration matches
                           to. If the operator is Exists, the value should be empty,
                           otherwise just a regular string.
                         type: string
                     type: object
                   type: array
                 topologySpreadConstraints:
-                  description:
-                    TopologySpreadConstraints describes how a group of VMIs
+                  description: TopologySpreadConstraints describes how a group of VMIs
                     will be spread across a given topology domains. K8s scheduler will
                     schedule VMI pods in a way which abides by the constraints.
                   items:
-                    description:
-                      TopologySpreadConstraint specifies how to spread matching
+                    description: TopologySpreadConstraint specifies how to spread matching
                       pods among the given topology.
                     properties:
                       labelSelector:
-                        description:
-                          LabelSelector is used to find matching pods. Pods
+                        description: LabelSelector is used to find matching pods. Pods
                           that match this label selector are counted to determine the
                           number of pods in their corresponding topology domain.
                         properties:
                           matchExpressions:
-                            description:
-                              matchExpressions is a list of label selector
+                            description: matchExpressions is a list of label selector
                               requirements. The requirements are ANDed.
                             items:
-                              description:
-                                A label selector requirement is a selector
+                              description: A label selector requirement is a selector
                                 that contains values, a key, and an operator that relates
                                 the key and values.
                               properties:
                                 key:
-                                  description:
-                                    key is the label key that the selector
+                                  description: key is the label key that the selector
                                     applies to.
                                   type: string
                                 operator:
-                                  description:
-                                    operator represents a key's relationship
+                                  description: operator represents a key's relationship
                                     to a set of values. Valid operators are In, NotIn,
                                     Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description:
-                                    values is an array of string values.
+                                  description: values is an array of string values.
                                     If the operator is In or NotIn, the values array
                                     must be non-empty. If the operator is Exists or
                                     DoesNotExist, the values array must be empty. This
@@ -2863,17 +2581,18 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description:
-                              matchLabels is a map of {key,value} pairs.
+                            description: matchLabels is a map of {key,value} pairs.
                               A single {key,value} in the matchLabels map is equivalent
                               to an element of matchExpressions, whose key field is
                               "key", the operator is "In", and the values array contains
                               only "value". The requirements are ANDed.
                             type: object
+                          session:
+                            description: Base64 encoded session blob.
+                            type: string
                         type: object
                       matchLabelKeys:
-                        description:
-                          MatchLabelKeys is a set of pod label keys to select
+                        description: MatchLabelKeys is a set of pod label keys to select
                           the pods over which spreading will be calculated. The keys
                           are used to lookup values from the incoming pod labels, those
                           key-value labels are ANDed with labelSelector to select the
@@ -2886,77 +2605,72 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       maxSkew:
-                        description:
-                          "MaxSkew describes the degree to which pods may
-                          be unevenly distributed. When 'whenUnsatisfiable=DoNotSchedule',
-                          it is the maximum permitted difference between the number
-                          of matching pods in the target topology and the global minimum.
-                          The global minimum is the minimum number of matching pods
-                          in an eligible domain or zero if the number of eligible domains
-                          is less than MinDomains. For example, in a 3-zone cluster,
-                          MaxSkew is set to 1, and pods with the same labelSelector
-                          spread as 2/2/1: In this case, the global minimum is 1. |
-                          zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
-                          is 1, incoming pod can only be scheduled to zone3 to become
-                          2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1)
-                          on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming
-                          pod can be scheduled onto any zone. When 'whenUnsatisfiable=ScheduleAnyway',
-                          it is used to give higher precedence to topologies that satisfy
-                          it. It's a required field. Default value is 1 and 0 is not
-                          allowed."
+                        description: 'MaxSkew describes the degree to which pods may
+                        be unevenly distributed. When ''whenUnsatisfiable=DoNotSchedule'',
+                        it is the maximum permitted difference between the number
+                        of matching pods in the target topology and the global minimum.
+                        The global minimum is the minimum number of matching pods
+                        in an eligible domain or zero if the number of eligible domains
+                        is less than MinDomains. For example, in a 3-zone cluster,
+                        MaxSkew is set to 1, and pods with the same labelSelector
+                        spread as 2/2/1: In this case, the global minimum is 1. |
+                        zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
+                        is 1, incoming pod can only be scheduled to zone3 to become
+                        2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1)
+                        on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming
+                        pod can be scheduled onto any zone. When ''whenUnsatisfiable=ScheduleAnyway'',
+                        it is used to give higher precedence to topologies that satisfy
+                        it. It''s a required field. Default value is 1 and 0 is not
+                        allowed.'
                         format: int32
                         type: integer
                       minDomains:
-                        description:
-                          "MinDomains indicates a minimum number of eligible
-                          domains. When the number of eligible domains with matching
-                          topology keys is less than minDomains, Pod Topology Spread
-                          treats \"global minimum\" as 0, and then the calculation of
-                          Skew is performed. And when the number of eligible domains
-                          with matching topology keys equals or greater than minDomains,
-                          this value has no effect on scheduling. As a result, when
-                          the number of eligible domains is less than minDomains, scheduler
-                          won't schedule more than maxSkew Pods to those domains. If
-                          value is nil, the constraint behaves as if MinDomains is equal
-                          to 1. Valid values are integers greater than 0. When value
-                          is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For
-                          example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains
-                          is set to 5 and pods with the same labelSelector spread as
-                          2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  |
-                          The number of domains is less than 5(MinDomains), so \"global
-                          minimum\" is treated as 0. In this situation, new pod with
-                          the same labelSelector cannot be scheduled, because computed
-                          skew will be 3(3 - 0) if new Pod is scheduled to any of the
-                          three zones, it will violate MaxSkew. \n This is a beta field
-                          and requires the MinDomainsInPodTopologySpread feature gate
-                          to be enabled (enabled by default)."
+                        description: "MinDomains indicates a minimum number of eligible
+                        domains. When the number of eligible domains with matching
+                        topology keys is less than minDomains, Pod Topology Spread
+                        treats \"global minimum\" as 0, and then the calculation of
+                        Skew is performed. And when the number of eligible domains
+                        with matching topology keys equals or greater than minDomains,
+                        this value has no effect on scheduling. As a result, when
+                        the number of eligible domains is less than minDomains, scheduler
+                        won't schedule more than maxSkew Pods to those domains. If
+                        value is nil, the constraint behaves as if MinDomains is equal
+                        to 1. Valid values are integers greater than 0. When value
+                        is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For
+                        example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains
+                        is set to 5 and pods with the same labelSelector spread as
+                        2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  |
+                        The number of domains is less than 5(MinDomains), so \"global
+                        minimum\" is treated as 0. In this situation, new pod with
+                        the same labelSelector cannot be scheduled, because computed
+                        skew will be 3(3 - 0) if new Pod is scheduled to any of the
+                        three zones, it will violate MaxSkew. \n This is a beta field
+                        and requires the MinDomainsInPodTopologySpread feature gate
+                        to be enabled (enabled by default)."
                         format: int32
                         type: integer
                       nodeAffinityPolicy:
-                        description:
-                          "NodeAffinityPolicy indicates how we will treat
-                          Pod's nodeAffinity/nodeSelector when calculating pod topology
-                          spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector
-                          are included in the calculations. - Ignore: nodeAffinity/nodeSelector
-                          are ignored. All nodes are included in the calculations. \n
-                          If this value is nil, the behavior is equivalent to the Honor
-                          policy. This is a beta-level feature default enabled by the
-                          NodeInclusionPolicyInPodTopologySpread feature flag."
+                        description: "NodeAffinityPolicy indicates how we will treat
+                        Pod's nodeAffinity/nodeSelector when calculating pod topology
+                        spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector
+                        are included in the calculations. - Ignore: nodeAffinity/nodeSelector
+                        are ignored. All nodes are included in the calculations. \n
+                        If this value is nil, the behavior is equivalent to the Honor
+                        policy. This is a beta-level feature default enabled by the
+                        NodeInclusionPolicyInPodTopologySpread feature flag."
                         type: string
                       nodeTaintsPolicy:
-                        description:
-                          "NodeTaintsPolicy indicates how we will treat node
-                          taints when calculating pod topology spread skew. Options
-                          are: - Honor: nodes without taints, along with tainted nodes
-                          for which the incoming pod has a toleration, are included.
-                          - Ignore: node taints are ignored. All nodes are included.
-                          \n If this value is nil, the behavior is equivalent to the
-                          Ignore policy. This is a beta-level feature default enabled
-                          by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                        description: "NodeTaintsPolicy indicates how we will treat node
+                        taints when calculating pod topology spread skew. Options
+                        are: - Honor: nodes without taints, along with tainted nodes
+                        for which the incoming pod has a toleration, are included.
+                        - Ignore: node taints are ignored. All nodes are included.
+                        \n If this value is nil, the behavior is equivalent to the
+                        Ignore policy. This is a beta-level feature default enabled
+                        by the NodeInclusionPolicyInPodTopologySpread feature flag."
                         type: string
                       topologyKey:
-                        description:
-                          TopologyKey is the key of node labels. Nodes that
+                        description: TopologyKey is the key of node labels. Nodes that
                           have a label with this key and identical values are considered
                           to be in the same topology. We consider each <key, value>
                           as a "bucket", and try to put balanced number of pods into
@@ -2969,23 +2683,22 @@ spec:
                           that topology. It's a required field.
                         type: string
                       whenUnsatisfiable:
-                        description:
-                          'WhenUnsatisfiable indicates how to deal with a
-                          pod if it doesn''t satisfy the spread constraint. - DoNotSchedule
-                          (default) tells the scheduler not to schedule it. - ScheduleAnyway
-                          tells the scheduler to schedule the pod in any location,   but
-                          giving higher precedence to topologies that would help reduce
-                          the   skew. A constraint is considered "Unsatisfiable" for
-                          an incoming pod if and only if every possible node assignment
-                          for that pod would violate "MaxSkew" on some topology. For
-                          example, in a 3-zone cluster, MaxSkew is set to 1, and pods
-                          with the same labelSelector spread as 3/1/1: | zone1 | zone2
-                          | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is
-                          set to DoNotSchedule, incoming pod can only be scheduled to
-                          zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on
-                          zone2(zone3) satisfies MaxSkew(1). In other words, the cluster
-                          can still be imbalanced, but scheduler won''t make it *more*
-                          imbalanced. It''s a required field.'
+                        description: 'WhenUnsatisfiable indicates how to deal with a
+                        pod if it doesn''t satisfy the spread constraint. - DoNotSchedule
+                        (default) tells the scheduler not to schedule it. - ScheduleAnyway
+                        tells the scheduler to schedule the pod in any location,   but
+                        giving higher precedence to topologies that would help reduce
+                        the   skew. A constraint is considered "Unsatisfiable" for
+                        an incoming pod if and only if every possible node assignment
+                        for that pod would violate "MaxSkew" on some topology. For
+                        example, in a 3-zone cluster, MaxSkew is set to 1, and pods
+                        with the same labelSelector spread as 3/1/1: | zone1 | zone2
+                        | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is
+                        set to DoNotSchedule, incoming pod can only be scheduled to
+                        zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on
+                        zone2(zone3) satisfies MaxSkew(1). In other words, the cluster
+                        can still be imbalanced, but scheduler won''t make it *more*
+                        imbalanced. It''s a required field.'
                         type: string
                     required:
                       - maxSkew
@@ -2998,154 +2711,127 @@ spec:
                     - whenUnsatisfiable
                   x-kubernetes-list-type: map
                 volumes:
-                  description:
-                    List of volumes that can be mounted by disks belonging
+                  description: List of volumes that can be mounted by disks belonging
                     to the vmi.
                   items:
                     description: Volume represents a named volume in a vmi.
                     properties:
                       cloudInitConfigDrive:
-                        description:
-                          "CloudInitConfigDrive represents a cloud-init Config
-                          Drive user-data source. The Config Drive data will be added
-                          as a disk to the vmi. A proper cloud-init installation is
-                          required inside the guest. More info: https://cloudinit.readthedocs.io/en/latest/topics/datasources/configdrive.html"
+                        description: 'CloudInitConfigDrive represents a cloud-init Config
+                        Drive user-data source. The Config Drive data will be added
+                        as a disk to the vmi. A proper cloud-init installation is
+                        required inside the guest. More info: https://cloudinit.readthedocs.io/en/latest/topics/datasources/configdrive.html'
                         properties:
                           networkData:
-                            description:
-                              NetworkData contains config drive inline cloud-init
+                            description: NetworkData contains config drive inline cloud-init
                               networkdata.
                             type: string
                           networkDataBase64:
-                            description:
-                              NetworkDataBase64 contains config drive cloud-init
+                            description: NetworkDataBase64 contains config drive cloud-init
                               networkdata as a base64 encoded string.
                             type: string
                           networkDataSecretRef:
-                            description:
-                              NetworkDataSecretRef references a k8s secret
+                            description: NetworkDataSecretRef references a k8s secret
                               that contains config drive networkdata.
                             properties:
                               name:
-                                description:
-                                  "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind, uid?"
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                             type: object
                           secretRef:
-                            description:
-                              UserDataSecretRef references a k8s secret that
+                            description: UserDataSecretRef references a k8s secret that
                               contains config drive userdata.
                             properties:
                               name:
-                                description:
-                                  "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind, uid?"
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                             type: object
                           userData:
-                            description:
-                              UserData contains config drive inline cloud-init
+                            description: UserData contains config drive inline cloud-init
                               userdata.
                             type: string
                           userDataBase64:
-                            description:
-                              UserDataBase64 contains config drive cloud-init
+                            description: UserDataBase64 contains config drive cloud-init
                               userdata as a base64 encoded string.
                             type: string
                         type: object
                       cloudInitNoCloud:
-                        description:
-                          "CloudInitNoCloud represents a cloud-init NoCloud
-                          user-data source. The NoCloud data will be added as a disk
-                          to the vmi. A proper cloud-init installation is required inside
-                          the guest. More info: http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html"
+                        description: 'CloudInitNoCloud represents a cloud-init NoCloud
+                        user-data source. The NoCloud data will be added as a disk
+                        to the vmi. A proper cloud-init installation is required inside
+                        the guest. More info: http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html'
                         properties:
                           networkData:
-                            description:
-                              NetworkData contains NoCloud inline cloud-init
+                            description: NetworkData contains NoCloud inline cloud-init
                               networkdata.
                             type: string
                           networkDataBase64:
-                            description:
-                              NetworkDataBase64 contains NoCloud cloud-init
+                            description: NetworkDataBase64 contains NoCloud cloud-init
                               networkdata as a base64 encoded string.
                             type: string
                           networkDataSecretRef:
-                            description:
-                              NetworkDataSecretRef references a k8s secret
+                            description: NetworkDataSecretRef references a k8s secret
                               that contains NoCloud networkdata.
                             properties:
                               name:
-                                description:
-                                  "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind, uid?"
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                             type: object
                           secretRef:
-                            description:
-                              UserDataSecretRef references a k8s secret that
+                            description: UserDataSecretRef references a k8s secret that
                               contains NoCloud userdata.
                             properties:
                               name:
-                                description:
-                                  "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind, uid?"
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                             type: object
                           userData:
-                            description:
-                              UserData contains NoCloud inline cloud-init
+                            description: UserData contains NoCloud inline cloud-init
                               userdata.
                             type: string
                           userDataBase64:
-                            description:
-                              UserDataBase64 contains NoCloud cloud-init
+                            description: UserDataBase64 contains NoCloud cloud-init
                               userdata as a base64 encoded string.
                             type: string
                         type: object
                       configMap:
-                        description:
-                          "ConfigMapSource represents a reference to a ConfigMap
-                          in the same namespace. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/"
+                        description: 'ConfigMapSource represents a reference to a ConfigMap
+                        in the same namespace. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/'
                         properties:
                           name:
-                            description:
-                              "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?"
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                           optional:
-                            description:
-                              Specify whether the ConfigMap or it's keys
+                            description: Specify whether the ConfigMap or it's keys
                               must be defined
                             type: boolean
                           volumeLabel:
-                            description:
-                              The volume label of the resulting disk inside
+                            description: The volume label of the resulting disk inside
                               the VMI. Different bootstrapping mechanisms require different
                               values. Typical values are "cidata" (cloud-init), "config-2"
                               (cloud-init) or "OEMDRV" (kickstart).
                             type: string
                         type: object
                       containerDisk:
-                        description:
-                          "ContainerDisk references a docker image, embedding
-                          a qcow or raw disk. More info: https://kubevirt.gitbooks.io/user-guide/registry-disk.html"
+                        description: 'ContainerDisk references a docker image, embedding
+                        a qcow or raw disk. More info: https://kubevirt.gitbooks.io/user-guide/registry-disk.html'
                         properties:
                           image:
-                            description:
-                              Image is the name of the image with the embedded
+                            description: Image is the name of the image with the embedded
                               disk.
                             type: string
                           imagePullPolicy:
-                            description:
-                              "Image pull policy. One of Always, Never, IfNotPresent.
-                              Defaults to Always if :latest tag is specified, or IfNotPresent
-                              otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images"
+                            description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                            Defaults to Always if :latest tag is specified, or IfNotPresent
+                            otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                             type: string
                           imagePullSecret:
-                            description:
-                              ImagePullSecret is the name of the Docker registry
+                            description: ImagePullSecret is the name of the Docker registry
                               secret required to pull the image. The secret must already
                               exist.
                             type: string
@@ -3156,19 +2842,16 @@ spec:
                           - image
                         type: object
                       dataVolume:
-                        description:
-                          DataVolume represents the dynamic creation a PVC
+                        description: DataVolume represents the dynamic creation a PVC
                           for this volume as well as the process of populating that
                           PVC with a disk image.
                         properties:
                           hotpluggable:
-                            description:
-                              Hotpluggable indicates whether the volume can
+                            description: Hotpluggable indicates whether the volume can
                               be hotplugged and hotunplugged.
                             type: boolean
                           name:
-                            description:
-                              Name of both the DataVolume and the PVC in
+                            description: Name of both the DataVolume and the PVC in
                               the same namespace. After PVC population the DataVolume
                               is garbage collected by default.
                             type: string
@@ -3176,80 +2859,70 @@ spec:
                           - name
                         type: object
                       downwardAPI:
-                        description:
-                          DownwardAPI represents downward API about the pod
+                        description: DownwardAPI represents downward API about the pod
                           that should populate this volume
                         properties:
                           fields:
                             description: Fields is a list of downward API volume file
                             items:
-                              description:
-                                DownwardAPIVolumeFile represents information
+                              description: DownwardAPIVolumeFile represents information
                                 to create the file containing the pod field
                               properties:
                                 fieldRef:
-                                  description:
-                                    "Required: Selects a field of the pod:
-                                    only annotations, labels, name and namespace are
-                                    supported."
+                                  description: 'Required: Selects a field of the pod:
+                                  only annotations, labels, name and namespace are
+                                  supported.'
                                   properties:
                                     apiVersion:
-                                      description:
-                                        Version of the schema the FieldPath
+                                      description: Version of the schema the FieldPath
                                         is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description:
-                                        Path of the field to select in the
+                                      description: Path of the field to select in the
                                         specified API version.
                                       type: string
                                   required:
                                     - fieldPath
                                   type: object
                                 mode:
-                                  description:
-                                    "Optional: mode bits used to set permissions
-                                    on this file, must be an octal value between 0000
-                                    and 0777 or a decimal value between 0 and 511. YAML
-                                    accepts both octal and decimal values, JSON requires
-                                    decimal values for mode bits. If not specified,
-                                    the volume defaultMode will be used. This might
-                                    be in conflict with other options that affect the
-                                    file mode, like fsGroup, and the result can be other
-                                    mode bits set."
+                                  description: 'Optional: mode bits used to set permissions
+                                  on this file, must be an octal value between 0000
+                                  and 0777 or a decimal value between 0 and 511. YAML
+                                  accepts both octal and decimal values, JSON requires
+                                  decimal values for mode bits. If not specified,
+                                  the volume defaultMode will be used. This might
+                                  be in conflict with other options that affect the
+                                  file mode, like fsGroup, and the result can be other
+                                  mode bits set.'
                                   format: int32
                                   type: integer
                                 path:
-                                  description:
-                                    "Required: Path is  the relative path
-                                    name of the file to be created. Must not be absolute
-                                    or contain the '..' path. Must be utf-8 encoded.
-                                    The first item of the relative path must not start
-                                    with '..'"
+                                  description: 'Required: Path is  the relative path
+                                  name of the file to be created. Must not be absolute
+                                  or contain the ''..'' path. Must be utf-8 encoded.
+                                  The first item of the relative path must not start
+                                  with ''..'''
                                   type: string
                                 resourceFieldRef:
-                                  description:
-                                    "Selects a resource of the container:
-                                    only resources limits and requests (limits.cpu,
-                                    limits.memory, requests.cpu and requests.memory)
-                                    are currently supported."
+                                  description: 'Selects a resource of the container:
+                                  only resources limits and requests (limits.cpu,
+                                  limits.memory, requests.cpu and requests.memory)
+                                  are currently supported.'
                                   properties:
                                     containerName:
-                                      description:
-                                        "Container name: required for volumes,
-                                        optional for env vars"
+                                      description: 'Container name: required for volumes,
+                                      optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                         - type: integer
                                         - type: string
-                                      description:
-                                        Specifies the output format of the
+                                      description: Specifies the output format of the
                                         exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: "Required: resource to select"
+                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                     - resource
@@ -3259,24 +2932,21 @@ spec:
                               type: object
                             type: array
                           volumeLabel:
-                            description:
-                              The volume label of the resulting disk inside
+                            description: The volume label of the resulting disk inside
                               the VMI. Different bootstrapping mechanisms require different
                               values. Typical values are "cidata" (cloud-init), "config-2"
                               (cloud-init) or "OEMDRV" (kickstart).
                             type: string
                         type: object
                       downwardMetrics:
-                        description:
-                          DownwardMetrics adds a very small disk to VMIs
+                        description: DownwardMetrics adds a very small disk to VMIs
                           which contains a limited view of host and guest metrics. The
                           disk content is compatible with vhostmd (https://github.com/vhostmd/vhostmd)
                           and vm-dump-metrics.
                         type: object
                       emptyDisk:
-                        description:
-                          "EmptyDisk represents a temporary disk which shares
-                          the vmis lifecycle. More info: https://kubevirt.gitbooks.io/user-guide/disks-and-volumes.html"
+                        description: 'EmptyDisk represents a temporary disk which shares
+                        the vmis lifecycle. More info: https://kubevirt.gitbooks.io/user-guide/disks-and-volumes.html'
                         properties:
                           capacity:
                             anyOf:
@@ -3289,35 +2959,33 @@ spec:
                           - capacity
                         type: object
                       ephemeral:
-                        description:
-                          Ephemeral is a special volume source that "wraps"
+                        description: Ephemeral is a special volume source that "wraps"
                           specified source and provides copy-on-write image on top of
                           it.
                         properties:
                           persistentVolumeClaim:
-                            description:
-                              "PersistentVolumeClaimVolumeSource represents
-                              a reference to a PersistentVolumeClaim in the same namespace.
-                              Directly attached to the vmi via qemu. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims"
+                            description: 'PersistentVolumeClaimVolumeSource represents
+                            a reference to a PersistentVolumeClaim in the same namespace.
+                            Directly attached to the vmi via qemu. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                             properties:
                               claimName:
-                                description:
-                                  "claimName is the name of a PersistentVolumeClaim
-                                  in the same namespace as the pod using this volume.
-                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims"
+                                description: 'claimName is the name of a PersistentVolumeClaim
+                                in the same namespace as the pod using this volume.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                 type: string
                               readOnly:
-                                description:
-                                  readOnly Will force the ReadOnly setting
+                                description: readOnly Will force the ReadOnly setting
                                   in VolumeMounts. Default false.
                                 type: boolean
                             required:
                               - claimName
                             type: object
+                          session:
+                            description: Base64 encoded session blob.
+                            type: string
                         type: object
                       hostDisk:
-                        description:
-                          HostDisk represents a disk created on the cluster
+                        description: HostDisk represents a disk created on the cluster
                           level
                         properties:
                           capacity:
@@ -3331,13 +2999,11 @@ spec:
                             description: The path to HostDisk image located on the cluster
                             type: string
                           shared:
-                            description:
-                              Shared indicate whether the path is shared
+                            description: Shared indicate whether the path is shared
                               between nodes
                             type: boolean
                           type:
-                            description:
-                              Contains information if disk.img exists or
+                            description: Contains information if disk.img exists or
                               should be created allowed options are 'Disk' and 'DiskOrCreate'
                             type: string
                         required:
@@ -3345,119 +3011,100 @@ spec:
                           - type
                         type: object
                       memoryDump:
-                        description:
-                          MemoryDump is attached to the virt launcher and
+                        description: MemoryDump is attached to the virt launcher and
                           is populated with a memory dump of the vmi
                         properties:
                           claimName:
-                            description:
-                              "claimName is the name of a PersistentVolumeClaim
-                              in the same namespace as the pod using this volume. More
-                              info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims"
+                            description: 'claimName is the name of a PersistentVolumeClaim
+                            in the same namespace as the pod using this volume. More
+                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                             type: string
                           hotpluggable:
-                            description:
-                              Hotpluggable indicates whether the volume can
+                            description: Hotpluggable indicates whether the volume can
                               be hotplugged and hotunplugged.
                             type: boolean
                           readOnly:
-                            description:
-                              readOnly Will force the ReadOnly setting in
+                            description: readOnly Will force the ReadOnly setting in
                               VolumeMounts. Default false.
                             type: boolean
                         required:
                           - claimName
                         type: object
                       name:
-                        description:
-                          "Volume's name. Must be a DNS_LABEL and unique
-                          within the vmi. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+                        description: 'Volume''s name. Must be a DNS_LABEL and unique
+                        within the vmi. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                         type: string
                       persistentVolumeClaim:
-                        description:
-                          "PersistentVolumeClaimVolumeSource represents a
-                          reference to a PersistentVolumeClaim in the same namespace.
-                          Directly attached to the vmi via qemu. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims"
+                        description: 'PersistentVolumeClaimVolumeSource represents a
+                        reference to a PersistentVolumeClaim in the same namespace.
+                        Directly attached to the vmi via qemu. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                         properties:
                           claimName:
-                            description:
-                              "claimName is the name of a PersistentVolumeClaim
-                              in the same namespace as the pod using this volume. More
-                              info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims"
+                            description: 'claimName is the name of a PersistentVolumeClaim
+                            in the same namespace as the pod using this volume. More
+                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                             type: string
                           hotpluggable:
-                            description:
-                              Hotpluggable indicates whether the volume can
+                            description: Hotpluggable indicates whether the volume can
                               be hotplugged and hotunplugged.
                             type: boolean
                           readOnly:
-                            description:
-                              readOnly Will force the ReadOnly setting in
+                            description: readOnly Will force the ReadOnly setting in
                               VolumeMounts. Default false.
                             type: boolean
                         required:
                           - claimName
                         type: object
                       secret:
-                        description:
-                          "SecretVolumeSource represents a reference to a
-                          secret data in the same namespace. More info: https://kubernetes.io/docs/concepts/configuration/secret/"
+                        description: 'SecretVolumeSource represents a reference to a
+                        secret data in the same namespace. More info: https://kubernetes.io/docs/concepts/configuration/secret/'
                         properties:
                           optional:
-                            description:
-                              Specify whether the Secret or it's keys must
+                            description: Specify whether the Secret or it's keys must
                               be defined
                             type: boolean
                           secretName:
-                            description:
-                              "Name of the secret in the pod's namespace
-                              to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret"
+                            description: 'Name of the secret in the pod''s namespace
+                            to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                             type: string
                           volumeLabel:
-                            description:
-                              The volume label of the resulting disk inside
+                            description: The volume label of the resulting disk inside
                               the VMI. Different bootstrapping mechanisms require different
                               values. Typical values are "cidata" (cloud-init), "config-2"
                               (cloud-init) or "OEMDRV" (kickstart).
                             type: string
                         type: object
                       serviceAccount:
-                        description:
-                          "ServiceAccountVolumeSource represents a reference
-                          to a service account. There can only be one volume of this
-                          type! More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/"
+                        description: 'ServiceAccountVolumeSource represents a reference
+                        to a service account. There can only be one volume of this
+                        type! More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                         properties:
                           serviceAccountName:
-                            description:
-                              "Name of the service account in the pod's
-                              namespace to use. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/"
+                            description: 'Name of the service account in the pod''s
+                            namespace to use. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                             type: string
                         type: object
                       sysprep:
                         description: Represents a Sysprep volume source.
                         properties:
                           configMap:
-                            description:
-                              ConfigMap references a ConfigMap that contains
+                            description: ConfigMap references a ConfigMap that contains
                               Sysprep answer file named autounattend.xml that should
                               be attached as disk of CDROM type.
                             properties:
                               name:
-                                description:
-                                  "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind, uid?"
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                             type: object
                           secret:
-                            description:
-                              Secret references a k8s Secret that contains
+                            description: Secret references a k8s Secret that contains
                               Sysprep answer file named autounattend.xml that should
                               be attached as disk of CDROM type.
                             properties:
                               name:
-                                description:
-                                  "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind, uid?"
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                             type: object
                         type: object
@@ -3469,27 +3116,23 @@ spec:
                 - domain
               type: object
             status:
-              description:
-                Status is the high level overview of how the VirtualMachineInstance
+              description: Status is the high level overview of how the VirtualMachineInstance
                 is doing. It contains information available to controllers and users.
               properties:
                 VSOCKCID:
-                  description:
-                    VSOCKCID is used to track the allocated VSOCK CID in
+                  description: VSOCKCID is used to track the allocated VSOCK CID in
                     the VM.
                   format: int32
                   type: integer
                 activePods:
                   additionalProperties:
                     type: string
-                  description:
-                    ActivePods is a mapping of pod UID to node name. It is
+                  description: ActivePods is a mapping of pod UID to node name. It is
                     possible for multiple pods to be running for a single VMI during
                     migration.
                   type: object
                 conditions:
-                  description:
-                    Conditions are specific points in VirtualMachineInstance's
+                  description: Conditions are specific points in VirtualMachineInstance's
                     pod runtime.
                   items:
                     properties:
@@ -3515,40 +3158,34 @@ spec:
                     type: object
                   type: array
                 currentCPUTopology:
-                  description:
-                    CurrentCPUTopology specifies the current CPU topology
+                  description: CurrentCPUTopology specifies the current CPU topology
                     used by the VM workload. Current topology may differ from the desired
                     topology in the spec while CPU hotplug takes place.
                   properties:
                     cores:
-                      description:
-                        Cores specifies the number of cores inside the vmi.
+                      description: Cores specifies the number of cores inside the vmi.
                         Must be a value greater or equal 1.
                       format: int32
                       type: integer
                     sockets:
-                      description:
-                        Sockets specifies the number of sockets inside the
+                      description: Sockets specifies the number of sockets inside the
                         vmi. Must be a value greater or equal 1.
                       format: int32
                       type: integer
                     threads:
-                      description:
-                        Threads specifies the number of threads inside the
+                      description: Threads specifies the number of threads inside the
                         vmi. Must be a value greater or equal 1.
                       format: int32
                       type: integer
                   type: object
                 evacuationNodeName:
-                  description:
-                    EvacuationNodeName is used to track the eviction process
+                  description: EvacuationNodeName is used to track the eviction process
                     of a VMI. It stores the name of the node that we want to evacuate.
                     It is meant to be used by KubeVirt core components only and can't
                     be set or modified by users.
                   type: string
                 fsFreezeStatus:
-                  description:
-                    FSFreezeStatus is the state of the fs of the guest it
+                  description: FSFreezeStatus is the state of the fs of the guest it
                     can be either frozen or thawed
                   type: string
                 guestOSInfo:
@@ -3580,22 +3217,19 @@ spec:
                       type: string
                   type: object
                 interfaces:
-                  description:
-                    Interfaces represent the details of available network
+                  description: Interfaces represent the details of available network
                     interfaces.
                   items:
                     properties:
                       infoSource:
-                        description:
-                          "Specifies the origin of the interface data collected.
-                          values: domain, guest-agent, multus-status."
+                        description: 'Specifies the origin of the interface data collected.
+                        values: domain, guest-agent, multus-status.'
                         type: string
                       interfaceName:
                         description: The interface name inside the Virtual Machine
                         type: string
                       ipAddress:
-                        description:
-                          IP address of a Virtual Machine interface. It is
+                        description: IP address of a Virtual Machine interface. It is
                           always the first item of IPs
                         type: string
                       ipAddresses:
@@ -3607,8 +3241,7 @@ spec:
                         description: Hardware address of a Virtual Machine interface
                         type: string
                       name:
-                        description:
-                          Name of the interface, corresponds to name of the
+                        description: Name of the interface, corresponds to name of the
                           network assigned to the interface
                         type: string
                       queueCount:
@@ -3617,14 +3250,32 @@ spec:
                         type: integer
                     type: object
                   type: array
+                kernelBootStatus:
+                  description: KernelBootStatus contains info about the kernelBootContainer
+                  properties:
+                    initrdInfo:
+                      description: InitrdInfo show info about the initrd file
+                      properties:
+                        checksum:
+                          description: Checksum is the checksum of the initrd file
+                          format: int32
+                          type: integer
+                      type: object
+                    kernelInfo:
+                      description: KernelInfo show info about the kernel image
+                      properties:
+                        checksum:
+                          description: Checksum is the checksum of the kernel image
+                          format: int32
+                          type: integer
+                      type: object
+                  type: object
                 launcherContainerImageVersion:
-                  description:
-                    LauncherContainerImageVersion indicates what container
+                  description: LauncherContainerImageVersion indicates what container
                     image is currently active for the vmi.
                   type: string
                 machine:
-                  description:
-                    Machine shows the final resulting qemu machine type.
+                  description: Machine shows the final resulting qemu machine type.
                     This can be different than the machine type selected in the spec,
                     due to qemus machine type alias mechanism.
                   properties:
@@ -3632,22 +3283,48 @@ spec:
                       description: QEMU machine type is the actual chipset of the VirtualMachineInstance.
                       type: string
                   type: object
+                memory:
+                  description: Memory shows various informations about the VirtualMachine
+                    memory.
+                  properties:
+                    guestAtBoot:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: GuestAtBoot specifies with how much memory the VirtualMachine
+                        intiallly booted with.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    guestCurrent:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: GuestCurrent specifies how much memory is currently
+                        available for the VirtualMachine.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    guestRequested:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: GuestRequested specifies how much memory was requested
+                        (hotplug) for the VirtualMachine.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
                 migrationMethod:
-                  description:
-                    "Represents the method using which the vmi can be migrated:
-                    live migration or block migration"
+                  description: 'Represents the method using which the vmi can be migrated:
+                  live migration or block migration'
                   type: string
                 migrationState:
                   description: Represents the status of a live migration
                   properties:
                     abortRequested:
-                      description:
-                        Indicates that the migration has been requested to
+                      description: Indicates that the migration has been requested to
                         abort
                       type: boolean
                     abortStatus:
-                      description:
-                        Indicates the final status of the live migration
+                      description: Indicates the final status of the live migration
                         abortion
                       type: string
                     completed:
@@ -3661,18 +3338,19 @@ spec:
                     failed:
                       description: Indicates that the migration failed
                       type: boolean
+                    failureReason:
+                      description: Contains the reason why the migration failed
+                      type: string
                     migrationConfiguration:
                       description: Migration configurations to apply
                       properties:
                         allowAutoConverge:
-                          description:
-                            AllowAutoConverge allows the platform to compromise
+                          description: AllowAutoConverge allows the platform to compromise
                             performance/availability of VMIs to guarantee successful
                             VMI live migrations. Defaults to false
                           type: boolean
                         allowPostCopy:
-                          description:
-                            AllowPostCopy enables post-copy live migrations.
+                          description: AllowPostCopy enables post-copy live migrations.
                             Such migrations allow even the busiest VMIs to successfully
                             live-migrate. However, events like a network failure can
                             cause a VMI crash. If set to true, migrations will still
@@ -3683,15 +3361,13 @@ spec:
                           anyOf:
                             - type: integer
                             - type: string
-                          description:
-                            BandwidthPerMigration limits the amount of network
+                          description: BandwidthPerMigration limits the amount of network
                             bandwidth live migrations are allowed to use. The value
                             is in quantity per second. Defaults to 0 (no limit)
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         completionTimeoutPerGiB:
-                          description:
-                            CompletionTimeoutPerGiB is the maximum number
+                          description: CompletionTimeoutPerGiB is the maximum number
                             of seconds per GiB a migration is allowed to take. If a
                             live-migration takes longer to migrate than this value multiplied
                             by the size of the VMI, the migration will be cancelled,
@@ -3699,14 +3375,12 @@ spec:
                           format: int64
                           type: integer
                         disableTLS:
-                          description:
-                            When set to true, DisableTLS will disable the
+                          description: When set to true, DisableTLS will disable the
                             additional layer of live migration encryption provided by
                             KubeVirt. This is usually a bad idea. Defaults to false
                           type: boolean
                         matchSELinuxLevelOnMigration:
-                          description:
-                            By default, the SELinux level of target virt-launcher
+                          description: By default, the SELinux level of target virt-launcher
                             pods is forced to the level of the source virt-launcher.
                             When set to true, MatchSELinuxLevelOnMigration lets the
                             CRI auto-assign a random level to the target. That will
@@ -3716,34 +3390,29 @@ spec:
                             SELinux levels.
                           type: boolean
                         network:
-                          description:
-                            Network is the name of the CNI network to use
+                          description: Network is the name of the CNI network to use
                             for live migrations. By default, migrations go through the
                             pod network.
                           type: string
                         nodeDrainTaintKey:
-                          description:
-                            "NodeDrainTaintKey defines the taint key that
-                            indicates a node should be drained. Note: this option relies
-                            on the deprecated node taint feature. Default: kubevirt.io/drain"
+                          description: 'NodeDrainTaintKey defines the taint key that
+                          indicates a node should be drained. Note: this option relies
+                          on the deprecated node taint feature. Default: kubevirt.io/drain'
                           type: string
                         parallelMigrationsPerCluster:
-                          description:
-                            ParallelMigrationsPerCluster is the total number
+                          description: ParallelMigrationsPerCluster is the total number
                             of concurrent live migrations allowed cluster-wide. Defaults
                             to 5
                           format: int32
                           type: integer
                         parallelOutboundMigrationsPerNode:
-                          description:
-                            ParallelOutboundMigrationsPerNode is the maximum
+                          description: ParallelOutboundMigrationsPerNode is the maximum
                             number of concurrent outgoing live migrations allowed per
                             node. Defaults to 2
                           format: int32
                           type: integer
                         progressTimeout:
-                          description:
-                            ProgressTimeout is the maximum number of seconds
+                          description: ProgressTimeout is the maximum number of seconds
                             a live migration is allowed to make no progress. Hitting
                             this timeout means a migration transferred 0 data for that
                             many seconds. The migration is then considered stuck and
@@ -3751,29 +3420,27 @@ spec:
                           format: int64
                           type: integer
                         unsafeMigrationOverride:
-                          description:
-                            UnsafeMigrationOverride allows live migrations
+                          description: UnsafeMigrationOverride allows live migrations
                             to occur even if the compatibility check indicates the migration
                             will be unsafe to the guest. Defaults to false
                           type: boolean
                       type: object
                     migrationPolicyName:
-                      description:
-                        Name of the migration policy. If string is empty,
+                      description: Name of the migration policy. If string is empty,
                         no policy is matched
                       type: string
                     migrationUid:
-                      description:
-                        The VirtualMachineInstanceMigration object associated
+                      description: The VirtualMachineInstanceMigration object associated
                         with this migration
                       type: string
                     mode:
-                      description:
-                        Lets us know if the vmi is currently running pre
+                      description: Lets us know if the vmi is currently running pre
                         or post copy migration
                       type: string
                     sourceNode:
                       description: The source node that the VMI originated on
+                      type: string
+                    sourcePod:
                       type: string
                     startTimestamp:
                       description: The time the migration action began
@@ -3781,13 +3448,11 @@ spec:
                       nullable: true
                       type: string
                     targetAttachmentPodUID:
-                      description:
-                        The UID of the target attachment pod for hotplug
+                      description: The UID of the target attachment pod for hotplug
                         volumes
                       type: string
                     targetCPUSet:
-                      description:
-                        If the VMI requires dedicated CPUs, this field will
+                      description: If the VMI requires dedicated CPUs, this field will
                         hold the dedicated CPU set on the target node
                       items:
                         type: integer
@@ -3796,8 +3461,7 @@ spec:
                     targetDirectMigrationNodePorts:
                       additionalProperties:
                         type: integer
-                      description:
-                        The list of ports opened for live migration on the
+                      description: The list of ports opened for live migration on the
                         destination node
                       type: object
                     targetNode:
@@ -3810,14 +3474,12 @@ spec:
                       description: The Target Node has seen the Domain Start Event
                       type: boolean
                     targetNodeDomainReadyTimestamp:
-                      description:
-                        The timestamp at which the target node detects the
+                      description: The timestamp at which the target node detects the
                         domain is active
                       format: date-time
                       type: string
                     targetNodeTopology:
-                      description:
-                        If the VMI requires dedicated CPUs, this field will
+                      description: If the VMI requires dedicated CPUs, this field will
                         hold the numa topology on the target node
                       type: string
                     targetPod:
@@ -3828,34 +3490,28 @@ spec:
                   description: This represents the migration transport
                   type: string
                 nodeName:
-                  description:
-                    NodeName is the name where the VirtualMachineInstance
+                  description: NodeName is the name where the VirtualMachineInstance
                     is currently running.
                   type: string
                 phase:
-                  description:
-                    Phase is the status of the VirtualMachineInstance in
+                  description: Phase is the status of the VirtualMachineInstance in
                     kubernetes world. It is not the VirtualMachineInstance status, but
                     partially correlates to it.
                   type: string
                 phaseTransitionTimestamps:
-                  description:
-                    PhaseTransitionTimestamp is the timestamp of when the
+                  description: PhaseTransitionTimestamp is the timestamp of when the
                     last phase change occurred
                   items:
-                    description:
-                      VirtualMachineInstancePhaseTransitionTimestamp gives
+                    description: VirtualMachineInstancePhaseTransitionTimestamp gives
                       a timestamp in relation to when a phase is set on a vmi
                     properties:
                       phase:
-                        description:
-                          Phase is the status of the VirtualMachineInstance
+                        description: Phase is the status of the VirtualMachineInstance
                           in kubernetes world. It is not the VirtualMachineInstance
                           status, but partially correlates to it.
                         type: string
                       phaseTransitionTimestamp:
-                        description:
-                          PhaseTransitionTimestamp is the timestamp of when
+                        description: PhaseTransitionTimestamp is the timestamp of when
                           the phase change occurred
                         format: date-time
                         type: string
@@ -3863,25 +3519,21 @@ spec:
                   type: array
                   x-kubernetes-list-type: atomic
                 qosClass:
-                  description:
-                    "The Quality of Service (QOS) classification assigned
-                    to the virtual machine instance based on resource requirements See
-                    PodQOSClass type for available QOS classes More info: https://git.k8s.io/community/contributors/design-proposals/node/resource-qos.md"
+                  description: 'The Quality of Service (QOS) classification assigned
+                  to the virtual machine instance based on resource requirements See
+                  PodQOSClass type for available QOS classes More info: https://git.k8s.io/community/contributors/design-proposals/node/resource-qos.md'
                   type: string
                 reason:
-                  description:
-                    A brief CamelCase message indicating details about why
+                  description: A brief CamelCase message indicating details about why
                     the VMI is in this state. e.g. 'NodeUnresponsive'
                   type: string
                 runtimeUser:
-                  description:
-                    RuntimeUser is used to determine what user will be used
+                  description: RuntimeUser is used to determine what user will be used
                     in launcher
                   format: int64
                   type: integer
                 selinuxContext:
-                  description:
-                    SELinuxContext is the actual SELinux context of the virt-launcher
+                  description: SELinuxContext is the actual SELinux context of the virt-launcher
                     pod
                   type: string
                 topologyHints:
@@ -3891,78 +3543,75 @@ spec:
                       type: integer
                   type: object
                 virtualMachineRevisionName:
-                  description:
-                    VirtualMachineRevisionName is used to get the vm revision
+                  description: VirtualMachineRevisionName is used to get the vm revision
                     of the vmi when doing an online vm snapshot
                   type: string
                 volumeStatus:
                   description: VolumeStatus contains the statuses of all the volumes
                   items:
-                    description:
-                      VolumeStatus represents information about the status
+                    description: VolumeStatus represents information about the status
                       of volumes attached to the VirtualMachineInstance.
                     properties:
+                      containerDiskVolume:
+                        description: ContainerDiskVolume shows info about the containerdisk,
+                          if the volume is a containerdisk
+                        properties:
+                          checksum:
+                            description: Checksum is the checksum of the rootdisk or
+                              kernel artifacts inside the containerdisk
+                            format: int32
+                            type: integer
+                        type: object
                       hotplugVolume:
-                        description:
-                          If the volume is hotplug, this will contain the
+                        description: If the volume is hotplug, this will contain the
                           hotplug status.
                         properties:
                           attachPodName:
-                            description:
-                              AttachPodName is the name of the pod used to
+                            description: AttachPodName is the name of the pod used to
                               attach the volume to the node.
                             type: string
                           attachPodUID:
-                            description:
-                              AttachPodUID is the UID of the pod used to
+                            description: AttachPodUID is the UID of the pod used to
                               attach the volume to the node.
                             type: string
                         type: object
                       memoryDumpVolume:
-                        description:
-                          If the volume is memorydump volume, this will contain
+                        description: If the volume is memorydump volume, this will contain
                           the memorydump info.
                         properties:
                           claimName:
-                            description:
-                              ClaimName is the name of the pvc the memory
+                            description: ClaimName is the name of the pvc the memory
                               was dumped to
                             type: string
                           endTimestamp:
-                            description:
-                              EndTimestamp is the time when the memory dump
+                            description: EndTimestamp is the time when the memory dump
                               completed
                             format: date-time
                             type: string
                           startTimestamp:
-                            description:
-                              StartTimestamp is the time when the memory
+                            description: StartTimestamp is the time when the memory
                               dump started
                             format: date-time
                             type: string
                           targetFileName:
-                            description:
-                              TargetFileName is the name of the memory dump
+                            description: TargetFileName is the name of the memory dump
                               output
                             type: string
                         type: object
                       message:
-                        description:
-                          Message is a detailed message about the current
+                        description: Message is a detailed message about the current
                           hotplug volume phase
                         type: string
                       name:
                         description: Name is the name of the volume
                         type: string
                       persistentVolumeClaimInfo:
-                        description:
-                          PersistentVolumeClaimInfo is information about
+                        description: PersistentVolumeClaimInfo is information about
                           the PVC that handler requires during start flow
                         properties:
                           accessModes:
-                            description:
-                              "AccessModes contains the desired access modes
-                              the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1"
+                            description: 'AccessModes contains the desired access modes
+                            the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                             items:
                               type: string
                             type: array
@@ -3974,19 +3623,16 @@ spec:
                                 - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description:
-                              Capacity represents the capacity set on the
+                            description: Capacity represents the capacity set on the
                               corresponding PVC status
                             type: object
                           filesystemOverhead:
-                            description:
-                              Percentage of filesystem's size to be reserved
+                            description: Percentage of filesystem's size to be reserved
                               when resizing the PVC
                             pattern: ^(0(?:\.\d{1,3})?|1)$
                             type: string
                           preallocated:
-                            description:
-                              Preallocated indicates if the PVC's storage
+                            description: Preallocated indicates if the PVC's storage
                               is preallocated or not
                             type: boolean
                           requests:
@@ -3996,13 +3642,11 @@ spec:
                                 - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description:
-                              Requests represents the resources requested
+                            description: Requests represents the resources requested
                               by the corresponding PVC spec
                             type: object
                           volumeMode:
-                            description:
-                              VolumeMode defines what type of volume is required
+                            description: VolumeMode defines what type of volume is required
                               by the claim. Value of Filesystem is implied when not
                               included in claim spec.
                             type: string
@@ -4011,8 +3655,7 @@ spec:
                         description: Phase is the phase
                         type: string
                       reason:
-                        description:
-                          Reason is a brief description of why we are in
+                        description: Reason is a brief description of why we are in
                           the current hotplug volume phase
                         type: string
                       size:
@@ -4020,9 +3663,8 @@ spec:
                         format: int64
                         type: integer
                       target:
-                        description:
-                          "Target is the target name used when adding the
-                          volume to the VM, eg: vda"
+                        description: 'Target is the target name used when adding the
+                        volume to the VM, eg: vda'
                         type: string
                     required:
                       - name

--- a/crds/embedded/virtualmachines.yaml
+++ b/crds/embedded/virtualmachines.yaml
@@ -1,11 +1,11 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: internalvirtualizationvirtualmachines.internal.virtualization.deckhouse.io
   labels:
+    app.kubernetes.io/component: kubevirt
     heritage: deckhouse
     module: virtualization
-    app.kubernetes.io/component: kubevirt
+  name: internalvirtualizationvirtualmachines.internal.virtualization.deckhouse.io
 spec:
   conversion:
     strategy: None
@@ -36,34 +36,29 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description:
-            VirtualMachine handles the VirtualMachines that are not running
+          description: VirtualMachine handles the VirtualMachines that are not running
             or are in a stopped state The VirtualMachine contains the template to create
             the VirtualMachineInstance. It also mirrors the running state of the created
             VirtualMachineInstance in its status.
           properties:
             apiVersion:
-              description:
-                "APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description:
-                "Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
             spec:
-              description:
-                Spec contains the specification of VirtualMachineInstance
+              description: Spec contains the specification of VirtualMachineInstance
                 created
               properties:
                 dataVolumeTemplates:
-                  description:
-                    dataVolumeTemplates is a list of dataVolumes that the
+                  description: dataVolumeTemplates is a list of dataVolumes that the
                     VirtualMachineInstance template can reference. DataVolumes in this
                     list are dynamically created for the VirtualMachine and are tied
                     to the VirtualMachine's life-cycle.
@@ -71,18 +66,16 @@ spec:
                     nullable: true
                     properties:
                       apiVersion:
-                        description:
-                          "APIVersion defines the versioned schema of this
-                          representation of an object. Servers should convert recognized
-                          schemas to the latest internal value, and may reject unrecognized
-                          values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+                        description: 'APIVersion defines the versioned schema of this
+                        representation of an object. Servers should convert recognized
+                        schemas to the latest internal value, and may reject unrecognized
+                        values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                         type: string
                       kind:
-                        description:
-                          "Kind is a string value representing the REST resource
-                          this object represents. Servers may infer this from the endpoint
-                          the client submits requests to. Cannot be updated. In CamelCase.
-                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+                        description: 'Kind is a string value representing the REST resource
+                        this object represents. Servers may infer this from the endpoint
+                        the client submits requests to. Cannot be updated. In CamelCase.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                         type: string
                       metadata:
                         nullable: true
@@ -92,22 +85,18 @@ spec:
                         description: DataVolumeSpec contains the DataVolume specification.
                         properties:
                           checkpoints:
-                            description:
-                              Checkpoints is a list of DataVolumeCheckpoints,
+                            description: Checkpoints is a list of DataVolumeCheckpoints,
                               representing stages in a multistage import.
                             items:
-                              description:
-                                DataVolumeCheckpoint defines a stage in a
+                              description: DataVolumeCheckpoint defines a stage in a
                                 warm migration.
                               properties:
                                 current:
-                                  description:
-                                    Current is the identifier of the snapshot
+                                  description: Current is the identifier of the snapshot
                                     created for this checkpoint.
                                   type: string
                                 previous:
-                                  description:
-                                    Previous is the identifier of the snapshot
+                                  description: Previous is the identifier of the snapshot
                                     from the previous checkpoint.
                                   type: string
                               required:
@@ -116,67 +105,58 @@ spec:
                               type: object
                             type: array
                           contentType:
-                            description:
-                              'DataVolumeContentType options: "kubevirt",
-                              "archive"'
+                            description: 'DataVolumeContentType options: "kubevirt",
+                            "archive"'
                             enum:
                               - kubevirt
                               - archive
                             type: string
                           finalCheckpoint:
-                            description:
-                              FinalCheckpoint indicates whether the current
+                            description: FinalCheckpoint indicates whether the current
                               DataVolumeCheckpoint is the final checkpoint.
                             type: boolean
                           preallocation:
-                            description:
-                              Preallocation controls whether storage for
+                            description: Preallocation controls whether storage for
                               DataVolumes should be allocated in advance.
                             type: boolean
                           priorityClassName:
-                            description:
-                              PriorityClassName for Importer, Cloner and
+                            description: PriorityClassName for Importer, Cloner and
                               Uploader pod
                             type: string
                           pvc:
                             description: PVC is the PVC specification
                             properties:
                               accessModes:
-                                description:
-                                  "accessModes contains the desired access
-                                  modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1"
+                                description: 'accessModes contains the desired access
+                                modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                 items:
                                   type: string
                                 type: array
                               dataSource:
-                                description:
-                                  "dataSource field can be used to specify
-                                  either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                  * An existing PVC (PersistentVolumeClaim) If the provisioner
-                                  or an external controller can support the specified
-                                  data source, it will create a new volume based on
-                                  the contents of the specified data source. When the
-                                  AnyVolumeDataSource feature gate is enabled, dataSource
-                                  contents will be copied to dataSourceRef, and dataSourceRef
-                                  contents will be copied to dataSource when dataSourceRef.namespace
-                                  is not specified. If the namespace is specified, then
-                                  dataSourceRef will not be copied to dataSource."
+                                description: 'dataSource field can be used to specify
+                                either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                * An existing PVC (PersistentVolumeClaim) If the provisioner
+                                or an external controller can support the specified
+                                data source, it will create a new volume based on
+                                the contents of the specified data source. When the
+                                AnyVolumeDataSource feature gate is enabled, dataSource
+                                contents will be copied to dataSourceRef, and dataSourceRef
+                                contents will be copied to dataSource when dataSourceRef.namespace
+                                is not specified. If the namespace is specified, then
+                                dataSourceRef will not be copied to dataSource.'
                                 properties:
                                   apiGroup:
-                                    description:
-                                      APIGroup is the group for the resource
+                                    description: APIGroup is the group for the resource
                                       being referenced. If APIGroup is not specified,
                                       the specified Kind must be in the core API group.
                                       For any other third-party types, APIGroup is required.
                                     type: string
                                   kind:
-                                    description:
-                                      Kind is the type of resource being
+                                    description: Kind is the type of resource being
                                       referenced
                                     type: string
                                   name:
-                                    description:
-                                      Name is the name of resource being
+                                    description: Name is the name of resource being
                                       referenced
                                     type: string
                                 required:
@@ -184,57 +164,52 @@ spec:
                                   - name
                                 type: object
                               dataSourceRef:
-                                description:
-                                  "dataSourceRef specifies the object from
-                                  which to populate the volume with data, if a non-empty
-                                  volume is desired. This may be any object from a non-empty
-                                  API group (non core object) or a PersistentVolumeClaim
-                                  object. When this field is specified, volume binding
-                                  will only succeed if the type of the specified object
-                                  matches some installed volume populator or dynamic
-                                  provisioner. This field will replace the functionality
-                                  of the dataSource field and as such if both fields
-                                  are non-empty, they must have the same value. For
-                                  backwards compatibility, when namespace isn't specified
-                                  in dataSourceRef, both fields (dataSource and dataSourceRef)
-                                  will be set to the same value automatically if one
-                                  of them is empty and the other is non-empty. When
-                                  namespace is specified in dataSourceRef, dataSource
-                                  isn't set to the same value and must be empty. There
-                                  are three important differences between dataSource
-                                  and dataSourceRef: * While dataSource only allows
-                                  two specific types of objects, dataSourceRef   allows
-                                  any non-core object, as well as PersistentVolumeClaim
-                                  objects. * While dataSource ignores disallowed values
-                                  (dropping them), dataSourceRef   preserves all values,
-                                  and generates an error if a disallowed value is   specified.
-                                  * While dataSource only allows local objects, dataSourceRef
-                                  allows objects   in any namespaces. (Beta) Using this
-                                  field requires the AnyVolumeDataSource feature gate
-                                  to be enabled. (Alpha) Using the namespace field of
-                                  dataSourceRef requires the CrossNamespaceVolumeDataSource
-                                  feature gate to be enabled."
+                                description: 'dataSourceRef specifies the object from
+                                which to populate the volume with data, if a non-empty
+                                volume is desired. This may be any object from a non-empty
+                                API group (non core object) or a PersistentVolumeClaim
+                                object. When this field is specified, volume binding
+                                will only succeed if the type of the specified object
+                                matches some installed volume populator or dynamic
+                                provisioner. This field will replace the functionality
+                                of the dataSource field and as such if both fields
+                                are non-empty, they must have the same value. For
+                                backwards compatibility, when namespace isn''t specified
+                                in dataSourceRef, both fields (dataSource and dataSourceRef)
+                                will be set to the same value automatically if one
+                                of them is empty and the other is non-empty. When
+                                namespace is specified in dataSourceRef, dataSource
+                                isn''t set to the same value and must be empty. There
+                                are three important differences between dataSource
+                                and dataSourceRef: * While dataSource only allows
+                                two specific types of objects, dataSourceRef   allows
+                                any non-core object, as well as PersistentVolumeClaim
+                                objects. * While dataSource ignores disallowed values
+                                (dropping them), dataSourceRef   preserves all values,
+                                and generates an error if a disallowed value is   specified.
+                                * While dataSource only allows local objects, dataSourceRef
+                                allows objects   in any namespaces. (Beta) Using this
+                                field requires the AnyVolumeDataSource feature gate
+                                to be enabled. (Alpha) Using the namespace field of
+                                dataSourceRef requires the CrossNamespaceVolumeDataSource
+                                feature gate to be enabled.'
                                 properties:
                                   apiGroup:
-                                    description:
-                                      APIGroup is the group for the resource
+                                    description: APIGroup is the group for the resource
                                       being referenced. If APIGroup is not specified,
                                       the specified Kind must be in the core API group.
                                       For any other third-party types, APIGroup is required.
                                     type: string
                                   kind:
-                                    description:
-                                      Kind is the type of resource being
+                                    description: Kind is the type of resource being
                                       referenced
                                     type: string
                                   name:
-                                    description:
-                                      Name is the name of resource being
+                                    description: Name is the name of resource being
                                       referenced
                                     type: string
                                   namespace:
-                                    description:
-                                      Namespace is the namespace of resource
+                                    description: Namespace is the namespace of resource
                                       being referenced Note that when a namespace is
                                       specified, a gateway.networking.k8s.io/ReferenceGrant
                                       object is required in the referent namespace to
@@ -248,30 +223,26 @@ spec:
                                   - name
                                 type: object
                               resources:
-                                description:
-                                  "resources represents the minimum resources
-                                  the volume should have. If RecoverVolumeExpansionFailure
-                                  feature is enabled users are allowed to specify resource
-                                  requirements that are lower than previous value but
-                                  must still be higher than capacity recorded in the
-                                  status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources"
+                                description: 'resources represents the minimum resources
+                                the volume should have. If RecoverVolumeExpansionFailure
+                                feature is enabled users are allowed to specify resource
+                                requirements that are lower than previous value but
+                                must still be higher than capacity recorded in the
+                                status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                 properties:
                                   claims:
-                                    description:
-                                      "Claims lists the names of resources,
-                                      defined in spec.resourceClaims, that are used
-                                      by this container. \n This is an alpha field and
-                                      requires enabling the DynamicResourceAllocation
-                                      feature gate. \n This field is immutable. It can
-                                      only be set for containers."
+                                    description: "Claims lists the names of resources,
+                                    defined in spec.resourceClaims, that are used
+                                    by this container. \n This is an alpha field and
+                                    requires enabling the DynamicResourceAllocation
+                                    feature gate. \n This field is immutable. It can
+                                    only be set for containers."
                                     items:
-                                      description:
-                                        ResourceClaim references one entry
+                                      description: ResourceClaim references one entry
                                         in PodSpec.ResourceClaims.
                                       properties:
                                         name:
-                                          description:
-                                            Name must match the name of one
+                                          description: Name must match the name of one
                                             entry in pod.spec.resourceClaims of the
                                             Pod where this field is used. It makes that
                                             resource available inside a container.
@@ -290,9 +261,8 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description:
-                                      "Limits describes the maximum amount
-                                      of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
+                                    description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                     type: object
                                   requests:
                                     additionalProperties:
@@ -301,43 +271,36 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description:
-                                      "Requests describes the minimum amount
-                                      of compute resources required. If Requests is
-                                      omitted for a container, it defaults to Limits
-                                      if that is explicitly specified, otherwise to
-                                      an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
+                                    description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                     type: object
                                 type: object
                               selector:
-                                description:
-                                  selector is a label query over volumes
+                                description: selector is a label query over volumes
                                   to consider for binding.
                                 properties:
                                   matchExpressions:
-                                    description:
-                                      matchExpressions is a list of label
+                                    description: matchExpressions is a list of label
                                       selector requirements. The requirements are ANDed.
                                     items:
-                                      description:
-                                        A label selector requirement is a
+                                      description: A label selector requirement is a
                                         selector that contains values, a key, and an
                                         operator that relates the key and values.
                                       properties:
                                         key:
-                                          description:
-                                            key is the label key that the
+                                          description: key is the label key that the
                                             selector applies to.
                                           type: string
                                         operator:
-                                          description:
-                                            operator represents a key's relationship
+                                          description: operator represents a key's relationship
                                             to a set of values. Valid operators are
                                             In, NotIn, Exists and DoesNotExist.
                                           type: string
                                         values:
-                                          description:
-                                            values is an array of string
+                                          description: values is an array of string
                                             values. If the operator is In or NotIn,
                                             the values array must be non-empty. If the
                                             operator is Exists or DoesNotExist, the
@@ -354,8 +317,7 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description:
-                                      matchLabels is a map of {key,value}
+                                    description: matchLabels is a map of {key,value}
                                       pairs. A single {key,value} in the matchLabels
                                       map is equivalent to an element of matchExpressions,
                                       whose key field is "key", the operator is "In",
@@ -364,40 +326,33 @@ spec:
                                     type: object
                                 type: object
                               storageClassName:
-                                description:
-                                  "storageClassName is the name of the StorageClass
-                                  required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1"
+                                description: 'storageClassName is the name of the StorageClass
+                                required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                 type: string
                               volumeMode:
-                                description:
-                                  volumeMode defines what type of volume
+                                description: volumeMode defines what type of volume
                                   is required by the claim. Value of Filesystem is implied
                                   when not included in claim spec.
                                 type: string
                               volumeName:
-                                description:
-                                  volumeName is the binding reference to
+                                description: volumeName is the binding reference to
                                   the PersistentVolume backing this claim.
                                 type: string
                             type: object
                           source:
-                            description:
-                              Source is the src of the data for the requested
+                            description: Source is the src of the data for the requested
                               DataVolume
                             properties:
                               blank:
-                                description:
-                                  DataVolumeBlankImage provides the parameters
+                                description: DataVolumeBlankImage provides the parameters
                                   to create a new raw blank image for the PVC
                                 type: object
                               gcs:
-                                description:
-                                  DataVolumeSourceGCS provides the parameters
+                                description: DataVolumeSourceGCS provides the parameters
                                   to create a Data Volume from an GCS source
                                 properties:
                                   secretRef:
-                                    description:
-                                      SecretRef provides the secret reference
+                                    description: SecretRef provides the secret reference
                                       needed to access the GCS source
                                     type: string
                                   url:
@@ -407,36 +362,31 @@ spec:
                                   - url
                                 type: object
                               http:
-                                description:
-                                  DataVolumeSourceHTTP can be either an http
+                                description: DataVolumeSourceHTTP can be either an http
                                   or https endpoint, with an optional basic auth user
                                   name and password, and an optional configmap containing
                                   additional CAs
                                 properties:
                                   certConfigMap:
-                                    description:
-                                      CertConfigMap is a configmap reference,
+                                    description: CertConfigMap is a configmap reference,
                                       containing a Certificate Authority(CA) public
                                       key, and a base64 encoded pem certificate
                                     type: string
                                   extraHeaders:
-                                    description:
-                                      ExtraHeaders is a list of strings containing
+                                    description: ExtraHeaders is a list of strings containing
                                       extra headers to include with HTTP transfer requests
                                     items:
                                       type: string
                                     type: array
                                   secretExtraHeaders:
-                                    description:
-                                      SecretExtraHeaders is a list of Secret
+                                    description: SecretExtraHeaders is a list of Secret
                                       references, each containing an extra HTTP header
                                       that may include sensitive information
                                     items:
                                       type: string
                                     type: array
                                   secretRef:
-                                    description:
-                                      SecretRef A Secret reference, the secret
+                                    description: SecretRef A Secret reference, the secret
                                       should contain accessKeyId (user name) base64
                                       encoded, and secretKey (password) also base64
                                       encoded
@@ -448,23 +398,19 @@ spec:
                                   - url
                                 type: object
                               imageio:
-                                description:
-                                  DataVolumeSourceImageIO provides the parameters
+                                description: DataVolumeSourceImageIO provides the parameters
                                   to create a Data Volume from an imageio source
                                 properties:
                                   certConfigMap:
-                                    description:
-                                      CertConfigMap provides a reference
+                                    description: CertConfigMap provides a reference
                                       to the CA cert
                                     type: string
                                   diskId:
-                                    description:
-                                      DiskID provides id of a disk to be
+                                    description: DiskID provides id of a disk to be
                                       imported
                                     type: string
                                   secretRef:
-                                    description:
-                                      SecretRef provides the secret reference
+                                    description: SecretRef provides the secret reference
                                       needed to access the ovirt-engine
                                     type: string
                                   url:
@@ -475,8 +421,7 @@ spec:
                                   - url
                                 type: object
                               pvc:
-                                description:
-                                  DataVolumeSourcePVC provides the parameters
+                                description: DataVolumeSourcePVC provides the parameters
                                   to create a Data Volume from an existing PVC
                                 properties:
                                   name:
@@ -490,50 +435,41 @@ spec:
                                   - namespace
                                 type: object
                               registry:
-                                description:
-                                  DataVolumeSourceRegistry provides the parameters
+                                description: DataVolumeSourceRegistry provides the parameters
                                   to create a Data Volume from an registry source
                                 properties:
                                   certConfigMap:
-                                    description:
-                                      CertConfigMap provides a reference
+                                    description: CertConfigMap provides a reference
                                       to the Registry certs
                                     type: string
                                   imageStream:
-                                    description:
-                                      ImageStream is the name of image stream
+                                    description: ImageStream is the name of image stream
                                       for import
                                     type: string
                                   pullMethod:
-                                    description:
-                                      PullMethod can be either "pod" (default
+                                    description: PullMethod can be either "pod" (default
                                       import), or "node" (node docker cache based import)
                                     type: string
                                   secretRef:
-                                    description:
-                                      SecretRef provides the secret reference
+                                    description: SecretRef provides the secret reference
                                       needed to access the Registry source
                                     type: string
                                   url:
-                                    description:
-                                      "URL is the url of the registry source
-                                      (starting with the scheme: docker, oci-archive)"
+                                    description: 'URL is the url of the registry source
+                                    (starting with the scheme: docker, oci-archive)'
                                     type: string
                                 type: object
                               s3:
-                                description:
-                                  DataVolumeSourceS3 provides the parameters
+                                description: DataVolumeSourceS3 provides the parameters
                                   to create a Data Volume from an S3 source
                                 properties:
                                   certConfigMap:
-                                    description:
-                                      CertConfigMap is a configmap reference,
+                                    description: CertConfigMap is a configmap reference,
                                       containing a Certificate Authority(CA) public
                                       key, and a base64 encoded pem certificate
                                     type: string
                                   secretRef:
-                                    description:
-                                      SecretRef provides the secret reference
+                                    description: SecretRef provides the secret reference
                                       needed to access the S3 source
                                     type: string
                                   url:
@@ -543,8 +479,7 @@ spec:
                                   - url
                                 type: object
                               snapshot:
-                                description:
-                                  DataVolumeSourceSnapshot provides the parameters
+                                description: DataVolumeSourceSnapshot provides the parameters
                                   to create a Data Volume from an existing VolumeSnapshot
                                 properties:
                                   name:
@@ -558,65 +493,54 @@ spec:
                                   - namespace
                                 type: object
                               upload:
-                                description:
-                                  DataVolumeSourceUpload provides the parameters
+                                description: DataVolumeSourceUpload provides the parameters
                                   to create a Data Volume by uploading the source
                                 type: object
                               vddk:
-                                description:
-                                  DataVolumeSourceVDDK provides the parameters
+                                description: DataVolumeSourceVDDK provides the parameters
                                   to create a Data Volume from a Vmware source
                                 properties:
                                   backingFile:
-                                    description:
-                                      BackingFile is the path to the virtual
+                                    description: BackingFile is the path to the virtual
                                       hard disk to migrate from vCenter/ESXi
                                     type: string
                                   initImageURL:
-                                    description:
-                                      InitImageURL is an optional URL to
+                                    description: InitImageURL is an optional URL to
                                       an image containing an extracted VDDK library,
                                       overrides v2v-vmware config map
                                     type: string
                                   secretRef:
-                                    description:
-                                      SecretRef provides a reference to a
+                                    description: SecretRef provides a reference to a
                                       secret containing the username and password needed
                                       to access the vCenter or ESXi host
                                     type: string
                                   thumbprint:
-                                    description:
-                                      Thumbprint is the certificate thumbprint
+                                    description: Thumbprint is the certificate thumbprint
                                       of the vCenter or ESXi host
                                     type: string
                                   url:
-                                    description:
-                                      URL is the URL of the vCenter or ESXi
+                                    description: URL is the URL of the vCenter or ESXi
                                       host with the VM to migrate
                                     type: string
                                   uuid:
-                                    description:
-                                      UUID is the UUID of the virtual machine
+                                    description: UUID is the UUID of the virtual machine
                                       that the backing file is attached to in vCenter/ESXi
                                     type: string
                                 type: object
                             type: object
                           sourceRef:
-                            description:
-                              SourceRef is an indirect reference to the source
+                            description: SourceRef is an indirect reference to the source
                               of data for the requested DataVolume
                             properties:
                               kind:
-                                description:
-                                  The kind of the source reference, currently
+                                description: The kind of the source reference, currently
                                   only "DataSource" is supported
                                 type: string
                               name:
                                 description: The name of the source reference
                                 type: string
                               namespace:
-                                description:
-                                  The namespace of the source reference,
+                                description: The namespace of the source reference,
                                   defaults to the DataVolume namespace
                                 type: string
                             required:
@@ -627,42 +551,37 @@ spec:
                             description: Storage is the requested storage specification
                             properties:
                               accessModes:
-                                description:
-                                  "AccessModes contains the desired access
-                                  modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1"
+                                description: 'AccessModes contains the desired access
+                                modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                 items:
                                   type: string
                                 type: array
                               dataSource:
-                                description:
-                                  "This field can be used to specify either:
-                                  * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                  * An existing PVC (PersistentVolumeClaim) * An existing
-                                  custom resource that implements data population (Alpha)
-                                  In order to use custom resource types that implement
-                                  data population, the AnyVolumeDataSource feature gate
-                                  must be enabled. If the provisioner or an external
-                                  controller can support the specified data source,
-                                  it will create a new volume based on the contents
-                                  of the specified data source. If the AnyVolumeDataSource
-                                  feature gate is enabled, this field will always have
-                                  the same contents as the DataSourceRef field."
+                                description: 'This field can be used to specify either:
+                                * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                * An existing PVC (PersistentVolumeClaim) * An existing
+                                custom resource that implements data population (Alpha)
+                                In order to use custom resource types that implement
+                                data population, the AnyVolumeDataSource feature gate
+                                must be enabled. If the provisioner or an external
+                                controller can support the specified data source,
+                                it will create a new volume based on the contents
+                                of the specified data source. If the AnyVolumeDataSource
+                                feature gate is enabled, this field will always have
+                                the same contents as the DataSourceRef field.'
                                 properties:
                                   apiGroup:
-                                    description:
-                                      APIGroup is the group for the resource
+                                    description: APIGroup is the group for the resource
                                       being referenced. If APIGroup is not specified,
                                       the specified Kind must be in the core API group.
                                       For any other third-party types, APIGroup is required.
                                     type: string
                                   kind:
-                                    description:
-                                      Kind is the type of resource being
+                                    description: Kind is the type of resource being
                                       referenced
                                     type: string
                                   name:
-                                    description:
-                                      Name is the name of resource being
+                                    description: Name is the name of resource being
                                       referenced
                                     type: string
                                 required:
@@ -670,50 +589,45 @@ spec:
                                   - name
                                 type: object
                               dataSourceRef:
-                                description:
-                                  "Specifies the object from which to populate
-                                  the volume with data, if a non-empty volume is desired.
-                                  This may be any local object from a non-empty API
-                                  group (non core object) or a PersistentVolumeClaim
-                                  object. When this field is specified, volume binding
-                                  will only succeed if the type of the specified object
-                                  matches some installed volume populator or dynamic
-                                  provisioner. This field will replace the functionality
-                                  of the DataSource field and as such if both fields
-                                  are non-empty, they must have the same value. For
-                                  backwards compatibility, both fields (DataSource and
-                                  DataSourceRef) will be set to the same value automatically
-                                  if one of them is empty and the other is non-empty.
-                                  There are two important differences between DataSource
-                                  and DataSourceRef: * While DataSource only allows
-                                  two specific types of objects, DataSourceRef allows
-                                  any non-core object, as well as PersistentVolumeClaim
-                                  objects. * While DataSource ignores disallowed values
-                                  (dropping them), DataSourceRef preserves all values,
-                                  and generates an error if a disallowed value is specified.
-                                  (Beta) Using this field requires the AnyVolumeDataSource
-                                  feature gate to be enabled."
+                                description: 'Specifies the object from which to populate
+                                the volume with data, if a non-empty volume is desired.
+                                This may be any local object from a non-empty API
+                                group (non core object) or a PersistentVolumeClaim
+                                object. When this field is specified, volume binding
+                                will only succeed if the type of the specified object
+                                matches some installed volume populator or dynamic
+                                provisioner. This field will replace the functionality
+                                of the DataSource field and as such if both fields
+                                are non-empty, they must have the same value. For
+                                backwards compatibility, both fields (DataSource and
+                                DataSourceRef) will be set to the same value automatically
+                                if one of them is empty and the other is non-empty.
+                                There are two important differences between DataSource
+                                and DataSourceRef: * While DataSource only allows
+                                two specific types of objects, DataSourceRef allows
+                                any non-core object, as well as PersistentVolumeClaim
+                                objects. * While DataSource ignores disallowed values
+                                (dropping them), DataSourceRef preserves all values,
+                                and generates an error if a disallowed value is specified.
+                                (Beta) Using this field requires the AnyVolumeDataSource
+                                feature gate to be enabled.'
                                 properties:
                                   apiGroup:
-                                    description:
-                                      APIGroup is the group for the resource
+                                    description: APIGroup is the group for the resource
                                       being referenced. If APIGroup is not specified,
                                       the specified Kind must be in the core API group.
                                       For any other third-party types, APIGroup is required.
                                     type: string
                                   kind:
-                                    description:
-                                      Kind is the type of resource being
+                                    description: Kind is the type of resource being
                                       referenced
                                     type: string
                                   name:
-                                    description:
-                                      Name is the name of resource being
+                                    description: Name is the name of resource being
                                       referenced
                                     type: string
                                   namespace:
-                                    description:
-                                      Namespace is the namespace of resource
+                                    description: Namespace is the namespace of resource
                                       being referenced Note that when a namespace is
                                       specified, a gateway.networking.k8s.io/ReferenceGrant
                                       object is required in the referent namespace to
@@ -727,26 +641,22 @@ spec:
                                   - name
                                 type: object
                               resources:
-                                description:
-                                  "Resources represents the minimum resources
-                                  the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources"
+                                description: 'Resources represents the minimum resources
+                                the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                 properties:
                                   claims:
-                                    description:
-                                      "Claims lists the names of resources,
-                                      defined in spec.resourceClaims, that are used
-                                      by this container. \n This is an alpha field and
-                                      requires enabling the DynamicResourceAllocation
-                                      feature gate. \n This field is immutable. It can
-                                      only be set for containers."
+                                    description: "Claims lists the names of resources,
+                                    defined in spec.resourceClaims, that are used
+                                    by this container. \n This is an alpha field and
+                                    requires enabling the DynamicResourceAllocation
+                                    feature gate. \n This field is immutable. It can
+                                    only be set for containers."
                                     items:
-                                      description:
-                                        ResourceClaim references one entry
+                                      description: ResourceClaim references one entry
                                         in PodSpec.ResourceClaims.
                                       properties:
                                         name:
-                                          description:
-                                            Name must match the name of one
+                                          description: Name must match the name of one
                                             entry in pod.spec.resourceClaims of the
                                             Pod where this field is used. It makes that
                                             resource available inside a container.
@@ -765,9 +675,8 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description:
-                                      "Limits describes the maximum amount
-                                      of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
+                                    description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                     type: object
                                   requests:
                                     additionalProperties:
@@ -776,43 +685,36 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description:
-                                      "Requests describes the minimum amount
-                                      of compute resources required. If Requests is
-                                      omitted for a container, it defaults to Limits
-                                      if that is explicitly specified, otherwise to
-                                      an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
+                                    description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                     type: object
                                 type: object
                               selector:
-                                description:
-                                  A label query over volumes to consider
+                                description: A label query over volumes to consider
                                   for binding.
                                 properties:
                                   matchExpressions:
-                                    description:
-                                      matchExpressions is a list of label
+                                    description: matchExpressions is a list of label
                                       selector requirements. The requirements are ANDed.
                                     items:
-                                      description:
-                                        A label selector requirement is a
+                                      description: A label selector requirement is a
                                         selector that contains values, a key, and an
                                         operator that relates the key and values.
                                       properties:
                                         key:
-                                          description:
-                                            key is the label key that the
+                                          description: key is the label key that the
                                             selector applies to.
                                           type: string
                                         operator:
-                                          description:
-                                            operator represents a key's relationship
+                                          description: operator represents a key's relationship
                                             to a set of values. Valid operators are
                                             In, NotIn, Exists and DoesNotExist.
                                           type: string
                                         values:
-                                          description:
-                                            values is an array of string
+                                          description: values is an array of string
                                             values. If the operator is In or NotIn,
                                             the values array must be non-empty. If the
                                             operator is Exists or DoesNotExist, the
@@ -829,8 +731,7 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description:
-                                      matchLabels is a map of {key,value}
+                                    description: matchLabels is a map of {key,value}
                                       pairs. A single {key,value} in the matchLabels
                                       map is equivalent to an element of matchExpressions,
                                       whose key field is "key", the operator is "In",
@@ -839,26 +740,22 @@ spec:
                                     type: object
                                 type: object
                               storageClassName:
-                                description:
-                                  "Name of the StorageClass required by the
-                                  claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1"
+                                description: 'Name of the StorageClass required by the
+                                claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                 type: string
                               volumeMode:
-                                description:
-                                  volumeMode defines what type of volume
+                                description: volumeMode defines what type of volume
                                   is required by the claim. Value of Filesystem is implied
                                   when not included in claim spec.
                                 type: string
                               volumeName:
-                                description:
-                                  VolumeName is the binding reference to
+                                description: VolumeName is the binding reference to
                                   the PersistentVolume backing this claim.
                                 type: string
                             type: object
                         type: object
                       status:
-                        description:
-                          DataVolumeTemplateDummyStatus is here simply for
+                        description: DataVolumeTemplateDummyStatus is here simply for
                           backwards compatibility with a previous API.
                         nullable: true
                         type: object
@@ -867,97 +764,79 @@ spec:
                     type: object
                   type: array
                 instancetype:
-                  description:
-                    InstancetypeMatcher references a instancetype that is
+                  description: InstancetypeMatcher references a instancetype that is
                     used to fill fields in Template
                   properties:
                     inferFromVolume:
-                      description:
-                        InferFromVolume lists the name of a volume that should
+                      description: InferFromVolume lists the name of a volume that should
                         be used to infer or discover the instancetype to be used through
                         known annotations on the underlying resource. Once applied to
                         the InstancetypeMatcher this field is removed.
                       type: string
+                    inferFromVolumeFailurePolicy:
+                      description: 'InferFromVolumeFailurePolicy controls what should
+                      happen on failure when inferring the instancetype. Allowed values
+                      are: "RejectInferFromVolumeFailure" and "IgnoreInferFromVolumeFailure".
+                      If not specified, "RejectInferFromVolumeFailure" is used by
+                      default.'
+                      type: string
                     kind:
-                      description:
-                        'Kind specifies which instancetype resource is referenced.
-                        Allowed values are: "VirtualMachineInstancetype" and "VirtualMachineClusterInstancetype".
-                        If not specified, "VirtualMachineClusterInstancetype" is used
-                        by default.'
+                      description: 'Kind specifies which instancetype resource is referenced.
+                      Allowed values are: "VirtualMachineInstancetype" and "VirtualMachineClusterInstancetype".
+                      If not specified, "VirtualMachineClusterInstancetype" is used
+                      by default.'
                       type: string
                     name:
-                      description:
-                        Name is the name of the VirtualMachineInstancetype
+                      description: Name is the name of the VirtualMachineInstancetype
                         or VirtualMachineClusterInstancetype
                       type: string
                     revisionName:
-                      description:
-                        RevisionName specifies a ControllerRevision containing
+                      description: RevisionName specifies a ControllerRevision containing
                         a specific copy of the VirtualMachineInstancetype or VirtualMachineClusterInstancetype
                         to be used. This is initially captured the first time the instancetype
                         is applied to the VirtualMachineInstance.
                       type: string
                   type: object
-                liveUpdateFeatures:
-                  description:
-                    LiveUpdateFeatures references a configuration of hotpluggable
-                    resources
-                  properties:
-                    cpu:
-                      description:
-                        LiveUpdateCPU holds hotplug configuration for the
-                        CPU resource. Empty struct indicates that default will be used
-                        for maxSockets. Default is specified on cluster level. Absence
-                        of the struct means opt-out from CPU hotplug functionality.
-                      properties:
-                        maxSockets:
-                          description:
-                            The maximum amount of sockets that can be hot-plugged
-                            to the Virtual Machine
-                          format: int32
-                          type: integer
-                      type: object
-                  type: object
                 preference:
-                  description:
-                    PreferenceMatcher references a set of preference that
+                  description: PreferenceMatcher references a set of preference that
                     is used to fill fields in Template
                   properties:
                     inferFromVolume:
-                      description:
-                        InferFromVolume lists the name of a volume that should
+                      description: InferFromVolume lists the name of a volume that should
                         be used to infer or discover the preference to be used through
                         known annotations on the underlying resource. Once applied to
                         the PreferenceMatcher this field is removed.
                       type: string
+                    inferFromVolumeFailurePolicy:
+                      description: 'InferFromVolumeFailurePolicy controls what should
+                      happen on failure when preference the instancetype. Allowed
+                      values are: "RejectInferFromVolumeFailure" and "IgnoreInferFromVolumeFailure".
+                      If not specified, "RejectInferFromVolumeFailure" is used by
+                      default.'
+                      type: string
                     kind:
-                      description:
-                        'Kind specifies which preference resource is referenced.
-                        Allowed values are: "VirtualMachinePreference" and "VirtualMachineClusterPreference".
-                        If not specified, "VirtualMachineClusterPreference" is used
-                        by default.'
+                      description: 'Kind specifies which preference resource is referenced.
+                      Allowed values are: "VirtualMachinePreference" and "VirtualMachineClusterPreference".
+                      If not specified, "VirtualMachineClusterPreference" is used
+                      by default.'
                       type: string
                     name:
-                      description:
-                        Name is the name of the VirtualMachinePreference
+                      description: Name is the name of the VirtualMachinePreference
                         or VirtualMachineClusterPreference
                       type: string
                     revisionName:
-                      description:
-                        RevisionName specifies a ControllerRevision containing
+                      description: RevisionName specifies a ControllerRevision containing
                         a specific copy of the VirtualMachinePreference or VirtualMachineClusterPreference
                         to be used. This is initially captured the first time the instancetype
                         is applied to the VirtualMachineInstance.
                       type: string
                   type: object
                 runStrategy:
-                  description:
-                    Running state indicates the requested running state of
+                  description: Running state indicates the requested running state of
                     the VirtualMachineInstance mutually exclusive with Running
                   type: string
                 running:
-                  description:
-                    Running controls whether the associatied VirtualMachineInstance
+                  description: Running controls whether the associatied VirtualMachineInstance
                     is created or not Mutually exclusive with RunStrategy
                   type: boolean
                 template:
@@ -968,49 +847,46 @@ spec:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     spec:
-                      description:
-                        VirtualMachineInstance Spec contains the VirtualMachineInstance
+                      description: VirtualMachineInstance Spec contains the VirtualMachineInstance
                         specification.
                       properties:
                         accessCredentials:
-                          description:
-                            Specifies a set of public keys to inject into
+                          description: Specifies a set of public keys to inject into
                             the vm guest
                           items:
-                            description:
-                              AccessCredential represents a credential source
+                            description: AccessCredential represents a credential source
                               that can be used to authorize remote access to the vm
                               guest Only one of its members may be specified.
                             properties:
                               sshPublicKey:
-                                description:
-                                  SSHPublicKey represents the source and
+                                description: SSHPublicKey represents the source and
                                   method of applying a ssh public key into a guest virtual
                                   machine.
                                 properties:
                                   propagationMethod:
-                                    description:
-                                      PropagationMethod represents how the
+                                    description: PropagationMethod represents how the
                                       public key is injected into the vm guest.
                                     properties:
                                       configDrive:
-                                        description:
-                                          ConfigDrivePropagation means that
+                                        description: ConfigDrivePropagation means that
                                           the ssh public keys are injected into the
                                           VM using metadata using the configDrive cloud-init
                                           provider
                                         type: object
+                                      noCloud:
+                                        description: NoCloudPropagation means that the
+                                          ssh public keys are injected into the VM using
+                                          metadata using the noCloud cloud-init provider
+                                        type: object
                                       qemuGuestAgent:
-                                        description:
-                                          QemuGuestAgentAccessCredentailPropagation
+                                        description: QemuGuestAgentAccessCredentailPropagation
                                           means ssh public keys are dynamically injected
                                           into the vm at runtime via the qemu guest
                                           agent. This feature requires the qemu guest
                                           agent to be running within the guest.
                                         properties:
                                           users:
-                                            description:
-                                              Users represents a list of
+                                            description: Users represents a list of
                                               guest users that should have the ssh public
                                               keys added to their authorized_keys file.
                                             items:
@@ -1022,18 +898,15 @@ spec:
                                         type: object
                                     type: object
                                   source:
-                                    description:
-                                      Source represents where the public
+                                    description: Source represents where the public
                                       keys are pulled from
                                     properties:
                                       secret:
-                                        description:
-                                          Secret means that the access credential
+                                        description: Secret means that the access credential
                                           is pulled from a kubernetes secret
                                         properties:
                                           secretName:
-                                            description:
-                                              SecretName represents the name
+                                            description: SecretName represents the name
                                               of the secret in the VMI's namespace
                                             type: string
                                         required:
@@ -1045,18 +918,15 @@ spec:
                                   - source
                                 type: object
                               userPassword:
-                                description:
-                                  UserPassword represents the source and
+                                description: UserPassword represents the source and
                                   method for applying a guest user's password
                                 properties:
                                   propagationMethod:
-                                    description:
-                                      propagationMethod represents how the
+                                    description: propagationMethod represents how the
                                       user passwords are injected into the vm guest.
                                     properties:
                                       qemuGuestAgent:
-                                        description:
-                                          QemuGuestAgentAccessCredentailPropagation
+                                        description: QemuGuestAgentAccessCredentailPropagation
                                           means passwords are dynamically injected into
                                           the vm at runtime via the qemu guest agent.
                                           This feature requires the qemu guest agent
@@ -1064,18 +934,15 @@ spec:
                                         type: object
                                     type: object
                                   source:
-                                    description:
-                                      Source represents where the user passwords
+                                    description: Source represents where the user passwords
                                       are pulled from
                                     properties:
                                       secret:
-                                        description:
-                                          Secret means that the access credential
+                                        description: Secret means that the access credential
                                           is pulled from a kubernetes secret
                                         properties:
                                           secretName:
-                                            description:
-                                              SecretName represents the name
+                                            description: SecretName represents the name
                                               of the secret in the VMI's namespace
                                             type: string
                                         required:
@@ -1090,18 +957,15 @@ spec:
                           type: array
                           x-kubernetes-list-type: atomic
                         affinity:
-                          description:
-                            If affinity is specifies, obey all the affinity
+                          description: If affinity is specifies, obey all the affinity
                             rules
                           properties:
                             nodeAffinity:
-                              description:
-                                Describes node affinity scheduling rules
+                              description: Describes node affinity scheduling rules
                                 for the pod.
                               properties:
                                 preferredDuringSchedulingIgnoredDuringExecution:
-                                  description:
-                                    The scheduler will prefer to schedule
+                                  description: The scheduler will prefer to schedule
                                     pods to nodes that satisfy the affinity expressions
                                     specified by this field, but it may choose a node
                                     that violates one or more of the expressions. The
@@ -1114,43 +978,36 @@ spec:
                                     the node matches the corresponding matchExpressions;
                                     the node(s) with the highest sum are the most preferred.
                                   items:
-                                    description:
-                                      An empty preferred scheduling term
+                                    description: An empty preferred scheduling term
                                       matches all objects with implicit weight 0 (i.e.
                                       it's a no-op). A null preferred scheduling term
                                       matches no objects (i.e. is also a no-op).
                                     properties:
                                       preference:
-                                        description:
-                                          A node selector term, associated
+                                        description: A node selector term, associated
                                           with the corresponding weight.
                                         properties:
                                           matchExpressions:
-                                            description:
-                                              A list of node selector requirements
+                                            description: A list of node selector requirements
                                               by node's labels.
                                             items:
-                                              description:
-                                                A node selector requirement
+                                              description: A node selector requirement
                                                 is a selector that contains values,
                                                 a key, and an operator that relates
                                                 the key and values.
                                               properties:
                                                 key:
-                                                  description:
-                                                    The label key that the
+                                                  description: The label key that the
                                                     selector applies to.
                                                   type: string
                                                 operator:
-                                                  description:
-                                                    Represents a key's relationship
+                                                  description: Represents a key's relationship
                                                     to a set of values. Valid operators
                                                     are In, NotIn, Exists, DoesNotExist.
                                                     Gt, and Lt.
                                                   type: string
                                                 values:
-                                                  description:
-                                                    An array of string values.
+                                                  description: An array of string values.
                                                     If the operator is In or NotIn,
                                                     the values array must be non-empty.
                                                     If the operator is Exists or DoesNotExist,
@@ -1169,31 +1026,26 @@ spec:
                                               type: object
                                             type: array
                                           matchFields:
-                                            description:
-                                              A list of node selector requirements
+                                            description: A list of node selector requirements
                                               by node's fields.
                                             items:
-                                              description:
-                                                A node selector requirement
+                                              description: A node selector requirement
                                                 is a selector that contains values,
                                                 a key, and an operator that relates
                                                 the key and values.
                                               properties:
                                                 key:
-                                                  description:
-                                                    The label key that the
+                                                  description: The label key that the
                                                     selector applies to.
                                                   type: string
                                                 operator:
-                                                  description:
-                                                    Represents a key's relationship
+                                                  description: Represents a key's relationship
                                                     to a set of values. Valid operators
                                                     are In, NotIn, Exists, DoesNotExist.
                                                     Gt, and Lt.
                                                   type: string
                                                 values:
-                                                  description:
-                                                    An array of string values.
+                                                  description: An array of string values.
                                                     If the operator is In or NotIn,
                                                     the values array must be non-empty.
                                                     If the operator is Exists or DoesNotExist,
@@ -1213,8 +1065,7 @@ spec:
                                             type: array
                                         type: object
                                       weight:
-                                        description:
-                                          Weight associated with matching
+                                        description: Weight associated with matching
                                           the corresponding nodeSelectorTerm, in the
                                           range 1-100.
                                         format: int32
@@ -1225,8 +1076,7 @@ spec:
                                     type: object
                                   type: array
                                 requiredDuringSchedulingIgnoredDuringExecution:
-                                  description:
-                                    If the affinity requirements specified
+                                  description: If the affinity requirements specified
                                     by this field are not met at scheduling time, the
                                     pod will not be scheduled onto the node. If the
                                     affinity requirements specified by this field cease
@@ -1235,42 +1085,35 @@ spec:
                                     to eventually evict the pod from its node.
                                   properties:
                                     nodeSelectorTerms:
-                                      description:
-                                        Required. A list of node selector
+                                      description: Required. A list of node selector
                                         terms. The terms are ORed.
                                       items:
-                                        description:
-                                          A null or empty node selector term
+                                        description: A null or empty node selector term
                                           matches no objects. The requirements of them
                                           are ANDed. The TopologySelectorTerm type implements
                                           a subset of the NodeSelectorTerm.
                                         properties:
                                           matchExpressions:
-                                            description:
-                                              A list of node selector requirements
+                                            description: A list of node selector requirements
                                               by node's labels.
                                             items:
-                                              description:
-                                                A node selector requirement
+                                              description: A node selector requirement
                                                 is a selector that contains values,
                                                 a key, and an operator that relates
                                                 the key and values.
                                               properties:
                                                 key:
-                                                  description:
-                                                    The label key that the
+                                                  description: The label key that the
                                                     selector applies to.
                                                   type: string
                                                 operator:
-                                                  description:
-                                                    Represents a key's relationship
+                                                  description: Represents a key's relationship
                                                     to a set of values. Valid operators
                                                     are In, NotIn, Exists, DoesNotExist.
                                                     Gt, and Lt.
                                                   type: string
                                                 values:
-                                                  description:
-                                                    An array of string values.
+                                                  description: An array of string values.
                                                     If the operator is In or NotIn,
                                                     the values array must be non-empty.
                                                     If the operator is Exists or DoesNotExist,
@@ -1289,31 +1132,26 @@ spec:
                                               type: object
                                             type: array
                                           matchFields:
-                                            description:
-                                              A list of node selector requirements
+                                            description: A list of node selector requirements
                                               by node's fields.
                                             items:
-                                              description:
-                                                A node selector requirement
+                                              description: A node selector requirement
                                                 is a selector that contains values,
                                                 a key, and an operator that relates
                                                 the key and values.
                                               properties:
                                                 key:
-                                                  description:
-                                                    The label key that the
+                                                  description: The label key that the
                                                     selector applies to.
                                                   type: string
                                                 operator:
-                                                  description:
-                                                    Represents a key's relationship
+                                                  description: Represents a key's relationship
                                                     to a set of values. Valid operators
                                                     are In, NotIn, Exists, DoesNotExist.
                                                     Gt, and Lt.
                                                   type: string
                                                 values:
-                                                  description:
-                                                    An array of string values.
+                                                  description: An array of string values.
                                                     If the operator is In or NotIn,
                                                     the values array must be non-empty.
                                                     If the operator is Exists or DoesNotExist,
@@ -1338,14 +1176,12 @@ spec:
                                   type: object
                               type: object
                             podAffinity:
-                              description:
-                                Describes pod affinity scheduling rules (e.g.
+                              description: Describes pod affinity scheduling rules (e.g.
                                 co-locate this pod in the same node, zone, etc. as some
                                 other pod(s)).
                               properties:
                                 preferredDuringSchedulingIgnoredDuringExecution:
-                                  description:
-                                    The scheduler will prefer to schedule
+                                  description: The scheduler will prefer to schedule
                                     pods to nodes that satisfy the affinity expressions
                                     specified by this field, but it may choose a node
                                     that violates one or more of the expressions. The
@@ -1359,49 +1195,41 @@ spec:
                                     podAffinityTerm; the node(s) with the highest sum
                                     are the most preferred.
                                   items:
-                                    description:
-                                      The weights of all of the matched WeightedPodAffinityTerm
+                                    description: The weights of all of the matched WeightedPodAffinityTerm
                                       fields are added per-node to find the most preferred
                                       node(s)
                                     properties:
                                       podAffinityTerm:
-                                        description:
-                                          Required. A pod affinity term,
+                                        description: Required. A pod affinity term,
                                           associated with the corresponding weight.
                                         properties:
                                           labelSelector:
-                                            description:
-                                              A label query over a set of
+                                            description: A label query over a set of
                                               resources, in this case pods.
                                             properties:
                                               matchExpressions:
-                                                description:
-                                                  matchExpressions is a list
+                                                description: matchExpressions is a list
                                                   of label selector requirements. The
                                                   requirements are ANDed.
                                                 items:
-                                                  description:
-                                                    A label selector requirement
+                                                  description: A label selector requirement
                                                     is a selector that contains values,
                                                     a key, and an operator that relates
                                                     the key and values.
                                                   properties:
                                                     key:
-                                                      description:
-                                                        key is the label
+                                                      description: key is the label
                                                         key that the selector applies
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description:
-                                                        operator represents
+                                                      description: operator represents
                                                         a key's relationship to a set
                                                         of values. Valid operators are
                                                         In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description:
-                                                        values is an array
+                                                      description: values is an array
                                                         of string values. If the operator
                                                         is In or NotIn, the values array
                                                         must be non-empty. If the operator
@@ -1420,8 +1248,7 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description:
-                                                  matchLabels is a map of
+                                                description: matchLabels is a map of
                                                   {key,value} pairs. A single {key,value}
                                                   in the matchLabels map is equivalent
                                                   to an element of matchExpressions,
@@ -1432,8 +1259,7 @@ spec:
                                                 type: object
                                             type: object
                                           namespaceSelector:
-                                            description:
-                                              A label query over the set
+                                            description: A label query over the set
                                               of namespaces that the term applies to.
                                               The term is applied to the union of the
                                               namespaces selected by this field and
@@ -1443,33 +1269,28 @@ spec:
                                               empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
-                                                description:
-                                                  matchExpressions is a list
+                                                description: matchExpressions is a list
                                                   of label selector requirements. The
                                                   requirements are ANDed.
                                                 items:
-                                                  description:
-                                                    A label selector requirement
+                                                  description: A label selector requirement
                                                     is a selector that contains values,
                                                     a key, and an operator that relates
                                                     the key and values.
                                                   properties:
                                                     key:
-                                                      description:
-                                                        key is the label
+                                                      description: key is the label
                                                         key that the selector applies
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description:
-                                                        operator represents
+                                                      description: operator represents
                                                         a key's relationship to a set
                                                         of values. Valid operators are
                                                         In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description:
-                                                        values is an array
+                                                      description: values is an array
                                                         of string values. If the operator
                                                         is In or NotIn, the values array
                                                         must be non-empty. If the operator
@@ -1488,8 +1309,7 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description:
-                                                  matchLabels is a map of
+                                                description: matchLabels is a map of
                                                   {key,value} pairs. A single {key,value}
                                                   in the matchLabels map is equivalent
                                                   to an element of matchExpressions,
@@ -1500,8 +1320,7 @@ spec:
                                                 type: object
                                             type: object
                                           namespaces:
-                                            description:
-                                              namespaces specifies a static
+                                            description: namespaces specifies a static
                                               list of namespace names that the term
                                               applies to. The term is applied to the
                                               union of the namespaces listed in this
@@ -1512,8 +1331,7 @@ spec:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description:
-                                              This pod should be co-located
+                                            description: This pod should be co-located
                                               (affinity) or not co-located (anti-affinity)
                                               with the pods matching the labelSelector
                                               in the specified namespaces, where co-located
@@ -1527,8 +1345,7 @@ spec:
                                           - topologyKey
                                         type: object
                                       weight:
-                                        description:
-                                          weight associated with matching
+                                        description: weight associated with matching
                                           the corresponding podAffinityTerm, in the
                                           range 1-100.
                                         format: int32
@@ -1539,8 +1356,7 @@ spec:
                                     type: object
                                   type: array
                                 requiredDuringSchedulingIgnoredDuringExecution:
-                                  description:
-                                    If the affinity requirements specified
+                                  description: If the affinity requirements specified
                                     by this field are not met at scheduling time, the
                                     pod will not be scheduled onto the node. If the
                                     affinity requirements specified by this field cease
@@ -1551,8 +1367,7 @@ spec:
                                     corresponding to each podAffinityTerm are intersected,
                                     i.e. all terms must be satisfied.
                                   items:
-                                    description:
-                                      Defines a set of pods (namely those
+                                    description: Defines a set of pods (namely those
                                       matching the labelSelector relative to the given
                                       namespace(s)) that this pod should be co-located
                                       (affinity) or not co-located (anti-affinity) with,
@@ -1562,37 +1377,31 @@ spec:
                                       set of pods is running
                                     properties:
                                       labelSelector:
-                                        description:
-                                          A label query over a set of resources,
+                                        description: A label query over a set of resources,
                                           in this case pods.
                                         properties:
                                           matchExpressions:
-                                            description:
-                                              matchExpressions is a list
+                                            description: matchExpressions is a list
                                               of label selector requirements. The requirements
                                               are ANDed.
                                             items:
-                                              description:
-                                                A label selector requirement
+                                              description: A label selector requirement
                                                 is a selector that contains values,
                                                 a key, and an operator that relates
                                                 the key and values.
                                               properties:
                                                 key:
-                                                  description:
-                                                    key is the label key
+                                                  description: key is the label key
                                                     that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description:
-                                                    operator represents a
+                                                  description: operator represents a
                                                     key's relationship to a set of values.
                                                     Valid operators are In, NotIn, Exists
                                                     and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description:
-                                                    values is an array of
+                                                  description: values is an array of
                                                     string values. If the operator is
                                                     In or NotIn, the values array must
                                                     be non-empty. If the operator is
@@ -1611,8 +1420,7 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description:
-                                              matchLabels is a map of {key,value}
+                                            description: matchLabels is a map of {key,value}
                                               pairs. A single {key,value} in the matchLabels
                                               map is equivalent to an element of matchExpressions,
                                               whose key field is "key", the operator
@@ -1621,8 +1429,7 @@ spec:
                                             type: object
                                         type: object
                                       namespaceSelector:
-                                        description:
-                                          A label query over the set of namespaces
+                                        description: A label query over the set of namespaces
                                           that the term applies to. The term is applied
                                           to the union of the namespaces selected by
                                           this field and the ones listed in the namespaces
@@ -1631,32 +1438,27 @@ spec:
                                           selector ({}) matches all namespaces.
                                         properties:
                                           matchExpressions:
-                                            description:
-                                              matchExpressions is a list
+                                            description: matchExpressions is a list
                                               of label selector requirements. The requirements
                                               are ANDed.
                                             items:
-                                              description:
-                                                A label selector requirement
+                                              description: A label selector requirement
                                                 is a selector that contains values,
                                                 a key, and an operator that relates
                                                 the key and values.
                                               properties:
                                                 key:
-                                                  description:
-                                                    key is the label key
+                                                  description: key is the label key
                                                     that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description:
-                                                    operator represents a
+                                                  description: operator represents a
                                                     key's relationship to a set of values.
                                                     Valid operators are In, NotIn, Exists
                                                     and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description:
-                                                    values is an array of
+                                                  description: values is an array of
                                                     string values. If the operator is
                                                     In or NotIn, the values array must
                                                     be non-empty. If the operator is
@@ -1675,8 +1477,7 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description:
-                                              matchLabels is a map of {key,value}
+                                            description: matchLabels is a map of {key,value}
                                               pairs. A single {key,value} in the matchLabels
                                               map is equivalent to an element of matchExpressions,
                                               whose key field is "key", the operator
@@ -1685,8 +1486,7 @@ spec:
                                             type: object
                                         type: object
                                       namespaces:
-                                        description:
-                                          namespaces specifies a static list
+                                        description: namespaces specifies a static list
                                           of namespace names that the term applies to.
                                           The term is applied to the union of the namespaces
                                           listed in this field and the ones selected
@@ -1697,8 +1497,7 @@ spec:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description:
-                                          This pod should be co-located (affinity)
+                                        description: This pod should be co-located (affinity)
                                           or not co-located (anti-affinity) with the
                                           pods matching the labelSelector in the specified
                                           namespaces, where co-located is defined as
@@ -1713,14 +1512,12 @@ spec:
                                   type: array
                               type: object
                             podAntiAffinity:
-                              description:
-                                Describes pod anti-affinity scheduling rules
+                              description: Describes pod anti-affinity scheduling rules
                                 (e.g. avoid putting this pod in the same node, zone,
                                 etc. as some other pod(s)).
                               properties:
                                 preferredDuringSchedulingIgnoredDuringExecution:
-                                  description:
-                                    The scheduler will prefer to schedule
+                                  description: The scheduler will prefer to schedule
                                     pods to nodes that satisfy the anti-affinity expressions
                                     specified by this field, but it may choose a node
                                     that violates one or more of the expressions. The
@@ -1734,49 +1531,41 @@ spec:
                                     podAffinityTerm; the node(s) with the highest sum
                                     are the most preferred.
                                   items:
-                                    description:
-                                      The weights of all of the matched WeightedPodAffinityTerm
+                                    description: The weights of all of the matched WeightedPodAffinityTerm
                                       fields are added per-node to find the most preferred
                                       node(s)
                                     properties:
                                       podAffinityTerm:
-                                        description:
-                                          Required. A pod affinity term,
+                                        description: Required. A pod affinity term,
                                           associated with the corresponding weight.
                                         properties:
                                           labelSelector:
-                                            description:
-                                              A label query over a set of
+                                            description: A label query over a set of
                                               resources, in this case pods.
                                             properties:
                                               matchExpressions:
-                                                description:
-                                                  matchExpressions is a list
+                                                description: matchExpressions is a list
                                                   of label selector requirements. The
                                                   requirements are ANDed.
                                                 items:
-                                                  description:
-                                                    A label selector requirement
+                                                  description: A label selector requirement
                                                     is a selector that contains values,
                                                     a key, and an operator that relates
                                                     the key and values.
                                                   properties:
                                                     key:
-                                                      description:
-                                                        key is the label
+                                                      description: key is the label
                                                         key that the selector applies
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description:
-                                                        operator represents
+                                                      description: operator represents
                                                         a key's relationship to a set
                                                         of values. Valid operators are
                                                         In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description:
-                                                        values is an array
+                                                      description: values is an array
                                                         of string values. If the operator
                                                         is In or NotIn, the values array
                                                         must be non-empty. If the operator
@@ -1795,8 +1584,7 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description:
-                                                  matchLabels is a map of
+                                                description: matchLabels is a map of
                                                   {key,value} pairs. A single {key,value}
                                                   in the matchLabels map is equivalent
                                                   to an element of matchExpressions,
@@ -1807,8 +1595,7 @@ spec:
                                                 type: object
                                             type: object
                                           namespaceSelector:
-                                            description:
-                                              A label query over the set
+                                            description: A label query over the set
                                               of namespaces that the term applies to.
                                               The term is applied to the union of the
                                               namespaces selected by this field and
@@ -1818,33 +1605,28 @@ spec:
                                               empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
-                                                description:
-                                                  matchExpressions is a list
+                                                description: matchExpressions is a list
                                                   of label selector requirements. The
                                                   requirements are ANDed.
                                                 items:
-                                                  description:
-                                                    A label selector requirement
+                                                  description: A label selector requirement
                                                     is a selector that contains values,
                                                     a key, and an operator that relates
                                                     the key and values.
                                                   properties:
                                                     key:
-                                                      description:
-                                                        key is the label
+                                                      description: key is the label
                                                         key that the selector applies
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description:
-                                                        operator represents
+                                                      description: operator represents
                                                         a key's relationship to a set
                                                         of values. Valid operators are
                                                         In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description:
-                                                        values is an array
+                                                      description: values is an array
                                                         of string values. If the operator
                                                         is In or NotIn, the values array
                                                         must be non-empty. If the operator
@@ -1863,8 +1645,7 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description:
-                                                  matchLabels is a map of
+                                                description: matchLabels is a map of
                                                   {key,value} pairs. A single {key,value}
                                                   in the matchLabels map is equivalent
                                                   to an element of matchExpressions,
@@ -1875,8 +1656,7 @@ spec:
                                                 type: object
                                             type: object
                                           namespaces:
-                                            description:
-                                              namespaces specifies a static
+                                            description: namespaces specifies a static
                                               list of namespace names that the term
                                               applies to. The term is applied to the
                                               union of the namespaces listed in this
@@ -1887,8 +1667,7 @@ spec:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description:
-                                              This pod should be co-located
+                                            description: This pod should be co-located
                                               (affinity) or not co-located (anti-affinity)
                                               with the pods matching the labelSelector
                                               in the specified namespaces, where co-located
@@ -1902,8 +1681,7 @@ spec:
                                           - topologyKey
                                         type: object
                                       weight:
-                                        description:
-                                          weight associated with matching
+                                        description: weight associated with matching
                                           the corresponding podAffinityTerm, in the
                                           range 1-100.
                                         format: int32
@@ -1914,8 +1692,7 @@ spec:
                                     type: object
                                   type: array
                                 requiredDuringSchedulingIgnoredDuringExecution:
-                                  description:
-                                    If the anti-affinity requirements specified
+                                  description: If the anti-affinity requirements specified
                                     by this field are not met at scheduling time, the
                                     pod will not be scheduled onto the node. If the
                                     anti-affinity requirements specified by this field
@@ -1926,8 +1703,7 @@ spec:
                                     lists of nodes corresponding to each podAffinityTerm
                                     are intersected, i.e. all terms must be satisfied.
                                   items:
-                                    description:
-                                      Defines a set of pods (namely those
+                                    description: Defines a set of pods (namely those
                                       matching the labelSelector relative to the given
                                       namespace(s)) that this pod should be co-located
                                       (affinity) or not co-located (anti-affinity) with,
@@ -1937,37 +1713,31 @@ spec:
                                       set of pods is running
                                     properties:
                                       labelSelector:
-                                        description:
-                                          A label query over a set of resources,
+                                        description: A label query over a set of resources,
                                           in this case pods.
                                         properties:
                                           matchExpressions:
-                                            description:
-                                              matchExpressions is a list
+                                            description: matchExpressions is a list
                                               of label selector requirements. The requirements
                                               are ANDed.
                                             items:
-                                              description:
-                                                A label selector requirement
+                                              description: A label selector requirement
                                                 is a selector that contains values,
                                                 a key, and an operator that relates
                                                 the key and values.
                                               properties:
                                                 key:
-                                                  description:
-                                                    key is the label key
+                                                  description: key is the label key
                                                     that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description:
-                                                    operator represents a
+                                                  description: operator represents a
                                                     key's relationship to a set of values.
                                                     Valid operators are In, NotIn, Exists
                                                     and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description:
-                                                    values is an array of
+                                                  description: values is an array of
                                                     string values. If the operator is
                                                     In or NotIn, the values array must
                                                     be non-empty. If the operator is
@@ -1986,8 +1756,7 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description:
-                                              matchLabels is a map of {key,value}
+                                            description: matchLabels is a map of {key,value}
                                               pairs. A single {key,value} in the matchLabels
                                               map is equivalent to an element of matchExpressions,
                                               whose key field is "key", the operator
@@ -1996,8 +1765,7 @@ spec:
                                             type: object
                                         type: object
                                       namespaceSelector:
-                                        description:
-                                          A label query over the set of namespaces
+                                        description: A label query over the set of namespaces
                                           that the term applies to. The term is applied
                                           to the union of the namespaces selected by
                                           this field and the ones listed in the namespaces
@@ -2006,32 +1774,27 @@ spec:
                                           selector ({}) matches all namespaces.
                                         properties:
                                           matchExpressions:
-                                            description:
-                                              matchExpressions is a list
+                                            description: matchExpressions is a list
                                               of label selector requirements. The requirements
                                               are ANDed.
                                             items:
-                                              description:
-                                                A label selector requirement
+                                              description: A label selector requirement
                                                 is a selector that contains values,
                                                 a key, and an operator that relates
                                                 the key and values.
                                               properties:
                                                 key:
-                                                  description:
-                                                    key is the label key
+                                                  description: key is the label key
                                                     that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description:
-                                                    operator represents a
+                                                  description: operator represents a
                                                     key's relationship to a set of values.
                                                     Valid operators are In, NotIn, Exists
                                                     and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description:
-                                                    values is an array of
+                                                  description: values is an array of
                                                     string values. If the operator is
                                                     In or NotIn, the values array must
                                                     be non-empty. If the operator is
@@ -2050,8 +1813,7 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description:
-                                              matchLabels is a map of {key,value}
+                                            description: matchLabels is a map of {key,value}
                                               pairs. A single {key,value} in the matchLabels
                                               map is equivalent to an element of matchExpressions,
                                               whose key field is "key", the operator
@@ -2060,8 +1822,7 @@ spec:
                                             type: object
                                         type: object
                                       namespaces:
-                                        description:
-                                          namespaces specifies a static list
+                                        description: namespaces specifies a static list
                                           of namespace names that the term applies to.
                                           The term is applied to the union of the namespaces
                                           listed in this field and the ones selected
@@ -2072,8 +1833,7 @@ spec:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description:
-                                          This pod should be co-located (affinity)
+                                        description: This pod should be co-located (affinity)
                                           or not co-located (anti-affinity) with the
                                           pods matching the labelSelector in the specified
                                           namespaces, where co-located is defined as
@@ -2089,35 +1849,30 @@ spec:
                               type: object
                           type: object
                         architecture:
-                          description:
-                            Specifies the architecture of the vm guest you
+                          description: Specifies the architecture of the vm guest you
                             are attempting to run. Defaults to the compiled architecture
                             of the KubeVirt components
                           type: string
                         dnsConfig:
-                          description:
-                            Specifies the DNS parameters of a pod. Parameters
+                          description: Specifies the DNS parameters of a pod. Parameters
                             specified here will be merged to the generated DNS configuration
                             based on DNSPolicy.
                           properties:
                             nameservers:
-                              description:
-                                A list of DNS name server IP addresses. This
+                              description: A list of DNS name server IP addresses. This
                                 will be appended to the base nameservers generated from
                                 DNSPolicy. Duplicated nameservers will be removed.
                               items:
                                 type: string
                               type: array
                             options:
-                              description:
-                                A list of DNS resolver options. This will
+                              description: A list of DNS resolver options. This will
                                 be merged with the base options generated from DNSPolicy.
                                 Duplicated entries will be removed. Resolution options
                                 given in Options will override those that appear in
                                 the base DNSPolicy.
                               items:
-                                description:
-                                  PodDNSConfigOption defines DNS resolver
+                                description: PodDNSConfigOption defines DNS resolver
                                   options of a pod.
                                 properties:
                                   name:
@@ -2128,8 +1883,7 @@ spec:
                                 type: object
                               type: array
                             searches:
-                              description:
-                                A list of DNS search domains for host-name
+                              description: A list of DNS search domains for host-name
                                 lookup. This will be appended to the base search paths
                                 generated from DNSPolicy. Duplicated search paths will
                                 be removed.
@@ -2138,8 +1892,7 @@ spec:
                               type: array
                           type: object
                         dnsPolicy:
-                          description:
-                            Set DNS policy for the pod. Defaults to "ClusterFirst".
+                          description: Set DNS policy for the pod. Defaults to "ClusterFirst".
                             Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst',
                             'Default' or 'None'. DNS parameters given in DNSConfig will
                             be merged with the policy selected with DNSPolicy. To have
@@ -2147,13 +1900,11 @@ spec:
                             DNS policy explicitly to 'ClusterFirstWithHostNet'.
                           type: string
                         domain:
-                          description:
-                            Specification of the desired behavior of the
+                          description: Specification of the desired behavior of the
                             VirtualMachineInstance on the host.
                           properties:
                             chassis:
-                              description:
-                                Chassis specifies the chassis info passed
+                              description: Chassis specifies the chassis info passed
                                 to the domain.
                               properties:
                                 asset:
@@ -2171,88 +1922,74 @@ spec:
                               description: Clock sets the clock and timers of the vmi.
                               properties:
                                 timer:
-                                  description:
-                                    Timer specifies whih timers are attached
+                                  description: Timer specifies whih timers are attached
                                     to the vmi.
                                   properties:
                                     hpet:
-                                      description:
-                                        HPET (High Precision Event Timer)
+                                      description: HPET (High Precision Event Timer)
                                         - multiple timers with periodic interrupts.
                                       properties:
                                         present:
-                                          description:
-                                            Enabled set to false makes sure
+                                          description: Enabled set to false makes sure
                                             that the machine type or a preset can't
                                             add the timer. Defaults to true.
                                           type: boolean
                                         tickPolicy:
-                                          description:
-                                            TickPolicy determines what happens
+                                          description: TickPolicy determines what happens
                                             when QEMU misses a deadline for injecting
                                             a tick to the guest. One of "delay", "catchup",
                                             "merge", "discard".
                                           type: string
                                       type: object
                                     hyperv:
-                                      description:
-                                        Hyperv (Hypervclock) - lets guests
+                                      description: Hyperv (Hypervclock) - lets guests
                                         read the host’s wall clock time (paravirtualized).
                                         For windows guests.
                                       properties:
                                         present:
-                                          description:
-                                            Enabled set to false makes sure
+                                          description: Enabled set to false makes sure
                                             that the machine type or a preset can't
                                             add the timer. Defaults to true.
                                           type: boolean
                                       type: object
                                     kvm:
-                                      description:
-                                        "KVM \t(KVM clock) - lets guests
-                                        read the host’s wall clock time (paravirtualized).
-                                        For linux guests."
+                                      description: "KVM \t(KVM clock) - lets guests
+                                      read the host’s wall clock time (paravirtualized).
+                                      For linux guests."
                                       properties:
                                         present:
-                                          description:
-                                            Enabled set to false makes sure
+                                          description: Enabled set to false makes sure
                                             that the machine type or a preset can't
                                             add the timer. Defaults to true.
                                           type: boolean
                                       type: object
                                     pit:
-                                      description:
-                                        PIT (Programmable Interval Timer)
+                                      description: PIT (Programmable Interval Timer)
                                         - a timer with periodic interrupts.
                                       properties:
                                         present:
-                                          description:
-                                            Enabled set to false makes sure
+                                          description: Enabled set to false makes sure
                                             that the machine type or a preset can't
                                             add the timer. Defaults to true.
                                           type: boolean
                                         tickPolicy:
-                                          description:
-                                            TickPolicy determines what happens
+                                          description: TickPolicy determines what happens
                                             when QEMU misses a deadline for injecting
                                             a tick to the guest. One of "delay", "catchup",
                                             "discard".
                                           type: string
                                       type: object
                                     rtc:
-                                      description:
-                                        RTC (Real Time Clock) - a continuously
+                                      description: RTC (Real Time Clock) - a continuously
                                         running timer with periodic interrupts.
                                       properties:
                                         present:
-                                          description:
-                                            Enabled set to false makes sure
+                                          description: Enabled set to false makes sure
                                             that the machine type or a preset can't
                                             add the timer. Defaults to true.
                                           type: boolean
                                         tickPolicy:
-                                          description:
-                                            TickPolicy determines what happens
+                                          description: TickPolicy determines what happens
                                             when QEMU misses a deadline for injecting
                                             a tick to the guest. One of "delay", "catchup".
                                           type: string
@@ -2262,21 +1999,18 @@ spec:
                                       type: object
                                   type: object
                                 timezone:
-                                  description:
-                                    Timezone sets the guest clock to the
+                                  description: Timezone sets the guest clock to the
                                     specified timezone. Zone name follows the TZ environment
                                     variable format (e.g. 'America/New_York').
                                   type: string
                                 utc:
-                                  description:
-                                    UTC sets the guest clock to UTC on each
+                                  description: UTC sets the guest clock to UTC on each
                                     boot. If an offset is specified, guest changes to
                                     the clock will be kept during reboots and are not
                                     reset.
                                   properties:
                                     offsetSeconds:
-                                      description:
-                                        OffsetSeconds specifies an offset
+                                      description: OffsetSeconds specifies an offset
                                         in seconds, relative to UTC. If set, guest changes
                                         to the clock will be kept during reboots and
                                         not reset.
@@ -2284,69 +2018,60 @@ spec:
                                   type: object
                               type: object
                             cpu:
-                              description:
-                                CPU allow specified the detailed CPU topology
+                              description: CPU allow specified the detailed CPU topology
                                 inside the vmi.
                               properties:
                                 cores:
-                                  description:
-                                    Cores specifies the number of cores inside
+                                  description: Cores specifies the number of cores inside
                                     the vmi. Must be a value greater or equal 1.
                                   format: int32
                                   type: integer
                                 dedicatedCpuPlacement:
-                                  description:
-                                    DedicatedCPUPlacement requests the scheduler
+                                  description: DedicatedCPUPlacement requests the scheduler
                                     to place the VirtualMachineInstance on a node with
                                     enough dedicated pCPUs and pin the vCPUs to it.
                                   type: boolean
                                 features:
-                                  description:
-                                    Features specifies the CPU features list
+                                  description: Features specifies the CPU features list
                                     inside the VMI.
                                   items:
-                                    description:
-                                      CPUFeature allows specifying a CPU
+                                    description: CPUFeature allows specifying a CPU
                                       feature.
                                     properties:
                                       name:
                                         description: Name of the CPU feature
                                         type: string
                                       policy:
-                                        description:
-                                          "Policy is the CPU feature attribute
-                                          which can have the following attributes: force    -
-                                          The virtual CPU will claim the feature is
-                                          supported regardless of it being supported
-                                          by host CPU. require  - Guest creation will
-                                          fail unless the feature is supported by the
-                                          host CPU or the hypervisor is able to emulate
-                                          it. optional - The feature will be supported
-                                          by virtual CPU if and only if it is supported
-                                          by host CPU. disable  - The feature will not
-                                          be supported by virtual CPU. forbid   - Guest
-                                          creation will fail if the feature is supported
-                                          by host CPU. Defaults to require"
+                                        description: 'Policy is the CPU feature attribute
+                                        which can have the following attributes: force    -
+                                        The virtual CPU will claim the feature is
+                                        supported regardless of it being supported
+                                        by host CPU. require  - Guest creation will
+                                        fail unless the feature is supported by the
+                                        host CPU or the hypervisor is able to emulate
+                                        it. optional - The feature will be supported
+                                        by virtual CPU if and only if it is supported
+                                        by host CPU. disable  - The feature will not
+                                        be supported by virtual CPU. forbid   - Guest
+                                        creation will fail if the feature is supported
+                                        by host CPU. Defaults to require'
                                         type: string
                                     required:
                                       - name
                                     type: object
                                   type: array
                                 isolateEmulatorThread:
-                                  description:
-                                    IsolateEmulatorThread requests one more
+                                  description: IsolateEmulatorThread requests one more
                                     dedicated pCPU to be allocated for the VMI to place
                                     the emulator thread on it.
                                   type: boolean
                                 maxSockets:
-                                  description:
-                                    MaxSockets specifies the maximum amount
+                                  description: MaxSockets specifies the maximum amount
                                     of sockets that can be hotplugged
                                   format: int32
                                   type: integer
                                 model:
-                                  description:
-                                    Model specifies the CPU model inside
+                                  description: Model specifies the CPU model inside
                                     the VMI. List of available models https://github.com/libvirt/libvirt/tree/master/src/cpu_map.
                                     It is possible to specify special cases like "host-passthrough"
                                     to get the same CPU as the node and "host-model"
@@ -2354,13 +2079,11 @@ spec:
                                     host-model.
                                   type: string
                                 numa:
-                                  description:
-                                    NUMA allows specifying settings for the
+                                  description: NUMA allows specifying settings for the
                                     guest NUMA topology
                                   properties:
                                     guestMappingPassthrough:
-                                      description:
-                                        GuestMappingPassthrough will create
+                                      description: GuestMappingPassthrough will create
                                         an efficient guest topology based on host CPUs
                                         exclusively assigned to a pod. The created topology
                                         ensures that memory and CPUs on the virtual
@@ -2369,102 +2092,85 @@ spec:
                                       type: object
                                   type: object
                                 realtime:
-                                  description:
-                                    Realtime instructs the virt-launcher
+                                  description: Realtime instructs the virt-launcher
                                     to tune the VMI for lower latency, optional for
                                     real time workloads
                                   properties:
                                     mask:
-                                      description:
-                                        'Mask defines the vcpu mask expression
-                                        that defines which vcpus are used for realtime.
-                                        Format matches libvirt''s expressions. Example:
-                                        "0-3,^1","0,2,3","2-3"'
+                                      description: 'Mask defines the vcpu mask expression
+                                      that defines which vcpus are used for realtime.
+                                      Format matches libvirt''s expressions. Example:
+                                      "0-3,^1","0,2,3","2-3"'
                                       type: string
                                   type: object
                                 sockets:
-                                  description:
-                                    Sockets specifies the number of sockets
+                                  description: Sockets specifies the number of sockets
                                     inside the vmi. Must be a value greater or equal
                                     1.
                                   format: int32
                                   type: integer
                                 threads:
-                                  description:
-                                    Threads specifies the number of threads
+                                  description: Threads specifies the number of threads
                                     inside the vmi. Must be a value greater or equal
                                     1.
                                   format: int32
                                   type: integer
                               type: object
                             devices:
-                              description:
-                                Devices allows adding disks, network interfaces,
+                              description: Devices allows adding disks, network interfaces,
                                 and others
                               properties:
                                 autoattachGraphicsDevice:
-                                  description:
-                                    Whether to attach the default graphics
+                                  description: Whether to attach the default graphics
                                     device or not. VNC will not be available if set
                                     to false. Defaults to true.
                                   type: boolean
                                 autoattachInputDevice:
-                                  description:
-                                    Whether to attach an Input Device. Defaults
+                                  description: Whether to attach an Input Device. Defaults
                                     to false.
                                   type: boolean
                                 autoattachMemBalloon:
-                                  description:
-                                    Whether to attach the Memory balloon
+                                  description: Whether to attach the Memory balloon
                                     device with default period. Period can be adjusted
                                     in virt-config. Defaults to true.
                                   type: boolean
                                 autoattachPodInterface:
-                                  description:
-                                    Whether to attach a pod network interface.
+                                  description: Whether to attach a pod network interface.
                                     Defaults to true.
                                   type: boolean
                                 autoattachSerialConsole:
-                                  description:
-                                    Whether to attach the default serial
+                                  description: Whether to attach the default virtio-serial
                                     console or not. Serial console access will not be
                                     available if set to false. Defaults to true.
                                   type: boolean
                                 autoattachVSOCK:
-                                  description:
-                                    Whether to attach the VSOCK CID to the
+                                  description: Whether to attach the VSOCK CID to the
                                     VM or not. VSOCK access will be available if set
                                     to true. Defaults to false.
                                   type: boolean
                                 blockMultiQueue:
-                                  description:
-                                    Whether or not to enable virtio multi-queue
+                                  description: Whether or not to enable virtio multi-queue
                                     for block devices. Defaults to false.
                                   type: boolean
                                 clientPassthrough:
-                                  description:
-                                    To configure and access client devices
+                                  description: To configure and access client devices
                                     such as redirecting USB
                                   type: object
                                 disableHotplug:
-                                  description:
-                                    DisableHotplug disabled the ability to
+                                  description: DisableHotplug disabled the ability to
                                     hotplug disks.
                                   type: boolean
                                 disks:
-                                  description:
-                                    Disks describes disks, cdroms and luns
+                                  description: Disks describes disks, cdroms and luns
                                     which are connected to the vmi.
                                   items:
                                     properties:
                                       blockSize:
-                                        description:
-                                          If specified, the virtual disk
+                                        description: If specified, the virtual disk
                                           will be presented with the given block sizes.
                                         properties:
                                           custom:
-                                            description:
-                                              CustomBlockSize represents
+                                            description: CustomBlockSize represents
                                               the desired logical and physical block
                                               size for a VM disk.
                                             properties:
@@ -2477,21 +2183,18 @@ spec:
                                               - physical
                                             type: object
                                           matchVolume:
-                                            description:
-                                              Represents if a feature is
+                                            description: Represents if a feature is
                                               enabled or disabled.
                                             properties:
                                               enabled:
-                                                description:
-                                                  Enabled determines if the
+                                                description: Enabled determines if the
                                                   feature should be enabled or disabled
                                                   on the guest. Defaults to true.
                                                 type: boolean
                                             type: object
                                         type: object
                                       bootOrder:
-                                        description:
-                                          BootOrder is an integer value >
+                                        description: BootOrder is an integer value >
                                           0, used to determine ordering of boot devices.
                                           Lower values take precedence. Each disk or
                                           interface that has a boot order must have
@@ -2500,85 +2203,77 @@ spec:
                                           exists.
                                         type: integer
                                       cache:
-                                        description:
-                                          "Cache specifies which kvm disk
-                                          cache mode should be used. Supported values
-                                          are: CacheNone, CacheWriteThrough."
+                                        description: 'Cache specifies which kvm disk
+                                        cache mode should be used. Supported values
+                                        are: CacheNone, CacheWriteThrough.'
                                         type: string
                                       cdrom:
-                                        description:
-                                          Attach a volume as a cdrom to the
+                                        description: Attach a volume as a cdrom to the
                                           vmi.
                                         properties:
                                           bus:
-                                            description:
-                                              "Bus indicates the type of
-                                              disk device to emulate. supported values:
-                                              virtio, sata, scsi."
+                                            description: 'Bus indicates the type of
+                                            disk device to emulate. supported values:
+                                            virtio, sata, scsi.'
                                             type: string
                                           readonly:
                                             description: ReadOnly. Defaults to true.
                                             type: boolean
                                           tray:
-                                            description:
-                                              Tray indicates if the tray
+                                            description: Tray indicates if the tray
                                               of the device is open or closed. Allowed
                                               values are "open" and "closed". Defaults
                                               to closed.
                                             type: string
                                         type: object
                                       dedicatedIOThread:
-                                        description:
-                                          dedicatedIOThread indicates this
+                                        description: dedicatedIOThread indicates this
                                           disk should have an exclusive IO Thread. Enabling
                                           this implies useIOThreads = true. Defaults
                                           to false.
                                         type: boolean
                                       disk:
-                                        description:
-                                          Attach a volume as a disk to the
+                                        description: Attach a volume as a disk to the
                                           vmi.
                                         properties:
                                           bus:
-                                            description:
-                                              "Bus indicates the type of
-                                              disk device to emulate. supported values:
-                                              virtio, sata, scsi, usb."
+                                            description: 'Bus indicates the type of
+                                            disk device to emulate. supported values:
+                                            virtio, sata, scsi, usb.'
                                             type: string
                                           pciAddress:
-                                            description:
-                                              "If specified, the virtual
-                                              disk will be placed on the guests pci
-                                              address with the specified PCI address.
-                                              For example: 0000:81:01.10"
+                                            description: 'If specified, the virtual
+                                            disk will be placed on the guests pci
+                                            address with the specified PCI address.
+                                            For example: 0000:81:01.10'
                                             type: string
                                           readonly:
                                             description: ReadOnly. Defaults to false.
                                             type: boolean
                                         type: object
+                                      errorPolicy:
+                                        description: If specified, it can change the
+                                          default error policy (stop) for the disk
+                                        type: string
                                       io:
-                                        description:
-                                          "IO specifies which QEMU disk IO
-                                          mode should be used. Supported values are:
-                                          native, default, threads."
+                                        description: 'IO specifies which QEMU disk IO
+                                        mode should be used. Supported values are:
+                                        native, default, threads.'
                                         type: string
                                       lun:
-                                        description:
-                                          Attach a volume as a LUN to the
+                                        description: Attach a volume as a LUN to the
                                           vmi.
                                         properties:
                                           bus:
-                                            description:
-                                              "Bus indicates the type of
-                                              disk device to emulate. supported values:
-                                              virtio, sata, scsi."
+                                            description: 'Bus indicates the type of
+                                            disk device to emulate. supported values:
+                                            virtio, sata, scsi.'
                                             type: string
                                           readonly:
                                             description: ReadOnly. Defaults to false.
                                             type: boolean
                                           reservation:
-                                            description:
-                                              Reservation indicates if the
+                                            description: Reservation indicates if the
                                               disk needs to support the persistent reservation
                                               for the SCSI disk
                                             type: boolean
@@ -2587,19 +2282,16 @@ spec:
                                         description: Name is the device name
                                         type: string
                                       serial:
-                                        description:
-                                          Serial provides the ability to
+                                        description: Serial provides the ability to
                                           specify a serial number for the disk device.
                                         type: string
                                       shareable:
-                                        description:
-                                          If specified the disk is made sharable
+                                        description: If specified the disk is made sharable
                                           and multiple write from different VMs are
                                           permitted
                                         type: boolean
                                       tag:
-                                        description:
-                                          If specified, disk address and
+                                        description: If specified, disk address and
                                           its tag will be provided to the guest via
                                           config drive metadata
                                         type: string
@@ -2607,9 +2299,12 @@ spec:
                                       - name
                                     type: object
                                   type: array
+                                downwardMetrics:
+                                  description: DownwardMetrics creates a virtio serials
+                                    for exposing the downward metrics to the vmi.
+                                  type: object
                                 filesystems:
-                                  description:
-                                    Filesystems describes filesystem which
+                                  description: Filesystems describes filesystem which
                                     is connected to the vmi.
                                   items:
                                     properties:
@@ -2626,21 +2321,18 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 gpus:
-                                  description:
-                                    Whether to attach a GPU device to the
+                                  description: Whether to attach a GPU device to the
                                     vmi.
                                   items:
                                     properties:
                                       deviceName:
                                         type: string
                                       name:
-                                        description:
-                                          Name of the GPU device as exposed
+                                        description: Name of the GPU device as exposed
                                           by a device plugin
                                         type: string
                                       tag:
-                                        description:
-                                          If specified, the virtual network
+                                        description: If specified, the virtual network
                                           interface address and its tag will be provided
                                           to the guest via config drive
                                         type: string
@@ -2649,21 +2341,18 @@ spec:
                                           display:
                                             properties:
                                               enabled:
-                                                description:
-                                                  Enabled determines if a
+                                                description: Enabled determines if a
                                                   display addapter backed by a vGPU
                                                   should be enabled or disabled on the
                                                   guest. Defaults to true.
                                                 type: boolean
                                               ramFB:
-                                                description:
-                                                  Enables a boot framebuffer,
+                                                description: Enables a boot framebuffer,
                                                   until the guest OS loads a real GPU
                                                   driver Defaults to true.
                                                 properties:
                                                   enabled:
-                                                    description:
-                                                      Enabled determines
+                                                    description: Enabled determines
                                                       if the feature should be enabled
                                                       or disabled on the guest. Defaults
                                                       to true.
@@ -2678,21 +2367,18 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 hostDevices:
-                                  description:
-                                    Whether to attach a host device to the
+                                  description: Whether to attach a host device to the
                                     vmi.
                                   items:
                                     properties:
                                       deviceName:
-                                        description:
-                                          DeviceName is the resource name
+                                        description: DeviceName is the resource name
                                           of the host device exposed by a device plugin
                                         type: string
                                       name:
                                         type: string
                                       tag:
-                                        description:
-                                          If specified, the virtual network
+                                        description: If specified, the virtual network
                                           interface address and its tag will be provided
                                           to the guest via config drive
                                         type: string
@@ -2707,18 +2393,16 @@ spec:
                                   items:
                                     properties:
                                       bus:
-                                        description:
-                                          "Bus indicates the bus of input
-                                          device to emulate. Supported values: virtio,
-                                          usb."
+                                        description: 'Bus indicates the bus of input
+                                        device to emulate. Supported values: virtio,
+                                        usb.'
                                         type: string
                                       name:
                                         description: Name is the device name
                                         type: string
                                       type:
-                                        description:
-                                          "Type indicated the type of input
-                                          device. Supported values: tablet."
+                                        description: 'Type indicated the type of input
+                                        device. Supported values: tablet.'
                                         type: string
                                     required:
                                       - name
@@ -2726,23 +2410,34 @@ spec:
                                     type: object
                                   type: array
                                 interfaces:
-                                  description:
-                                    Interfaces describe network interfaces
+                                  description: Interfaces describe network interfaces
                                     which are added to the vmi.
                                   items:
                                     properties:
                                       acpiIndex:
-                                        description:
-                                          If specified, the ACPI index is
+                                        description: If specified, the ACPI index is
                                           used to provide network interface device naming,
                                           that is stable across changes in PCI addresses
                                           assigned to the device. This value is required
                                           to be unique across all devices and be between
                                           1 and (16*1024-1).
                                         type: integer
+                                      binding:
+                                        description: 'Binding specifies the binding
+                                        plugin that will be used to connect the interface
+                                        to the guest. It provides an alternative to
+                                        InterfaceBindingMethod. version: 1alphav1'
+                                        properties:
+                                          name:
+                                            description: 'Name references to the binding
+                                            name as denined in the kubevirt CR. version:
+                                            1alphav1'
+                                            type: string
+                                        required:
+                                          - name
+                                        type: object
                                       bootOrder:
-                                        description:
-                                          BootOrder is an integer value >
+                                        description: BootOrder is an integer value >
                                           0, used to determine ordering of boot devices.
                                           Lower values take precedence. Each interface
                                           or disk that has a boot order must have a
@@ -2750,45 +2445,37 @@ spec:
                                           are not tried.
                                         type: integer
                                       bridge:
-                                        description:
-                                          InterfaceBridge connects to a given
+                                        description: InterfaceBridge connects to a given
                                           network via a linux bridge.
                                         type: object
                                       dhcpOptions:
-                                        description:
-                                          If specified the network interface
+                                        description: If specified the network interface
                                           will pass additional DHCP options to the VMI
                                         properties:
                                           bootFileName:
-                                            description:
-                                              If specified will pass option
+                                            description: If specified will pass option
                                               67 to interface's DHCP server
                                             type: string
                                           ntpServers:
-                                            description:
-                                              If specified will pass the
+                                            description: If specified will pass the
                                               configured NTP server to the VM via DHCP
                                               option 042.
                                             items:
                                               type: string
                                             type: array
                                           privateOptions:
-                                            description:
-                                              "If specified will pass extra
-                                              DHCP options for private use, range: 224-254"
+                                            description: 'If specified will pass extra
+                                            DHCP options for private use, range: 224-254'
                                             items:
-                                              description:
-                                                DHCPExtraOptions defines
+                                              description: DHCPExtraOptions defines
                                                 Extra DHCP options for a VM.
                                               properties:
                                                 option:
-                                                  description:
-                                                    Option is an Integer
+                                                  description: Option is an Integer
                                                     value from 224-254 Required.
                                                   type: integer
                                                 value:
-                                                  description:
-                                                    Value is a String value
+                                                  description: Value is a String value
                                                     for the Option provided Required.
                                                   type: string
                                               required:
@@ -2797,82 +2484,68 @@ spec:
                                               type: object
                                             type: array
                                           tftpServerName:
-                                            description:
-                                              If specified will pass option
+                                            description: If specified will pass option
                                               66 to interface's DHCP server
                                             type: string
                                         type: object
                                       macAddress:
-                                        description:
-                                          "Interface MAC address. For example:
-                                          de:ad:00:00:be:af or DE-AD-00-00-BE-AF."
+                                        description: 'Interface MAC address. For example:
+                                        de:ad:00:00:be:af or DE-AD-00-00-BE-AF.'
                                         type: string
                                       macvtap:
-                                        description:
-                                          InterfaceMacvtap connects to a
-                                          given network by extending the Kubernetes
-                                          node's L2 networks via a macvtap interface.
+                                        description: Deprecated, please refer to Kubevirt
+                                          user guide for alternatives.
                                         type: object
                                       masquerade:
-                                        description:
-                                          InterfaceMasquerade connects to
+                                        description: InterfaceMasquerade connects to
                                           a given network using netfilter rules to nat
                                           the traffic.
                                         type: object
                                       model:
-                                        description:
-                                          "Interface model. One of: e1000,
-                                          e1000e, ne2k_pci, pcnet, rtl8139, virtio.
-                                          Defaults to virtio. TODO:(ihar) switch to
-                                          enums once opengen-api supports them. See:
-                                          https://github.com/kubernetes/kube-openapi/issues/51"
+                                        description: 'Interface model. One of: e1000,
+                                        e1000e, ne2k_pci, pcnet, rtl8139, virtio.
+                                        Defaults to virtio. TODO:(ihar) switch to
+                                        enums once opengen-api supports them. See:
+                                        https://github.com/kubernetes/kube-openapi/issues/51'
                                         type: string
                                       name:
-                                        description:
-                                          Logical name of the interface as
+                                        description: Logical name of the interface as
                                           well as a reference to the associated networks.
                                           Must match the Name of a Network.
                                         type: string
                                       passt:
-                                        description:
-                                          InterfacePasst connects to a given
-                                          network.
+                                        description: Deprecated, please refer to Kubevirt
+                                          user guide for alternatives.
                                         type: object
                                       pciAddress:
-                                        description:
-                                          "If specified, the virtual network
-                                          interface will be placed on the guests pci
-                                          address with the specified PCI address. For
-                                          example: 0000:81:01.10"
+                                        description: 'If specified, the virtual network
+                                        interface will be placed on the guests pci
+                                        address with the specified PCI address. For
+                                        example: 0000:81:01.10'
                                         type: string
                                       ports:
-                                        description:
-                                          List of ports to be forwarded to
+                                        description: List of ports to be forwarded to
                                           the virtual machine.
                                         items:
-                                          description:
-                                            Port represents a port to expose
+                                          description: Port represents a port to expose
                                             from the virtual machine. Default protocol
                                             TCP. The port field is mandatory
                                           properties:
                                             name:
-                                              description:
-                                                If specified, this must be
+                                              description: If specified, this must be
                                                 an IANA_SVC_NAME and unique within the
                                                 pod. Each named port in a pod must have
                                                 a unique name. Name for the port that
                                                 can be referred to by services.
                                               type: string
                                             port:
-                                              description:
-                                                Number of port to expose
+                                              description: Number of port to expose
                                                 for the virtual machine. This must be
                                                 a valid port number, 0 < x < 65536.
                                               format: int32
                                               type: integer
                                             protocol:
-                                              description:
-                                                Protocol for port. Must be
+                                              description: Protocol for port. Must be
                                                 UDP or TCP. Defaults to "TCP".
                                               type: string
                                           required:
@@ -2880,26 +2553,22 @@ spec:
                                           type: object
                                         type: array
                                       slirp:
-                                        description:
-                                          InterfaceSlirp connects to a given
+                                        description: InterfaceSlirp connects to a given
                                           network using QEMU user networking mode.
                                         type: object
                                       sriov:
-                                        description:
-                                          InterfaceSRIOV connects to a given
+                                        description: InterfaceSRIOV connects to a given
                                           network by passing-through an SR-IOV PCI device
                                           via vfio.
                                         type: object
                                       state:
-                                        description:
-                                          State represents the requested
+                                        description: State represents the requested
                                           operational state of the interface. The (only)
                                           value supported is 'absent', expressing a
                                           request to remove the interface.
                                         type: string
                                       tag:
-                                        description:
-                                          If specified, the virtual network
+                                        description: If specified, the virtual network
                                           interface address and its tag will be provided
                                           to the guest via config drive
                                         type: string
@@ -2907,9 +2576,16 @@ spec:
                                       - name
                                     type: object
                                   type: array
+                                logSerialConsole:
+                                  description: Whether to log the auto-attached default
+                                    serial console or not. Serial console logs will
+                                    be collect to a file and then streamed from a named
+                                    'guest-console-log'. Not relevant if autoattachSerialConsole
+                                    is disabled. Defaults to cluster wide setting on
+                                    VirtualMachineOptions.
+                                  type: boolean
                                 networkInterfaceMultiqueue:
-                                  description:
-                                    If specified, virtual network interfaces
+                                  description: If specified, virtual network interfaces
                                     configured with a virtio bus will also enable the
                                     vhost multiqueue feature for network devices. The
                                     number of queues created depends on additional factors
@@ -2917,22 +2593,19 @@ spec:
                                     guest CPUs.
                                   type: boolean
                                 rng:
-                                  description:
-                                    Whether to have random number generator
+                                  description: Whether to have random number generator
                                     from host
                                   type: object
                                 sound:
                                   description: Whether to emulate a sound device.
                                   properties:
                                     model:
-                                      description:
-                                        "We only support ich9 or ac97. If
-                                        SoundDevice is not set: No sound card is emulated.
-                                        If SoundDevice is set but Model is not: ich9"
+                                      description: 'We only support ich9 or ac97. If
+                                      SoundDevice is not set: No sound card is emulated.
+                                      If SoundDevice is set but Model is not: ich9'
                                       type: string
                                     name:
-                                      description:
-                                        User's defined name for this sound
+                                      description: User's defined name for this sound
                                         device
                                       type: string
                                   required:
@@ -2942,30 +2615,26 @@ spec:
                                   description: Whether to emulate a TPM device.
                                   properties:
                                     persistent:
-                                      description:
-                                        Persistent indicates the state of
+                                      description: Persistent indicates the state of
                                         the TPM device should be kept accross reboots
                                         Defaults to false
                                       type: boolean
                                   type: object
                                 useVirtioTransitional:
-                                  description:
-                                    Fall back to legacy virtio 0.9 support
+                                  description: Fall back to legacy virtio 0.9 support
                                     if virtio bus is selected on devices. This is helpful
                                     for old machines like CentOS6 or RHEL6 which do
                                     not understand virtio_non_transitional (virtio 1.0).
                                   type: boolean
                                 watchdog:
-                                  description:
-                                    Watchdog describes a watchdog device
+                                  description: Watchdog describes a watchdog device
                                     which can be added to the vmi.
                                   properties:
                                     i6300esb:
                                       description: i6300esb watchdog device.
                                       properties:
                                         action:
-                                          description:
-                                            The action to take. Valid values
+                                          description: The action to take. Valid values
                                             are poweroff, reset, shutdown. Defaults
                                             to reset.
                                           type: string
@@ -2981,13 +2650,11 @@ spec:
                               description: Features like acpi, apic, hyperv, smm.
                               properties:
                                 acpi:
-                                  description:
-                                    ACPI enables/disables ACPI inside the
+                                  description: ACPI enables/disables ACPI inside the
                                     guest. Defaults to enabled.
                                   properties:
                                     enabled:
-                                      description:
-                                        Enabled determines if the feature
+                                      description: Enabled determines if the feature
                                         should be enabled or disabled on the guest.
                                         Defaults to true.
                                       type: boolean
@@ -2996,14 +2663,12 @@ spec:
                                   description: Defaults to the machine type setting.
                                   properties:
                                     enabled:
-                                      description:
-                                        Enabled determines if the feature
+                                      description: Enabled determines if the feature
                                         should be enabled or disabled on the guest.
                                         Defaults to true.
                                       type: boolean
                                     endOfInterrupt:
-                                      description:
-                                        EndOfInterrupt enables the end of
+                                      description: EndOfInterrupt enables the end of
                                         interrupt notification in the guest. Defaults
                                         to false.
                                       type: boolean
@@ -3012,141 +2677,119 @@ spec:
                                   description: Defaults to the machine type setting.
                                   properties:
                                     evmcs:
-                                      description:
-                                        EVMCS Speeds up L2 vmexits, but disables
+                                      description: EVMCS Speeds up L2 vmexits, but disables
                                         other virtualization features. Requires vapic.
                                         Defaults to the machine type setting.
                                       properties:
                                         enabled:
-                                          description:
-                                            Enabled determines if the feature
+                                          description: Enabled determines if the feature
                                             should be enabled or disabled on the guest.
                                             Defaults to true.
                                           type: boolean
                                       type: object
                                     frequencies:
-                                      description:
-                                        Frequencies improves the TSC clock
+                                      description: Frequencies improves the TSC clock
                                         source handling for Hyper-V on KVM. Defaults
                                         to the machine type setting.
                                       properties:
                                         enabled:
-                                          description:
-                                            Enabled determines if the feature
+                                          description: Enabled determines if the feature
                                             should be enabled or disabled on the guest.
                                             Defaults to true.
                                           type: boolean
                                       type: object
                                     ipi:
-                                      description:
-                                        IPI improves performances in overcommited
+                                      description: IPI improves performances in overcommited
                                         environments. Requires vpindex. Defaults to
                                         the machine type setting.
                                       properties:
                                         enabled:
-                                          description:
-                                            Enabled determines if the feature
+                                          description: Enabled determines if the feature
                                             should be enabled or disabled on the guest.
                                             Defaults to true.
                                           type: boolean
                                       type: object
                                     reenlightenment:
-                                      description:
-                                        Reenlightenment enables the notifications
+                                      description: Reenlightenment enables the notifications
                                         on TSC frequency changes. Defaults to the machine
                                         type setting.
                                       properties:
                                         enabled:
-                                          description:
-                                            Enabled determines if the feature
+                                          description: Enabled determines if the feature
                                             should be enabled or disabled on the guest.
                                             Defaults to true.
                                           type: boolean
                                       type: object
                                     relaxed:
-                                      description:
-                                        Relaxed instructs the guest OS to
+                                      description: Relaxed instructs the guest OS to
                                         disable watchdog timeouts. Defaults to the machine
                                         type setting.
                                       properties:
                                         enabled:
-                                          description:
-                                            Enabled determines if the feature
+                                          description: Enabled determines if the feature
                                             should be enabled or disabled on the guest.
                                             Defaults to true.
                                           type: boolean
                                       type: object
                                     reset:
-                                      description:
-                                        Reset enables Hyperv reboot/reset
+                                      description: Reset enables Hyperv reboot/reset
                                         for the vmi. Requires synic. Defaults to the
                                         machine type setting.
                                       properties:
                                         enabled:
-                                          description:
-                                            Enabled determines if the feature
+                                          description: Enabled determines if the feature
                                             should be enabled or disabled on the guest.
                                             Defaults to true.
                                           type: boolean
                                       type: object
                                     runtime:
-                                      description:
-                                        Runtime improves the time accounting
+                                      description: Runtime improves the time accounting
                                         to improve scheduling in the guest. Defaults
                                         to the machine type setting.
                                       properties:
                                         enabled:
-                                          description:
-                                            Enabled determines if the feature
+                                          description: Enabled determines if the feature
                                             should be enabled or disabled on the guest.
                                             Defaults to true.
                                           type: boolean
                                       type: object
                                     spinlocks:
-                                      description:
-                                        Spinlocks allows to configure the
+                                      description: Spinlocks allows to configure the
                                         spinlock retry attempts.
                                       properties:
                                         enabled:
-                                          description:
-                                            Enabled determines if the feature
+                                          description: Enabled determines if the feature
                                             should be enabled or disabled on the guest.
                                             Defaults to true.
                                           type: boolean
                                         spinlocks:
-                                          description:
-                                            Retries indicates the number
+                                          description: Retries indicates the number
                                             of retries. Must be a value greater or equal
                                             4096. Defaults to 4096.
                                           format: int32
                                           type: integer
                                       type: object
                                     synic:
-                                      description:
-                                        SyNIC enables the Synthetic Interrupt
+                                      description: SyNIC enables the Synthetic Interrupt
                                         Controller. Defaults to the machine type setting.
                                       properties:
                                         enabled:
-                                          description:
-                                            Enabled determines if the feature
+                                          description: Enabled determines if the feature
                                             should be enabled or disabled on the guest.
                                             Defaults to true.
                                           type: boolean
                                       type: object
                                     synictimer:
-                                      description:
-                                        SyNICTimer enables Synthetic Interrupt
+                                      description: SyNICTimer enables Synthetic Interrupt
                                         Controller Timers, reducing CPU load. Defaults
                                         to the machine type setting.
                                       properties:
                                         direct:
-                                          description:
-                                            Represents if a feature is enabled
+                                          description: Represents if a feature is enabled
                                             or disabled.
                                           properties:
                                             enabled:
-                                              description:
-                                                Enabled determines if the
+                                              description: Enabled determines if the
                                                 feature should be enabled or disabled
                                                 on the guest. Defaults to true.
                                               type: boolean
@@ -3155,95 +2798,80 @@ spec:
                                           type: boolean
                                       type: object
                                     tlbflush:
-                                      description:
-                                        TLBFlush improves performances in
+                                      description: TLBFlush improves performances in
                                         overcommited environments. Requires vpindex.
                                         Defaults to the machine type setting.
                                       properties:
                                         enabled:
-                                          description:
-                                            Enabled determines if the feature
+                                          description: Enabled determines if the feature
                                             should be enabled or disabled on the guest.
                                             Defaults to true.
                                           type: boolean
                                       type: object
                                     vapic:
-                                      description:
-                                        VAPIC improves the paravirtualized
+                                      description: VAPIC improves the paravirtualized
                                         handling of interrupts. Defaults to the machine
                                         type setting.
                                       properties:
                                         enabled:
-                                          description:
-                                            Enabled determines if the feature
+                                          description: Enabled determines if the feature
                                             should be enabled or disabled on the guest.
                                             Defaults to true.
                                           type: boolean
                                       type: object
                                     vendorid:
-                                      description:
-                                        VendorID allows setting the hypervisor
+                                      description: VendorID allows setting the hypervisor
                                         vendor id. Defaults to the machine type setting.
                                       properties:
                                         enabled:
-                                          description:
-                                            Enabled determines if the feature
+                                          description: Enabled determines if the feature
                                             should be enabled or disabled on the guest.
                                             Defaults to true.
                                           type: boolean
                                         vendorid:
-                                          description:
-                                            VendorID sets the hypervisor
+                                          description: VendorID sets the hypervisor
                                             vendor id, visible to the vmi. String up
                                             to twelve characters.
                                           type: string
                                       type: object
                                     vpindex:
-                                      description:
-                                        VPIndex enables the Virtual Processor
+                                      description: VPIndex enables the Virtual Processor
                                         Index to help windows identifying virtual processors.
                                         Defaults to the machine type setting.
                                       properties:
                                         enabled:
-                                          description:
-                                            Enabled determines if the feature
+                                          description: Enabled determines if the feature
                                             should be enabled or disabled on the guest.
                                             Defaults to true.
                                           type: boolean
                                       type: object
                                   type: object
                                 kvm:
-                                  description:
-                                    Configure how KVM presence is exposed
+                                  description: Configure how KVM presence is exposed
                                     to the guest.
                                   properties:
                                     hidden:
-                                      description:
-                                        Hide the KVM hypervisor from standard
+                                      description: Hide the KVM hypervisor from standard
                                         MSR based discovery. Defaults to false
                                       type: boolean
                                   type: object
                                 pvspinlock:
-                                  description:
-                                    Notify the guest that the host supports
+                                  description: Notify the guest that the host supports
                                     paravirtual spinlocks. For older kernels this feature
                                     should be explicitly disabled.
                                   properties:
                                     enabled:
-                                      description:
-                                        Enabled determines if the feature
+                                      description: Enabled determines if the feature
                                         should be enabled or disabled on the guest.
                                         Defaults to true.
                                       type: boolean
                                   type: object
                                 smm:
-                                  description:
-                                    SMM enables/disables System Management
+                                  description: SMM enables/disables System Management
                                     Mode. TSEG not yet implemented.
                                   properties:
                                     enabled:
-                                      description:
-                                        Enabled determines if the feature
+                                      description: Enabled determines if the feature
                                         should be enabled or disabled on the guest.
                                         Defaults to true.
                                       type: boolean
@@ -3252,28 +2880,40 @@ spec:
                             firmware:
                               description: Firmware.
                               properties:
+                                acpi:
+                                  description: Information that can be set in the ACPI
+                                    table
+                                  properties:
+                                    slicNameRef:
+                                      description: 'SlicNameRef should match the volume
+                                      name of a secret object. The data in the secret
+                                      should be a binary blob that follows the ACPI
+                                      SLIC standard, see: https://learn.microsoft.com/en-us/previous-versions/windows/hardware/design/dn653305(v=vs.85)'
+                                      type: string
+                                  type: object
                                 bootloader:
-                                  description:
-                                    Settings to control the bootloader that
+                                  description: Settings to control the bootloader that
                                     is used.
                                   properties:
                                     bios:
                                       description: If set (default), BIOS will be used.
                                       properties:
                                         useSerial:
-                                          description:
-                                            If set, the BIOS output will
+                                          description: If set, the BIOS output will
                                             be transmitted over serial
                                           type: boolean
                                       type: object
                                     efi:
-                                      description:
-                                        If set, EFI will be used instead
+                                      description: If set, EFI will be used instead
                                         of BIOS.
                                       properties:
+                                        persistent:
+                                          description: If set to true, Persistent will
+                                            persist the EFI NVRAM across reboots. Defaults
+                                            to false
+                                          type: boolean
                                         secureBoot:
-                                          description:
-                                            If set, SecureBoot will be enabled
+                                          description: If set, SecureBoot will be enabled
                                             and the OVMF roms will be swapped for SecureBoot-enabled
                                             ones. Requires SMM to be enabled. Defaults
                                             to true
@@ -3284,45 +2924,38 @@ spec:
                                   description: Settings to set the kernel for booting.
                                   properties:
                                     container:
-                                      description:
-                                        Container defines the container that
+                                      description: Container defines the container that
                                         containes kernel artifacts
                                       properties:
                                         image:
-                                          description:
-                                            Image that contains initrd /
+                                          description: Image that contains initrd /
                                             kernel files.
                                           type: string
                                         imagePullPolicy:
-                                          description:
-                                            "Image pull policy. One of Always,
-                                            Never, IfNotPresent. Defaults to Always
-                                            if :latest tag is specified, or IfNotPresent
-                                            otherwise. Cannot be updated. More info:
-                                            https://kubernetes.io/docs/concepts/containers/images#updating-images"
+                                          description: 'Image pull policy. One of Always,
+                                          Never, IfNotPresent. Defaults to Always
+                                          if :latest tag is specified, or IfNotPresent
+                                          otherwise. Cannot be updated. More info:
+                                          https://kubernetes.io/docs/concepts/containers/images#updating-images'
                                           type: string
                                         imagePullSecret:
-                                          description:
-                                            ImagePullSecret is the name of
+                                          description: ImagePullSecret is the name of
                                             the Docker registry secret required to pull
                                             the image. The secret must already exist.
                                           type: string
                                         initrdPath:
-                                          description:
-                                            the fully-qualified path to the
+                                          description: the fully-qualified path to the
                                             ramdisk image in the host OS
                                           type: string
                                         kernelPath:
-                                          description:
-                                            The fully-qualified path to the
+                                          description: The fully-qualified path to the
                                             kernel image in the host OS
                                           type: string
                                       required:
                                         - image
                                       type: object
                                     kernelArgs:
-                                      description:
-                                        Arguments to be passed to the kernel
+                                      description: Arguments to be passed to the kernel
                                         at boot time
                                       type: string
                                   type: object
@@ -3330,16 +2963,14 @@ spec:
                                   description: The system-serial-number in SMBIOS
                                   type: string
                                 uuid:
-                                  description:
-                                    UUID reported by the vmi bios. Defaults
+                                  description: UUID reported by the vmi bios. Defaults
                                     to a random generated uid.
                                   type: string
                               type: object
                             ioThreadsPolicy:
-                              description:
-                                "Controls whether or not disks will share
-                                IOThreads. Omitting IOThreadsPolicy disables use of
-                                IOThreads. One of: shared, auto"
+                              description: 'Controls whether or not disks will share
+                              IOThreads. Omitting IOThreadsPolicy disables use of
+                              IOThreads. One of: shared, auto'
                               type: string
                             launchSecurity:
                               description: Launch Security setting of the vmi.
@@ -3347,28 +2978,36 @@ spec:
                                 sev:
                                   description: AMD Secure Encrypted Virtualization (SEV).
                                   properties:
+                                    attestation:
+                                      description: If specified, run the attestation
+                                        process for a vmi.
+                                      type: object
+                                    dhCert:
+                                      description: Base64 encoded guest owner's Diffie-Hellman
+                                        key.
+                                      type: string
                                     policy:
-                                      description:
-                                        "Guest policy flags as defined in
-                                        AMD SEV API specification. Note: due to security
-                                        reasons it is not allowed to enable guest debugging.
-                                        Therefore NoDebug flag is not exposed to users
-                                        and is always true."
+                                      description: 'Guest policy flags as defined in
+                                      AMD SEV API specification. Note: due to security
+                                      reasons it is not allowed to enable guest debugging.
+                                      Therefore NoDebug flag is not exposed to users
+                                      and is always true.'
                                       properties:
                                         encryptedState:
-                                          description:
-                                            SEV-ES is required. Defaults
+                                          description: SEV-ES is required. Defaults
                                             to false.
                                           type: boolean
                                       type: object
+                                    session:
+                                      description: Base64 encoded session blob.
+                                      type: string
                                   type: object
                               type: object
                             machine:
                               description: Machine type.
                               properties:
                                 type:
-                                  description:
-                                    QEMU machine type is the actual chipset
+                                  description: QEMU machine type is the actual chipset
                                     of the VirtualMachineInstance.
                                   type: string
                               type: object
@@ -3379,8 +3018,7 @@ spec:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description:
-                                    Guest allows to specifying the amount
+                                  description: Guest allows to specifying the amount
                                     of memory which is visible inside the Guest OS.
                                     The Guest must lie between Requests and Limits from
                                     the resources section. Defaults to the requested
@@ -3388,21 +3026,28 @@ spec:
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 hugepages:
-                                  description:
-                                    Hugepages allow to use hugepages for
+                                  description: Hugepages allow to use hugepages for
                                     the VirtualMachineInstance instead of regular memory.
                                   properties:
                                     pageSize:
-                                      description:
-                                        PageSize specifies the hugepage size,
+                                      description: PageSize specifies the hugepage size,
                                         for x86_64 architecture valid values are 1Gi
                                         and 2Mi.
                                       type: string
                                   type: object
+                                maxGuest:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: MaxGuest allows to specify the maximum
+                                    amount of memory which is visible inside the Guest
+                                    OS. The delta between MaxGuest and Guest is the
+                                    amount of memory that can be hot(un)plugged.
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
                               type: object
                             resources:
-                              description:
-                                Resources describes the Compute Resources
+                              description: Resources describes the Compute Resources
                                 required by this vmi.
                               properties:
                                 limits:
@@ -3412,14 +3057,12 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description:
-                                    Limits describes the maximum amount of
+                                  description: Limits describes the maximum amount of
                                     compute resources allowed. Valid resource keys are
                                     "memory" and "cpu".
                                   type: object
                                 overcommitGuestOverhead:
-                                  description:
-                                    Don't ask the scheduler to take the guest-management
+                                  description: Don't ask the scheduler to take the guest-management
                                     overhead into account. Instead put the overhead
                                     only into the container's memory limit. This can
                                     lead to crashes if all memory is in use on a node.
@@ -3432,8 +3075,7 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description:
-                                    Requests is a description of the initial
+                                  description: Requests is a description of the initial
                                     vmi resources. Valid resource keys are "memory"
                                     and "cpu".
                                   type: object
@@ -3442,34 +3084,40 @@ spec:
                             - devices
                           type: object
                         evictionStrategy:
-                          description:
-                            EvictionStrategy can be set to "LiveMigrate"
-                            if the VirtualMachineInstance should be migrated instead
-                            of shut-off in case of a node drain.
+                          description: 'EvictionStrategy describes the strategy to follow
+                          when a node drain occurs. The possible options are: - "None":
+                          No action will be taken, according to the specified ''RunStrategy''
+                          the VirtualMachine will be restarted or shutdown. - "LiveMigrate":
+                          the VirtualMachineInstance will be migrated instead of being
+                          shutdown. - "LiveMigrateIfPossible": the same as "LiveMigrate"
+                          but only if the VirtualMachine is Live-Migratable, otherwise
+                          it will behave as "None". - "External": the VirtualMachineInstance
+                          will be protected by a PDB and ''vmi.Status.EvacuationNodeName''
+                          will be set on eviction. This is mainly useful for cluster-api-provider-kubevirt
+                          (capk) which needs a way for VMI''s to be blocked from eviction,
+                          yet signal capk that eviction has been called on the VMI
+                          so the capk controller can handle tearing the VMI down.
+                          Details can be found in the commit description https://github.com/kubevirt/kubevirt/commit/c1d77face705c8b126696bac9a3ee3825f27f1fa.'
                           type: string
                         hostname:
-                          description:
-                            Specifies the hostname of the vmi If not specified,
+                          description: Specifies the hostname of the vmi If not specified,
                             the hostname will be set to the name of the vmi, if dhcp
                             or cloud-init is configured properly.
                           type: string
                         livenessProbe:
-                          description:
-                            "Periodic probe of VirtualMachineInstance liveness.
-                            VirtualmachineInstances will be stopped if the probe fails.
-                            Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
+                          description: 'Periodic probe of VirtualMachineInstance liveness.
+                          VirtualmachineInstances will be stopped if the probe fails.
+                          Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           properties:
                             exec:
-                              description:
-                                One and only one of the following should
+                              description: One and only one of the following should
                                 be specified. Exec specifies the action to take, it
                                 will be executed on the guest through the qemu-guest-agent.
                                 If the guest agent is not available, this probe will
                                 fail.
                               properties:
                                 command:
-                                  description:
-                                    Command is the command line to execute
+                                  description: Command is the command line to execute
                                     inside the container, the working directory for
                                     the command  is root ('/') in the container's filesystem.
                                     The command is simply exec'd, it is not run inside
@@ -3482,33 +3130,28 @@ spec:
                                   type: array
                               type: object
                             failureThreshold:
-                              description:
-                                Minimum consecutive failures for the probe
+                              description: Minimum consecutive failures for the probe
                                 to be considered failed after having succeeded. Defaults
                                 to 3. Minimum value is 1.
                               format: int32
                               type: integer
                             guestAgentPing:
-                              description:
-                                GuestAgentPing contacts the qemu-guest-agent
+                              description: GuestAgentPing contacts the qemu-guest-agent
                                 for availability checks.
                               type: object
                             httpGet:
                               description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description:
-                                    Host name to connect to, defaults to
+                                  description: Host name to connect to, defaults to
                                     the pod IP. You probably want to set "Host" in httpHeaders
                                     instead.
                                   type: string
                                 httpHeaders:
-                                  description:
-                                    Custom headers to set in the request.
+                                  description: Custom headers to set in the request.
                                     HTTP allows repeated headers.
                                   items:
-                                    description:
-                                      HTTPHeader describes a custom header
+                                    description: HTTPHeader describes a custom header
                                       to be used in HTTP probes
                                     properties:
                                       name:
@@ -3529,56 +3172,48 @@ spec:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description:
-                                    Name or number of the port to access
+                                  description: Name or number of the port to access
                                     on the container. Number must be in the range 1
                                     to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description:
-                                    Scheme to use for connecting to the host.
+                                  description: Scheme to use for connecting to the host.
                                     Defaults to HTTP.
                                   type: string
                               required:
                                 - port
                               type: object
                             initialDelaySeconds:
-                              description:
-                                "Number of seconds after the VirtualMachineInstance
-                                has started before liveness probes are initiated. More
-                                info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
+                              description: 'Number of seconds after the VirtualMachineInstance
+                              has started before liveness probes are initiated. More
+                              info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                               format: int32
                               type: integer
                             periodSeconds:
-                              description:
-                                How often (in seconds) to perform the probe.
+                              description: How often (in seconds) to perform the probe.
                                 Default to 10 seconds. Minimum value is 1.
                               format: int32
                               type: integer
                             successThreshold:
-                              description:
-                                Minimum consecutive successes for the probe
+                              description: Minimum consecutive successes for the probe
                                 to be considered successful after having failed. Defaults
                                 to 1. Must be 1 for liveness. Minimum value is 1.
                               format: int32
                               type: integer
                             tcpSocket:
-                              description:
-                                "TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook"
+                              description: 'TCPSocket specifies an action involving
+                              a TCP port. TCP hooks not yet supported TODO: implement
+                              a realistic TCP lifecycle hook'
                               properties:
                                 host:
-                                  description:
-                                    "Optional: Host name to connect to, defaults
-                                    to the pod IP."
+                                  description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description:
-                                    Number or name of the port to access
+                                  description: Number or name of the port to access
                                     on the container. Number must be in the range 1
                                     to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
@@ -3586,61 +3221,53 @@ spec:
                                 - port
                               type: object
                             timeoutSeconds:
-                              description:
-                                "Number of seconds after which the probe
-                                times out. For exec probes the timeout fails the probe
-                                but does not terminate the command running on the guest.
-                                This means a blocking command can result in an increasing
-                                load on the guest. A small buffer will be added to the
-                                resulting workload exec probe to compensate for delays
-                                caused by the qemu guest exec mechanism. Defaults to
-                                1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
+                              description: 'Number of seconds after which the probe
+                              times out. For exec probes the timeout fails the probe
+                              but does not terminate the command running on the guest.
+                              This means a blocking command can result in an increasing
+                              load on the guest. A small buffer will be added to the
+                              resulting workload exec probe to compensate for delays
+                              caused by the qemu guest exec mechanism. Defaults to
+                              1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                               format: int32
                               type: integer
                           type: object
                         networks:
-                          description:
-                            List of networks that can be attached to a vm's
+                          description: List of networks that can be attached to a vm's
                             virtual interface.
                           items:
-                            description:
-                              Network represents a network type and a resource
+                            description: Network represents a network type and a resource
                               that should be connected to the vm.
                             properties:
                               multus:
                                 description: Represents the multus cni network.
                                 properties:
                                   default:
-                                    description:
-                                      Select the default network and add
+                                    description: Select the default network and add
                                       it to the multus-cni.io/default-network annotation.
                                     type: boolean
                                   networkName:
-                                    description:
-                                      "References to a NetworkAttachmentDefinition
-                                      CRD object. Format: <networkName>, <namespace>/<networkName>.
-                                      If namespace is not specified, VMI namespace is
-                                      assumed."
+                                    description: 'References to a NetworkAttachmentDefinition
+                                    CRD object. Format: <networkName>, <namespace>/<networkName>.
+                                    If namespace is not specified, VMI namespace is
+                                    assumed.'
                                     type: string
                                 required:
                                   - networkName
                                 type: object
                               name:
-                                description:
-                                  "Network name. Must be a DNS_LABEL and
-                                  unique within the vm. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+                                description: 'Network name. Must be a DNS_LABEL and
+                                unique within the vm. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                 type: string
                               pod:
                                 description: Represents the stock pod network interface.
                                 properties:
                                   vmIPv6NetworkCIDR:
-                                    description:
-                                      IPv6 CIDR for the vm network. Defaults
+                                    description: IPv6 CIDR for the vm network. Defaults
                                       to fd10:0:2::/120 if not specified.
                                     type: string
                                   vmNetworkCIDR:
-                                    description:
-                                      CIDR for vm network. Default 10.0.2.0/24
+                                    description: CIDR for vm network. Default 10.0.2.0/24
                                       if not specified.
                                     type: string
                                 type: object
@@ -3651,36 +3278,31 @@ spec:
                         nodeSelector:
                           additionalProperties:
                             type: string
-                          description:
-                            "NodeSelector is a selector which must be true
-                            for the vmi to fit on a node. Selector which must match
-                            a node's labels for the vmi to be scheduled on that node.
-                            More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/"
+                          description: 'NodeSelector is a selector which must be true
+                          for the vmi to fit on a node. Selector which must match
+                          a node''s labels for the vmi to be scheduled on that node.
+                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                           type: object
                         priorityClassName:
-                          description:
-                            If specified, indicates the pod's priority. If
+                          description: If specified, indicates the pod's priority. If
                             not specified, the pod priority will be default or zero
                             if there is no default.
                           type: string
                         readinessProbe:
-                          description:
-                            "Periodic probe of VirtualMachineInstance service
-                            readiness. VirtualmachineInstances will be removed from
-                            service endpoints if the probe fails. Cannot be updated.
-                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
+                          description: 'Periodic probe of VirtualMachineInstance service
+                          readiness. VirtualmachineInstances will be removed from
+                          service endpoints if the probe fails. Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           properties:
                             exec:
-                              description:
-                                One and only one of the following should
+                              description: One and only one of the following should
                                 be specified. Exec specifies the action to take, it
                                 will be executed on the guest through the qemu-guest-agent.
                                 If the guest agent is not available, this probe will
                                 fail.
                               properties:
                                 command:
-                                  description:
-                                    Command is the command line to execute
+                                  description: Command is the command line to execute
                                     inside the container, the working directory for
                                     the command  is root ('/') in the container's filesystem.
                                     The command is simply exec'd, it is not run inside
@@ -3693,33 +3315,28 @@ spec:
                                   type: array
                               type: object
                             failureThreshold:
-                              description:
-                                Minimum consecutive failures for the probe
+                              description: Minimum consecutive failures for the probe
                                 to be considered failed after having succeeded. Defaults
                                 to 3. Minimum value is 1.
                               format: int32
                               type: integer
                             guestAgentPing:
-                              description:
-                                GuestAgentPing contacts the qemu-guest-agent
+                              description: GuestAgentPing contacts the qemu-guest-agent
                                 for availability checks.
                               type: object
                             httpGet:
                               description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description:
-                                    Host name to connect to, defaults to
+                                  description: Host name to connect to, defaults to
                                     the pod IP. You probably want to set "Host" in httpHeaders
                                     instead.
                                   type: string
                                 httpHeaders:
-                                  description:
-                                    Custom headers to set in the request.
+                                  description: Custom headers to set in the request.
                                     HTTP allows repeated headers.
                                   items:
-                                    description:
-                                      HTTPHeader describes a custom header
+                                    description: HTTPHeader describes a custom header
                                       to be used in HTTP probes
                                     properties:
                                       name:
@@ -3740,56 +3357,48 @@ spec:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description:
-                                    Name or number of the port to access
+                                  description: Name or number of the port to access
                                     on the container. Number must be in the range 1
                                     to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description:
-                                    Scheme to use for connecting to the host.
+                                  description: Scheme to use for connecting to the host.
                                     Defaults to HTTP.
                                   type: string
                               required:
                                 - port
                               type: object
                             initialDelaySeconds:
-                              description:
-                                "Number of seconds after the VirtualMachineInstance
-                                has started before liveness probes are initiated. More
-                                info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
+                              description: 'Number of seconds after the VirtualMachineInstance
+                              has started before liveness probes are initiated. More
+                              info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                               format: int32
                               type: integer
                             periodSeconds:
-                              description:
-                                How often (in seconds) to perform the probe.
+                              description: How often (in seconds) to perform the probe.
                                 Default to 10 seconds. Minimum value is 1.
                               format: int32
                               type: integer
                             successThreshold:
-                              description:
-                                Minimum consecutive successes for the probe
+                              description: Minimum consecutive successes for the probe
                                 to be considered successful after having failed. Defaults
                                 to 1. Must be 1 for liveness. Minimum value is 1.
                               format: int32
                               type: integer
                             tcpSocket:
-                              description:
-                                "TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook"
+                              description: 'TCPSocket specifies an action involving
+                              a TCP port. TCP hooks not yet supported TODO: implement
+                              a realistic TCP lifecycle hook'
                               properties:
                                 host:
-                                  description:
-                                    "Optional: Host name to connect to, defaults
-                                    to the pod IP."
+                                  description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description:
-                                    Number or name of the port to access
+                                  description: Number or name of the port to access
                                     on the container. Number must be in the range 1
                                     to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
@@ -3797,79 +3406,68 @@ spec:
                                 - port
                               type: object
                             timeoutSeconds:
-                              description:
-                                "Number of seconds after which the probe
-                                times out. For exec probes the timeout fails the probe
-                                but does not terminate the command running on the guest.
-                                This means a blocking command can result in an increasing
-                                load on the guest. A small buffer will be added to the
-                                resulting workload exec probe to compensate for delays
-                                caused by the qemu guest exec mechanism. Defaults to
-                                1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
+                              description: 'Number of seconds after which the probe
+                              times out. For exec probes the timeout fails the probe
+                              but does not terminate the command running on the guest.
+                              This means a blocking command can result in an increasing
+                              load on the guest. A small buffer will be added to the
+                              resulting workload exec probe to compensate for delays
+                              caused by the qemu guest exec mechanism. Defaults to
+                              1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                               format: int32
                               type: integer
                           type: object
                         schedulerName:
-                          description:
-                            If specified, the VMI will be dispatched by specified
+                          description: If specified, the VMI will be dispatched by specified
                             scheduler. If not specified, the VMI will be dispatched
                             by default scheduler.
                           type: string
                         startStrategy:
-                          description:
-                            StartStrategy can be set to "Paused" if Virtual
+                          description: StartStrategy can be set to "Paused" if Virtual
                             Machine should be started in paused state.
                           type: string
                         subdomain:
-                          description:
-                            If specified, the fully qualified vmi hostname
+                          description: If specified, the fully qualified vmi hostname
                             will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
                             domain>". If not specified, the vmi will not have a domainname
                             at all. The DNS entry will resolve to the vmi, no matter
                             if the vmi itself can pick up a hostname.
                           type: string
                         terminationGracePeriodSeconds:
-                          description:
-                            Grace period observed after signalling a VirtualMachineInstance
+                          description: Grace period observed after signalling a VirtualMachineInstance
                             to stop after which the VirtualMachineInstance is force
                             terminated.
                           format: int64
                           type: integer
                         tolerations:
-                          description:
-                            If toleration is specified, obey all the toleration
+                          description: If toleration is specified, obey all the toleration
                             rules.
                           items:
-                            description:
-                              The pod this Toleration is attached to tolerates
+                            description: The pod this Toleration is attached to tolerates
                               any taint that matches the triple <key,value,effect> using
                               the matching operator <operator>.
                             properties:
                               effect:
-                                description:
-                                  Effect indicates the taint effect to match.
+                                description: Effect indicates the taint effect to match.
                                   Empty means match all taint effects. When specified,
                                   allowed values are NoSchedule, PreferNoSchedule and
                                   NoExecute.
                                 type: string
                               key:
-                                description:
-                                  Key is the taint key that the toleration
+                                description: Key is the taint key that the toleration
                                   applies to. Empty means match all taint keys. If the
                                   key is empty, operator must be Exists; this combination
                                   means to match all values and all keys.
                                 type: string
                               operator:
-                                description:
-                                  Operator represents a key's relationship
+                                description: Operator represents a key's relationship
                                   to the value. Valid operators are Exists and Equal.
                                   Defaults to Equal. Exists is equivalent to wildcard
                                   for value, so that a pod can tolerate all taints of
                                   a particular category.
                                 type: string
                               tolerationSeconds:
-                                description:
-                                  TolerationSeconds represents the period
+                                description: TolerationSeconds represents the period
                                   of time the toleration (which must be of effect NoExecute,
                                   otherwise this field is ignored) tolerates the taint.
                                   By default, it is not set, which means tolerate the
@@ -3878,55 +3476,46 @@ spec:
                                 format: int64
                                 type: integer
                               value:
-                                description:
-                                  Value is the taint value the toleration
+                                description: Value is the taint value the toleration
                                   matches to. If the operator is Exists, the value should
                                   be empty, otherwise just a regular string.
                                 type: string
                             type: object
                           type: array
                         topologySpreadConstraints:
-                          description:
-                            TopologySpreadConstraints describes how a group
+                          description: TopologySpreadConstraints describes how a group
                             of VMIs will be spread across a given topology domains.
                             K8s scheduler will schedule VMI pods in a way which abides
                             by the constraints.
                           items:
-                            description:
-                              TopologySpreadConstraint specifies how to spread
+                            description: TopologySpreadConstraint specifies how to spread
                               matching pods among the given topology.
                             properties:
                               labelSelector:
-                                description:
-                                  LabelSelector is used to find matching
+                                description: LabelSelector is used to find matching
                                   pods. Pods that match this label selector are counted
                                   to determine the number of pods in their corresponding
                                   topology domain.
                                 properties:
                                   matchExpressions:
-                                    description:
-                                      matchExpressions is a list of label
+                                    description: matchExpressions is a list of label
                                       selector requirements. The requirements are ANDed.
                                     items:
-                                      description:
-                                        A label selector requirement is a
+                                      description: A label selector requirement is a
                                         selector that contains values, a key, and an
                                         operator that relates the key and values.
                                       properties:
                                         key:
-                                          description:
-                                            key is the label key that the
+                                          description: key is the label key that the
                                             selector applies to.
                                           type: string
                                         operator:
-                                          description:
-                                            operator represents a key's relationship
+                                          description: operator represents a key's relationship
                                             to a set of values. Valid operators are
                                             In, NotIn, Exists and DoesNotExist.
                                           type: string
                                         values:
-                                          description:
-                                            values is an array of string
+                                          description: values is an array of string
                                             values. If the operator is In or NotIn,
                                             the values array must be non-empty. If the
                                             operator is Exists or DoesNotExist, the
@@ -3943,8 +3532,7 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description:
-                                      matchLabels is a map of {key,value}
+                                    description: matchLabels is a map of {key,value}
                                       pairs. A single {key,value} in the matchLabels
                                       map is equivalent to an element of matchExpressions,
                                       whose key field is "key", the operator is "In",
@@ -3953,8 +3541,7 @@ spec:
                                     type: object
                                 type: object
                               matchLabelKeys:
-                                description:
-                                  MatchLabelKeys is a set of pod label keys
+                                description: MatchLabelKeys is a set of pod label keys
                                   to select the pods over which spreading will be calculated.
                                   The keys are used to lookup values from the incoming
                                   pod labels, those key-value labels are ANDed with
@@ -3968,85 +3555,80 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                               maxSkew:
-                                description:
-                                  "MaxSkew describes the degree to which
-                                  pods may be unevenly distributed. When 'whenUnsatisfiable=DoNotSchedule',
-                                  it is the maximum permitted difference between the
-                                  number of matching pods in the target topology and
-                                  the global minimum. The global minimum is the minimum
-                                  number of matching pods in an eligible domain or zero
-                                  if the number of eligible domains is less than MinDomains.
-                                  For example, in a 3-zone cluster, MaxSkew is set to
-                                  1, and pods with the same labelSelector spread as
-                                  2/2/1: In this case, the global minimum is 1. | zone1
-                                  | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
-                                  is 1, incoming pod can only be scheduled to zone3
-                                  to become 2/2/2; scheduling it onto zone1(zone2) would
-                                  make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1).
-                                  - if MaxSkew is 2, incoming pod can be scheduled onto
-                                  any zone. When 'whenUnsatisfiable=ScheduleAnyway',
-                                  it is used to give higher precedence to topologies
-                                  that satisfy it. It's a required field. Default value
-                                  is 1 and 0 is not allowed."
+                                description: 'MaxSkew describes the degree to which
+                                pods may be unevenly distributed. When ''whenUnsatisfiable=DoNotSchedule'',
+                                it is the maximum permitted difference between the
+                                number of matching pods in the target topology and
+                                the global minimum. The global minimum is the minimum
+                                number of matching pods in an eligible domain or zero
+                                if the number of eligible domains is less than MinDomains.
+                                For example, in a 3-zone cluster, MaxSkew is set to
+                                1, and pods with the same labelSelector spread as
+                                2/2/1: In this case, the global minimum is 1. | zone1
+                                | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
+                                is 1, incoming pod can only be scheduled to zone3
+                                to become 2/2/2; scheduling it onto zone1(zone2) would
+                                make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1).
+                                - if MaxSkew is 2, incoming pod can be scheduled onto
+                                any zone. When ''whenUnsatisfiable=ScheduleAnyway'',
+                                it is used to give higher precedence to topologies
+                                that satisfy it. It''s a required field. Default value
+                                is 1 and 0 is not allowed.'
                                 format: int32
                                 type: integer
                               minDomains:
-                                description:
-                                  "MinDomains indicates a minimum number
-                                  of eligible domains. When the number of eligible domains
-                                  with matching topology keys is less than minDomains,
-                                  Pod Topology Spread treats \"global minimum\" as 0,
-                                  and then the calculation of Skew is performed. And
-                                  when the number of eligible domains with matching
-                                  topology keys equals or greater than minDomains, this
-                                  value has no effect on scheduling. As a result, when
-                                  the number of eligible domains is less than minDomains,
-                                  scheduler won't schedule more than maxSkew Pods to
-                                  those domains. If value is nil, the constraint behaves
-                                  as if MinDomains is equal to 1. Valid values are integers
-                                  greater than 0. When value is not nil, WhenUnsatisfiable
-                                  must be DoNotSchedule. \n For example, in a 3-zone
-                                  cluster, MaxSkew is set to 2, MinDomains is set to
-                                  5 and pods with the same labelSelector spread as 2/2/2:
-                                  | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  |
-                                  The number of domains is less than 5(MinDomains),
-                                  so \"global minimum\" is treated as 0. In this situation,
-                                  new pod with the same labelSelector cannot be scheduled,
-                                  because computed skew will be 3(3 - 0) if new Pod
-                                  is scheduled to any of the three zones, it will violate
-                                  MaxSkew. \n This is a beta field and requires the
-                                  MinDomainsInPodTopologySpread feature gate to be enabled
-                                  (enabled by default)."
+                                description: "MinDomains indicates a minimum number
+                                of eligible domains. When the number of eligible domains
+                                with matching topology keys is less than minDomains,
+                                Pod Topology Spread treats \"global minimum\" as 0,
+                                and then the calculation of Skew is performed. And
+                                when the number of eligible domains with matching
+                                topology keys equals or greater than minDomains, this
+                                value has no effect on scheduling. As a result, when
+                                the number of eligible domains is less than minDomains,
+                                scheduler won't schedule more than maxSkew Pods to
+                                those domains. If value is nil, the constraint behaves
+                                as if MinDomains is equal to 1. Valid values are integers
+                                greater than 0. When value is not nil, WhenUnsatisfiable
+                                must be DoNotSchedule. \n For example, in a 3-zone
+                                cluster, MaxSkew is set to 2, MinDomains is set to
+                                5 and pods with the same labelSelector spread as 2/2/2:
+                                | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  |
+                                The number of domains is less than 5(MinDomains),
+                                so \"global minimum\" is treated as 0. In this situation,
+                                new pod with the same labelSelector cannot be scheduled,
+                                because computed skew will be 3(3 - 0) if new Pod
+                                is scheduled to any of the three zones, it will violate
+                                MaxSkew. \n This is a beta field and requires the
+                                MinDomainsInPodTopologySpread feature gate to be enabled
+                                (enabled by default)."
                                 format: int32
                                 type: integer
                               nodeAffinityPolicy:
-                                description:
-                                  "NodeAffinityPolicy indicates how we will
-                                  treat Pod's nodeAffinity/nodeSelector when calculating
-                                  pod topology spread skew. Options are: - Honor: only
-                                  nodes matching nodeAffinity/nodeSelector are included
-                                  in the calculations. - Ignore: nodeAffinity/nodeSelector
-                                  are ignored. All nodes are included in the calculations.
-                                  \n If this value is nil, the behavior is equivalent
-                                  to the Honor policy. This is a beta-level feature
-                                  default enabled by the NodeInclusionPolicyInPodTopologySpread
-                                  feature flag."
+                                description: "NodeAffinityPolicy indicates how we will
+                                treat Pod's nodeAffinity/nodeSelector when calculating
+                                pod topology spread skew. Options are: - Honor: only
+                                nodes matching nodeAffinity/nodeSelector are included
+                                in the calculations. - Ignore: nodeAffinity/nodeSelector
+                                are ignored. All nodes are included in the calculations.
+                                \n If this value is nil, the behavior is equivalent
+                                to the Honor policy. This is a beta-level feature
+                                default enabled by the NodeInclusionPolicyInPodTopologySpread
+                                feature flag."
                                 type: string
                               nodeTaintsPolicy:
-                                description:
-                                  "NodeTaintsPolicy indicates how we will
-                                  treat node taints when calculating pod topology spread
-                                  skew. Options are: - Honor: nodes without taints,
-                                  along with tainted nodes for which the incoming pod
-                                  has a toleration, are included. - Ignore: node taints
-                                  are ignored. All nodes are included. \n If this value
-                                  is nil, the behavior is equivalent to the Ignore policy.
-                                  This is a beta-level feature default enabled by the
-                                  NodeInclusionPolicyInPodTopologySpread feature flag."
+                                description: "NodeTaintsPolicy indicates how we will
+                                treat node taints when calculating pod topology spread
+                                skew. Options are: - Honor: nodes without taints,
+                                along with tainted nodes for which the incoming pod
+                                has a toleration, are included. - Ignore: node taints
+                                are ignored. All nodes are included. \n If this value
+                                is nil, the behavior is equivalent to the Ignore policy.
+                                This is a beta-level feature default enabled by the
+                                NodeInclusionPolicyInPodTopologySpread feature flag."
                                 type: string
                               topologyKey:
-                                description:
-                                  TopologyKey is the key of node labels.
+                                description: TopologyKey is the key of node labels.
                                   Nodes that have a label with this key and identical
                                   values are considered to be in the same topology.
                                   We consider each <key, value> as a "bucket", and try
@@ -4060,25 +3642,24 @@ spec:
                                   of that topology. It's a required field.
                                 type: string
                               whenUnsatisfiable:
-                                description:
-                                  'WhenUnsatisfiable indicates how to deal
-                                  with a pod if it doesn''t satisfy the spread constraint.
-                                  - DoNotSchedule (default) tells the scheduler not
-                                  to schedule it. - ScheduleAnyway tells the scheduler
-                                  to schedule the pod in any location,   but giving
-                                  higher precedence to topologies that would help reduce
-                                  the   skew. A constraint is considered "Unsatisfiable"
-                                  for an incoming pod if and only if every possible
-                                  node assignment for that pod would violate "MaxSkew"
-                                  on some topology. For example, in a 3-zone cluster,
-                                  MaxSkew is set to 1, and pods with the same labelSelector
-                                  spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P
-                                  |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule,
-                                  incoming pod can only be scheduled to zone2(zone3)
-                                  to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3)
-                                  satisfies MaxSkew(1). In other words, the cluster
-                                  can still be imbalanced, but scheduler won''t make
-                                  it *more* imbalanced. It''s a required field.'
+                                description: 'WhenUnsatisfiable indicates how to deal
+                                with a pod if it doesn''t satisfy the spread constraint.
+                                - DoNotSchedule (default) tells the scheduler not
+                                to schedule it. - ScheduleAnyway tells the scheduler
+                                to schedule the pod in any location,   but giving
+                                higher precedence to topologies that would help reduce
+                                the   skew. A constraint is considered "Unsatisfiable"
+                                for an incoming pod if and only if every possible
+                                node assignment for that pod would violate "MaxSkew"
+                                on some topology. For example, in a 3-zone cluster,
+                                MaxSkew is set to 1, and pods with the same labelSelector
+                                spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P
+                                |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule,
+                                incoming pod can only be scheduled to zone2(zone3)
+                                to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3)
+                                satisfies MaxSkew(1). In other words, the cluster
+                                can still be imbalanced, but scheduler won''t make
+                                it *more* imbalanced. It''s a required field.'
                                 type: string
                             required:
                               - maxSkew
@@ -4091,140 +3672,117 @@ spec:
                             - whenUnsatisfiable
                           x-kubernetes-list-type: map
                         volumes:
-                          description:
-                            List of volumes that can be mounted by disks
+                          description: List of volumes that can be mounted by disks
                             belonging to the vmi.
                           items:
                             description: Volume represents a named volume in a vmi.
                             properties:
                               cloudInitConfigDrive:
-                                description:
-                                  "CloudInitConfigDrive represents a cloud-init
-                                  Config Drive user-data source. The Config Drive data
-                                  will be added as a disk to the vmi. A proper cloud-init
-                                  installation is required inside the guest. More info:
-                                  https://cloudinit.readthedocs.io/en/latest/topics/datasources/configdrive.html"
+                                description: 'CloudInitConfigDrive represents a cloud-init
+                                Config Drive user-data source. The Config Drive data
+                                will be added as a disk to the vmi. A proper cloud-init
+                                installation is required inside the guest. More info:
+                                https://cloudinit.readthedocs.io/en/latest/topics/datasources/configdrive.html'
                                 properties:
                                   networkData:
-                                    description:
-                                      NetworkData contains config drive inline
+                                    description: NetworkData contains config drive inline
                                       cloud-init networkdata.
                                     type: string
                                   networkDataBase64:
-                                    description:
-                                      NetworkDataBase64 contains config drive
+                                    description: NetworkDataBase64 contains config drive
                                       cloud-init networkdata as a base64 encoded string.
                                     type: string
                                   networkDataSecretRef:
-                                    description:
-                                      NetworkDataSecretRef references a k8s
+                                    description: NetworkDataSecretRef references a k8s
                                       secret that contains config drive networkdata.
                                     properties:
                                       name:
-                                        description:
-                                          "Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?"
+                                        description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
                                         type: string
                                     type: object
                                   secretRef:
-                                    description:
-                                      UserDataSecretRef references a k8s
+                                    description: UserDataSecretRef references a k8s
                                       secret that contains config drive userdata.
                                     properties:
                                       name:
-                                        description:
-                                          "Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?"
+                                        description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
                                         type: string
                                     type: object
                                   userData:
-                                    description:
-                                      UserData contains config drive inline
+                                    description: UserData contains config drive inline
                                       cloud-init userdata.
                                     type: string
                                   userDataBase64:
-                                    description:
-                                      UserDataBase64 contains config drive
+                                    description: UserDataBase64 contains config drive
                                       cloud-init userdata as a base64 encoded string.
                                     type: string
                                 type: object
                               cloudInitNoCloud:
-                                description:
-                                  "CloudInitNoCloud represents a cloud-init
-                                  NoCloud user-data source. The NoCloud data will be
-                                  added as a disk to the vmi. A proper cloud-init installation
-                                  is required inside the guest. More info: http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html"
+                                description: 'CloudInitNoCloud represents a cloud-init
+                                NoCloud user-data source. The NoCloud data will be
+                                added as a disk to the vmi. A proper cloud-init installation
+                                is required inside the guest. More info: http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html'
                                 properties:
                                   networkData:
-                                    description:
-                                      NetworkData contains NoCloud inline
+                                    description: NetworkData contains NoCloud inline
                                       cloud-init networkdata.
                                     type: string
                                   networkDataBase64:
-                                    description:
-                                      NetworkDataBase64 contains NoCloud
+                                    description: NetworkDataBase64 contains NoCloud
                                       cloud-init networkdata as a base64 encoded string.
                                     type: string
                                   networkDataSecretRef:
-                                    description:
-                                      NetworkDataSecretRef references a k8s
+                                    description: NetworkDataSecretRef references a k8s
                                       secret that contains NoCloud networkdata.
                                     properties:
                                       name:
-                                        description:
-                                          "Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?"
+                                        description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
                                         type: string
                                     type: object
                                   secretRef:
-                                    description:
-                                      UserDataSecretRef references a k8s
+                                    description: UserDataSecretRef references a k8s
                                       secret that contains NoCloud userdata.
                                     properties:
                                       name:
-                                        description:
-                                          "Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?"
+                                        description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
                                         type: string
                                     type: object
                                   userData:
-                                    description:
-                                      UserData contains NoCloud inline cloud-init
+                                    description: UserData contains NoCloud inline cloud-init
                                       userdata.
                                     type: string
                                   userDataBase64:
-                                    description:
-                                      UserDataBase64 contains NoCloud cloud-init
+                                    description: UserDataBase64 contains NoCloud cloud-init
                                       userdata as a base64 encoded string.
                                     type: string
                                 type: object
                               configMap:
-                                description:
-                                  "ConfigMapSource represents a reference
-                                  to a ConfigMap in the same namespace. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/"
+                                description: 'ConfigMapSource represents a reference
+                                to a ConfigMap in the same namespace. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/'
                                 properties:
                                   name:
-                                    description:
-                                      "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?"
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
                                     type: string
                                   optional:
-                                    description:
-                                      Specify whether the ConfigMap or it's
+                                    description: Specify whether the ConfigMap or it's
                                       keys must be defined
                                     type: boolean
                                   volumeLabel:
-                                    description:
-                                      The volume label of the resulting disk
+                                    description: The volume label of the resulting disk
                                       inside the VMI. Different bootstrapping mechanisms
                                       require different values. Typical values are "cidata"
                                       (cloud-init), "config-2" (cloud-init) or "OEMDRV"
@@ -4232,50 +3790,42 @@ spec:
                                     type: string
                                 type: object
                               containerDisk:
-                                description:
-                                  "ContainerDisk references a docker image,
-                                  embedding a qcow or raw disk. More info: https://kubevirt.gitbooks.io/user-guide/registry-disk.html"
+                                description: 'ContainerDisk references a docker image,
+                                embedding a qcow or raw disk. More info: https://kubevirt.gitbooks.io/user-guide/registry-disk.html'
                                 properties:
                                   image:
-                                    description:
-                                      Image is the name of the image with
+                                    description: Image is the name of the image with
                                       the embedded disk.
                                     type: string
                                   imagePullPolicy:
-                                    description:
-                                      "Image pull policy. One of Always,
-                                      Never, IfNotPresent. Defaults to Always if :latest
-                                      tag is specified, or IfNotPresent otherwise. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images"
+                                    description: 'Image pull policy. One of Always,
+                                    Never, IfNotPresent. Defaults to Always if :latest
+                                    tag is specified, or IfNotPresent otherwise. Cannot
+                                    be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                                     type: string
                                   imagePullSecret:
-                                    description:
-                                      ImagePullSecret is the name of the
+                                    description: ImagePullSecret is the name of the
                                       Docker registry secret required to pull the image.
                                       The secret must already exist.
                                     type: string
                                   path:
-                                    description:
-                                      Path defines the path to disk file
+                                    description: Path defines the path to disk file
                                       in the container
                                     type: string
                                 required:
                                   - image
                                 type: object
                               dataVolume:
-                                description:
-                                  DataVolume represents the dynamic creation
+                                description: DataVolume represents the dynamic creation
                                   a PVC for this volume as well as the process of populating
                                   that PVC with a disk image.
                                 properties:
                                   hotpluggable:
-                                    description:
-                                      Hotpluggable indicates whether the
+                                    description: Hotpluggable indicates whether the
                                       volume can be hotplugged and hotunplugged.
                                     type: boolean
                                   name:
-                                    description:
-                                      Name of both the DataVolume and the
+                                    description: Name of both the DataVolume and the
                                       PVC in the same namespace. After PVC population
                                       the DataVolume is garbage collected by default.
                                     type: string
@@ -4283,86 +3833,75 @@ spec:
                                   - name
                                 type: object
                               downwardAPI:
-                                description:
-                                  DownwardAPI represents downward API about
+                                description: DownwardAPI represents downward API about
                                   the pod that should populate this volume
                                 properties:
                                   fields:
-                                    description:
-                                      Fields is a list of downward API volume
+                                    description: Fields is a list of downward API volume
                                       file
                                     items:
-                                      description:
-                                        DownwardAPIVolumeFile represents
+                                      description: DownwardAPIVolumeFile represents
                                         information to create the file containing the
                                         pod field
                                       properties:
                                         fieldRef:
-                                          description:
-                                            "Required: Selects a field of
-                                            the pod: only annotations, labels, name
-                                            and namespace are supported."
+                                          description: 'Required: Selects a field of
+                                          the pod: only annotations, labels, name
+                                          and namespace are supported.'
                                           properties:
                                             apiVersion:
-                                              description:
-                                                Version of the schema the
+                                              description: Version of the schema the
                                                 FieldPath is written in terms of, defaults
                                                 to "v1".
                                               type: string
                                             fieldPath:
-                                              description:
-                                                Path of the field to select
+                                              description: Path of the field to select
                                                 in the specified API version.
                                               type: string
                                           required:
                                             - fieldPath
                                           type: object
                                         mode:
-                                          description:
-                                            "Optional: mode bits used to
-                                            set permissions on this file, must be an
-                                            octal value between 0000 and 0777 or a decimal
-                                            value between 0 and 511. YAML accepts both
-                                            octal and decimal values, JSON requires
-                                            decimal values for mode bits. If not specified,
-                                            the volume defaultMode will be used. This
-                                            might be in conflict with other options
-                                            that affect the file mode, like fsGroup,
-                                            and the result can be other mode bits set."
+                                          description: 'Optional: mode bits used to
+                                          set permissions on this file, must be an
+                                          octal value between 0000 and 0777 or a decimal
+                                          value between 0 and 511. YAML accepts both
+                                          octal and decimal values, JSON requires
+                                          decimal values for mode bits. If not specified,
+                                          the volume defaultMode will be used. This
+                                          might be in conflict with other options
+                                          that affect the file mode, like fsGroup,
+                                          and the result can be other mode bits set.'
                                           format: int32
                                           type: integer
                                         path:
-                                          description:
-                                            "Required: Path is  the relative
-                                            path name of the file to be created. Must
-                                            not be absolute or contain the '..' path.
-                                            Must be utf-8 encoded. The first item of
-                                            the relative path must not start with '..'"
+                                          description: 'Required: Path is  the relative
+                                          path name of the file to be created. Must
+                                          not be absolute or contain the ''..'' path.
+                                          Must be utf-8 encoded. The first item of
+                                          the relative path must not start with ''..'''
                                           type: string
                                         resourceFieldRef:
-                                          description:
-                                            "Selects a resource of the container:
-                                            only resources limits and requests (limits.cpu,
-                                            limits.memory, requests.cpu and requests.memory)
-                                            are currently supported."
+                                          description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, requests.cpu and requests.memory)
+                                          are currently supported.'
                                           properties:
                                             containerName:
-                                              description:
-                                                "Container name: required
-                                                for volumes, optional for env vars"
+                                              description: 'Container name: required
+                                              for volumes, optional for env vars'
                                               type: string
                                             divisor:
                                               anyOf:
                                                 - type: integer
                                                 - type: string
-                                              description:
-                                                Specifies the output format
+                                              description: Specifies the output format
                                                 of the exposed resources, defaults to
                                                 "1"
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             resource:
-                                              description: "Required: resource to select"
+                                              description: 'Required: resource to select'
                                               type: string
                                           required:
                                             - resource
@@ -4372,8 +3911,7 @@ spec:
                                       type: object
                                     type: array
                                   volumeLabel:
-                                    description:
-                                      The volume label of the resulting disk
+                                    description: The volume label of the resulting disk
                                       inside the VMI. Different bootstrapping mechanisms
                                       require different values. Typical values are "cidata"
                                       (cloud-init), "config-2" (cloud-init) or "OEMDRV"
@@ -4381,16 +3919,14 @@ spec:
                                     type: string
                                 type: object
                               downwardMetrics:
-                                description:
-                                  DownwardMetrics adds a very small disk
+                                description: DownwardMetrics adds a very small disk
                                   to VMIs which contains a limited view of host and
                                   guest metrics. The disk content is compatible with
                                   vhostmd (https://github.com/vhostmd/vhostmd) and vm-dump-metrics.
                                 type: object
                               emptyDisk:
-                                description:
-                                  "EmptyDisk represents a temporary disk
-                                  which shares the vmis lifecycle. More info: https://kubevirt.gitbooks.io/user-guide/disks-and-volumes.html"
+                                description: 'EmptyDisk represents a temporary disk
+                                which shares the vmis lifecycle. More info: https://kubevirt.gitbooks.io/user-guide/disks-and-volumes.html'
                                 properties:
                                   capacity:
                                     anyOf:
@@ -4403,27 +3939,23 @@ spec:
                                   - capacity
                                 type: object
                               ephemeral:
-                                description:
-                                  Ephemeral is a special volume source that
+                                description: Ephemeral is a special volume source that
                                   "wraps" specified source and provides copy-on-write
                                   image on top of it.
                                 properties:
                                   persistentVolumeClaim:
-                                    description:
-                                      "PersistentVolumeClaimVolumeSource
-                                      represents a reference to a PersistentVolumeClaim
-                                      in the same namespace. Directly attached to the
-                                      vmi via qemu. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims"
+                                    description: 'PersistentVolumeClaimVolumeSource
+                                    represents a reference to a PersistentVolumeClaim
+                                    in the same namespace. Directly attached to the
+                                    vmi via qemu. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                     properties:
                                       claimName:
-                                        description:
-                                          "claimName is the name of a PersistentVolumeClaim
-                                          in the same namespace as the pod using this
-                                          volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims"
+                                        description: 'claimName is the name of a PersistentVolumeClaim
+                                        in the same namespace as the pod using this
+                                        volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                         type: string
                                       readOnly:
-                                        description:
-                                          readOnly Will force the ReadOnly
+                                        description: readOnly Will force the ReadOnly
                                           setting in VolumeMounts. Default false.
                                         type: boolean
                                     required:
@@ -4431,8 +3963,7 @@ spec:
                                     type: object
                                 type: object
                               hostDisk:
-                                description:
-                                  HostDisk represents a disk created on the
+                                description: HostDisk represents a disk created on the
                                   cluster level
                                 properties:
                                   capacity:
@@ -4443,18 +3974,15 @@ spec:
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   path:
-                                    description:
-                                      The path to HostDisk image located
+                                    description: The path to HostDisk image located
                                       on the cluster
                                     type: string
                                   shared:
-                                    description:
-                                      Shared indicate whether the path is
+                                    description: Shared indicate whether the path is
                                       shared between nodes
                                     type: boolean
                                   type:
-                                    description:
-                                      Contains information if disk.img exists
+                                    description: Contains information if disk.img exists
                                       or should be created allowed options are 'Disk'
                                       and 'DiskOrCreate'
                                     type: string
@@ -4463,79 +3991,66 @@ spec:
                                   - type
                                 type: object
                               memoryDump:
-                                description:
-                                  MemoryDump is attached to the virt launcher
+                                description: MemoryDump is attached to the virt launcher
                                   and is populated with a memory dump of the vmi
                                 properties:
                                   claimName:
-                                    description:
-                                      "claimName is the name of a PersistentVolumeClaim
-                                      in the same namespace as the pod using this volume.
-                                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims"
+                                    description: 'claimName is the name of a PersistentVolumeClaim
+                                    in the same namespace as the pod using this volume.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                     type: string
                                   hotpluggable:
-                                    description:
-                                      Hotpluggable indicates whether the
+                                    description: Hotpluggable indicates whether the
                                       volume can be hotplugged and hotunplugged.
                                     type: boolean
                                   readOnly:
-                                    description:
-                                      readOnly Will force the ReadOnly setting
+                                    description: readOnly Will force the ReadOnly setting
                                       in VolumeMounts. Default false.
                                     type: boolean
                                 required:
                                   - claimName
                                 type: object
                               name:
-                                description:
-                                  "Volume's name. Must be a DNS_LABEL and
-                                  unique within the vmi. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+                                description: 'Volume''s name. Must be a DNS_LABEL and
+                                unique within the vmi. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                 type: string
                               persistentVolumeClaim:
-                                description:
-                                  "PersistentVolumeClaimVolumeSource represents
-                                  a reference to a PersistentVolumeClaim in the same
-                                  namespace. Directly attached to the vmi via qemu.
-                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims"
+                                description: 'PersistentVolumeClaimVolumeSource represents
+                                a reference to a PersistentVolumeClaim in the same
+                                namespace. Directly attached to the vmi via qemu.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                 properties:
                                   claimName:
-                                    description:
-                                      "claimName is the name of a PersistentVolumeClaim
-                                      in the same namespace as the pod using this volume.
-                                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims"
+                                    description: 'claimName is the name of a PersistentVolumeClaim
+                                    in the same namespace as the pod using this volume.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                     type: string
                                   hotpluggable:
-                                    description:
-                                      Hotpluggable indicates whether the
+                                    description: Hotpluggable indicates whether the
                                       volume can be hotplugged and hotunplugged.
                                     type: boolean
                                   readOnly:
-                                    description:
-                                      readOnly Will force the ReadOnly setting
+                                    description: readOnly Will force the ReadOnly setting
                                       in VolumeMounts. Default false.
                                     type: boolean
                                 required:
                                   - claimName
                                 type: object
                               secret:
-                                description:
-                                  "SecretVolumeSource represents a reference
-                                  to a secret data in the same namespace. More info:
-                                  https://kubernetes.io/docs/concepts/configuration/secret/"
+                                description: 'SecretVolumeSource represents a reference
+                                to a secret data in the same namespace. More info:
+                                https://kubernetes.io/docs/concepts/configuration/secret/'
                                 properties:
                                   optional:
-                                    description:
-                                      Specify whether the Secret or it's
+                                    description: Specify whether the Secret or it's
                                       keys must be defined
                                     type: boolean
                                   secretName:
-                                    description:
-                                      "Name of the secret in the pod's namespace
-                                      to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret"
+                                    description: 'Name of the secret in the pod''s namespace
+                                    to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                     type: string
                                   volumeLabel:
-                                    description:
-                                      The volume label of the resulting disk
+                                    description: The volume label of the resulting disk
                                       inside the VMI. Different bootstrapping mechanisms
                                       require different values. Typical values are "cidata"
                                       (cloud-init), "config-2" (cloud-init) or "OEMDRV"
@@ -4543,46 +4058,40 @@ spec:
                                     type: string
                                 type: object
                               serviceAccount:
-                                description:
-                                  "ServiceAccountVolumeSource represents
-                                  a reference to a service account. There can only be
-                                  one volume of this type! More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/"
+                                description: 'ServiceAccountVolumeSource represents
+                                a reference to a service account. There can only be
+                                one volume of this type! More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                                 properties:
                                   serviceAccountName:
-                                    description:
-                                      "Name of the service account in the
-                                      pod's namespace to use. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/"
+                                    description: 'Name of the service account in the
+                                    pod''s namespace to use. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                                     type: string
                                 type: object
                               sysprep:
                                 description: Represents a Sysprep volume source.
                                 properties:
                                   configMap:
-                                    description:
-                                      ConfigMap references a ConfigMap that
+                                    description: ConfigMap references a ConfigMap that
                                       contains Sysprep answer file named autounattend.xml
                                       that should be attached as disk of CDROM type.
                                     properties:
                                       name:
-                                        description:
-                                          "Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?"
+                                        description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
                                         type: string
                                     type: object
                                   secret:
-                                    description:
-                                      Secret references a k8s Secret that
+                                    description: Secret references a k8s Secret that
                                       contains Sysprep answer file named autounattend.xml
                                       that should be attached as disk of CDROM type.
                                     properties:
                                       name:
-                                        description:
-                                          "Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?"
+                                        description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
                                         type: string
                                     type: object
                                 type: object
@@ -4598,13 +4107,11 @@ spec:
                 - template
               type: object
             status:
-              description:
-                Status holds the current state of the controller and brief
+              description: Status holds the current state of the controller and brief
                 information about its associated VirtualMachineInstance
               properties:
                 conditions:
-                  description:
-                    Hold the state information of the VirtualMachine and
+                  description: Hold the state information of the VirtualMachine and
                     its VirtualMachineInstance
                   items:
                     description: VirtualMachineCondition represents the state of VirtualMachine
@@ -4631,13 +4138,11 @@ spec:
                     type: object
                   type: array
                 created:
-                  description:
-                    Created indicates if the virtual machine is created in
+                  description: Created indicates if the virtual machine is created in
                     the cluster
                   type: boolean
                 desiredGeneration:
-                  description:
-                    DesiredGeneration is the generation which is desired
+                  description: DesiredGeneration is the generation which is desired
                     for the VMI. This will be used in comparisons with ObservedGeneration
                     to understand when the VMI is out of sync. This will be changed
                     at the same time as ObservedGeneration to remove errors which could
@@ -4645,61 +4150,17 @@ spec:
                     in Status.
                   format: int64
                   type: integer
-                interfaceRequests:
-                  description:
-                    InterfaceRequests indicates a list of interfaces added
-                    to the VMI template and hot-plugged on an active running VMI.
-                  items:
-                    properties:
-                      addInterfaceOptions:
-                        description:
-                          AddInterfaceOptions when set indicates a network
-                          interface should be added. The details within this field specify
-                          how to add the interface
-                        properties:
-                          name:
-                            description: Name indicates the logical name of the interface.
-                            type: string
-                          networkAttachmentDefinitionName:
-                            description:
-                              "NetworkAttachmentDefinitionName references
-                              a NetworkAttachmentDefinition CRD object. Format: <networkAttachmentDefinitionName>,
-                              <namespace>/<networkAttachmentDefinitionName>. If namespace
-                              is not specified, VMI namespace is assumed."
-                            type: string
-                        required:
-                          - name
-                          - networkAttachmentDefinitionName
-                        type: object
-                      removeInterfaceOptions:
-                        description:
-                          RemoveInterfaceOptions when set indicates a network
-                          interface should be removed. The details within this field
-                          specify how to remove the interface
-                        properties:
-                          name:
-                            description: Name indicates the logical name of the interface.
-                            type: string
-                        required:
-                          - name
-                        type: object
-                    type: object
-                  type: array
-                  x-kubernetes-list-type: atomic
                 memoryDumpRequest:
-                  description:
-                    MemoryDumpRequest tracks memory dump request phase and
+                  description: MemoryDumpRequest tracks memory dump request phase and
                     info of getting a memory dump to the given pvc
                   nullable: true
                   properties:
                     claimName:
-                      description:
-                        ClaimName is the name of the pvc that will contain
+                      description: ClaimName is the name of the pvc that will contain
                         the memory dump
                       type: string
                     endTimestamp:
-                      description:
-                        EndTimestamp represents the time the memory dump
+                      description: EndTimestamp represents the time the memory dump
                         was completed
                       format: date-time
                       type: string
@@ -4707,21 +4168,18 @@ spec:
                       description: FileName represents the name of the output file
                       type: string
                     message:
-                      description:
-                        Message is a detailed message about failure of the
+                      description: Message is a detailed message about failure of the
                         memory dump
                       type: string
                     phase:
                       description: Phase represents the memory dump phase
                       type: string
                     remove:
-                      description:
-                        Remove represents request of dissociating the memory
+                      description: Remove represents request of dissociating the memory
                         dump pvc
                       type: boolean
                     startTimestamp:
-                      description:
-                        StartTimestamp represents the time the memory dump
+                      description: StartTimestamp represents the time the memory dump
                         started
                       format: date-time
                       type: string
@@ -4730,42 +4188,41 @@ spec:
                     - phase
                   type: object
                 observedGeneration:
-                  description:
-                    ObservedGeneration is the generation observed by the
+                  description: ObservedGeneration is the generation observed by the
                     vmi when started.
                   format: int64
                   type: integer
                 printableStatus:
-                  description:
-                    PrintableStatus is a human readable, high-level representation
+                  default: Stopped
+                  description: PrintableStatus is a human readable, high-level representation
                     of the status of the virtual machine
                   type: string
                 ready:
-                  description:
-                    Ready indicates if the virtual machine is running and
+                  description: Ready indicates if the virtual machine is running and
                     ready
                   type: boolean
                 restoreInProgress:
-                  description:
-                    RestoreInProgress is the name of the VirtualMachineRestore
+                  description: RestoreInProgress is the name of the VirtualMachineRestore
                     currently executing
                   type: string
+                runStrategy:
+                  description: RunStrategy tracks the last recorded RunStrategy used
+                    by the VM. This is needed to correctly process the next strategy
+                    (for now only the RerunOnFailure)
+                  type: string
                 snapshotInProgress:
-                  description:
-                    SnapshotInProgress is the name of the VirtualMachineSnapshot
+                  description: SnapshotInProgress is the name of the VirtualMachineSnapshot
                     currently executing
                   type: string
                 startFailure:
-                  description:
-                    StartFailure tracks consecutive VMI startup failures
+                  description: StartFailure tracks consecutive VMI startup failures
                     for the purposes of crash loop backoffs
                   nullable: true
                   properties:
                     consecutiveFailCount:
                       type: integer
                     lastFailedVMIUID:
-                      description:
-                        UID is a type that holds unique ID values, including
+                      description: UID is a type that holds unique ID values, including
                         UUIDs.  Because we don't ONLY use UUIDs, this is an alias to
                         string.  Being a type captures intent and helps make sure that
                         UIDs and names do not get conflated.
@@ -4775,27 +4232,23 @@ spec:
                       type: string
                   type: object
                 stateChangeRequests:
-                  description:
-                    StateChangeRequests indicates a list of actions that
+                  description: StateChangeRequests indicates a list of actions that
                     should be taken on a VMI e.g. stop a specific VMI then start a new
                     one.
                   items:
                     properties:
                       action:
-                        description:
-                          Indicates the type of action that is requested.
+                        description: Indicates the type of action that is requested.
                           e.g. Start or Stop
                         type: string
                       data:
                         additionalProperties:
                           type: string
-                        description:
-                          Provides additional data in order to perform the
+                        description: Provides additional data in order to perform the
                           Action
                         type: object
                       uid:
-                        description:
-                          Indicates the UUID of an existing Virtual Machine
+                        description: Indicates the UUID of an existing Virtual Machine
                           Instance that this change request applies to -- if applicable
                         type: string
                     required:
@@ -4803,30 +4256,25 @@ spec:
                     type: object
                   type: array
                 volumeRequests:
-                  description:
-                    VolumeRequests indicates a list of volumes add or remove
+                  description: VolumeRequests indicates a list of volumes add or remove
                     from the VMI template and hotplug on an active running VMI.
                   items:
                     properties:
                       addVolumeOptions:
-                        description:
-                          AddVolumeOptions when set indicates a volume should
+                        description: AddVolumeOptions when set indicates a volume should
                           be added. The details within this field specify how to add
                           the volume
                         properties:
                           disk:
-                            description:
-                              Disk represents the hotplug disk that will
+                            description: Disk represents the hotplug disk that will
                               be plugged into the running VMI
                             properties:
                               blockSize:
-                                description:
-                                  If specified, the virtual disk will be
+                                description: If specified, the virtual disk will be
                                   presented with the given block sizes.
                                 properties:
                                   custom:
-                                    description:
-                                      CustomBlockSize represents the desired
+                                    description: CustomBlockSize represents the desired
                                       logical and physical block size for a VM disk.
                                     properties:
                                       logical:
@@ -4838,21 +4286,18 @@ spec:
                                       - physical
                                     type: object
                                   matchVolume:
-                                    description:
-                                      Represents if a feature is enabled
+                                    description: Represents if a feature is enabled
                                       or disabled.
                                     properties:
                                       enabled:
-                                        description:
-                                          Enabled determines if the feature
+                                        description: Enabled determines if the feature
                                           should be enabled or disabled on the guest.
                                           Defaults to true.
                                         type: boolean
                                     type: object
                                 type: object
                               bootOrder:
-                                description:
-                                  BootOrder is an integer value > 0, used
+                                description: BootOrder is an integer value > 0, used
                                   to determine ordering of boot devices. Lower values
                                   take precedence. Each disk or interface that has a
                                   boot order must have a unique value. Disks without
@@ -4860,31 +4305,27 @@ spec:
                                   exists.
                                 type: integer
                               cache:
-                                description:
-                                  "Cache specifies which kvm disk cache mode
-                                  should be used. Supported values are: CacheNone, CacheWriteThrough."
+                                description: 'Cache specifies which kvm disk cache mode
+                                should be used. Supported values are: CacheNone, CacheWriteThrough.'
                                 type: string
                               cdrom:
                                 description: Attach a volume as a cdrom to the vmi.
                                 properties:
                                   bus:
-                                    description:
-                                      "Bus indicates the type of disk device
-                                      to emulate. supported values: virtio, sata, scsi."
+                                    description: 'Bus indicates the type of disk device
+                                    to emulate. supported values: virtio, sata, scsi.'
                                     type: string
                                   readonly:
                                     description: ReadOnly. Defaults to true.
                                     type: boolean
                                   tray:
-                                    description:
-                                      Tray indicates if the tray of the device
+                                    description: Tray indicates if the tray of the device
                                       is open or closed. Allowed values are "open" and
                                       "closed". Defaults to closed.
                                     type: string
                                 type: object
                               dedicatedIOThread:
-                                description:
-                                  dedicatedIOThread indicates this disk should
+                                description: dedicatedIOThread indicates this disk should
                                   have an exclusive IO Thread. Enabling this implies
                                   useIOThreads = true. Defaults to false.
                                 type: boolean
@@ -4892,40 +4333,39 @@ spec:
                                 description: Attach a volume as a disk to the vmi.
                                 properties:
                                   bus:
-                                    description:
-                                      "Bus indicates the type of disk device
-                                      to emulate. supported values: virtio, sata, scsi,
-                                      usb."
+                                    description: 'Bus indicates the type of disk device
+                                    to emulate. supported values: virtio, sata, scsi,
+                                    usb.'
                                     type: string
                                   pciAddress:
-                                    description:
-                                      "If specified, the virtual disk will
-                                      be placed on the guests pci address with the specified
-                                      PCI address. For example: 0000:81:01.10"
+                                    description: 'If specified, the virtual disk will
+                                    be placed on the guests pci address with the specified
+                                    PCI address. For example: 0000:81:01.10'
                                     type: string
                                   readonly:
                                     description: ReadOnly. Defaults to false.
                                     type: boolean
                                 type: object
+                              errorPolicy:
+                                description: If specified, it can change the default
+                                  error policy (stop) for the disk
+                                type: string
                               io:
-                                description:
-                                  "IO specifies which QEMU disk IO mode should
-                                  be used. Supported values are: native, default, threads."
+                                description: 'IO specifies which QEMU disk IO mode should
+                                be used. Supported values are: native, default, threads.'
                                 type: string
                               lun:
                                 description: Attach a volume as a LUN to the vmi.
                                 properties:
                                   bus:
-                                    description:
-                                      "Bus indicates the type of disk device
-                                      to emulate. supported values: virtio, sata, scsi."
+                                    description: 'Bus indicates the type of disk device
+                                    to emulate. supported values: virtio, sata, scsi.'
                                     type: string
                                   readonly:
                                     description: ReadOnly. Defaults to false.
                                     type: boolean
                                   reservation:
-                                    description:
-                                      Reservation indicates if the disk needs
+                                    description: Reservation indicates if the disk needs
                                       to support the persistent reservation for the
                                       SCSI disk
                                     type: boolean
@@ -4934,59 +4374,50 @@ spec:
                                 description: Name is the device name
                                 type: string
                               serial:
-                                description:
-                                  Serial provides the ability to specify
+                                description: Serial provides the ability to specify
                                   a serial number for the disk device.
                                 type: string
                               shareable:
-                                description:
-                                  If specified the disk is made sharable
+                                description: If specified the disk is made sharable
                                   and multiple write from different VMs are permitted
                                 type: boolean
                               tag:
-                                description:
-                                  If specified, disk address and its tag
+                                description: If specified, disk address and its tag
                                   will be provided to the guest via config drive metadata
                                 type: string
                             required:
                               - name
                             type: object
                           dryRun:
-                            description:
-                              "When present, indicates that modifications
-                              should not be persisted. An invalid or unrecognized dryRun
-                              directive will result in an error response and no further
-                              processing of the request. Valid values are: - All: all
-                              dry run stages will be processed"
+                            description: 'When present, indicates that modifications
+                            should not be persisted. An invalid or unrecognized dryRun
+                            directive will result in an error response and no further
+                            processing of the request. Valid values are: - All: all
+                            dry run stages will be processed'
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           name:
-                            description:
-                              Name represents the name that will be used
+                            description: Name represents the name that will be used
                               to map the disk to the corresponding volume. This overrides
                               any name set inside the Disk struct itself.
                             type: string
                           volumeSource:
-                            description:
-                              VolumeSource represents the source of the volume
+                            description: VolumeSource represents the source of the volume
                               to map to the disk.
                             properties:
                               dataVolume:
-                                description:
-                                  DataVolume represents the dynamic creation
+                                description: DataVolume represents the dynamic creation
                                   a PVC for this volume as well as the process of populating
                                   that PVC with a disk image.
                                 properties:
                                   hotpluggable:
-                                    description:
-                                      Hotpluggable indicates whether the
+                                    description: Hotpluggable indicates whether the
                                       volume can be hotplugged and hotunplugged.
                                     type: boolean
                                   name:
-                                    description:
-                                      Name of both the DataVolume and the
+                                    description: Name of both the DataVolume and the
                                       PVC in the same namespace. After PVC population
                                       the DataVolume is garbage collected by default.
                                     type: string
@@ -4994,26 +4425,22 @@ spec:
                                   - name
                                 type: object
                               persistentVolumeClaim:
-                                description:
-                                  "PersistentVolumeClaimVolumeSource represents
-                                  a reference to a PersistentVolumeClaim in the same
-                                  namespace. Directly attached to the vmi via qemu.
-                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims"
+                                description: 'PersistentVolumeClaimVolumeSource represents
+                                a reference to a PersistentVolumeClaim in the same
+                                namespace. Directly attached to the vmi via qemu.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                 properties:
                                   claimName:
-                                    description:
-                                      "claimName is the name of a PersistentVolumeClaim
-                                      in the same namespace as the pod using this volume.
-                                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims"
+                                    description: 'claimName is the name of a PersistentVolumeClaim
+                                    in the same namespace as the pod using this volume.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                     type: string
                                   hotpluggable:
-                                    description:
-                                      Hotpluggable indicates whether the
+                                    description: Hotpluggable indicates whether the
                                       volume can be hotplugged and hotunplugged.
                                     type: boolean
                                   readOnly:
-                                    description:
-                                      readOnly Will force the ReadOnly setting
+                                    description: readOnly Will force the ReadOnly setting
                                       in VolumeMounts. Default false.
                                     type: boolean
                                 required:
@@ -5026,25 +4453,22 @@ spec:
                           - volumeSource
                         type: object
                       removeVolumeOptions:
-                        description:
-                          RemoveVolumeOptions when set indicates a volume
+                        description: RemoveVolumeOptions when set indicates a volume
                           should be removed. The details within this field specify how
                           to add the volume
                         properties:
                           dryRun:
-                            description:
-                              "When present, indicates that modifications
-                              should not be persisted. An invalid or unrecognized dryRun
-                              directive will result in an error response and no further
-                              processing of the request. Valid values are: - All: all
-                              dry run stages will be processed"
+                            description: 'When present, indicates that modifications
+                            should not be persisted. An invalid or unrecognized dryRun
+                            directive will result in an error response and no further
+                            processing of the request. Valid values are: - All: all
+                            dry run stages will be processed'
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           name:
-                            description:
-                              Name represents the name that maps to both
+                            description: Name represents the name that maps to both
                               the disk and volume that should be removed
                             type: string
                         required:
@@ -5054,8 +4478,7 @@ spec:
                   type: array
                   x-kubernetes-list-type: atomic
                 volumeSnapshotStatuses:
-                  description:
-                    VolumeSnapshotStatuses indicates a list of statuses whether
+                  description: VolumeSnapshotStatuses indicates a list of statuses whether
                     snapshotting is supported by each volume.
                   items:
                     properties:
@@ -5066,8 +4489,7 @@ spec:
                         description: Volume name
                         type: string
                       reason:
-                        description:
-                          Empty if snapshotting is enabled, contains reason
+                        description: Empty if snapshotting is enabled, contains reason
                           otherwise
                         type: string
                     required:


### PR DESCRIPTION
- Ignore prettier for embedded CRDs
- No changes in CRD structure, only formatting.

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

Updating embedded CRDs lead to a huge diff that is hard to review. Use kubectl output and ignore prettier to get smaller diffs in subsequent PRs.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
