### PR TITLE
refactor(ci): get rid of bazel build

### DIFF
--- a/base-images/alt_image_versions.yml
+++ b/base-images/alt_image_versions.yml
@@ -1,0 +1,5 @@
+# REGISTRY_PATH is a special key which is concatenated with other base images
+REGISTRY_PATH: "registry.altlinux.org/"
+
+# Virtualization images
+DISTROLESS_ALT_P11: "alt/distroless-base:p11@sha256:256886b532513294e84688f63ba06b380b5160aac30f45cb7c7542ae4365bf29"

--- a/images/README.md
+++ b/images/README.md
@@ -2,6 +2,6 @@ Specifics of kubevirt build and image naming.
 
 Kubevirt is built as a single bundle as a virt-artifact. Then all necessary virt-* and libguestfs images are created from this artifact. It should be noted that the naming of these images is directly related to the naming of these images in the source artifact. Therefore, if you need to rename them, you should take this into consideration and make the appropriate edits in the kubevirt build code.
 
-https://github.com/kubevirt/kubevirt/blob/main/BUILD.bazel#L215-L224
+https://github.com/kubevirt/kubevirt/blob/v1.3.1/BUILD.bazel#L215-L224
 
 The same thing for cdi (cdi-artifact).

--- a/images/dvcr-artifact/pkg/datasource/datasource.go
+++ b/images/dvcr-artifact/pkg/datasource/datasource.go
@@ -20,7 +20,7 @@ import "io"
 
 const (
 	// containerDiskImageDir - Expected disk image location in container image as described in
-	// https://github.com/kubevirt/kubevirt/blob/main/docs/container-register-disks.md
+	// https://github.com/kubevirt/kubevirt/blob/v1.3.1/docs/container-register-disks.md
 	containerDiskImageDir = "disk"
 )
 

--- a/images/libguestfs/werf.inc.yaml
+++ b/images/libguestfs/werf.inc.yaml
@@ -23,10 +23,12 @@ shell:
   - mkdir -p /usr/local/lib/guestfs/
   - curl -L {{ $libguestfsApplianceTar }} | tar -xJ -C /usr/local/lib/guestfs/
   - apt-get remove curl --yes
