### PR TITLE
fix(vmip): add validating ip address for VMIP with type 'Static'

### DIFF
--- a/images/virtualization-artifact/pkg/controller/common/util.go
+++ b/images/virtualization-artifact/pkg/controller/common/util.go
@@ -249,6 +249,9 @@ const (
 	// LabelVirtualMachineName is a label to link VirtualMachineOperation to VirtualMachine.
 	LabelVirtualMachineName = LabelsPrefix + "/virtual-machine-name"
 
+	// LabelVirtualMachineUID is a label to link VirtualMachineIPAddress to VirtualMachine.
+	LabelVirtualMachineUID = LabelsPrefix + "/virtual-machine-uid"
+
 	UploaderServiceLabel = "service"
 	// ProgressDone this means we are DONE
 	ProgressDone = "100.0%"

--- a/images/virtualization-artifact/pkg/controller/ipam/ipam.go
+++ b/images/virtualization-artifact/pkg/controller/ipam/ipam.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/deckhouse/virtualization-controller/pkg/controller/common"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
@@ -59,6 +60,9 @@ func (m IPAM) CreateIPAddress(ctx context.Context, vm *virtv2.VirtualMachine, cl
 	ownerRef := metav1.NewControllerRef(vm, vm.GroupVersionKind())
 	return client.Create(ctx, &virtv2.VirtualMachineIPAddress{
 		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				common.LabelVirtualMachineUID: string(vm.GetUID()),
+			},
 			GenerateName:    GenerateName(vm),
 			Namespace:       vm.Namespace,
 			OwnerReferences: []metav1.OwnerReference{*ownerRef},

--- a/images/virtualization-artifact/pkg/controller/service/ip_address_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/ip_address_service.go
@@ -64,11 +64,18 @@ func (s IpAddressService) IsAvailableAddress(address string, allocatedIPs common
 	}
 
 	for _, cidr := range s.parsedCIDRs {
-		if cidr.Contains(ip) {
-			// available
-			return nil
+		isFirstLast, err := isFirstLastIP(ip, cidr)
+		if err != nil {
+			return err
+		}
+		if !isFirstLast {
+			if cidr.Contains(ip) {
+				// available
+				return nil
+			}
 		}
 	}
+
 	// out of range
 	return ErrIPAddressOutOfRange
 }

--- a/images/virtualization-artifact/pkg/controller/vm/internal/state/state.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/state/state.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kvvmutil "github.com/deckhouse/virtualization-controller/pkg/common/kvvm"
-	"github.com/deckhouse/virtualization-controller/pkg/controller/indexer"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/common"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/powerstate"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization-controller/pkg/sdk/framework/helper"
@@ -304,12 +304,10 @@ func (s *state) IPAddress(ctx context.Context) (*virtv2.VirtualMachineIPAddress,
 	if vmipName == "" {
 		vmipList := &virtv2.VirtualMachineIPAddressList{}
 
-		err := s.client.List(ctx, vmipList,
-			client.InNamespace(s.vm.Current().GetNamespace()),
-			&client.MatchingFields{
-				indexer.IndexFieldVMIPByVM: s.vm.Current().GetName(),
-			},
-		)
+		err := s.client.List(ctx, vmipList, &client.ListOptions{
+			Namespace:     s.vm.Current().GetNamespace(),
+			LabelSelector: labels.SelectorFromSet(map[string]string{common.LabelVirtualMachineUID: string(s.vm.Current().GetUID())}),
+		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to list VirtualMachineIPAddress: %w", err)
 		}

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
@@ -123,12 +123,9 @@ func (h *SyncKvvmHandler) isWaiting(vm *virtv2.VirtualMachine) bool {
 			if c.Status != metav1.ConditionTrue && c.Reason != vmcondition.ReasonWaitingForProvisioningToPVC.String() {
 				return true
 			}
-		case vmcondition.TypeIPAddressReady:
-			if c.Status != metav1.ConditionTrue && c.Reason != vmcondition.ReasonIPAddressNotAssigned.String() {
-				return true
-			}
 
-		case vmcondition.TypeProvisioningReady,
+		case vmcondition.TypeIPAddressReady,
+			vmcondition.TypeProvisioningReady,
 			vmcondition.TypeClassReady:
 			if c.Status != metav1.ConditionTrue {
 				return true

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
@@ -124,8 +124,12 @@ func (h *SyncKvvmHandler) isWaiting(vm *virtv2.VirtualMachine) bool {
 				return true
 			}
 
-		case vmcondition.TypeIPAddressReady,
-			vmcondition.TypeProvisioningReady,
+		case vmcondition.TypeIPAddressReady:
+			if c.Status != metav1.ConditionTrue && c.Reason != vmcondition.ReasonIPAddressNotAssigned.String() {
+				return true
+			}
+
+		case vmcondition.TypeProvisioningReady,
 			vmcondition.TypeClassReady:
 			if c.Status != metav1.ConditionTrue {
 				return true

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
@@ -123,8 +123,12 @@ func (h *SyncKvvmHandler) isWaiting(vm *virtv2.VirtualMachine) bool {
 			if c.Status != metav1.ConditionTrue && c.Reason != vmcondition.ReasonWaitingForProvisioningToPVC.String() {
 				return true
 			}
-		case vmcondition.TypeIPAddressReady,
-			vmcondition.TypeProvisioningReady,
+		case vmcondition.TypeIPAddressReady:
+			if c.Status != metav1.ConditionTrue && c.Reason != vmcondition.ReasonIPAddressNotAssigned.String() {
+				return true
+			}
+
+		case vmcondition.TypeProvisioningReady,
 			vmcondition.TypeClassReady:
 			if c.Status != metav1.ConditionTrue {
 				return true


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This PR introduces several fixes:
- Fix the issue with creating duplicate VirtualMachineIPAddresses when creating a VirtualMachine with an automatically assigned IP address.
- Fix the functionality of the 'need restart' option in the VirtualMachine status.
- Add IP address validation when manually creating a VirtualMachineIPAddress of type 'Static' (the first and last addresses in the CIDR can no longer be specified).
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
