### PR TITLE
fix(vmip): fix deleting unattached vmip

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vmip/internal/protection_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/protection_handler.go
@@ -50,25 +50,26 @@ func (h *ProtectionHandler) Handle(ctx context.Context, state state.VMIPState) (
 		return reconcile.Result{}, err
 	}
 
-	attachedVMs, err := h.getAttachedVM(ctx, vmip)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
-	switch {
-	case len(attachedVMs) == 0:
-		log.Debug("Allow VirtualMachineIPAddress deletion")
-		controllerutil.RemoveFinalizer(vmip, virtv2.FinalizerIPAddressProtection)
-	case vmip.DeletionTimestamp == nil:
-		log.Debug("Protect VirtualMachineIPAddress from deletion")
-		controllerutil.AddFinalizer(vmip, virtv2.FinalizerIPAddressProtection)
-	default:
-		log.Debug("VirtualMachineIPAddress deletion is delayed: it's protected by virtual machines")
-	}
+	//attachedVMs, err := h.getAttachedVM(ctx, vmip)
+	//if err != nil {
+	//	return reconcile.Result{}, err
+	//}
+	//
+	//switch {
+	//case len(attachedVMs) == 0:
+	//	log.Debug("Allow VirtualMachineIPAddress deletion")
+	//	controllerutil.RemoveFinalizer(vmip, virtv2.FinalizerIPAddressProtection)
+	//case vmip.DeletionTimestamp == nil:
+	//	log.Debug("Protect VirtualMachineIPAddress from deletion")
+	//	controllerutil.AddFinalizer(vmip, virtv2.FinalizerIPAddressProtection)
+	//default:
+	//	log.Debug("VirtualMachineIPAddress deletion is delayed: it's protected by virtual machines")
+	//}
 
 	if vm == nil || vm.DeletionTimestamp != nil {
 		log.Info("VirtualMachineIP is no longer attached to any VM, proceeding with detachment", "VirtualMachineIPName", vmip.Name)
 		controllerutil.RemoveFinalizer(vmip, virtv2.FinalizerIPAddressCleanup)
+		controllerutil.RemoveFinalizer(vmip, virtv2.FinalizerIPAddressProtection)
 	} else if vmip.GetDeletionTimestamp() == nil {
 		controllerutil.AddFinalizer(vmip, virtv2.FinalizerIPAddressCleanup)
 		log.Info("VirtualMachineIP is still attached, finalizer added", "VirtualMachineIPName", vmip.Name)


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix the problem: protection finalizer of VirtualMachineIPAddress does not removed when VirtualMachine deleted.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