+  - apt-get clean
+  - rm --recursive --force /var/lib/apt/lists/ftp.altlinux.org* /var/cache/apt/*.bin
   install:
   # Install main packages, update GPG keys and vendor IDs list.
   - |
-    apt-get install --yes \
+    apt-get update && apt-get install --yes \
     acl \
     seabios \
     edk2-ovmf \

--- a/images/libguestfs/werf.inc.yaml
+++ b/images/libguestfs/werf.inc.yaml
@@ -1,25 +1,39 @@
 ---
+{{- $libguestfsApplianceTar := "https://storage.googleapis.com/kubevirt-prow/devel/release/kubevirt/libguestfs-appliance/libguestfs-appliance-1.48.4-qcow2-linux-5.14.0-183-centos9.tar.xz" }}
+
+
 image: {{ $.ImageName }}
 fromImage: base-alt-p11
 import:
-- image: virt-artifact
-  add: /images/kubevirt/{{ $.ImageName }}:latest/usr/local/lib/guestfs/appliance
+# - image: virt-artifact
+#   add: /images/kubevirt/{{ $.ImageName }}:latest/usr/local/lib/guestfs/appliance
+#   includePaths:
+#   - '*'
+#   to: /usr/local/lib/guestfs/appliance
+#   before: setup
+- image: virt-artifact-classic-go
+  add: /kubevirt/cmd/{{ $.ImageName }}/
+  to: /
   includePaths:
-  - '*'
-  to: /usr/local/lib/guestfs/appliance
+  - entrypoint.sh
   before: setup
-- image: virt-artifact
-  add: /images/kubevirt/{{ $.ImageName }}:latest
+- image: virt-artifact-classic-go
+  add: /kubevirt/
+  to: /
   includePaths:
   - .version
-  - entrypoint.sh
-  to: /
   before: setup
 shell:
+  beforeInstall:
+  - apt-get update && apt-get install --yes curl
+  - mkdir -p /usr/local/lib/guestfs/
+  - curl -L {{ $libguestfsApplianceTar }} | tar -xJ -C /usr/local/lib/guestfs/
+  - apt-get remove curl --yes
   install:
   # Install main packages, update GPG keys and vendor IDs list.
+  # apt-get update && apt-get install --yes \
   - |
-    apt-get update && apt-get install --yes \
+    apt-get install --yes \
     acl \
     seabios \
     edk2-ovmf \
@@ -33,3 +47,38 @@ shell:
 docker:
   ENTRYPOINT: ["/entrypoint.sh"]
   USER: 1001
+# ============================
+# image: {{ $.ImageName }}
+# fromImage: base-alt-p11
+# import:
+# - image: virt-artifact
+#   add: /images/kubevirt/{{ $.ImageName }}:latest/usr/local/lib/guestfs/appliance
+#   includePaths:
+#   - '*'
+#   to: /usr/local/lib/guestfs/appliance
+#   before: setup
+# - image: virt-artifact
+#   add: /images/kubevirt/{{ $.ImageName }}:latest
+#   includePaths:
+#   - .version
+#   - entrypoint.sh
+#   to: /
+#   before: setup
+# shell:
+#   install:
+#   # Install main packages, update GPG keys and vendor IDs list.
+#   - |
+#     apt-get update && apt-get install --yes \
+#     acl \
+#     seabios \
+#     edk2-ovmf \
+#     libvirt-daemon-driver-qemu==10.2.0-alt1 \
+#     qemu-kvm-core==9.0.2-alt2 \
+#     libguestfs==1.52.0-alt2 \
+#     guestfs-tools==1.52.0-alt1
+#   - apt-get clean
+#   - rm --recursive --force /var/lib/apt/lists/ftp.altlinux.org* /var/cache/apt/*.bin
+# # Source https://github.com/kubevirt/kubevirt/blob/v1.0.0/cmd/libguestfs/BUILD.bazel
+# docker:
+#   ENTRYPOINT: ["/entrypoint.sh"]
+#   USER: 1001

--- a/images/libguestfs/werf.inc.yaml
+++ b/images/libguestfs/werf.inc.yaml
@@ -12,7 +12,7 @@ import:
   - entrypoint.sh
   before: setup
 - image: virt-artifact
-  add: /kubevirt/
+  add: /kubevirt-config-files/
   to: /
   includePaths:
   - .version

--- a/images/libguestfs/werf.inc.yaml
+++ b/images/libguestfs/werf.inc.yaml
@@ -36,7 +36,7 @@ shell:
     guestfs-tools==1.52.0-alt1
   - apt-get clean
   - rm --recursive --force /var/lib/apt/lists/ftp.altlinux.org* /var/cache/apt/*.bin
-# Source https://github.com/kubevirt/kubevirt/blob/v1.0.0/cmd/libguestfs/BUILD.bazel
+# Source https://github.com/kubevirt/kubevirt/blob/v1.3.1/cmd/libguestfs/BUILD.bazel
 docker:
   ENTRYPOINT: ["/entrypoint.sh"]
   USER: 1001

--- a/images/libguestfs/werf.inc.yaml
+++ b/images/libguestfs/werf.inc.yaml
@@ -19,12 +19,8 @@ import:
   before: setup
 shell:
   beforeInstall:
-  - apt-get update && apt-get install --yes curl
   - mkdir -p /usr/local/lib/guestfs/
-  - curl -L {{ $libguestfsApplianceTar }} | tar -xJ -C /usr/local/lib/guestfs/
-  - apt-get remove curl --yes
-  - apt-get clean
-  - rm --recursive --force /var/lib/apt/lists/ftp.altlinux.org* /var/cache/apt/*.bin
+  - /.werf/stapel/embedded/bin/curl -L {{ $libguestfsApplianceTar }} | tar -xJ -C /usr/local/lib/guestfs/
   install:
   # Install main packages, update GPG keys and vendor IDs list.
   - |

--- a/images/libguestfs/werf.inc.yaml
+++ b/images/libguestfs/werf.inc.yaml
@@ -5,13 +5,13 @@
 image: {{ $.ImageName }}
 fromImage: base-alt-p11
 import:
-- image: virt-artifact-classic-go
+- image: virt-artifact
   add: /kubevirt/cmd/{{ $.ImageName }}/
   to: /
   includePaths:
   - entrypoint.sh
   before: setup
-- image: virt-artifact-classic-go
+- image: virt-artifact
   add: /kubevirt/
   to: /
   includePaths:

--- a/images/libguestfs/werf.inc.yaml
+++ b/images/libguestfs/werf.inc.yaml
@@ -1,16 +1,10 @@
 ---
+# libguestfs-appliance from kubevirt/WORKSPACE
 {{- $libguestfsApplianceTar := "https://storage.googleapis.com/kubevirt-prow/devel/release/kubevirt/libguestfs-appliance/libguestfs-appliance-1.48.4-qcow2-linux-5.14.0-183-centos9.tar.xz" }}
-
 
 image: {{ $.ImageName }}
 fromImage: base-alt-p11
 import:
-# - image: virt-artifact
-#   add: /images/kubevirt/{{ $.ImageName }}:latest/usr/local/lib/guestfs/appliance
-#   includePaths:
-#   - '*'
-#   to: /usr/local/lib/guestfs/appliance
-#   before: setup
 - image: virt-artifact-classic-go
   add: /kubevirt/cmd/{{ $.ImageName }}/
   to: /
@@ -31,7 +25,6 @@ shell:
   - apt-get remove curl --yes
   install:
   # Install main packages, update GPG keys and vendor IDs list.
-  # apt-get update && apt-get install --yes \
   - |
     apt-get install --yes \
     acl \
@@ -47,38 +40,3 @@ shell:
 docker:
   ENTRYPOINT: ["/entrypoint.sh"]
   USER: 1001
-# ============================
-# image: {{ $.ImageName }}
-# fromImage: base-alt-p11
-# import:
-# - image: virt-artifact
-#   add: /images/kubevirt/{{ $.ImageName }}:latest/usr/local/lib/guestfs/appliance
-#   includePaths:
-#   - '*'
-#   to: /usr/local/lib/guestfs/appliance
-#   before: setup
-# - image: virt-artifact
-#   add: /images/kubevirt/{{ $.ImageName }}:latest
-#   includePaths:
-#   - .version
-#   - entrypoint.sh
-#   to: /
-#   before: setup
-# shell:
-#   install:
-#   # Install main packages, update GPG keys and vendor IDs list.
-#   - |
-#     apt-get update && apt-get install --yes \
-#     acl \
-#     seabios \
-#     edk2-ovmf \
-#     libvirt-daemon-driver-qemu==10.2.0-alt1 \
-#     qemu-kvm-core==9.0.2-alt2 \
-#     libguestfs==1.52.0-alt2 \
-#     guestfs-tools==1.52.0-alt1
-#   - apt-get clean
-#   - rm --recursive --force /var/lib/apt/lists/ftp.altlinux.org* /var/cache/apt/*.bin
-# # Source https://github.com/kubevirt/kubevirt/blob/v1.0.0/cmd/libguestfs/BUILD.bazel
-# docker:
-#   ENTRYPOINT: ["/entrypoint.sh"]
-#   USER: 1001

--- a/images/virt-api/werf.inc.yaml
+++ b/images/virt-api/werf.inc.yaml
@@ -9,18 +9,13 @@ import:
   - virt-api
   before: setup
 - image: virt-artifact
-  add: /kubevirt/cmd/virt-launcher/
+  add: /kubevirt-config-files/
   to: /etc
   includePaths:
   - passwd
   - group
-  before: setup
-- image: virt-artifact
-  add: /kubevirt/
-  to: /
-  includePaths:
   - .version
-  after: setup
+  before: setup
 # Source https://github.com/kubevirt/kubevirt/blob/main/cmd/virt-api/BUILD.bazel
 docker:
   ENTRYPOINT: ["/usr/bin/virt-api"]

--- a/images/virt-api/werf.inc.yaml
+++ b/images/virt-api/werf.inc.yaml
@@ -16,7 +16,7 @@ import:
   - group
   - .version
   before: setup
-# Source https://github.com/kubevirt/kubevirt/blob/main/cmd/virt-api/BUILD.bazel
+# Source https://github.com/kubevirt/kubevirt/blob/v1.3.1/cmd/virt-api/BUILD.bazel
 docker:
   ENTRYPOINT: ["/usr/bin/virt-api"]
   USER: 1001

--- a/images/virt-api/werf.inc.yaml
+++ b/images/virt-api/werf.inc.yaml
@@ -1,14 +1,42 @@
 ---
 image: {{ $.ImageName }}
-from: {{ .Images.BASE_SCRATCH }}
+from: {{ .Images.DISTROLESS_ALT_P11 }}
+# from: {{ .Images.BASE_SCRATCH }}
 import:
-- image: virt-artifact
-  add: /images/kubevirt/{{ $.ImageName }}:latest
-  excludePaths:
-  - 'sys'
-  to: /
+- image: virt-artifact-classic-go
+  add: /kubevirt-binaries/
+  to: /usr/bin
+  includePaths:
+  - virt-api
   before: setup
+- image: virt-artifact-classic-go
+  add: /kubevirt/cmd/virt-launcher/
+  to: /etc
+  includePaths:
+  - passwd
+  - group
+  before: setup
+- image: virt-artifact-classic-go
+  add: /kubevirt/
+  to: /
+  includePaths:
+  - .version
+  after: setup
 # Source https://github.com/kubevirt/kubevirt/blob/main/cmd/virt-api/BUILD.bazel
 docker:
   ENTRYPOINT: ["/usr/bin/virt-api"]
   USER: 1001
+# ========================
+# image: {{ $.ImageName }}
+# from: {{ .Images.BASE_SCRATCH }}
+# import:
+# - image: virt-artifact
+#   add: /images/kubevirt/{{ $.ImageName }}:latest
+#   excludePaths:
+#   - 'sys'
+#   to: /
+#   before: setup
+# # Source https://github.com/kubevirt/kubevirt/blob/main/cmd/virt-api/BUILD.bazel
+# docker:
+#   ENTRYPOINT: ["/usr/bin/virt-api"]
+#   USER: 1001

--- a/images/virt-api/werf.inc.yaml
+++ b/images/virt-api/werf.inc.yaml
@@ -1,7 +1,6 @@
 ---
 image: {{ $.ImageName }}
 from: {{ .Images.DISTROLESS_ALT_P11 }}
-# from: {{ .Images.BASE_SCRATCH }}
 import:
 - image: virt-artifact-classic-go
   add: /kubevirt-binaries/
@@ -26,17 +25,3 @@ import:
 docker:
   ENTRYPOINT: ["/usr/bin/virt-api"]
   USER: 1001
-# ========================
-# image: {{ $.ImageName }}
-# from: {{ .Images.BASE_SCRATCH }}
-# import:
-# - image: virt-artifact
-#   add: /images/kubevirt/{{ $.ImageName }}:latest
-#   excludePaths:
-#   - 'sys'
-#   to: /
-#   before: setup
-# # Source https://github.com/kubevirt/kubevirt/blob/main/cmd/virt-api/BUILD.bazel
-# docker:
-#   ENTRYPOINT: ["/usr/bin/virt-api"]
-#   USER: 1001

--- a/images/virt-api/werf.inc.yaml
+++ b/images/virt-api/werf.inc.yaml
@@ -2,20 +2,20 @@
 image: {{ $.ImageName }}
 from: {{ .Images.DISTROLESS_ALT_P11 }}
 import:
-- image: virt-artifact-classic-go
+- image: virt-artifact
   add: /kubevirt-binaries/
   to: /usr/bin
   includePaths:
   - virt-api
   before: setup
-- image: virt-artifact-classic-go
+- image: virt-artifact
   add: /kubevirt/cmd/virt-launcher/
   to: /etc
   includePaths:
   - passwd
   - group
   before: setup
-- image: virt-artifact-classic-go
+- image: virt-artifact
   add: /kubevirt/
   to: /
   includePaths:

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -25,6 +25,11 @@ docker:
 image: {{ $.ImageName }}
 final: false
 fromImage: {{ $.ImageName }}-builder
+import:
+- image: {{ $.ImageName }}-classic-go
+  add: /kubevirt-binaries
+  to: /kubevirt-binaries
+  after: setup
 git:
   - add: /images/{{ $.ImageName }}
     to: /
@@ -64,3 +69,86 @@ shell:
   - rm -rf /virt-components-bundle
   - rm -rf /kubevirt
   - rm -rf /tmp/*
+---
+image: {{ $.ImageName }}-classic-go
+final: false
+fromImage: base-alt-p10
+# fromImage: {{ $.ImageName }}-builder
+mount:
+  - fromPath: ~/go-pkg-cache
+    to: /go/pkg
+git:
+  - add: /images/{{ $.ImageName }}
+    to: /
+    stageDependencies:
+      setup:
+      - '**/*'
+    includePaths:
+    - patches
+    - unpack-bundle.sh
+    - bazel-build-virtctl-amd64.sh
+    excludePaths:
+    - patches/README.md
+shell:
+  beforeInstall:
+    - apt-get update
+    - |
+      apt-get install -y \
+      git curl pkg-config \
+      libvirt-libs libtool libvirt-devel libncurses-devel \
+      libvirt-client libvirt-daemon libvirt \
+      gcc gcc-c++ \
+      glibc \
+      golang
+    - apt-get clean
+    - rm --recursive --force /var/lib/apt/lists/ftp.altlinux.org* /var/cache/apt/*.bin
+
+  install:
+    - git clone --depth 1 --branch v{{ $version }} https://github.com/kubevirt/kubevirt.git /kubevirt
+    - cd /kubevirt
+    - |
+      for p in /patches/*.patch ; do
+        echo -n "Apply ${p} ... "
+        git apply  --ignore-space-change --ignore-whitespace ${p} && echo OK || (echo FAIL ; exit 1)
+      done
+    - go mod edit -go={{ $goVersion }}
+    - go mod download
+
+  setup:
+    - mkdir /kubevirt-binaries
+    - cd /kubevirt
+
+    - export GO111MODULE=on
+    - export GOOS=linux
+    - export CGO_ENABLED=0
+    - export GOARCH=amd64
+
+    - echo ============== Build virt-launcher ===========
+    - CGO_ENABLED=1 go build -o /kubevirt-binaries/virt-launcher ./cmd/virt-launcher/
+    
+    - echo ============== Build virt-handler ============
+    - CGO_ENABLED=1 go build -o /kubevirt-binaries/virt-handler ./cmd/virt-handler/
+    
+    - echo ============== Build virt-launcher-monitor ============
+    - go build -o /kubevirt-binaries/virt-launcher-monitor ./cmd/virt-launcher-monitor/
+    
+    - echo ============== Build virt-freezer =====================
+    - go build -o /kubevirt-binaries/virt-freezer ./cmd/virt-freezer/
+    
+    - echo ============== Build virt-api =========================
+    - go build -o /kubevirt-binaries/virt-api ./cmd/virt-api/
+    
+    - echo ============== Build virt-chroot ======================
+    - go build -o /kubevirt-binaries/virt-chroot ./cmd/virt-chroot/
+    
+    - echo ============== Build virt-exportserver ================
+    - go build -o /kubevirt-binaries/virt-exportserver ./cmd/virt-exportserver/
+   
+    - echo ============== Build virt-operator ====================
+    - go build -o /kubevirt-binaries/virt-operator ./cmd/virt-operator/
+    
+    - echo ============== Build sidecars ====================
+    - go build -o /kubevirt-binaries/sidecars ./cmd/sidecars/
+    
+    - echo ============== Build virtctl ==========================
+    - go build -o /kubevirt-binaries/virtctl ./cmd/virtctl/

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -21,54 +21,49 @@ shell:
 docker:
   ENV:
     GIMME_GO_VERSION: "{{ $goVersion }}"
----
-image: {{ $.ImageName }}
-final: false
-fromImage: {{ $.ImageName }}-builder
-import:
-- image: {{ $.ImageName }}-classic-go
-  add: /kubevirt-binaries
-  to: /kubevirt-binaries
-  after: setup
-git:
-  - add: /images/{{ $.ImageName }}
-    to: /
-    stageDependencies:
-      setup:
-      - '**/*'
-    includePaths:
-    - patches
-    - unpack-bundle.sh
-    - bazel-build-virtctl-amd64.sh
-    excludePaths:
-    - patches/README.md
-shell:
-  setup:
-  - git clone --depth 1 --branch v{{ $version }} https://github.com/kubevirt/kubevirt.git /kubevirt
-  - cd /kubevirt
-  - sed -i -e 's/go_version = ".*"/go_version = "{{ $goVersion }}"/' WORKSPACE
-  - |
-    source /etc/profile.d/gimme.sh
-    go mod edit -go={{ $goVersion }}
-    go mod tidy
-  - |
-    for p in /patches/*.patch ; do
-      echo -n "Apply ${p} ... "
-      git apply  --ignore-space-change --ignore-whitespace ${p} && echo OK || (echo FAIL ; exit 1)
-    done
-  - mkdir -p _out
-  - echo "========== Build kubevirt images ============"
-  - make bazel-build-image-bundle KUBEVIRT_RUN_UNNESTED=true
-  - echo "=============== Build virtctl ==============="
-  - /bazel-build-virtctl-amd64.sh && mv /kubevirt/_out/cmd/virtctl/virtctl-linux-amd64 /virtctl
-  - echo "======  Unpack kubevirt images into /  ======"
-  - tar -C / --one-top-level -xf /kubevirt/_out/virt-components-bundle.tar
-  - mkdir -p /images && cd /images && /unpack-bundle.sh /virt-components-bundle/
-  # reduce image size (~17Gb)
-  - rm -rf /root/.cache
-  - rm -rf /virt-components-bundle
-  - rm -rf /kubevirt
-  - rm -rf /tmp/*
+# ---
+# image: {{ $.ImageName }}
+# final: false
+# fromImage: {{ $.ImageName }}-builder
+# git:
+#   - add: /images/{{ $.ImageName }}
+#     to: /
+#     stageDependencies:
+#       setup:
+#       - '**/*'
+#     includePaths:
+#     - patches
+#     - unpack-bundle.sh
+#     - bazel-build-virtctl-amd64.sh
+#     excludePaths:
+#     - patches/README.md
+# shell:
+#   setup:
+#   - git clone --depth 1 --branch v{{ $version }} https://github.com/kubevirt/kubevirt.git /kubevirt
+#   - cd /kubevirt
+#   - sed -i -e 's/go_version = ".*"/go_version = "{{ $goVersion }}"/' WORKSPACE
+#   - |
+#     source /etc/profile.d/gimme.sh
+#     go mod edit -go={{ $goVersion }}
+#     go mod tidy
+#   - |
+#     for p in /patches/*.patch ; do
+#       echo -n "Apply ${p} ... "
+#       git apply  --ignore-space-change --ignore-whitespace ${p} && echo OK || (echo FAIL ; exit 1)
+#     done
+#   - mkdir -p _out
+#   - echo "========== Build kubevirt images ============"
+#   - make bazel-build-image-bundle KUBEVIRT_RUN_UNNESTED=true
+#   - echo "=============== Build virtctl ==============="
+#   - /bazel-build-virtctl-amd64.sh && mv /kubevirt/_out/cmd/virtctl/virtctl-linux-amd64 /virtctl
+#   - echo "======  Unpack kubevirt images into /  ======"
+#   - tar -C / --one-top-level -xf /kubevirt/_out/virt-components-bundle.tar
+#   - mkdir -p /images && cd /images && /unpack-bundle.sh /virt-components-bundle/
+#   # reduce image size (~17Gb)
+#   - rm -rf /root/.cache
+#   - rm -rf /virt-components-bundle
+#   - rm -rf /kubevirt
+#   - rm -rf /tmp/*
 ---
 image: {{ $.ImageName }}-classic-go
 final: false

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -72,9 +72,7 @@ shell:
 ---
 image: {{ $.ImageName }}-classic-go
 final: false
