### PR TITLE
chore(vm,vd,vi,cvi): set max name length to 128

### DIFF
--- a/crds/clustervirtualimages.yaml
+++ b/crds/clustervirtualimages.yaml
@@ -33,6 +33,9 @@ spec:
             A container image is created under the hood of this resource, which is stored in a dedicated deckhouse virtualization container registry (DVCR).
           required:
             - spec
+          x-kubernetes-validations:
+            - rule: "self.metadata.name.size() <= 128"
+              message: "The name must be no longer than 128 characters."
           properties:
             spec:
               type: object

--- a/crds/virtualdisks.yaml
+++ b/crds/virtualdisks.yaml
@@ -32,6 +32,9 @@ spec:
             Once `VirtualDisk` is created, only the disk size `.spec.persistentVolumeClaim.size` can be changed, all other fields are immutable.
           required:
             - spec
+          x-kubernetes-validations:
+            - rule: "self.metadata.name.size() <= 128"
+              message: "The name must be no longer than 128 characters."
           properties:
             spec:
               type: object

--- a/crds/virtualimages.yaml
+++ b/crds/virtualimages.yaml
@@ -34,6 +34,9 @@ spec:
             A container image is created under the hood of this resource, which is stored in a dedicated deckhouse virtualization container registy (DVCR) or PVC, into which the data from the source is filled.
           required:
             - spec
+          x-kubernetes-validations:
+            - rule: "self.metadata.name.size() <= 128"
+              message: "The name must be no longer than 128 characters."
           properties:
             spec:
               type: object

--- a/crds/virtualmachines.yaml
+++ b/crds/virtualmachines.yaml
@@ -36,6 +36,9 @@ spec:
             - `.spec.disruptions.runPolicy`.
           required:
             - spec
+          x-kubernetes-validations:
+            - rule: "self.metadata.name.size() <= 128"
+              message: "The name must be no longer than 128 characters."
           properties:
             spec:
               x-kubernetes-validations:


### PR DESCRIPTION
## Description
Setting the maximum length for the names of the following resources: vm, vd, vi, cvi

## Why do we need it, and what problem does it solve?
We are resolving issues with the creation of sub-resources

## What is the expected result?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.