### PR TITLE
fix(vd): allow to change size in spec for not ready vd

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vd/internal/validators/pvc_size_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/validators/pvc_size_validator.go
@@ -134,11 +134,11 @@ func (v *PVCSizeValidator) ValidateUpdate(ctx context.Context, oldVD, newVD *vir
 	ready, _ := service.GetCondition(vdcondition.ReadyType, newVD.Status.Conditions)
 	if s := newVD.Spec.PersistentVolumeClaim.Size; s != nil {
 		newSize = *s
-	} else if ready.Status == metav1.ConditionTrue || newVD.Status.Phase == virtv2.DiskReady || newVD.Status.Phase == virtv2.DiskLost || newVD.Status.Phase == virtv2.DiskTerminating {
+	} else if ready.Status == metav1.ConditionTrue || newVD.Status.Phase != virtv2.DiskPending && newVD.Status.Phase != virtv2.DiskProvisioning {
 		return nil, errors.New("spec.persistentVolumeClaim.size cannot be omitted once set")
 	}
 
-	if ready.Status == metav1.ConditionTrue || newVD.Status.Phase == virtv2.DiskReady || newVD.Status.Phase == virtv2.DiskLost || newVD.Status.Phase == virtv2.DiskTerminating {
+	if ready.Status == metav1.ConditionTrue || newVD.Status.Phase != virtv2.DiskPending && newVD.Status.Phase != virtv2.DiskProvisioning {
 		if newSize.Cmp(oldSize) == -1 {
 			return nil, fmt.Errorf(
 				"spec.persistentVolumeClaim.size value (%s) should be greater than or equal to the current value (%s)",


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This PR includes a fix for the issue that prevents resizing in the Spec VirtualDisk when the VirtualDisk is in  "Pending" or "Provisioning" phases.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