-# fromImage: base-alt-p11
-fromImage: base-alt-p10
-# fromImage: {{ $.ImageName }}-builder
+fromImage: base-alt-p11
 mount:
   - fromPath: ~/go-pkg-cache
     to: /go/pkg
@@ -98,7 +96,7 @@ shell:
       git curl pkg-config \
       libvirt-libs libtool libvirt-devel libncurses-devel \
       libvirt-client libvirt-daemon libvirt \
-      gcc gcc-c++ \
+      gcc gcc-c++ glibc-devel-static \
       glibc \
       golang
     - apt-get clean
@@ -124,10 +122,13 @@ shell:
     - export CGO_ENABLED=0
     - export GOARCH=amd64
 
-    - echo ============== Build virt-launcher ===========
+    - echo ============== Build container-disk ====================
+    - gcc -static cmd/container-disk-v2alpha/main.c -o /kubevirt-binaries/container-disk
+
+    - echo ============== Build virt-launcher ====================
     - CGO_ENABLED=1 go build -o /kubevirt-binaries/virt-launcher ./cmd/virt-launcher/
     
-    - echo ============== Build virt-handler ============
+    - echo ============== Build virt-handler =====================
     - CGO_ENABLED=1 go build -o /kubevirt-binaries/virt-handler ./cmd/virt-handler/
     
     - echo ============== Build virt-launcher-monitor ============
@@ -135,6 +136,9 @@ shell:
     
     - echo ============== Build virt-freezer =====================
     - go build -o /kubevirt-binaries/virt-freezer ./cmd/virt-freezer/
+    
+    - echo ============== Build virt-probe =======================
+    - go build -o /kubevirt-binaries/virt-probe ./cmd/virt-probe/
     
     - echo ============== Build virt-api =========================
     - go build -o /kubevirt-binaries/virt-api ./cmd/virt-api/

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -164,9 +164,15 @@ shell:
     - echo ============== Build virt-chroot ======================
     - go build -o /kubevirt-binaries/virt-chroot ./cmd/virt-chroot/
     
+    - echo ============== Build virt-exportproxy ================
+    - go build -o /kubevirt-binaries/virt-exportproxy ./cmd/virt-exportproxy/
+    
     - echo ============== Build virt-exportserver ================
     - go build -o /kubevirt-binaries/virt-exportserver ./cmd/virt-exportserver/
    
+    - echo ============== Build virt-controller ====================
+    - go build -o /kubevirt-binaries/virt-controller ./cmd/virt-controller/
+    
     - echo ============== Build virt-operator ====================
     - go build -o /kubevirt-binaries/virt-operator ./cmd/virt-operator/
     

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -21,51 +21,8 @@ shell:
 docker:
   ENV:
     GIMME_GO_VERSION: "{{ $goVersion }}"
-# ---
-# image: {{ $.ImageName }}
-# final: false
-# fromImage: {{ $.ImageName }}-builder
-# git:
-#   - add: /images/{{ $.ImageName }}
-#     to: /
-#     stageDependencies:
-#       setup:
-#       - '**/*'
-#     includePaths:
-#     - patches
-#     - unpack-bundle.sh
-#     - bazel-build-virtctl-amd64.sh
-#     excludePaths:
-#     - patches/README.md
-# shell:
-#   setup:
-#   - git clone --depth 1 --branch v{{ $version }} https://github.com/kubevirt/kubevirt.git /kubevirt
-#   - cd /kubevirt
-#   - sed -i -e 's/go_version = ".*"/go_version = "{{ $goVersion }}"/' WORKSPACE
-#   - |
-#     source /etc/profile.d/gimme.sh
-#     go mod edit -go={{ $goVersion }}
-#     go mod tidy
-#   - |
-#     for p in /patches/*.patch ; do
-#       echo -n "Apply ${p} ... "
-#       git apply  --ignore-space-change --ignore-whitespace ${p} && echo OK || (echo FAIL ; exit 1)
-#     done
-#   - mkdir -p _out
-#   - echo "========== Build kubevirt images ============"
-#   - make bazel-build-image-bundle KUBEVIRT_RUN_UNNESTED=true
-#   - echo "=============== Build virtctl ==============="
-#   - /bazel-build-virtctl-amd64.sh && mv /kubevirt/_out/cmd/virtctl/virtctl-linux-amd64 /virtctl
-#   - echo "======  Unpack kubevirt images into /  ======"
-#   - tar -C / --one-top-level -xf /kubevirt/_out/virt-components-bundle.tar
-#   - mkdir -p /images && cd /images && /unpack-bundle.sh /virt-components-bundle/
-#   # reduce image size (~17Gb)
-#   - rm -rf /root/.cache
-#   - rm -rf /virt-components-bundle
-#   - rm -rf /kubevirt
-#   - rm -rf /tmp/*
 ---
-image: {{ $.ImageName }}-classic-go
+image: {{ $.ImageName }}
 final: false
 fromImage: base-alt-p11
 mount:

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -72,8 +72,8 @@ shell:
 ---
 image: {{ $.ImageName }}-classic-go
 final: false
-fromImage: base-alt-p11
-# fromImage: base-alt-p10
+# fromImage: base-alt-p11
+fromImage: base-alt-p10
 # fromImage: {{ $.ImageName }}-builder
 mount:
   - fromPath: ~/go-pkg-cache
@@ -86,8 +86,8 @@ git:
       - '**/*'
     includePaths:
     - patches
