### PR TITLE
fix(cvi,vi): unlock pending vi/cvi from vd ref

### DIFF
--- a/api/core/v1alpha2/cvicondition/condition.go
+++ b/api/core/v1alpha2/cvicondition/condition.go
@@ -56,6 +56,8 @@ const (
 	ClusterImageNotReady DatasourceReadyReason = "ClusterImageNotReady"
 	// VirtualDiskNotReady indicates that the `VirtualDisk` datasource is not ready, which prevents the import process from starting.
 	VirtualDiskNotReady DatasourceReadyReason = "VirtualDiskNotReady"
+	// VirtualDiskInUseInRunningVirtualMachine indicates that the `VirtualDisk` attached to running `VirtualMachine`
+	VirtualDiskInUseInRunningVirtualMachine DatasourceReadyReason = "VirtualDiskInUseInRunningVirtualMachine"
 
 	// WaitForUserUpload indicates that the `ClusterVirtualImage` is waiting for the user to upload a datasource for the import process to continue.
 	WaitForUserUpload ReadyReason = "WaitForUserUpload"

--- a/api/core/v1alpha2/vdcondition/condition.go
+++ b/api/core/v1alpha2/vdcondition/condition.go
@@ -34,7 +34,7 @@ const (
 	SnapshottingType Type = "Snapshotting"
 	// StorageClassReadyType indicates whether the storage class is ready.
 	StorageClassReadyType Type = "StorageClassReady"
-	// InUseType indicates whether the VirtualDisk is attached to a running VirtualMachine or is being used in a process of a VirtualImage creation.
+	// InUseType indicates whether the VirtualDisk is attached to a running VirtualMachine or is being used in a process of an image creation.
 	InUseType Type = "InUse"
 )
 

--- a/api/core/v1alpha2/vdcondition/condition.go
+++ b/api/core/v1alpha2/vdcondition/condition.go
@@ -50,7 +50,7 @@ type (
 	// StorageClassReadyReason represents the various reasons for the Storageclass ready condition type.
 	StorageClassReadyReason string
 	// InUseReason represents the various reasons for the InUse condition type.
-	InUseReason = string
+	InUseReason string
 )
 
 func (s DatasourceReadyReason) String() string {
@@ -70,6 +70,10 @@ func (s SnapshottingReason) String() string {
 }
 
 func (s StorageClassReadyReason) String() string {
+	return string(s)
+}
+
+func (s InUseReason) String() string {
 	return string(s)
 }
 
@@ -123,8 +127,8 @@ const (
 	// StorageClassNotFound indicates that the storage class is not ready
 	StorageClassNotFound StorageClassReadyReason = "StorageClassNotFound"
 
-	// InUseByVirtualImage indicates that the VirtualDisk is being used in a process of a VirtualImage creation.
-	InUseByVirtualImage InUseReason = "InUseByVirtualImage"
-	// InUseByVirtualMachine indicates that the VirtualDisk is attached to a running VirtualMachine.
-	InUseByVirtualMachine InUseReason = "InUseByVirtualMachine"
+	// AllowedForImageUsage indicates that the VirtualDisk is permitted for use in a process of an image creation.
+	AllowedForImageUsage InUseReason = "AllowedForImageUsage"
+	// AllowedForVirtualMachineUsage indicates that the VirtualDisk is permitted for use by a running VirtualMachine.
+	AllowedForVirtualMachineUsage InUseReason = "AllowedForVirtualMachineUsage"
 )

--- a/api/core/v1alpha2/vdcondition/condition.go
+++ b/api/core/v1alpha2/vdcondition/condition.go
@@ -34,6 +34,8 @@ const (
 	SnapshottingType Type = "Snapshotting"
 	// StorageClassReadyType indicates whether the storage class is ready.
 	StorageClassReadyType Type = "StorageClassReady"
+	// InUseType indicates whether the VirtualDisk is attached to a running VirtualMachine or is being used in a process of a VirtualImage creation.
+	InUseType Type = "InUse"
 )
 
 type (
@@ -47,6 +49,8 @@ type (
 	SnapshottingReason string
 	// StorageClassReadyReason represents the various reasons for the Storageclass ready condition type.
 	StorageClassReadyReason string
+	// InUseReason represents the various reasons for the InUse condition type.
+	InUseReason = string
 )
 
 func (s DatasourceReadyReason) String() string {
@@ -118,4 +122,9 @@ const (
 	StorageClassReady StorageClassReadyReason = "StorageClassReady"
 	// StorageClassNotFound indicates that the storage class is not ready
 	StorageClassNotFound StorageClassReadyReason = "StorageClassNotFound"
+
+	// InUseByVirtualImage indicates that the VirtualDisk is being used in a process of a VirtualImage creation.
+	InUseByVirtualImage InUseReason = "InUseByVirtualImage"
+	// InUseByVirtualMachine indicates that the VirtualDisk is attached to a running VirtualMachine.
+	InUseByVirtualMachine InUseReason = "InUseByVirtualMachine"
 )

--- a/api/core/v1alpha2/vicondition/condition.go
+++ b/api/core/v1alpha2/vicondition/condition.go
@@ -64,6 +64,8 @@ const (
 	ClusterImageNotReady DatasourceReadyReason = "ClusterImageNotReady"
 	// VirtualDiskNotReady indicates that the `VirtualDisk` datasource is not ready, which prevents the import process from starting.
 	VirtualDiskNotReady DatasourceReadyReason = "VirtualDiskNotReady"
+	// VirtualDiskInUseInRunningVirtualMachine indicates that the `VirtualDisk` attached to running `VirtualMachine`
+	VirtualDiskInUseInRunningVirtualMachine DatasourceReadyReason = "VirtualDiskInUseInRunningVirtualMachine"
 
 	// WaitForUserUpload indicates that the `VirtualImage` is waiting for the user to upload a datasource for the import process to continue.
 	WaitForUserUpload ReadyReason = "WaitForUserUpload"

--- a/images/virtualization-artifact/pkg/controller/cvi/cvi_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/cvi_reconciler.go
@@ -38,6 +38,7 @@ import (
 	"github.com/deckhouse/virtualization-controller/pkg/controller/watchers"
 	"github.com/deckhouse/virtualization-controller/pkg/logger"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
 )
 
 type Handler interface {
@@ -165,7 +166,14 @@ func (r *Reconciler) SetupController(_ context.Context, mgr manager.Manager, ctr
 					return false
 				}
 
-				return oldVD.Status.Phase != newVD.Status.Phase
+				oldInUseCondition, _ := service.GetCondition(vdcondition.InUseType, oldVD.Status.Conditions)
+				newInUseCondition, _ := service.GetCondition(vdcondition.InUseType, newVD.Status.Conditions)
+
+				if oldVD.Status.Phase != newVD.Status.Phase || len(oldVD.Status.AttachedToVirtualMachines) != len(newVD.Status.AttachedToVirtualMachines) || oldInUseCondition.Status != newInUseCondition.Status {
+					return true
+				}
+
+				return false
 			},
 		},
 	); err != nil {

--- a/images/virtualization-artifact/pkg/controller/cvi/cvi_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/cvi_reconciler.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/watchers"
 	"github.com/deckhouse/virtualization-controller/pkg/logger"
@@ -166,8 +167,8 @@ func (r *Reconciler) SetupController(_ context.Context, mgr manager.Manager, ctr
 					return false
 				}
 
-				oldInUseCondition, _ := service.GetCondition(vdcondition.InUseType, oldVD.Status.Conditions)
-				newInUseCondition, _ := service.GetCondition(vdcondition.InUseType, newVD.Status.Conditions)
+				oldInUseCondition, _ := conditions.GetCondition(vdcondition.InUseType, oldVD.Status.Conditions)
+				newInUseCondition, _ := conditions.GetCondition(vdcondition.InUseType, newVD.Status.Conditions)
 
 				if oldVD.Status.Phase != newVD.Status.Phase || len(oldVD.Status.AttachedToVirtualMachines) != len(newVD.Status.AttachedToVirtualMachines) || oldInUseCondition.Status != newInUseCondition.Status {
 					return true

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/datasource_ready.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/datasource_ready.go
@@ -89,7 +89,7 @@ func (h DatasourceReadyHandler) Handle(ctx context.Context, cvi *virtv2.ClusterV
 			Reason(cvicondition.VirtualDiskNotReady).
 			Message(service.CapitalizeFirstLetter(err.Error()))
 		return reconcile.Result{}, nil
-	case errors.As(err, &source.VirtualDiskInUseError{}):
+	case errors.As(err, &source.VirtualDiskNotAllowedForUseError{}):
 		cb.
 			Status(metav1.ConditionFalse).
 			Reason(cvicondition.VirtualDiskInUseInRunningVirtualMachine).

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/datasource_ready.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/datasource_ready.go
@@ -89,10 +89,10 @@ func (h DatasourceReadyHandler) Handle(ctx context.Context, cvi *virtv2.ClusterV
 			Reason(cvicondition.VirtualDiskNotReady).
 			Message(service.CapitalizeFirstLetter(err.Error()))
 		return reconcile.Result{}, nil
-	case errors.As(err, &source.VirtualDiskAttachedToRunningVMError{}):
+	case errors.As(err, &source.VirtualDiskInUseError{}):
 		cb.
 			Status(metav1.ConditionFalse).
-			Reason(cvicondition.VirtualDiskNotReady).
+			Reason(cvicondition.VirtualDiskInUseInRunningVirtualMachine).
 			Message(service.CapitalizeFirstLetter(err.Error()))
 		return reconcile.Result{}, nil
 	default:

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/errors.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/errors.go
@@ -65,18 +65,16 @@ func NewVirtualDiskNotReadyError(name string) error {
 	}
 }
 
-type VirtualDiskAttachedToRunningVMError struct {
-	name   string
-	vmName string
+type VirtualDiskInUseError struct {
+	name string
 }
 
-func (e VirtualDiskAttachedToRunningVMError) Error() string {
-	return fmt.Sprintf("VirtualDisk %q attached to running VirtualMachine %q", e.name, e.vmName)
+func (e VirtualDiskInUseError) Error() string {
+	return fmt.Sprintf("reading from the VirtualDisk is not possible while it is in use by the running VirtualMachine/%s", e.name)
 }
 
-func NewVirtualDiskAttachedToRunningVMError(name, vmName string) error {
-	return VirtualDiskAttachedToRunningVMError{
-		name:   name,
-		vmName: vmName,
+func NewVirtualDiskInUseError(name string) error {
+	return VirtualDiskInUseError{
+		name: name,
 	}
 }

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/errors.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/errors.go
@@ -65,16 +65,16 @@ func NewVirtualDiskNotReadyError(name string) error {
 	}
 }
 
-type VirtualDiskInUseError struct {
+type VirtualDiskNotAllowedForUseError struct {
 	name string
 }
 
-func (e VirtualDiskInUseError) Error() string {
-	return fmt.Sprintf("reading from the VirtualDisk is not possible while it is in use by the running VirtualMachine/%s", e.name)
+func (e VirtualDiskNotAllowedForUseError) Error() string {
+	return fmt.Sprintf("use of VirtualDisk %s is not allowed, it may be connected to a running VirtualMachine", e.name)
 }
 
-func NewVirtualDiskInUseError(name string) error {
-	return VirtualDiskInUseError{
+func NewVirtualDiskNotAllowedForUseError(name string) error {
+	return VirtualDiskNotAllowedForUseError{
 		name: name,
 	}
 }

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref_vd.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref_vd.go
@@ -228,10 +228,8 @@ func (ds ObjectRefVirtualDisk) Validate(ctx context.Context, cvi *virtv2.Cluster
 	}
 
 	inUseCondition, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
-	if inUseCondition.Status == metav1.ConditionTrue {
-		if inUseCondition.Reason == vdcondition.AllowedForImageUsage.String() {
-			return nil
-		}
+	if inUseCondition.Status == metav1.ConditionTrue && inUseCondition.Reason == vdcondition.AllowedForImageUsage.String() {
+		return nil
 	}
 
 	return NewVirtualDiskNotAllowedForUseError(vd.Name)

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref_vd.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref_vd.go
@@ -228,7 +228,9 @@ func (ds ObjectRefVirtualDisk) Validate(ctx context.Context, cvi *virtv2.Cluster
 	}
 
 	inUseCondition, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
-	if inUseCondition.Status == metav1.ConditionTrue && inUseCondition.Reason == vdcondition.AllowedForImageUsage.String() {
+	if inUseCondition.Status == metav1.ConditionTrue &&
+		inUseCondition.Reason == vdcondition.AllowedForImageUsage.String() &&
+		inUseCondition.ObservedGeneration == vd.Status.ObservedGeneration {
 		return nil
 	}
 

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref_vd.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref_vd.go
@@ -40,7 +40,6 @@ import (
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/cvicondition"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
-	"github.com/deckhouse/virtualization/api/core/v1alpha2/vicondition"
 )
 
 type ObjectRefVirtualDisk struct {
@@ -230,10 +229,10 @@ func (ds ObjectRefVirtualDisk) Validate(ctx context.Context, cvi *virtv2.Cluster
 
 	inUseCondition, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
 	if inUseCondition.Status == metav1.ConditionTrue {
-		if inUseCondition.Reason == vdcondition.InUseByVirtualMachine {
-			return NewVirtualDiskInUseError(vd.Name)
+		if inUseCondition.Reason == vdcondition.AllowedForImageUsage.String() {
+			return nil
 		}
 	}
 
-	return nil
+	return NewVirtualDiskNotAllowedForUseError(vd.Name)
 }

--- a/images/virtualization-artifact/pkg/controller/service/errors.go
+++ b/images/virtualization-artifact/pkg/controller/service/errors.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package service
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 var (
 	ErrStorageClassNotFound        = errors.New("storage class not found")
@@ -30,3 +33,31 @@ var (
 	ErrIPAddressAlreadyExist = errors.New("the IP address is already allocated")
 	ErrIPAddressOutOfRange   = errors.New("the IP address is out of range")
 )
+
+type VirtualDiskUsedByImageError struct {
+	vdName string
+}
+
+func (e VirtualDiskUsedByImageError) Error() string {
+	return fmt.Sprintf("the virtual disk %q already used by creating image", e.vdName)
+}
+
+func NewVirtualDiskUsedByImageError(name string) error {
+	return VirtualDiskUsedByImageError{
+		vdName: name,
+	}
+}
+
+type VirtualDiskUsedByVirtualMachineError struct {
+	vdName string
+}
+
+func (e VirtualDiskUsedByVirtualMachineError) Error() string {
+	return fmt.Sprintf("the virtual disk %q already used by running virtual machine", e.vdName)
+}
+
+func NewVirtualDiskUsedByVirtualMachineError(name string) error {
+	return VirtualDiskUsedByVirtualMachineError{
+		vdName: name,
+	}
+}

--- a/images/virtualization-artifact/pkg/controller/vd/internal/inuse.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/inuse.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	virtv1 "kubevirt.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
+	"github.com/deckhouse/virtualization-controller/pkg/sdk/framework/helper"
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmcondition"
+)
+
+type InUseHandler struct {
+	client client.Client
+}
+
+func NewInUseHandler(client client.Client) *InUseHandler {
+	return &InUseHandler{
+		client: client,
+	}
+}
+
+func (h InUseHandler) Handle(ctx context.Context, vd *virtv2.VirtualDisk) (reconcile.Result, error) {
+	inUseCondition, ok := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
+	if !ok {
+		cb := conditions.NewConditionBuilder(vdcondition.InUseType).
+			Status(metav1.ConditionUnknown).
+			Reason(conditions.ReasonUnknown).
+			Generation(vd.Generation)
+		conditions.SetCondition(cb, &vd.Status.Conditions)
+		inUseCondition = cb.Condition()
+	}
+
+	allowUseForVM, allowUseForImage := false, false
+
+	var vms virtv2.VirtualMachineList
+	err := h.client.List(ctx, &vms, &client.ListOptions{
+		Namespace: vd.GetNamespace(),
+	})
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("error getting virtual machines: %w", err)
+	}
+
+	for _, vm := range vms.Items {
+		if h.isVDAttachedToVM(vd.GetName(), vm) {
+			if vm.Status.Phase != virtv2.MachineStopped {
+				allowUseForVM = isVMReady(vm.Status.Conditions)
+
+				if allowUseForVM {
+					break
+				}
+			} else {
+				kvvm, err := helper.FetchObject(ctx, types.NamespacedName{Name: vm.Name, Namespace: vm.Namespace}, h.client, &virtv1.VirtualMachine{})
+				if err != nil {
+					return reconcile.Result{}, fmt.Errorf("error getting kvvms: %w", err)
+				}
+
+				if kvvm != nil && kvvm.Status.StateChangeRequests != nil {
+					allowUseForVM = true
+					break
+				}
+			}
+		}
+	}
+
+	var vis virtv2.VirtualImageList
+	err = h.client.List(ctx, &vis, &client.ListOptions{
+		Namespace: vd.GetNamespace(),
+	})
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("error getting virtual images: %w", err)
+	}
+
+	allowedPhases := []virtv2.ImagePhase{virtv2.ImageProvisioning, virtv2.ImagePending}
+
+	for _, vi := range vis.Items {
+		if slices.Contains(allowedPhases, vi.Status.Phase) && vi.Spec.DataSource.Type == virtv2.DataSourceTypeObjectRef && vi.Spec.DataSource.ObjectRef != nil && vi.Spec.DataSource.ObjectRef.Kind == virtv2.VirtualDiskKind {
+			allowUseForImage = true
+			break
+		}
+	}
+
+	var cvis virtv2.ClusterVirtualImageList
+	err = h.client.List(ctx, &cvis, &client.ListOptions{})
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("error getting cluster virtual images: %w", err)
+	}
+	for _, cvi := range cvis.Items {
+		if slices.Contains(allowedPhases, cvi.Status.Phase) && cvi.Spec.DataSource.Type == virtv2.DataSourceTypeObjectRef && cvi.Spec.DataSource.ObjectRef != nil && cvi.Spec.DataSource.ObjectRef.Kind == virtv2.VirtualDiskKind {
+			allowUseForImage = true
+		}
+	}
+
+	cb := conditions.NewConditionBuilder(vdcondition.InUseType)
+
+	switch {
+	case allowUseForVM && inUseCondition.Status == metav1.ConditionUnknown:
+		if inUseCondition.Reason != vdcondition.AllowedForVirtualMachineUsage.String() {
+			cb.
+				Generation(vd.Generation).
+				Status(metav1.ConditionTrue).
+				Reason(vdcondition.AllowedForVirtualMachineUsage).
+				Message("")
+			conditions.SetCondition(cb, &vd.Status.Conditions)
+		}
+	case allowUseForImage && inUseCondition.Status == metav1.ConditionUnknown:
+		if inUseCondition.Reason != vdcondition.AllowedForImageUsage.String() {
+			cb.
+				Generation(vd.Generation).
+				Status(metav1.ConditionTrue).
+				Reason(vdcondition.AllowedForImageUsage).
+				Message("")
+			conditions.SetCondition(cb, &vd.Status.Conditions)
+		}
+	default:
+		if inUseCondition.Reason == vdcondition.AllowedForVirtualMachineUsage.String() && !allowUseForVM || inUseCondition.Reason == vdcondition.AllowedForImageUsage.String() && !allowUseForImage {
+			cb.
+				Generation(vd.Generation).
+				Status(metav1.ConditionUnknown).
+				Reason(conditions.ReasonUnknown).
+				Message("")
+			conditions.SetCondition(cb, &vd.Status.Conditions)
+		}
+
+		if allowUseForImage || allowUseForVM {
+			return reconcile.Result{Requeue: true}, nil
+		}
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (h InUseHandler) isVDAttachedToVM(vdName string, vm virtv2.VirtualMachine) bool {
+	for _, bda := range vm.Status.BlockDeviceRefs {
+		if bda.Kind == virtv2.DiskDevice && bda.Name == vdName {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isVMReady(conditions []metav1.Condition) bool {
+	critConditions := []string{
+		vmcondition.TypeIPAddressReady.String(),
+		vmcondition.TypeClassReady.String(),
+	}
+
+	for _, c := range conditions {
+		if slices.Contains(critConditions, c.Type) && c.Status == metav1.ConditionFalse {
+			return false
+		}
+	}
+
+	return true
+}

--- a/images/virtualization-artifact/pkg/controller/vd/internal/inuse_test.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/inuse_test.go
@@ -1,0 +1,492 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	virtv1 "kubevirt.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmcondition"
+)
+
+var _ = ginkgo.Describe("InUseHandler", func() {
+	var (
+		scheme  *runtime.Scheme
+		ctx     context.Context
+		handler *InUseHandler
+	)
+
+	ginkgo.BeforeEach(func() {
+		scheme = runtime.NewScheme()
+		gomega.Expect(clientgoscheme.AddToScheme(scheme)).To(gomega.Succeed())
+		gomega.Expect(virtv2.AddToScheme(scheme)).To(gomega.Succeed())
+		gomega.Expect(virtv1.AddToScheme(scheme)).To(gomega.Succeed())
+
+		ctx = context.TODO()
+	})
+
+	ginkgo.Context("when VirtualDisk is not in use", func() {
+		ginkgo.It("must set status Unknown and reason Unknown", func() {
+			vd := &virtv2.VirtualDisk{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vd",
+					Namespace: "default",
+				},
+				Status: virtv2.VirtualDiskStatus{
+					Conditions: []metav1.Condition{},
+				},
+			}
+
+			k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(vd).Build()
+			handler = NewInUseHandler(k8sClient)
+
+			result, err := handler.Handle(ctx, vd)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(result).To(gomega.Equal(ctrl.Result{}))
+
+			cond, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
+			gomega.Expect(cond).ToNot(gomega.BeNil())
+			gomega.Expect(cond.Status).To(gomega.Equal(metav1.ConditionUnknown))
+		})
+	})
+
+	ginkgo.Context("when VirtualDisk is used by running VirtualMachine", func() {
+		ginkgo.It("must set status True and reason AllowedForVirtualMachineUsage", func() {
+			vd := &virtv2.VirtualDisk{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vd",
+					Namespace: "default",
+				},
+				Status: virtv2.VirtualDiskStatus{
+					Conditions: []metav1.Condition{},
+				},
+			}
+
+			vm := &virtv2.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vm",
+					Namespace: "default",
+				},
+				Spec: virtv2.VirtualMachineSpec{
+					BlockDeviceRefs: []virtv2.BlockDeviceSpecRef{
+						{
+							Kind: virtv2.DiskDevice,
+							Name: vd.Name,
+						},
+					},
+				},
+				Status: virtv2.VirtualMachineStatus{
+					Phase: virtv2.MachineRunning,
+					BlockDeviceRefs: []virtv2.BlockDeviceStatusRef{
+						{
+							Kind: virtv2.DiskDevice,
+							Name: vd.Name,
+						},
+					},
+				},
+			}
+
+			k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(vd, vm).Build()
+			handler = NewInUseHandler(k8sClient)
+
+			result, err := handler.Handle(ctx, vd)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(result).To(gomega.Equal(ctrl.Result{}))
+
+			cond, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
+			gomega.Expect(cond).ToNot(gomega.BeNil())
+			gomega.Expect(cond.Status).To(gomega.Equal(metav1.ConditionTrue))
+			gomega.Expect(cond.Reason).To(gomega.Equal(vdcondition.AllowedForVirtualMachineUsage.String()))
+		})
+	})
+
+	ginkgo.Context("when VirtualDisk is used by not ready VirtualMachine", func() {
+		ginkgo.It("must set status True and reason AllowedForVirtualMachineUsage", func() {
+			vd := &virtv2.VirtualDisk{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vd",
+					Namespace: "default",
+				},
+				Status: virtv2.VirtualDiskStatus{
+					Conditions: []metav1.Condition{},
+				},
+			}
+
+			vm := &virtv2.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vm",
+					Namespace: "default",
+				},
+				Status: virtv2.VirtualMachineStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   vmcondition.TypeMigrating.String(),
+							Status: metav1.ConditionFalse,
+						},
+						{
+							Type:   vmcondition.TypeIPAddressReady.String(),
+							Status: metav1.ConditionFalse,
+						},
+					},
+					BlockDeviceRefs: []virtv2.BlockDeviceStatusRef{
+						{
+							Kind: virtv2.DiskDevice,
+							Name: vd.Name,
+						},
+					},
+				},
+			}
+
+			k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(vd, vm).Build()
+			handler = NewInUseHandler(k8sClient)
+
+			result, err := handler.Handle(ctx, vd)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(result).To(gomega.Equal(ctrl.Result{}))
+
+			cond, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
+			gomega.Expect(cond).ToNot(gomega.BeNil())
+			gomega.Expect(cond.Status).To(gomega.Equal(metav1.ConditionUnknown))
+		})
+	})
+
+	ginkgo.Context("when VirtualDisk is used by VirtualImage", func() {
+		ginkgo.It("must set status True and reason AllowedForImageUsage", func() {
+			vd := &virtv2.VirtualDisk{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vd",
+					Namespace: "default",
+				},
+				Status: virtv2.VirtualDiskStatus{
+					Conditions: []metav1.Condition{},
+				},
+			}
+
+			vi := &virtv2.VirtualImage{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vi",
+					Namespace: "default",
+				},
+				Spec: virtv2.VirtualImageSpec{
+					DataSource: virtv2.VirtualImageDataSource{
+						Type: virtv2.DataSourceTypeObjectRef,
+						ObjectRef: &virtv2.VirtualImageObjectRef{
+							Kind: virtv2.VirtualDiskKind,
+							Name: "test-vd",
+						},
+					},
+				},
+				Status: virtv2.VirtualImageStatus{
+					Phase:      virtv2.ImageProvisioning,
+					Conditions: []metav1.Condition{},
+				},
+			}
+
+			k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(vd, vi).Build()
+			handler = NewInUseHandler(k8sClient)
+
+			result, err := handler.Handle(ctx, vd)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(result).To(gomega.Equal(ctrl.Result{}))
+
+			cond, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
+			gomega.Expect(cond).ToNot(gomega.BeNil())
+			gomega.Expect(cond.Status).To(gomega.Equal(metav1.ConditionTrue))
+			gomega.Expect(cond.Reason).To(gomega.Equal(vdcondition.AllowedForImageUsage.String()))
+		})
+	})
+
+	ginkgo.Context("when VirtualDisk is used by ClusterVirtualImage", func() {
+		ginkgo.It("must set status True and reason AllowedForImageUsage", func() {
+			vd := &virtv2.VirtualDisk{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vd",
+					Namespace: "default",
+				},
+				Status: virtv2.VirtualDiskStatus{
+					Conditions: []metav1.Condition{},
+				},
+			}
+
+			cvi := &virtv2.ClusterVirtualImage{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vi",
+					Namespace: "default",
+				},
+				Spec: virtv2.ClusterVirtualImageSpec{
+					DataSource: virtv2.ClusterVirtualImageDataSource{
+						Type: virtv2.DataSourceTypeObjectRef,
+						ObjectRef: &virtv2.ClusterVirtualImageObjectRef{
+							Kind:      virtv2.VirtualDiskKind,
+							Name:      "test-vd",
+							Namespace: "default",
+						},
+					},
+				},
+				Status: virtv2.ClusterVirtualImageStatus{
+					Phase:      virtv2.ImageProvisioning,
+					Conditions: []metav1.Condition{},
+				},
+			}
+
+			k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(vd, cvi).Build()
+			handler = NewInUseHandler(k8sClient)
+
+			result, err := handler.Handle(ctx, vd)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(result).To(gomega.Equal(ctrl.Result{}))
+
+			cond, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
+			gomega.Expect(cond).ToNot(gomega.BeNil())
+			gomega.Expect(cond.Status).To(gomega.Equal(metav1.ConditionTrue))
+			gomega.Expect(cond.Reason).To(gomega.Equal(vdcondition.AllowedForImageUsage.String()))
+		})
+	})
+
+	ginkgo.Context("when VirtualDisk is used by VirtualImage and VirtualMachine", func() {
+		ginkgo.It("must set status True and reason AllowedForVirtualMachineUsage", func() {
+			vd := &virtv2.VirtualDisk{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vd",
+					Namespace: "default",
+				},
+				Status: virtv2.VirtualDiskStatus{
+					Conditions: []metav1.Condition{},
+				},
+			}
+
+			vi := &virtv2.VirtualImage{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vi",
+					Namespace: "default",
+				},
+				Spec: virtv2.VirtualImageSpec{
+					DataSource: virtv2.VirtualImageDataSource{
+						Type: virtv2.DataSourceTypeObjectRef,
+						ObjectRef: &virtv2.VirtualImageObjectRef{
+							Kind: virtv2.VirtualDiskKind,
+							Name: "test-vd",
+						},
+					},
+				},
+				Status: virtv2.VirtualImageStatus{
+					Phase:      virtv2.ImageProvisioning,
+					Conditions: []metav1.Condition{},
+				},
+			}
+
+			vm := &virtv2.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vm",
+					Namespace: "default",
+				},
+				Status: virtv2.VirtualMachineStatus{
+					BlockDeviceRefs: []virtv2.BlockDeviceStatusRef{
+						{
+							Kind: virtv2.DiskDevice,
+							Name: vd.Name,
+						},
+					},
+				},
+			}
+
+			k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(vd, vi, vm).Build()
+			handler = NewInUseHandler(k8sClient)
+
+			result, err := handler.Handle(ctx, vd)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(result).To(gomega.Equal(ctrl.Result{}))
+
+			cond, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
+			gomega.Expect(cond).ToNot(gomega.BeNil())
+			gomega.Expect(cond.Status).To(gomega.Equal(metav1.ConditionTrue))
+			gomega.Expect(cond.Reason).To(gomega.Equal(vdcondition.AllowedForVirtualMachineUsage.String()))
+		})
+	})
+
+	ginkgo.Context("when VirtualDisk is used by VirtualMachine after create image", func() {
+		ginkgo.It("must set status True and reason AllowedForVirtualMachineUsage", func() {
+			vd := &virtv2.VirtualDisk{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vd",
+					Namespace: "default",
+				},
+				Status: virtv2.VirtualDiskStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   vdcondition.InUseType.String(),
+							Reason: conditions.ReasonUnknown.String(),
+							Status: metav1.ConditionUnknown,
+						},
+					},
+				},
+			}
+
+			vm := &virtv2.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vm",
+					Namespace: "default",
+				},
+				Status: virtv2.VirtualMachineStatus{
+					BlockDeviceRefs: []virtv2.BlockDeviceStatusRef{
+						{
+							Kind: virtv2.DiskDevice,
+							Name: vd.Name,
+						},
+					},
+				},
+			}
+
+			k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(vd, vm).Build()
+			handler = NewInUseHandler(k8sClient)
+
+			result, err := handler.Handle(ctx, vd)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(result).To(gomega.Equal(ctrl.Result{}))
+
+			cond, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
+			gomega.Expect(cond).ToNot(gomega.BeNil())
+			gomega.Expect(cond.Status).To(gomega.Equal(metav1.ConditionTrue))
+			gomega.Expect(cond.Reason).To(gomega.Equal(vdcondition.AllowedForVirtualMachineUsage.String()))
+		})
+	})
+
+	ginkgo.Context("when VirtualDisk is used by VirtualImage after running VM", func() {
+		ginkgo.It("must set status True and reason AllowedForImageUsage", func() {
+			vd := &virtv2.VirtualDisk{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vd",
+					Namespace: "default",
+				},
+				Status: virtv2.VirtualDiskStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   vdcondition.InUseType.String(),
+							Reason: conditions.ReasonUnknown.String(),
+							Status: metav1.ConditionUnknown,
+						},
+					},
+				},
+			}
+
+			vi := &virtv2.VirtualImage{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vi",
+					Namespace: "default",
+				},
+				Spec: virtv2.VirtualImageSpec{
+					DataSource: virtv2.VirtualImageDataSource{
+						Type: virtv2.DataSourceTypeObjectRef,
+						ObjectRef: &virtv2.VirtualImageObjectRef{
+							Kind: virtv2.VirtualDiskKind,
+							Name: "test-vd",
+						},
+					},
+				},
+				Status: virtv2.VirtualImageStatus{
+					Phase:      virtv2.ImageProvisioning,
+					Conditions: []metav1.Condition{},
+				},
+			}
+
+			k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(vd, vi).Build()
+			handler = NewInUseHandler(k8sClient)
+
+			result, err := handler.Handle(ctx, vd)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(result).To(gomega.Equal(ctrl.Result{}))
+
+			cond, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
+			gomega.Expect(cond).ToNot(gomega.BeNil())
+			gomega.Expect(cond.Status).To(gomega.Equal(metav1.ConditionTrue))
+			gomega.Expect(cond.Reason).To(gomega.Equal(vdcondition.AllowedForImageUsage.String()))
+		})
+	})
+
+	ginkgo.Context("when VirtualDisk is not in use after create image", func() {
+		ginkgo.It("must set status Unknown and reason Unknown", func() {
+			vd := &virtv2.VirtualDisk{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vd",
+					Namespace: "default",
+				},
+				Status: virtv2.VirtualDiskStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   vdcondition.InUseType.String(),
+							Reason: vdcondition.AllowedForImageUsage.String(),
+							Status: metav1.ConditionTrue,
+						},
+					},
+				},
+			}
+
+			k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(vd).Build()
+			handler = NewInUseHandler(k8sClient)
+
+			result, err := handler.Handle(ctx, vd)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(result).To(gomega.Equal(ctrl.Result{}))
+
+			cond, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
+			gomega.Expect(cond).ToNot(gomega.BeNil())
+			gomega.Expect(cond.Status).To(gomega.Equal(metav1.ConditionUnknown))
+		})
+	})
+
+	ginkgo.Context("when VirtualDisk is not in use after running VM", func() {
+		ginkgo.It("must set status Unknown and reason Unknown", func() {
+			vd := &virtv2.VirtualDisk{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vd",
+					Namespace: "default",
+				},
+				Status: virtv2.VirtualDiskStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   vdcondition.InUseType.String(),
+							Reason: vdcondition.AllowedForVirtualMachineUsage.String(),
+							Status: metav1.ConditionTrue,
+						},
+					},
+				},
+			}
+
+			k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(vd).Build()
+			handler = NewInUseHandler(k8sClient)
+
+			result, err := handler.Handle(ctx, vd)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(result).To(gomega.Equal(ctrl.Result{}))
+
+			cond, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
+			gomega.Expect(cond).ToNot(gomega.BeNil())
+			gomega.Expect(cond.Status).To(gomega.Equal(metav1.ConditionUnknown))
+		})
+	})
+})

