### PR TITLE
fix(vd,vi,cvi): fix vd uploader service creating

### DIFF
--- a/images/virtualization-artifact/pkg/controller/supplements/generator.go
+++ b/images/virtualization-artifact/pkg/controller/supplements/generator.go
@@ -86,13 +86,13 @@ func (g *Generator) UploaderPod() types.NamespacedName {
 
 // UploaderService generates name for uploader Service.
 func (g *Generator) UploaderService() types.NamespacedName {
-	name := fmt.Sprintf("%s-uploader-svc-%s", g.Prefix, g.Name)
+	name := fmt.Sprintf("%s-uploader-svc-%s", g.Prefix, g.UID)
 	return g.shortenNamespaced(name)
 }
 
 // UploaderIngress generates name for uploader Ingress.
 func (g *Generator) UploaderIngress() types.NamespacedName {
-	name := fmt.Sprintf("%s-uploader-ingress-%s", g.Prefix, g.Name)
+	name := fmt.Sprintf("%s-uploader-ingress-%s", g.Prefix, g.UID)
 	return g.shortenNamespaced(name)
 }
 


### PR DESCRIPTION
## Description
The UID is now used for generating the name of ingress and service instead of the name of the original resource (vd, vi, cvi). 

## Why do we need it, and what problem does it solve?
According to DNS rules, the service name cannot be longer than 63 characters, whereas the name of the original resource can be longer.

## What is the expected result?
A functional uploader when the name of vd/vi/cvi is of considerable length
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.