-    - unpack-bundle.sh
-    - bazel-build-virtctl-amd64.sh
+    # - unpack-bundle.sh
+    # - bazel-build-virtctl-amd64.sh
     excludePaths:
     - patches/README.md
 shell:

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -116,6 +116,7 @@ shell:
   setup:
     - mkdir /kubevirt-binaries
     - cd /kubevirt
+    - echo "v{{ $version }}-dirty" > .version
 
     - export GO111MODULE=on
     - export GOOS=linux

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -72,7 +72,8 @@ shell:
 ---
 image: {{ $.ImageName }}-classic-go
 final: false
-fromImage: base-alt-p10
+fromImage: base-alt-p11
+# fromImage: base-alt-p10
 # fromImage: {{ $.ImageName }}-builder
 mount:
   - fromPath: ~/go-pkg-cache

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -36,8 +36,6 @@ git:
       - '**/*'
     includePaths:
     - patches
-    # - unpack-bundle.sh
-    # - bazel-build-virtctl-amd64.sh
     excludePaths:
     - patches/README.md
 shell:
@@ -67,8 +65,9 @@ shell:
 
   setup:
     - mkdir /kubevirt-binaries
+    - mkdir /kubevirt-config-files
     - cd /kubevirt
-    - echo "v{{ $version }}-dirty" > .version
+    - echo "v{{ $version }}-dirty" > /kubevirt-config-files/.version
 
     - export GO111MODULE=on
     - export GOOS=linux
@@ -83,14 +82,14 @@ shell:
     
     - echo "Create group file"
     - |
-      GROUP_FILE=./cmd/virt-launcher/group
+      GROUP_FILE=/kubevirt-config-files/group
       echo "qemu:x:107:" > $GROUP_FILE
       echo "root:x:0:" >> $GROUP_FILE
       chmod 0644 $GROUP_FILE
     
     - echo "Create passwd file"
     - |
-      PASSWD_FILE=./cmd/virt-launcher/passwd
+      PASSWD_FILE=/kubevirt-config-files/passwd
       echo "qemu:x:107:107:user:/home/qemu:/bin/bash" > $PASSWD_FILE
       echo "root:x:0:0:root:/root:/bin/bash" >> $PASSWD_FILE
       chmod 0644 $PASSWD_FILE

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -76,6 +76,7 @@ shell:
       GROUP_FILE=/kubevirt-config-files/group
       echo "qemu:x:107:" > $GROUP_FILE
       echo "root:x:0:" >> $GROUP_FILE
+      echo "nonroot-user:x:1001:" >> $GROUP_FILE
       chmod 0644 $GROUP_FILE
     
     - echo "Create passwd file"
@@ -83,6 +84,7 @@ shell:
       PASSWD_FILE=/kubevirt-config-files/passwd
       echo "qemu:x:107:107:user:/home/qemu:/bin/bash" > $PASSWD_FILE
       echo "root:x:0:0:root:/root:/bin/bash" >> $PASSWD_FILE
+      echo "nonroot-user:x:1001:1001::/home/nonroot-user:/bin/bash" >> $PASSWD_FILE
       chmod 0644 $PASSWD_FILE
 
     - export GO111MODULE=on
@@ -129,7 +131,7 @@ shell:
     - echo ============== Build virt-operator ====================
     - go build -o /kubevirt-binaries/virt-operator ./cmd/virt-operator/
     
-    - echo "Build csv-generator"
+    - echo ============== Build csv-generator ====================
     - go build -o /kubevirt-binaries/csv-generator ./tools/csv-generator
     
     - echo ============== Build sidecars =========================

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -67,18 +67,9 @@ shell:
     - mkdir /kubevirt-binaries
     - mkdir /kubevirt-config-files
     - cd /kubevirt
+
+    - echo "Create .version file"
     - echo "v{{ $version }}-dirty" > /kubevirt-config-files/.version
-
-    - export GO111MODULE=on
-    - export GOOS=linux
-    - export CGO_ENABLED=0
-    - export GOARCH=amd64
-
-    - echo ============== Build container-disk ===================
-    - gcc -static cmd/container-disk-v2alpha/main.c -o /kubevirt-binaries/container-disk
-
-    - echo ============== Build virt-launcher ====================
-    - CGO_ENABLED=1 go build -o /kubevirt-binaries/virt-launcher ./cmd/virt-launcher/
     
     - echo "Create group file"
     - |
@@ -93,6 +84,17 @@ shell:
       echo "qemu:x:107:107:user:/home/qemu:/bin/bash" > $PASSWD_FILE
       echo "root:x:0:0:root:/root:/bin/bash" >> $PASSWD_FILE
       chmod 0644 $PASSWD_FILE
+
+    - export GO111MODULE=on
+    - export GOOS=linux
+    - export CGO_ENABLED=0
+    - export GOARCH=amd64
+
+    - echo ============== Build container-disk ===================
+    - gcc -static cmd/container-disk-v2alpha/main.c -o /kubevirt-binaries/container-disk
+
+    - echo ============== Build virt-launcher ====================
+    - CGO_ENABLED=1 go build -o /kubevirt-binaries/virt-launcher ./cmd/virt-launcher/
 
     - echo ============== Build virt-handler =====================
     - CGO_ENABLED=1 go build -o /kubevirt-binaries/virt-handler ./cmd/virt-handler/

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -176,6 +176,9 @@ shell:
     - echo ============== Build virt-operator ====================
     - go build -o /kubevirt-binaries/virt-operator ./cmd/virt-operator/
     
+    - echo "Build csv-generator"
+    - go build -o /kubevirt-binaries/csv-generator ./tools/csv-generator
+    
     - echo ============== Build sidecars =========================
     - go build -o /kubevirt-binaries/sidecars ./cmd/sidecars/
     

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -122,17 +122,34 @@ shell:
     - export CGO_ENABLED=0
     - export GOARCH=amd64
 
-    - echo ============== Build container-disk ====================
+    - echo ============== Build container-disk ===================
     - gcc -static cmd/container-disk-v2alpha/main.c -o /kubevirt-binaries/container-disk
 
     - echo ============== Build virt-launcher ====================
     - CGO_ENABLED=1 go build -o /kubevirt-binaries/virt-launcher ./cmd/virt-launcher/
     
+    - echo "Create group file"
+    - |
+      GROUP_FILE=./cmd/virt-launcher/group
+      echo "qemu:x:107:" > $GROUP_FILE
+      echo "root:x:0:" >> $GROUP_FILE
+      chmod 0644 $GROUP_FILE
+    
+    - echo "Create passwd file"
+    - |
+      PASSWD_FILE=./cmd/virt-launcher/passwd
+      echo "qemu:x:107:107:user:/home/qemu:/bin/bash" > $PASSWD_FILE
+      echo "root:x:0:0:root:/root:/bin/bash" >> $PASSWD_FILE
+      chmod 0644 $PASSWD_FILE
+
     - echo ============== Build virt-handler =====================
     - CGO_ENABLED=1 go build -o /kubevirt-binaries/virt-handler ./cmd/virt-handler/
     
     - echo ============== Build virt-launcher-monitor ============
     - go build -o /kubevirt-binaries/virt-launcher-monitor ./cmd/virt-launcher-monitor/
+    
+    - echo ============== Build virt-tail ========================
+    - go build -o /kubevirt-binaries/virt-tail ./cmd/virt-tail/
     
     - echo ============== Build virt-freezer =====================
     - go build -o /kubevirt-binaries/virt-freezer ./cmd/virt-freezer/
@@ -152,7 +169,7 @@ shell:
     - echo ============== Build virt-operator ====================
     - go build -o /kubevirt-binaries/virt-operator ./cmd/virt-operator/
     
-    - echo ============== Build sidecars ====================
+    - echo ============== Build sidecars =========================
     - go build -o /kubevirt-binaries/sidecars ./cmd/sidecars/
     
     - echo ============== Build virtctl ==========================

--- a/images/virt-controller/werf.inc.yaml
+++ b/images/virt-controller/werf.inc.yaml
@@ -2,20 +2,20 @@
 image: {{ $.ImageName }}
 from: {{ .Images.DISTROLESS_ALT_P11 }}
 import:
-- image: virt-artifact-classic-go
+- image: virt-artifact
   add: /kubevirt-binaries/
   to: /usr/bin
   includePaths:
   - virt-controller
   before: setup
-- image: virt-artifact-classic-go
+- image: virt-artifact
   add: /kubevirt/cmd/virt-launcher/
   to: /etc
   includePaths:
   - passwd
   - group
   before: setup
-- image: virt-artifact-classic-go
+- image: virt-artifact
   add: /kubevirt/
   to: /
   includePaths:

--- a/images/virt-controller/werf.inc.yaml
+++ b/images/virt-controller/werf.inc.yaml
@@ -16,7 +16,7 @@ import:
   - group
   - .version
   before: setup
-# Source https://github.com/kubevirt/kubevirt/blob/main/cmd/virt-controller/BUILD.bazel
+# Source https://github.com/kubevirt/kubevirt/blob/v1.3.1/cmd/virt-controller/BUILD.bazel
 docker:
   ENTRYPOINT: ["/usr/bin/virt-controller"]
   USER: 1001

--- a/images/virt-controller/werf.inc.yaml
+++ b/images/virt-controller/werf.inc.yaml
@@ -1,14 +1,42 @@
 ---
 image: {{ $.ImageName }}
-from: {{ .Images.BASE_SCRATCH }}
+from: {{ .Images.DISTROLESS_ALT_P11 }}
+# from: {{ .Images.BASE_SCRATCH }}
 import:
-- image: virt-artifact
-  add: /images/kubevirt/{{ $.ImageName }}:latest
-  excludePaths:
-  - 'sys'
-  to: /
+- image: virt-artifact-classic-go
+  add: /kubevirt-binaries/
+  to: /usr/bin
+  includePaths:
+  - virt-controller
   before: setup