--- a/images/virtualization-artifact/pkg/controller/vd/internal/inuse_test.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/inuse_test.go
@@ -19,8 +19,8 @@ package internal
 import (
 	"context"
 
-	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -34,24 +34,24 @@ import (
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmcondition"
 )
 
-var _ = ginkgo.Describe("InUseHandler", func() {
+var _ = Describe("InUseHandler", func() {
 	var (
 		scheme  *runtime.Scheme
 		ctx     context.Context
 		handler *InUseHandler
 	)
 
-	ginkgo.BeforeEach(func() {
+	BeforeEach(func() {
 		scheme = runtime.NewScheme()
-		gomega.Expect(clientgoscheme.AddToScheme(scheme)).To(gomega.Succeed())
-		gomega.Expect(virtv2.AddToScheme(scheme)).To(gomega.Succeed())
-		gomega.Expect(virtv1.AddToScheme(scheme)).To(gomega.Succeed())
+		Expect(clientgoscheme.AddToScheme(scheme)).To(Succeed())
+		Expect(virtv2.AddToScheme(scheme)).To(Succeed())
+		Expect(virtv1.AddToScheme(scheme)).To(Succeed())
 
 		ctx = context.TODO()
 	})
 
-	ginkgo.Context("when VirtualDisk is not in use", func() {
-		ginkgo.It("must set status Unknown and reason Unknown", func() {
+	Context("when VirtualDisk is not in use", func() {
+		It("must set status Unknown and reason Unknown", func() {
 			vd := &virtv2.VirtualDisk{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-vd",
@@ -66,17 +66,17 @@ var _ = ginkgo.Describe("InUseHandler", func() {
 			handler = NewInUseHandler(k8sClient)
 
 			result, err := handler.Handle(ctx, vd)
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			gomega.Expect(result).To(gomega.Equal(ctrl.Result{}))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(ctrl.Result{}))
 
 			cond, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
-			gomega.Expect(cond).ToNot(gomega.BeNil())
-			gomega.Expect(cond.Status).To(gomega.Equal(metav1.ConditionUnknown))
+			Expect(cond).ToNot(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionUnknown))
 		})
 	})
 
-	ginkgo.Context("when VirtualDisk is used by running VirtualMachine", func() {
-		ginkgo.It("must set status True and reason AllowedForVirtualMachineUsage", func() {
+	Context("when VirtualDisk is used by running VirtualMachine", func() {
+		It("must set status True and reason AllowedForVirtualMachineUsage", func() {
 			vd := &virtv2.VirtualDisk{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-vd",
@@ -115,18 +115,18 @@ var _ = ginkgo.Describe("InUseHandler", func() {
 			handler = NewInUseHandler(k8sClient)
 
 			result, err := handler.Handle(ctx, vd)
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			gomega.Expect(result).To(gomega.Equal(ctrl.Result{}))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(ctrl.Result{}))
 
 			cond, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
-			gomega.Expect(cond).ToNot(gomega.BeNil())
-			gomega.Expect(cond.Status).To(gomega.Equal(metav1.ConditionTrue))
-			gomega.Expect(cond.Reason).To(gomega.Equal(vdcondition.AllowedForVirtualMachineUsage.String()))
+			Expect(cond).ToNot(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(cond.Reason).To(Equal(vdcondition.AllowedForVirtualMachineUsage.String()))
 		})
 	})
 
-	ginkgo.Context("when VirtualDisk is used by not ready VirtualMachine", func() {
-		ginkgo.It("must set status True and reason AllowedForVirtualMachineUsage", func() {
+	Context("when VirtualDisk is used by not ready VirtualMachine", func() {
+		It("it sets Unknown", func() {
 			vd := &virtv2.VirtualDisk{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-vd",
@@ -166,17 +166,17 @@ var _ = ginkgo.Describe("InUseHandler", func() {
 			handler = NewInUseHandler(k8sClient)
 
 			result, err := handler.Handle(ctx, vd)
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			gomega.Expect(result).To(gomega.Equal(ctrl.Result{}))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(ctrl.Result{}))
 
 			cond, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
-			gomega.Expect(cond).ToNot(gomega.BeNil())
-			gomega.Expect(cond.Status).To(gomega.Equal(metav1.ConditionUnknown))
+			Expect(cond).ToNot(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionUnknown))
 		})
 	})
 
-	ginkgo.Context("when VirtualDisk is used by VirtualImage", func() {
-		ginkgo.It("must set status True and reason AllowedForImageUsage", func() {
+	Context("when VirtualDisk is used by VirtualImage", func() {
+		It("must set status True and reason AllowedForImageUsage", func() {
 			vd := &virtv2.VirtualDisk{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-vd",
@@ -211,18 +211,18 @@ var _ = ginkgo.Describe("InUseHandler", func() {
 			handler = NewInUseHandler(k8sClient)
 
 			result, err := handler.Handle(ctx, vd)
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			gomega.Expect(result).To(gomega.Equal(ctrl.Result{}))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(ctrl.Result{}))
 
 			cond, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
-			gomega.Expect(cond).ToNot(gomega.BeNil())
-			gomega.Expect(cond.Status).To(gomega.Equal(metav1.ConditionTrue))
-			gomega.Expect(cond.Reason).To(gomega.Equal(vdcondition.AllowedForImageUsage.String()))
+			Expect(cond).ToNot(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(cond.Reason).To(Equal(vdcondition.AllowedForImageUsage.String()))
 		})
 	})
 
-	ginkgo.Context("when VirtualDisk is used by ClusterVirtualImage", func() {
-		ginkgo.It("must set status True and reason AllowedForImageUsage", func() {
+	Context("when VirtualDisk is used by ClusterVirtualImage", func() {
+		It("must set status True and reason AllowedForImageUsage", func() {
 			vd := &virtv2.VirtualDisk{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-vd",
@@ -258,18 +258,18 @@ var _ = ginkgo.Describe("InUseHandler", func() {
 			handler = NewInUseHandler(k8sClient)
 
 			result, err := handler.Handle(ctx, vd)
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			gomega.Expect(result).To(gomega.Equal(ctrl.Result{}))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(ctrl.Result{}))
 
 			cond, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
-			gomega.Expect(cond).ToNot(gomega.BeNil())
-			gomega.Expect(cond.Status).To(gomega.Equal(metav1.ConditionTrue))
-			gomega.Expect(cond.Reason).To(gomega.Equal(vdcondition.AllowedForImageUsage.String()))
+			Expect(cond).ToNot(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(cond.Reason).To(Equal(vdcondition.AllowedForImageUsage.String()))
 		})
 	})
 
-	ginkgo.Context("when VirtualDisk is used by VirtualImage and VirtualMachine", func() {
-		ginkgo.It("must set status True and reason AllowedForVirtualMachineUsage", func() {
+	Context("when VirtualDisk is used by VirtualImage and VirtualMachine", func() {
+		It("must set status True and reason AllowedForVirtualMachineUsage", func() {
 			vd := &virtv2.VirtualDisk{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-vd",
@@ -319,18 +319,18 @@ var _ = ginkgo.Describe("InUseHandler", func() {
 			handler = NewInUseHandler(k8sClient)
 
 			result, err := handler.Handle(ctx, vd)
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			gomega.Expect(result).To(gomega.Equal(ctrl.Result{}))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(ctrl.Result{}))
 
 			cond, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
-			gomega.Expect(cond).ToNot(gomega.BeNil())
-			gomega.Expect(cond.Status).To(gomega.Equal(metav1.ConditionTrue))
-			gomega.Expect(cond.Reason).To(gomega.Equal(vdcondition.AllowedForVirtualMachineUsage.String()))
+			Expect(cond).ToNot(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(cond.Reason).To(Equal(vdcondition.AllowedForVirtualMachineUsage.String()))
 		})
 	})
 
-	ginkgo.Context("when VirtualDisk is used by VirtualMachine after create image", func() {
-		ginkgo.It("must set status True and reason AllowedForVirtualMachineUsage", func() {
+	Context("when VirtualDisk is used by VirtualMachine after create image", func() {
+		It("must set status True and reason AllowedForVirtualMachineUsage", func() {
 			vd := &virtv2.VirtualDisk{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-vd",
@@ -366,18 +366,18 @@ var _ = ginkgo.Describe("InUseHandler", func() {
 			handler = NewInUseHandler(k8sClient)
 
 			result, err := handler.Handle(ctx, vd)
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			gomega.Expect(result).To(gomega.Equal(ctrl.Result{}))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(ctrl.Result{}))
 
 			cond, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
-			gomega.Expect(cond).ToNot(gomega.BeNil())
-			gomega.Expect(cond.Status).To(gomega.Equal(metav1.ConditionTrue))
-			gomega.Expect(cond.Reason).To(gomega.Equal(vdcondition.AllowedForVirtualMachineUsage.String()))
+			Expect(cond).ToNot(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(cond.Reason).To(Equal(vdcondition.AllowedForVirtualMachineUsage.String()))
 		})
 	})
 
-	ginkgo.Context("when VirtualDisk is used by VirtualImage after running VM", func() {
-		ginkgo.It("must set status True and reason AllowedForImageUsage", func() {
+	Context("when VirtualDisk is used by VirtualImage after running VM", func() {
+		It("must set status True and reason AllowedForImageUsage", func() {
 			vd := &virtv2.VirtualDisk{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-vd",
@@ -418,18 +418,18 @@ var _ = ginkgo.Describe("InUseHandler", func() {
 			handler = NewInUseHandler(k8sClient)
 
 			result, err := handler.Handle(ctx, vd)
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			gomega.Expect(result).To(gomega.Equal(ctrl.Result{}))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(ctrl.Result{}))
 
 			cond, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
-			gomega.Expect(cond).ToNot(gomega.BeNil())
-			gomega.Expect(cond.Status).To(gomega.Equal(metav1.ConditionTrue))
-			gomega.Expect(cond.Reason).To(gomega.Equal(vdcondition.AllowedForImageUsage.String()))
+			Expect(cond).ToNot(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(cond.Reason).To(Equal(vdcondition.AllowedForImageUsage.String()))
 		})
 	})
 
-	ginkgo.Context("when VirtualDisk is not in use after create image", func() {
-		ginkgo.It("must set status Unknown and reason Unknown", func() {
+	Context("when VirtualDisk is not in use after image creation", func() {
+		It("must set status Unknown and reason Unknown", func() {
 			vd := &virtv2.VirtualDisk{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-vd",
@@ -450,17 +450,17 @@ var _ = ginkgo.Describe("InUseHandler", func() {
 			handler = NewInUseHandler(k8sClient)
 
 			result, err := handler.Handle(ctx, vd)
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			gomega.Expect(result).To(gomega.Equal(ctrl.Result{}))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(ctrl.Result{Requeue: true}))
 
 			cond, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
-			gomega.Expect(cond).ToNot(gomega.BeNil())
-			gomega.Expect(cond.Status).To(gomega.Equal(metav1.ConditionUnknown))
+			Expect(cond).ToNot(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionUnknown))
 		})
 	})
 
-	ginkgo.Context("when VirtualDisk is not in use after running VM", func() {
-		ginkgo.It("must set status Unknown and reason Unknown", func() {
+	Context("when VirtualDisk is not in use after VM deletion", func() {
+		It("must set status Unknown and reason Unknown", func() {
 			vd := &virtv2.VirtualDisk{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-vd",
@@ -481,12 +481,12 @@ var _ = ginkgo.Describe("InUseHandler", func() {
 			handler = NewInUseHandler(k8sClient)
 
 			result, err := handler.Handle(ctx, vd)
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			gomega.Expect(result).To(gomega.Equal(ctrl.Result{}))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(ctrl.Result{Requeue: true}))
 
 			cond, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
-			gomega.Expect(cond).ToNot(gomega.BeNil())
-			gomega.Expect(cond.Status).To(gomega.Equal(metav1.ConditionUnknown))
+			Expect(cond).ToNot(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionUnknown))
 		})
 	})
 })

--- a/images/virtualization-artifact/pkg/controller/vd/internal/validator/iso_source_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/validator/iso_source_validator.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package validators
+package validator
 
 import (
 	"context"

--- a/images/virtualization-artifact/pkg/controller/vd/internal/validator/pvc_size_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/validator/pvc_size_validator.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package validators
+package validator
 
 import (
 	"context"

--- a/images/virtualization-artifact/pkg/controller/vd/internal/validator/spec_changes_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/validator/spec_changes_validator.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package validators
+package validator
 
 import (
 	"context"

--- a/images/virtualization-artifact/pkg/controller/vd/vd_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vd/vd_controller.go
@@ -84,6 +84,7 @@ func NewController(
 		internal.NewDeletionHandler(sources),
 		internal.NewAttacheeHandler(mgr.GetClient()),
 		internal.NewStatsHandler(stat, importer, uploader),
+		internal.NewInUseHandler(mgr.GetClient()),
 	)
 
 	vdController, err := controller.New(ControllerName, mgr, controller.Options{

--- a/images/virtualization-artifact/pkg/controller/vd/vd_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/vd/vd_reconciler.go
@@ -232,8 +232,8 @@ func (r *Reconciler) SetupController(_ context.Context, mgr manager.Manager, ctr
 		return fmt.Errorf("error setting watch on CVIs: %w", err)
 	}
 
-	w := watcher.NewVirtualDiskSnapshotWatcher(mgr.GetClient())
-	if err := w.Watch(mgr, ctr); err != nil {
+	snapshotWatcher := watcher.NewVirtualDiskSnapshotWatcher(mgr.GetClient())
+	if err := snapshotWatcher.Watch(mgr, ctr); err != nil {
 		return fmt.Errorf("error setting watch on VDSnapshots: %w", err)
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vd/vd_webhook.go
+++ b/images/virtualization-artifact/pkg/controller/vd/vd_webhook.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	"github.com/deckhouse/virtualization-controller/pkg/controller/vd/internal/validators"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/vd/internal/validator"
 	"github.com/deckhouse/virtualization-controller/pkg/logger"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
@@ -41,9 +41,9 @@ type Validator struct {
 func NewValidator(client client.Client) *Validator {
 	return &Validator{
 		validators: []VirtualDiskValidator{
-			validators.NewPVCSizeValidator(client),
-			validators.NewSpecChangesValidator(),
-			validators.NewISOSourceValidator(client),
+			validator.NewPVCSizeValidator(client),
+			validator.NewSpecChangesValidator(),
+			validator.NewISOSourceValidator(client),
 		},
 	}
 }

--- a/images/virtualization-artifact/pkg/controller/vi/internal/datasource_ready.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/datasource_ready.go
@@ -89,10 +89,10 @@ func (h DatasourceReadyHandler) Handle(ctx context.Context, vi *virtv2.VirtualIm
 			Reason(vicondition.VirtualDiskNotReady).
 			Message(service.CapitalizeFirstLetter(err.Error() + "."))
 		return reconcile.Result{}, nil
-	case errors.As(err, &source.VirtualDiskAttachedToRunningVMError{}):
+	case errors.As(err, &source.VirtualDiskInUseError{}):
 		cb.
 			Status(metav1.ConditionFalse).
-			Reason(vicondition.VirtualDiskNotReady).
+			Reason(vicondition.VirtualDiskInUseInRunningVirtualMachine).
 			Message(service.CapitalizeFirstLetter(err.Error() + "."))
 		return reconcile.Result{}, nil
 	default:

--- a/images/virtualization-artifact/pkg/controller/vi/internal/datasource_ready.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/datasource_ready.go
@@ -89,7 +89,7 @@ func (h DatasourceReadyHandler) Handle(ctx context.Context, vi *virtv2.VirtualIm
 			Reason(vicondition.VirtualDiskNotReady).
 			Message(service.CapitalizeFirstLetter(err.Error() + "."))
 		return reconcile.Result{}, nil
-	case errors.As(err, &source.VirtualDiskInUseError{}):
+	case errors.As(err, &source.VirtualDiskNotAllowedForUseError{}):
 		cb.
 			Status(metav1.ConditionFalse).
 			Reason(vicondition.VirtualDiskInUseInRunningVirtualMachine).

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/errors.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/errors.go
@@ -65,18 +65,16 @@ func NewVirtualDiskNotReadyError(name string) error {
 	}
 }
 
-type VirtualDiskAttachedToRunningVMError struct {
-	name   string
-	vmName string
+type VirtualDiskInUseError struct {
+	name string
 }
 
-func (e VirtualDiskAttachedToRunningVMError) Error() string {
-	return fmt.Sprintf("VirtualDisk %q attached to running VirtualMachine %q", e.name, e.vmName)
+func (e VirtualDiskInUseError) Error() string {
+	return fmt.Sprintf("reading from the VirtualDisk is not possible while it is in use by the running VirtualMachine/%s", e.name)
 }
 
-func NewVirtualDiskAttachedToRunningVMError(name, vmName string) error {
-	return VirtualDiskAttachedToRunningVMError{
-		name:   name,
-		vmName: vmName,
+func NewVirtualDiskInUseError(name string) error {
+	return VirtualDiskInUseError{
+		name: name,
 	}
 }

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/errors.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/errors.go
@@ -65,16 +65,16 @@ func NewVirtualDiskNotReadyError(name string) error {
 	}
 }
 
-type VirtualDiskInUseError struct {
+type VirtualDiskNotAllowedForUseError struct {
 	name string
 }
 
-func (e VirtualDiskInUseError) Error() string {
-	return fmt.Sprintf("reading from the VirtualDisk is not possible while it is in use by the running VirtualMachine/%s", e.name)
+func (e VirtualDiskNotAllowedForUseError) Error() string {
+	return fmt.Sprintf("use of VirtualDisk %s is not allowed, it may be connected to a running VirtualMachine", e.name)
 }
 
-func NewVirtualDiskInUseError(name string) error {
-	return VirtualDiskInUseError{
+func NewVirtualDiskNotAllowedForUseError(name string) error {
+	return VirtualDiskNotAllowedForUseError{
 		name: name,
 	}
 }

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref.go
@@ -108,14 +108,14 @@ func (ds ObjectRefDataSource) StoreToPVC(ctx context.Context, vi *virtv2.Virtual
 			return ds.viObjectRefOnPvc.StoreToPVC(ctx, vi, viRef, cb)
 		}
 	case virtv2.VirtualDiskKind:
-		viKey := types.NamespacedName{Name: vi.Spec.DataSource.ObjectRef.Name, Namespace: vi.Namespace}
-		vd, err := object.FetchObject(ctx, viKey, ds.client, &virtv2.VirtualDisk{})
+		vdKey := types.NamespacedName{Name: vi.Spec.DataSource.ObjectRef.Name, Namespace: vi.Namespace}
+		vd, err := object.FetchObject(ctx, vdKey, ds.client, &virtv2.VirtualDisk{})
 		if err != nil {
-			return reconcile.Result{}, fmt.Errorf("unable to get VI %s: %w", viKey, err)
+			return reconcile.Result{}, fmt.Errorf("unable to get VD %s: %w", vdKey, err)
 		}
 
 		if vd == nil {
-			return reconcile.Result{}, fmt.Errorf("VD object ref %s is nil", viKey)
+			return reconcile.Result{}, fmt.Errorf("VD object ref %s is nil", vdKey)
 		}
 
 		return ds.vdSyncer.StoreToPVC(ctx, vi, vd, cb)

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vd.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vd.go
@@ -381,9 +381,10 @@ func (ds ObjectRefVirtualDisk) Validate(ctx context.Context, vi *virtv2.VirtualI
 
 	inUseCondition, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
 	if inUseCondition.Status == metav1.ConditionTrue {
-		if inUseCondition.Reason == vdcondition.InUseByVirtualMachine {
-			return NewVirtualDiskInUseError(vd.Name)
+		if inUseCondition.Reason == vdcondition.AllowedForImageUsage.String() {
+			return nil
 		}
 	}
-	return nil
+
+	return NewVirtualDiskNotAllowedForUseError(vd.Name)
 }

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vd.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vd.go
@@ -380,10 +380,8 @@ func (ds ObjectRefVirtualDisk) Validate(ctx context.Context, vi *virtv2.VirtualI
 	}
 
 	inUseCondition, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
-	if inUseCondition.Status == metav1.ConditionTrue {
-		if inUseCondition.Reason == vdcondition.AllowedForImageUsage.String() {
-			return nil
-		}
+	if inUseCondition.Status == metav1.ConditionTrue && inUseCondition.Reason == vdcondition.AllowedForImageUsage.String() {
+		return nil
 	}
 
 	return NewVirtualDiskNotAllowedForUseError(vd.Name)

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vd.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vd.go
@@ -380,7 +380,9 @@ func (ds ObjectRefVirtualDisk) Validate(ctx context.Context, vi *virtv2.VirtualI
 	}
 
 	inUseCondition, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
-	if inUseCondition.Status == metav1.ConditionTrue && inUseCondition.Reason == vdcondition.AllowedForImageUsage.String() {
+	if inUseCondition.Status == metav1.ConditionTrue &&
+		inUseCondition.Reason == vdcondition.AllowedForImageUsage.String() &&
+		inUseCondition.ObservedGeneration == vd.Status.ObservedGeneration {
 		return nil
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vi/vi_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/vi/vi_reconciler.go
@@ -40,6 +40,7 @@ import (
 	"github.com/deckhouse/virtualization-controller/pkg/controller/watchers"
 	"github.com/deckhouse/virtualization-controller/pkg/logger"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
 )
 
 type Handler interface {
@@ -220,7 +221,14 @@ func (r *Reconciler) SetupController(_ context.Context, mgr manager.Manager, ctr
 					return false
 				}
 
-				return oldVD.Status.Phase != newVD.Status.Phase
+				oldInUseCondition, _ := service.GetCondition(vdcondition.InUseType, oldVD.Status.Conditions)
+				newInUseCondition, _ := service.GetCondition(vdcondition.InUseType, newVD.Status.Conditions)
+
+				if oldVD.Status.Phase != newVD.Status.Phase || len(oldVD.Status.AttachedToVirtualMachines) != len(newVD.Status.AttachedToVirtualMachines) || oldInUseCondition.Status != newInUseCondition.Status {
+					return true
+				}
+
+				return false
 			},
 		},
 	); err != nil {

--- a/images/virtualization-artifact/pkg/controller/vi/vi_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/vi/vi_reconciler.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vi/internal/watcher"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/watchers"
@@ -221,8 +222,8 @@ func (r *Reconciler) SetupController(_ context.Context, mgr manager.Manager, ctr
 					return false
 				}
 
-				oldInUseCondition, _ := service.GetCondition(vdcondition.InUseType, oldVD.Status.Conditions)
-				newInUseCondition, _ := service.GetCondition(vdcondition.InUseType, newVD.Status.Conditions)
+				oldInUseCondition, _ := conditions.GetCondition(vdcondition.InUseType, oldVD.Status.Conditions)
+				newInUseCondition, _ := conditions.GetCondition(vdcondition.InUseType, newVD.Status.Conditions)
 
 				if oldVD.Status.Phase != newVD.Status.Phase || len(oldVD.Status.AttachedToVirtualMachines) != len(newVD.Status.AttachedToVirtualMachines) || oldInUseCondition.Status != newInUseCondition.Status {
 					return true

--- a/images/virtualization-artifact/pkg/controller/vm/internal/block_device.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/block_device.go
@@ -37,6 +37,7 @@ import (
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vm/internal/state"
 	"github.com/deckhouse/virtualization-controller/pkg/logger"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmcondition"
 )
 
@@ -317,8 +318,8 @@ func (h *BlockDeviceHandler) countReadyBlockDevices(vm *virtv2.VirtualMachine, s
 				canStartKVVM = false
 				continue
 			}
-
-			if vd.Status.Phase == virtv2.DiskReady {
+			readyCondition, _ := service.GetCondition(vdcondition.ReadyType, vd.Status.Conditions)
+			if readyCondition.Status == metav1.ConditionTrue {
 				ready++
 			} else {
 				msg := fmt.Sprintf("virtual disk %s is waiting for the it's pvc to be bound", vd.Name)

--- a/images/virtualization-artifact/pkg/controller/vm/internal/block_devices_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/block_devices_test.go
@@ -71,8 +71,13 @@ var _ = Describe("BlockDeviceHandler", func() {
 				Target: virtv2.DiskTarget{PersistentVolumeClaim: "pvc-foo"},
 				Conditions: []metav1.Condition{
 					{
-						Type:   vdcondition.ReadyType,
-						Reason: vdcondition.Ready,
+						Type:   vdcondition.ReadyType.String(),
+						Reason: vdcondition.Ready.String(),
+						Status: metav1.ConditionTrue,
+					},
+					{
+						Type:   vdcondition.InUseType.String(),
+						Reason: vdcondition.AllowedForVirtualMachineUsage.String(),
 						Status: metav1.ConditionTrue,
 					},
 				},
@@ -85,8 +90,13 @@ var _ = Describe("BlockDeviceHandler", func() {
 				Target: virtv2.DiskTarget{PersistentVolumeClaim: "pvc-bar"},
 				Conditions: []metav1.Condition{
 					{
-						Type:   vdcondition.ReadyType,
-						Reason: vdcondition.Ready,
+						Type:   vdcondition.ReadyType.String(),
+						Reason: vdcondition.Ready.String(),
+						Status: metav1.ConditionTrue,
+					},
+					{
+						Type:   vdcondition.InUseType.String(),
+						Reason: vdcondition.AllowedForVirtualMachineUsage.String(),
 						Status: metav1.ConditionTrue,
 					},
 				},
@@ -183,9 +193,14 @@ var _ = Describe("BlockDeviceHandler", func() {
 			vdFoo.Status.Phase = virtv2.DiskProvisioning
 			vdFoo.Status.Conditions = []metav1.Condition{
 				{
-					Type:   vdcondition.ReadyType,
-					Reason: vdcondition.Provisioning,
+					Type:   vdcondition.ReadyType.String(),
+					Reason: vdcondition.Provisioning.String(),
 					Status: metav1.ConditionFalse,
+				},
+				{
+					Type:   vdcondition.InUseType.String(),
+					Reason: vdcondition.AllowedForVirtualMachineUsage.String(),
+					Status: metav1.ConditionTrue,
 				},
 			}
 			state := getBlockDevicesState(vi, cvi, vdFoo, vdBar)

--- a/images/virtualization-artifact/pkg/controller/vm/internal/block_devices_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/block_devices_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
 )
 
 func TestBlockDeviceHandler(t *testing.T) {
@@ -68,6 +69,13 @@ var _ = Describe("BlockDeviceHandler", func() {
 			Status: virtv2.VirtualDiskStatus{
 				Phase:  virtv2.DiskReady,
 				Target: virtv2.DiskTarget{PersistentVolumeClaim: "pvc-foo"},
+				Conditions: []metav1.Condition{
+					{
+						Type:   vdcondition.ReadyType,
+						Reason: vdcondition.Ready,
+						Status: metav1.ConditionTrue,
+					},
+				},
 			},
 		}
 		vdBar = &virtv2.VirtualDisk{
@@ -75,6 +83,13 @@ var _ = Describe("BlockDeviceHandler", func() {
 			Status: virtv2.VirtualDiskStatus{
 				Phase:  virtv2.DiskReady,
 				Target: virtv2.DiskTarget{PersistentVolumeClaim: "pvc-bar"},
+				Conditions: []metav1.Condition{
+					{
+						Type:   vdcondition.ReadyType,
+						Reason: vdcondition.Ready,
+						Status: metav1.ConditionTrue,
+					},
+				},
 			},
 		}
 		vm = &virtv2.VirtualMachine{
@@ -166,6 +181,13 @@ var _ = Describe("BlockDeviceHandler", func() {
 
 		It("VirtualDisk's target pvc is created", func() {
 			vdFoo.Status.Phase = virtv2.DiskProvisioning
+			vdFoo.Status.Conditions = []metav1.Condition{
+				{
+					Type:   vdcondition.ReadyType,
+					Reason: vdcondition.Provisioning,
+					Status: metav1.ConditionFalse,
+				},
+			}
 			state := getBlockDevicesState(vi, cvi, vdFoo, vdBar)
 			ready, canStart, warnings := h.countReadyBlockDevices(vm, state, logger)
 			Expect(ready).To(Equal(3))

--- a/images/virtualization-artifact/pkg/controller/vm/vm_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/vm/vm_reconciler.go
@@ -40,6 +40,7 @@ import (
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vm/internal/watcher"
 	"github.com/deckhouse/virtualization-controller/pkg/logger"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
 )
 
 type Handler interface {
@@ -216,7 +217,15 @@ func (r *Reconciler) SetupController(_ context.Context, mgr manager.Manager, ctr
 				if !oldOk || !newOk {
 					return false
 				}
-				return oldVd.Status.Phase != newVd.Status.Phase
+
+				oldInUseCondition, _ := service.GetCondition(vdcondition.InUseType, oldVd.Status.Conditions)
+				newInUseCondition, _ := service.GetCondition(vdcondition.InUseType, newVd.Status.Conditions)
+
+				if oldVd.Status.Phase != newVd.Status.Phase || oldInUseCondition.Status != newInUseCondition.Status {
+					return true
+				}
+
+				return false
 			},
 		},
 	); err != nil {

--- a/images/virtualization-artifact/pkg/controller/vm/vm_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/vm/vm_reconciler.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/indexer"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vm/internal/state"
@@ -218,8 +219,8 @@ func (r *Reconciler) SetupController(_ context.Context, mgr manager.Manager, ctr
 					return false
 				}
 
-				oldInUseCondition, _ := service.GetCondition(vdcondition.InUseType, oldVd.Status.Conditions)
-				newInUseCondition, _ := service.GetCondition(vdcondition.InUseType, newVd.Status.Conditions)
+				oldInUseCondition, _ := conditions.GetCondition(vdcondition.InUseType, oldVd.Status.Conditions)
+				newInUseCondition, _ := conditions.GetCondition(vdcondition.InUseType, newVd.Status.Conditions)
 
 				if oldVd.Status.Phase != newVd.Status.Phase || oldInUseCondition.Status != newInUseCondition.Status {
 					return true

--- a/images/virtualization-artifact/pkg/controller/watchers/cvi_filter.go
+++ b/images/virtualization-artifact/pkg/controller/watchers/cvi_filter.go
@@ -52,6 +52,5 @@ func (f ClusterVirtualImageFilter) FilterUpdateEvents(e event.UpdateEvent) bool 
 		return false
 	}
 
-	// Triggered only if the resource phase changed to Ready.
-	return oldCVI.Status.Phase != newCVI.Status.Phase && newCVI.Status.Phase == virtv2.ImageReady
+	return oldCVI.Status.Phase != newCVI.Status.Phase
 }

--- a/images/virtualization-artifact/pkg/controller/watchers/object_ref_watcher.go
+++ b/images/virtualization-artifact/pkg/controller/watchers/object_ref_watcher.go
@@ -62,8 +62,8 @@ func (w ObjectRefWatcher) Run(mgr manager.Manager, ctr controller.Controller) er
 		source.Kind(mgr.GetCache(), w.enqueuer.GetEnqueueFrom()),
 		handler.EnqueueRequestsFromMapFunc(w.enqueuer.EnqueueRequests),
 		predicate.Funcs{
-			CreateFunc: func(e event.CreateEvent) bool { return false },
-			DeleteFunc: func(e event.DeleteEvent) bool { return false },
+			CreateFunc: func(e event.CreateEvent) bool { return true },
+			DeleteFunc: func(e event.DeleteEvent) bool { return true },
 			UpdateFunc: w.filter.FilterUpdateEvents,
 		},
 	)

--- a/images/virtualization-artifact/pkg/controller/watchers/vi_filter.go
+++ b/images/virtualization-artifact/pkg/controller/watchers/vi_filter.go
@@ -52,6 +52,5 @@ func (f VirtualImageFilter) FilterUpdateEvents(e event.UpdateEvent) bool {
 		return false
 	}
 
-	// Triggered only if the resource phase changed to Ready.
-	return oldVI.Status.Phase != newVI.Status.Phase && newVI.Status.Phase == virtv2.ImageReady
+	return oldVI.Status.Phase != newVI.Status.Phase
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
- Add conditon 'InUse" for VirtualDisk. This condition indicate:
  -  that the VirtualDisk may be used for create ClusterVirtualImage or VirtualImage
  - that the VirtualDisk may be attached to running VirtualMachine

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Fix problem with lock VirtualImage and ClusterVirtual image in phase 'Pending' after stopping or deleting VirtualMachine, when used needed VirtualDisk in them.
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