+- image: virt-artifact-classic-go
+  add: /kubevirt/cmd/virt-launcher/
+  to: /etc
+  includePaths:
+  - passwd
+  - group
+  before: setup
+- image: virt-artifact-classic-go
+  add: /kubevirt/
+  to: /
+  includePaths:
+  - .version
+  after: setup
 # Source https://github.com/kubevirt/kubevirt/blob/main/cmd/virt-controller/BUILD.bazel
 docker:
   ENTRYPOINT: ["/usr/bin/virt-controller"]
   USER: 1001
+# ===========
+# image: {{ $.ImageName }}
+# from: {{ .Images.BASE_SCRATCH }}
+# import:
+# - image: virt-artifact
+#   add: /images/kubevirt/{{ $.ImageName }}:latest
+#   excludePaths:
+#   - 'sys'
+#   to: /
+#   before: setup
+# # Source https://github.com/kubevirt/kubevirt/blob/main/cmd/virt-controller/BUILD.bazel
+# docker:
+#   ENTRYPOINT: ["/usr/bin/virt-controller"]
+#   USER: 1001

--- a/images/virt-controller/werf.inc.yaml
+++ b/images/virt-controller/werf.inc.yaml
@@ -1,7 +1,6 @@
 ---
 image: {{ $.ImageName }}
 from: {{ .Images.DISTROLESS_ALT_P11 }}
-# from: {{ .Images.BASE_SCRATCH }}
 import:
 - image: virt-artifact-classic-go
   add: /kubevirt-binaries/
@@ -26,17 +25,3 @@ import:
 docker:
   ENTRYPOINT: ["/usr/bin/virt-controller"]
   USER: 1001
-# ===========
-# image: {{ $.ImageName }}
-# from: {{ .Images.BASE_SCRATCH }}
-# import:
-# - image: virt-artifact
-#   add: /images/kubevirt/{{ $.ImageName }}:latest
-#   excludePaths:
-#   - 'sys'
-#   to: /
-#   before: setup
-# # Source https://github.com/kubevirt/kubevirt/blob/main/cmd/virt-controller/BUILD.bazel
-# docker:
-#   ENTRYPOINT: ["/usr/bin/virt-controller"]
-#   USER: 1001

--- a/images/virt-controller/werf.inc.yaml
+++ b/images/virt-controller/werf.inc.yaml
@@ -9,18 +9,13 @@ import:
   - virt-controller
   before: setup
 - image: virt-artifact
-  add: /kubevirt/cmd/virt-launcher/
+  add: /kubevirt-config-files/
   to: /etc
   includePaths:
   - passwd
   - group
-  before: setup
-- image: virt-artifact
-  add: /kubevirt/
-  to: /
-  includePaths:
   - .version
-  after: setup
+  before: setup
 # Source https://github.com/kubevirt/kubevirt/blob/main/cmd/virt-controller/BUILD.bazel
 docker:
   ENTRYPOINT: ["/usr/bin/virt-controller"]

--- a/images/virt-exportproxy/werf.inc.yaml
+++ b/images/virt-exportproxy/werf.inc.yaml
@@ -16,7 +16,7 @@ import:
   - group
   - .version
   before: setup
-# Source https://github.com/kubevirt/kubevirt/blob/v1.0.0/cmd/virt-exportproxy/BUILD.bazel
+# Source https://github.com/kubevirt/kubevirt/blob/v1.3.1/cmd/virt-exportproxy/BUILD.bazel
 docker:
   WORKDIR: /usr/bin/
   ENTRYPOINT: ["/usr/bin/virt-exportproxy"]

--- a/images/virt-exportproxy/werf.inc.yaml
+++ b/images/virt-exportproxy/werf.inc.yaml
@@ -1,21 +1,50 @@
 ---
 image: {{ $.ImageName }}
-from: {{ .Images.BASE_SCRATCH }}
+from: {{  .Images.DISTROLESS_ALT_P11 }}
+# from: {{ .Images.BASE_SCRATCH }}
 import:
-- image: virt-artifact
-  add: /images/kubevirt/{{ $.ImageName }}:latest/usr/bin
+- image: virt-artifact-classic-go
+  add: /kubevirt-binaries/
+  to: /usr/bin
   includePaths:
   - virt-exportproxy
-  to: /usr/bin
   before: setup
-- image: virt-artifact
-  add: /images/kubevirt/{{ $.ImageName }}:latest/
+- image: virt-artifact-classic-go
+  add: /kubevirt/cmd/virt-launcher/
+  to: /etc
+  includePaths:
+  - passwd
+  - group
+  before: setup
+- image: virt-artifact-classic-go
+  add: /kubevirt/
+  to: /
   includePaths:
   - .version
-  to: /
-  before: setup
+  after: setup
 # Source https://github.com/kubevirt/kubevirt/blob/v1.0.0/cmd/virt-exportproxy/BUILD.bazel
 docker:
   WORKDIR: /usr/bin/
   ENTRYPOINT: ["/usr/bin/virt-exportproxy"]
   USER: 1001
+# ==============
+# image: {{ $.ImageName }}
+# from: {{ .Images.BASE_SCRATCH }}
+# import:
+# - image: virt-artifact
+#   add: /images/kubevirt/{{ $.ImageName }}:latest/usr/bin
+#   includePaths:
+#   - virt-exportproxy
+#   to: /usr/bin
+#   before: setup
+# - image: virt-artifact
+#   add: /images/kubevirt/{{ $.ImageName }}:latest/
+#   includePaths:
+#   - .version
+#   to: /
+#   before: setup
+# # Source https://github.com/kubevirt/kubevirt/blob/v1.0.0/cmd/virt-exportproxy/BUILD.bazel
+# docker:
+#   WORKDIR: /usr/bin/
+#   ENTRYPOINT: ["/usr/bin/virt-exportproxy"]
+#   USER: 1001

--- a/images/virt-exportproxy/werf.inc.yaml
+++ b/images/virt-exportproxy/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ $.ImageName }}
-from: {{  .Images.DISTROLESS_ALT_P11 }}
+from: {{ .Images.DISTROLESS_ALT_P11 }}
 import:
 - image: virt-artifact
   add: /kubevirt-binaries/
@@ -9,18 +9,13 @@ import:
   - virt-exportproxy
   before: setup
 - image: virt-artifact
-  add: /kubevirt/cmd/virt-launcher/
+  add: /kubevirt-config-files/
   to: /etc
   includePaths:
   - passwd
   - group
-  before: setup
-- image: virt-artifact
-  add: /kubevirt/
-  to: /
-  includePaths:
   - .version
-  after: setup
+  before: setup
 # Source https://github.com/kubevirt/kubevirt/blob/v1.0.0/cmd/virt-exportproxy/BUILD.bazel
 docker:
   WORKDIR: /usr/bin/

--- a/images/virt-exportproxy/werf.inc.yaml
+++ b/images/virt-exportproxy/werf.inc.yaml
@@ -1,7 +1,6 @@
 ---
 image: {{ $.ImageName }}
 from: {{  .Images.DISTROLESS_ALT_P11 }}
-# from: {{ .Images.BASE_SCRATCH }}
 import:
 - image: virt-artifact-classic-go
   add: /kubevirt-binaries/
@@ -27,24 +26,3 @@ docker:
   WORKDIR: /usr/bin/
   ENTRYPOINT: ["/usr/bin/virt-exportproxy"]
   USER: 1001
-# ==============
-# image: {{ $.ImageName }}
-# from: {{ .Images.BASE_SCRATCH }}
-# import:
-# - image: virt-artifact
-#   add: /images/kubevirt/{{ $.ImageName }}:latest/usr/bin
-#   includePaths:
-#   - virt-exportproxy
-#   to: /usr/bin
-#   before: setup
-# - image: virt-artifact
-#   add: /images/kubevirt/{{ $.ImageName }}:latest/
-#   includePaths:
-#   - .version
-#   to: /
-#   before: setup
-# # Source https://github.com/kubevirt/kubevirt/blob/v1.0.0/cmd/virt-exportproxy/BUILD.bazel
-# docker:
-#   WORKDIR: /usr/bin/
-#   ENTRYPOINT: ["/usr/bin/virt-exportproxy"]
-#   USER: 1001

--- a/images/virt-exportproxy/werf.inc.yaml
+++ b/images/virt-exportproxy/werf.inc.yaml
@@ -2,20 +2,20 @@
 image: {{ $.ImageName }}
 from: {{  .Images.DISTROLESS_ALT_P11 }}
 import:
-- image: virt-artifact-classic-go
+- image: virt-artifact
   add: /kubevirt-binaries/
   to: /usr/bin
   includePaths:
   - virt-exportproxy
   before: setup
-- image: virt-artifact-classic-go
+- image: virt-artifact
   add: /kubevirt/cmd/virt-launcher/
   to: /etc
   includePaths:
   - passwd
   - group
   before: setup
-- image: virt-artifact-classic-go
+- image: virt-artifact
   add: /kubevirt/
   to: /
   includePaths:

--- a/images/virt-exportserver/werf.inc.yaml
+++ b/images/virt-exportserver/werf.inc.yaml
@@ -2,13 +2,13 @@
 image: {{ $.ImageName }}
 fromImage: base-alt-p11
 import:
-- image: virt-artifact-classic-go
+- image: virt-artifact
   add: /kubevirt-binaries/
   to: /usr/bin
   includePaths:
   - virt-exportserver
   before: setup
-- image: virt-artifact-classic-go
+- image: virt-artifact
   add: /kubevirt/
   to: /
   includePaths:

--- a/images/virt-exportserver/werf.inc.yaml
+++ b/images/virt-exportserver/werf.inc.yaml
@@ -2,19 +2,50 @@
 image: {{ $.ImageName }}
 fromImage: base-alt-p11
 import:
-- image: virt-artifact
-  add: /images/kubevirt/{{ $.ImageName }}:latest/usr/bin
+- image: virt-artifact-classic-go
+  add: /kubevirt-binaries/
+  to: /usr/bin
   includePaths:
   - virt-exportserver
-  to: /usr/bin
   before: setup
-- image: virt-artifact
-  add: /images/kubevirt/{{ $.ImageName }}:latest/
+# - image: virt-artifact-classic-go
+#   add: /kubevirt/cmd/virt-launcher/
+#   to: /etc
+#   includePaths:
+#   - passwd
+#   - group
+#   before: setup
+- image: virt-artifact-classic-go
+  add: /kubevirt/
+  to: /
   includePaths:
   - .version
-  to: /
-  before: setup
+  after: setup
+shell:
+  setup:
+    - groupadd --gid 107 qemu && useradd qemu --uid 107 --gid 107 --shell /bin/bash --create-home
 # Source https://github.com/kubevirt/kubevirt/blob/v1.3.1/cmd/virt-exportserver/BUILD.bazel
 docker:
   ENTRYPOINT: ["/usr/bin/virt-exportserver"]
   USER: 1001
+
+# ============
+# image: {{ $.ImageName }}
+# fromImage: base-alt-p11
+# import:
+# - image: virt-artifact
+#   add: /images/kubevirt/{{ $.ImageName }}:latest/usr/bin
+#   includePaths:
+#   - virt-exportserver
+#   to: /usr/bin
+#   before: setup
+# - image: virt-artifact
+#   add: /images/kubevirt/{{ $.ImageName }}:latest/
+#   includePaths:
+#   - .version
+#   to: /
+#   before: setup
+# # Source https://github.com/kubevirt/kubevirt/blob/v1.3.1/cmd/virt-exportserver/BUILD.bazel
+# docker:
+#   ENTRYPOINT: ["/usr/bin/virt-exportserver"]
+#   USER: 1001

--- a/images/virt-exportserver/werf.inc.yaml
+++ b/images/virt-exportserver/werf.inc.yaml
@@ -9,7 +9,7 @@ import:
   - virt-exportserver
   before: setup
 - image: virt-artifact
-  add: /kubevirt/
+  add: /kubevirt-config-files/
   to: /
   includePaths:
   - .version

--- a/images/virt-exportserver/werf.inc.yaml
+++ b/images/virt-exportserver/werf.inc.yaml
@@ -8,13 +8,6 @@ import:
   includePaths:
   - virt-exportserver
   before: setup
-# - image: virt-artifact-classic-go
-#   add: /kubevirt/cmd/virt-launcher/
-#   to: /etc
-#   includePaths:
-#   - passwd
-#   - group
-#   before: setup
 - image: virt-artifact-classic-go
   add: /kubevirt/
   to: /
@@ -28,24 +21,3 @@ shell:
 docker:
   ENTRYPOINT: ["/usr/bin/virt-exportserver"]
   USER: 1001
-
-# ============
-# image: {{ $.ImageName }}
-# fromImage: base-alt-p11
-# import:
-# - image: virt-artifact
-#   add: /images/kubevirt/{{ $.ImageName }}:latest/usr/bin
-#   includePaths:
-#   - virt-exportserver
-#   to: /usr/bin
-#   before: setup
-# - image: virt-artifact
-#   add: /images/kubevirt/{{ $.ImageName }}:latest/
-#   includePaths:
-#   - .version
-#   to: /
-#   before: setup
-# # Source https://github.com/kubevirt/kubevirt/blob/v1.3.1/cmd/virt-exportserver/BUILD.bazel
-# docker:
-#   ENTRYPOINT: ["/usr/bin/virt-exportserver"]
-#   USER: 1001

--- a/images/virt-handler/werf.inc.yaml
+++ b/images/virt-handler/werf.inc.yaml
@@ -31,7 +31,7 @@ import:
   includePaths:
   - virt_launcher.cil
 - image: virt-artifact
-  add: /kubevirt/
+  add: /kubevirt-config-files/
   to: /
   after: install
   includePaths:

--- a/images/virt-handler/werf.inc.yaml
+++ b/images/virt-handler/werf.inc.yaml
@@ -66,7 +66,7 @@ import:
 #   includePaths:
 #   # - group
 #   # - passwd
-#-----------
+# ==============
 # - image: virt-artifact
 #   add: /images/kubevirt/{{ $.ImageName }}:latest/etc
 #   to: /etc

--- a/images/virt-handler/werf.inc.yaml
+++ b/images/virt-handler/werf.inc.yaml
@@ -16,27 +16,55 @@ shell:
   # Create qemu group and user.
   - groupadd --gid 107 qemu && useradd qemu --uid 107 --gid 107 --shell /bin/bash --create-home
 import:
-- image: virt-artifact
-  add: /images/kubevirt/{{ $.ImageName }}:latest/usr/bin
+- image: virt-artifact-classic-go
+  add: /kubevirt-binaries/
   to: /usr/bin
   after: install
   includePaths:
   - virt-chroot
   - virt-handler
   - container-disk
-- image: virt-artifact
-  add: /images/kubevirt/{{ $.ImageName }}:latest
+# - image: virt-artifact
+#   add: /images/kubevirt/{{ $.ImageName }}:latest/usr/bin
+#   to: /usr/bin
+#   after: install
+#   includePaths:
+#   - virt-chroot
+#   - virt-handler
+#   - container-disk
+- image: virt-artifact-classic-go
+  add: /kubevirt/cmd/{{ $.ImageName }}/
+  to: /
+  after: install
+  includePaths:
+  # - .version
+  - virt_launcher.cil
+- image: virt-artifact-classic-go
+  add: /kubevirt/
   to: /
   after: install
   includePaths:
   - .version
-  - virt_launcher.cil
-- image: virt-artifact
-  add: /images/kubevirt/{{ $.ImageName }}:latest/etc
+  # - virt_launcher.cil
+# - image: virt-artifact
+#   add: /images/kubevirt/{{ $.ImageName }}:latest
+#   to: /
+#   after: install
+#   includePaths:
+#   - .version
+#   - virt_launcher.cil
+- image: virt-artifact-classic-go
+  add: /kubevirt/cmd/{{ $.ImageName }}/
   to: /etc
   after: install
   includePaths:
   - nsswitch.conf
+# - image: virt-artifact
+#   add: /images/kubevirt/{{ $.ImageName }}:latest/etc
+#   to: /etc
+#   after: install
+#   includePaths:
+#   - nsswitch.conf
 # Source https://github.com/kubevirt/kubevirt/blob/v1.0.0/cmd/virt-handler/BUILD.bazel
 docker:
   ENTRYPOINT: ["/usr/bin/virt-handler"]

--- a/images/virt-handler/werf.inc.yaml
+++ b/images/virt-handler/werf.inc.yaml
@@ -16,7 +16,7 @@ shell:
   # Create qemu group and user.
   - groupadd --gid 107 qemu && useradd qemu --uid 107 --gid 107 --shell /bin/bash --create-home
 import:
-- image: virt-artifact-classic-go
+- image: virt-artifact
   add: /kubevirt-binaries/
   to: /usr/bin
   after: install
@@ -24,19 +24,19 @@ import:
   - virt-chroot
   - virt-handler
   - container-disk
-- image: virt-artifact-classic-go
+- image: virt-artifact
   add: /kubevirt/cmd/{{ $.ImageName }}/
   to: /
   after: install
   includePaths:
   - virt_launcher.cil
-- image: virt-artifact-classic-go
+- image: virt-artifact
   add: /kubevirt/
   to: /
   after: install
   includePaths:
   - .version
-- image: virt-artifact-classic-go
+- image: virt-artifact
   add: /kubevirt/cmd/{{ $.ImageName }}/
   to: /etc
   after: install

--- a/images/virt-handler/werf.inc.yaml
+++ b/images/virt-handler/werf.inc.yaml
@@ -24,20 +24,11 @@ import:
   - virt-chroot
   - virt-handler
   - container-disk
-# - image: virt-artifact
-#   add: /images/kubevirt/{{ $.ImageName }}:latest/usr/bin
-#   to: /usr/bin
-#   after: install
-#   includePaths:
-#   - virt-chroot
-#   - virt-handler
-#   - container-disk
 - image: virt-artifact-classic-go
   add: /kubevirt/cmd/{{ $.ImageName }}/
   to: /
   after: install
   includePaths:
-  # - .version
   - virt_launcher.cil
 - image: virt-artifact-classic-go
   add: /kubevirt/
@@ -45,34 +36,12 @@ import:
   after: install
   includePaths:
   - .version
-  # - virt_launcher.cil
-# - image: virt-artifact
-#   add: /images/kubevirt/{{ $.ImageName }}:latest
-#   to: /
-#   after: install
-#   includePaths:
-#   - .version
-#   - virt_launcher.cil
 - image: virt-artifact-classic-go
   add: /kubevirt/cmd/{{ $.ImageName }}/
   to: /etc
   after: install
   includePaths:
   - nsswitch.conf
-# - image: virt-artifact-classic-go
-#   add: /kubevirt/cmd/virt-launcher/
-#   to: /etc
-#   after: install
-#   includePaths:
-#   # - group
-#   # - passwd
-# ==============
-# - image: virt-artifact
-#   add: /images/kubevirt/{{ $.ImageName }}:latest/etc
-#   to: /etc
-#   after: install
-#   includePaths:
-#   - nsswitch.conf
 # Source https://github.com/kubevirt/kubevirt/blob/v1.0.0/cmd/virt-handler/BUILD.bazel
 docker:
   ENTRYPOINT: ["/usr/bin/virt-handler"]

--- a/images/virt-handler/werf.inc.yaml
+++ b/images/virt-handler/werf.inc.yaml
@@ -42,6 +42,6 @@ import:
   after: install
   includePaths:
   - nsswitch.conf
-# Source https://github.com/kubevirt/kubevirt/blob/v1.0.0/cmd/virt-handler/BUILD.bazel
+# Source https://github.com/kubevirt/kubevirt/blob/v1.3.1/cmd/virt-handler/BUILD.bazel
 docker:
   ENTRYPOINT: ["/usr/bin/virt-handler"]

--- a/images/virt-handler/werf.inc.yaml
+++ b/images/virt-handler/werf.inc.yaml
@@ -59,6 +59,14 @@ import:
   after: install
   includePaths:
   - nsswitch.conf
+# - image: virt-artifact-classic-go
+#   add: /kubevirt/cmd/virt-launcher/
+#   to: /etc
+#   after: install
+#   includePaths:
+#   # - group
+#   # - passwd
+#-----------
 # - image: virt-artifact
 #   add: /images/kubevirt/{{ $.ImageName }}:latest/etc
 #   to: /etc

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -46,14 +46,20 @@ import:
   - liboverride.so
 
 # Add kubeivrt files from virt-artifact.
-- image: virt-artifact
-  add: /images/kubevirt/{{ $.ImageName }}:latest/
+- image: virt-artifact-classic-go
+  add: /images/kubevirt/
   to: /
   after: install
   includePaths:
   - .version
+# - image: virt-artifact
+#   add: /images/kubevirt/{{ $.ImageName }}:latest/
+#   to: /
+#   after: install
+#   includePaths:
+#   - .version
 - image: virt-artifact-classic-go
-  add: /kubevirt/cmd/{{ $.ImageName }}
+  add: /kubevirt/cmd/{{ $.ImageName }}/
   to: /etc/libvirt
   after: install
   includePaths:
@@ -66,12 +72,20 @@ import:
 #   includePaths:
 #   - qemu.conf
 #   - virtqemud.conf
-- image: virt-artifact
-  add: /images/kubevirt/{{ $.ImageName }}:latest/etc
+- image: virt-artifact-classic-go
+  add: /kubevirt/cmd/{{ $.ImageName }}/
   to: /etc
   after: install
   includePaths:
   - nsswitch.conf
+  - group
+  - passwd
+# - image: virt-artifact
+#   add: /images/kubevirt/{{ $.ImageName }}:latest/etc
+#   to: /etc
+#   after: install
+#   includePaths:
+#   - nsswitch.conf
 # - image: virt-artifact
   # add: /images/kubevirt/{{ $.ImageName }}:latest/usr/bin
 - image: virt-artifact-classic-go
@@ -87,7 +101,7 @@ import:
   - virt-tail
   # - kubevirt/cmd/virt-launcher/node-labeller
 - image: virt-artifact-classic-go
-  add: /kubevirt/cmd/virt-launcher/node-labeller/
+  add: /kubevirt/cmd/{{ $.ImageName }}/node-labeller/
   to: /usr/bin
   before: setup
 # - image: virt-artifact-classic-go

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -78,8 +78,9 @@ import:
   after: install
   includePaths:
   - nsswitch.conf
-  - group
-  - passwd
+  # - group
+  # - passwd
+#============
 # - image: virt-artifact
 #   add: /images/kubevirt/{{ $.ImageName }}:latest/etc
 #   to: /etc
@@ -104,10 +105,6 @@ import:
   add: /kubevirt/cmd/{{ $.ImageName }}/node-labeller/
   to: /usr/bin
   before: setup
-# - image: virt-artifact-classic-go
-#   add: /kubevirt-binaries/
-#   to: /kubevirt-binaries
-#   after: install
 git:
   - add: /images/{{ $.ImageName }}
     to: /

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -165,7 +165,7 @@ shell:
   - |
     [[ ! -e /usr/bin/cp ]] && ln -s /bin/cp /usr/bin/cp
   - mkdir -p /init/usr/bin && ln -s /usr/bin/container-disk /init/usr/bin/container-disk
-# Source https://github.com/kubevirt/kubevirt/blob/v1.0.0/cmd/virt-launcher/BUILD.bazel
+# Source https://github.com/kubevirt/kubevirt/blob/v1.3.1/cmd/virt-launcher/BUILD.bazel
 #docker:
 #  ENTRYPOINT: ["/usr/bin/virt-launcher"]
 ---

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -52,35 +52,48 @@ import:
   after: install
   includePaths:
   - .version
-- image: virt-artifact
-  add: /images/kubevirt/{{ $.ImageName }}:latest/etc/libvirt
+- image: virt-artifact-classic-go
+  add: /kubevirt/cmd/{{ $.ImageName }}
   to: /etc/libvirt
   after: install
   includePaths:
   - qemu.conf
   - virtqemud.conf
+# - image: virt-artifact
+#   add: /images/kubevirt/{{ $.ImageName }}:latest/etc/libvirt
+#   to: /etc/libvirt
+#   after: install
+#   includePaths:
+#   - qemu.conf
+#   - virtqemud.conf
 - image: virt-artifact
   add: /images/kubevirt/{{ $.ImageName }}:latest/etc
   to: /etc
   after: install
   includePaths:
   - nsswitch.conf
-- image: virt-artifact
-  add: /images/kubevirt/{{ $.ImageName }}:latest/usr/bin
+# - image: virt-artifact
+  # add: /images/kubevirt/{{ $.ImageName }}:latest/usr/bin
+- image: virt-artifact-classic-go
+  add: /kubevirt-binaries/
   to: /usr/bin
   before: setup
   includePaths:
   - container-disk
-  - node-labeller.sh
   - virt-freezer
   - virt-launcher
   - virt-launcher-monitor
   - virt-probe
   - virt-tail
+  # - kubevirt/cmd/virt-launcher/node-labeller
 - image: virt-artifact-classic-go
-  add: /kubevirt-binaries/
-  to: /kubevirt-binaries
-  after: install
+  add: /kubevirt/cmd/virt-launcher/node-labeller/
+  to: /usr/bin
+  before: setup
+# - image: virt-artifact-classic-go
+#   add: /kubevirt-binaries/
+#   to: /kubevirt-binaries
+#   after: install
 git:
   - add: /images/{{ $.ImageName }}
     to: /
@@ -312,3 +325,7 @@ shell:
     echo "Build RPMs from:" /home/builder/*.rpm
     echo "Note: time consuming operation, be patient ..."
     su - builder -c 'trap "echo Build log tail: ; tail -n 1024 /tmp/build.log" EXIT ; rpm -ba /home/builder/RPM/SPECS/edk2.spec > /tmp/build.log 2>&1'
+# ---
+# image: {{ $.ImageName }}-dir-sctruct
+# final: false
+# from: {{ .Images.DISTROLESS_ALT_P11 }}

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -47,7 +47,7 @@ import:
 
 # Add kubeivrt files from virt-artifact.
 - image: virt-artifact-classic-go
-  add: /images/kubevirt/
+  add: /kubevirt/
   to: /
   after: install
   includePaths:

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -47,7 +47,7 @@ import:
 
 # Add kubeivrt files from virt-artifact.
 - image: virt-artifact
-  add: /kubevirt/
+  add: /kubevirt-config-files/
   to: /
   after: install
   includePaths:
@@ -76,7 +76,6 @@ import:
   - virt-launcher-monitor
   - virt-probe
   - virt-tail
-  # - kubevirt/cmd/virt-launcher/node-labeller
 - image: virt-artifact
   add: /kubevirt/cmd/{{ $.ImageName }}/node-labeller/
   to: /usr/bin

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -117,7 +117,6 @@ shell:
     seabios \
     libffi8 \
     swtpm-tools \
-    glibc \
     libvirt-client==10.2.0-alt1 \
     libvirt-daemon-driver-qemu==10.2.0-alt1 \
     qemu-kvm-core==9.0.2-alt2

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -52,12 +52,6 @@ import:
   after: install
   includePaths:
   - .version
-# - image: virt-artifact
-#   add: /images/kubevirt/{{ $.ImageName }}:latest/
-#   to: /
-#   after: install
-#   includePaths:
-#   - .version
 - image: virt-artifact-classic-go
   add: /kubevirt/cmd/{{ $.ImageName }}/
   to: /etc/libvirt
@@ -65,30 +59,12 @@ import:
   includePaths:
   - qemu.conf
   - virtqemud.conf
-# - image: virt-artifact
-#   add: /images/kubevirt/{{ $.ImageName }}:latest/etc/libvirt
-#   to: /etc/libvirt
-#   after: install
-#   includePaths:
-#   - qemu.conf
-#   - virtqemud.conf
 - image: virt-artifact-classic-go
   add: /kubevirt/cmd/{{ $.ImageName }}/
   to: /etc
   after: install
   includePaths:
   - nsswitch.conf
-  # - group
-  # - passwd
-#============
-# - image: virt-artifact
-#   add: /images/kubevirt/{{ $.ImageName }}:latest/etc
-#   to: /etc
-#   after: install
-#   includePaths:
-#   - nsswitch.conf
-# - image: virt-artifact
-  # add: /images/kubevirt/{{ $.ImageName }}:latest/usr/bin
 - image: virt-artifact-classic-go
   add: /kubevirt-binaries/
   to: /usr/bin
@@ -336,7 +312,3 @@ shell:
     echo "Build RPMs from:" /home/builder/*.rpm
     echo "Note: time consuming operation, be patient ..."
     su - builder -c 'trap "echo Build log tail: ; tail -n 1024 /tmp/build.log" EXIT ; rpm -ba /home/builder/RPM/SPECS/edk2.spec > /tmp/build.log 2>&1'
-# ---
-# image: {{ $.ImageName }}-dir-sctruct
-# final: false
-# from: {{ .Images.DISTROLESS_ALT_P11 }}

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -78,9 +78,9 @@ import:
   - virt-probe
   - virt-tail
 - image: virt-artifact-classic-go
-  add: /kubevirt-binaries
+  add: /kubevirt-binaries/
   to: /kubevirt-binaries
-  after: setup
+  after: install
 git:
   - add: /images/{{ $.ImageName }}
     to: /

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -46,26 +46,26 @@ import:
   - liboverride.so
 
 # Add kubeivrt files from virt-artifact.
-- image: virt-artifact-classic-go
+- image: virt-artifact
   add: /kubevirt/
   to: /
   after: install
   includePaths:
   - .version
-- image: virt-artifact-classic-go
+- image: virt-artifact
   add: /kubevirt/cmd/{{ $.ImageName }}/
   to: /etc/libvirt
   after: install
   includePaths:
   - qemu.conf
   - virtqemud.conf
-- image: virt-artifact-classic-go
+- image: virt-artifact
   add: /kubevirt/cmd/{{ $.ImageName }}/
   to: /etc
   after: install
   includePaths:
   - nsswitch.conf
-- image: virt-artifact-classic-go
+- image: virt-artifact
   add: /kubevirt-binaries/
   to: /usr/bin
   before: setup
@@ -77,7 +77,7 @@ import:
   - virt-probe
   - virt-tail
   # - kubevirt/cmd/virt-launcher/node-labeller
-- image: virt-artifact-classic-go
+- image: virt-artifact
   add: /kubevirt/cmd/{{ $.ImageName }}/node-labeller/
   to: /usr/bin
   before: setup

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -77,6 +77,10 @@ import:
   - virt-launcher-monitor
   - virt-probe
   - virt-tail
+- image: virt-artifact-classic-go
+  add: /kubevirt-binaries
+  to: /kubevirt-binaries
+  after: setup
 git:
   - add: /images/{{ $.ImageName }}
     to: /
@@ -114,6 +118,7 @@ shell:
     seabios \
     libffi8 \
     swtpm-tools \
+    glibc \
     libvirt-client==10.2.0-alt1 \
     libvirt-daemon-driver-qemu==10.2.0-alt1 \
     qemu-kvm-core==9.0.2-alt2

--- a/images/virt-operator/werf.inc.yaml
+++ b/images/virt-operator/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ $.ImageName }}
-from: {{  .Images.DISTROLESS_ALT_P11 }}
+from: {{ .Images.DISTROLESS_ALT_P11 }}
 import:
 - image: virt-artifact
   add: /kubevirt-binaries/
@@ -11,18 +11,19 @@ import:
   - virt-operator
   before: setup
 - image: virt-artifact
-  add: /kubevirt/cmd/virt-launcher/
+  add: /kubevirt-config-files/
   to: /etc
   includePaths:
   - passwd
   - group
-  before: setup
-- image: virt-artifact
-  add: /kubevirt/
-  to: /
-  includePaths:
   - .version
-  after: setup
+  before: setup
+# - image: virt-artifact
+#   add: /kubevirt-config-files/
+#   to: /
+#   includePaths:
+#   - .version
+#   after: setup
 # Source https://github.com/kubevirt/kubevirt/blob/main/cmd/virt-operator/BUILD.bazel
 docker:
   ENTRYPOINT: ["/usr/bin/virt-operator"]

--- a/images/virt-operator/werf.inc.yaml
+++ b/images/virt-operator/werf.inc.yaml
@@ -18,7 +18,7 @@ import:
   - group
   - .version
   before: setup
-# Source https://github.com/kubevirt/kubevirt/blob/main/cmd/virt-operator/BUILD.bazel
+# Source https://github.com/kubevirt/kubevirt/blob/v1.3.1/cmd/virt-operator/BUILD.bazel
 docker:
   ENTRYPOINT: ["/usr/bin/virt-operator"]
   USER: 1001

--- a/images/virt-operator/werf.inc.yaml
+++ b/images/virt-operator/werf.inc.yaml
@@ -2,7 +2,7 @@
 image: {{ $.ImageName }}
 from: {{  .Images.DISTROLESS_ALT_P11 }}
 import:
-- image: virt-artifact-classic-go
+- image: virt-artifact
   add: /kubevirt-binaries/
   to: /usr/bin
   includePaths:
@@ -10,14 +10,14 @@ import:
   - csv-generator
   - virt-operator
   before: setup
-- image: virt-artifact-classic-go
+- image: virt-artifact
   add: /kubevirt/cmd/virt-launcher/
   to: /etc
   includePaths:
   - passwd
   - group
   before: setup
-- image: virt-artifact-classic-go
+- image: virt-artifact
   add: /kubevirt/
   to: /
   includePaths:

--- a/images/virt-operator/werf.inc.yaml
+++ b/images/virt-operator/werf.inc.yaml
@@ -1,20 +1,55 @@
 ---
 image: {{ $.ImageName }}
-from: {{ .Images.BASE_SCRATCH }}
+from: {{  .Images.DISTROLESS_ALT_P11 }}
+# from: {{ .Images.BASE_SCRATCH }}
 import:
-- image: virt-artifact
+- image: virt-artifact-classic-go
   add: /images/kubevirt/{{ $.ImageName }}:latest
   excludePaths:
   - 'sys'
   to: /
   before: setup
-- image: virt-artifact
-  add: /
-  to: /
+- image: virt-artifact-classic-go
+  add: /kubevirt-binaries/
+  to: /usr/bin
   includePaths:
   - 'virtctl'
+  - csv-generator
+  - virt-operator
   before: setup
+- image: virt-artifact-classic-go
+  add: /kubevirt/cmd/virt-launcher/
+  to: /etc
+  includePaths:
+  - passwd
+  - group
+  before: setup
+- image: virt-artifact-classic-go
+  add: /kubevirt/
+  to: /
+  includePaths:
+  - .version
+  after: setup
 # Source https://github.com/kubevirt/kubevirt/blob/main/cmd/virt-operator/BUILD.bazel
 docker:
   ENTRYPOINT: ["/usr/bin/virt-operator"]
   USER: 1001
+# image: {{ $.ImageName }}
+# from: {{ .Images.BASE_SCRATCH }}
+# import:
+# - image: virt-artifact
+#   add: /images/kubevirt/{{ $.ImageName }}:latest
+#   excludePaths:
+#   - 'sys'
+#   to: /
+#   before: setup
+# - image: virt-artifact
+#   add: /
+#   to: /
+#   includePaths:
+#   - 'virtctl'
+#   before: setup
+# # Source https://github.com/kubevirt/kubevirt/blob/main/cmd/virt-operator/BUILD.bazel
+# docker:
+#   ENTRYPOINT: ["/usr/bin/virt-operator"]
+#   USER: 1001

--- a/images/virt-operator/werf.inc.yaml
+++ b/images/virt-operator/werf.inc.yaml
@@ -4,12 +4,6 @@ from: {{  .Images.DISTROLESS_ALT_P11 }}
 # from: {{ .Images.BASE_SCRATCH }}
 import:
 - image: virt-artifact-classic-go
-  add: /images/kubevirt/{{ $.ImageName }}:latest
-  excludePaths:
-  - 'sys'
-  to: /
-  before: setup
-- image: virt-artifact-classic-go
   add: /kubevirt-binaries/
   to: /usr/bin
   includePaths:

--- a/images/virt-operator/werf.inc.yaml
+++ b/images/virt-operator/werf.inc.yaml
@@ -18,12 +18,6 @@ import:
   - group
   - .version
   before: setup
-# - image: virt-artifact
-#   add: /kubevirt-config-files/
-#   to: /
-#   includePaths:
-#   - .version
-#   after: setup
 # Source https://github.com/kubevirt/kubevirt/blob/main/cmd/virt-operator/BUILD.bazel
 docker:
   ENTRYPOINT: ["/usr/bin/virt-operator"]

--- a/images/virt-operator/werf.inc.yaml
+++ b/images/virt-operator/werf.inc.yaml
@@ -1,7 +1,6 @@
 ---
 image: {{ $.ImageName }}
 from: {{  .Images.DISTROLESS_ALT_P11 }}
-# from: {{ .Images.BASE_SCRATCH }}
 import:
 - image: virt-artifact-classic-go
   add: /kubevirt-binaries/
@@ -28,22 +27,3 @@ import:
 docker:
   ENTRYPOINT: ["/usr/bin/virt-operator"]
   USER: 1001
-# image: {{ $.ImageName }}
-# from: {{ .Images.BASE_SCRATCH }}
-# import:
-# - image: virt-artifact
-#   add: /images/kubevirt/{{ $.ImageName }}:latest
-#   excludePaths:
-#   - 'sys'
-#   to: /
-#   before: setup
-# - image: virt-artifact
-#   add: /
-#   to: /
-#   includePaths:
-#   - 'virtctl'
-#   before: setup
-# # Source https://github.com/kubevirt/kubevirt/blob/main/cmd/virt-operator/BUILD.bazel
-# docker:
-#   ENTRYPOINT: ["/usr/bin/virt-operator"]
-#   USER: 1001

--- a/werf.yaml
+++ b/werf.yaml
@@ -26,6 +26,19 @@ configVersion: 1
     {{- end }}
 
   {{- end }}
+
+# Distroless altlinux Images
+{{- $AltDistroVirtImagesPath := "base-images/alt_image_versions.yml" }}
+{{ $baseImages := (.Files.Get $AltDistroVirtImagesPath | fromYaml) }}
+
+  {{- range $k, $v := $baseImages }}
+    {{ $altDistroVirtImagePath := (printf "%s%s" $baseImages.REGISTRY_PATH (trimSuffix "/" $v)) }}
+
+    {{- if ne $k "REGISTRY_PATH" }}
+      {{- $_ := set $.Images $k $altDistroVirtImagePath }}
+    {{- end }}
+
+  {{- end }}
 # Modules_images
 {{- define "module_image_template" }}
   {{- if eq .ImageInstructionType "Dockerfile" }}


### PR DESCRIPTION
## Description

Switch to building kubevirt components on go and werf instead of building in bazel and werf

## Why do we need it, and what problem does it solve?

We need to simplify the build, make it more predictable and possible in closed environments

## What is the expected result?

All pods with prefix `virt-` in `d8-virtualization` will be restarted
All VM `'firmware'` will be updated by vm migration 

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
