### PR TITLE
feat(vi,vd): add storage class ready condition, waiting in pending while storage class not ready

### DIFF
--- a/api/core/v1alpha2/vdcondition/condition.go
+++ b/api/core/v1alpha2/vdcondition/condition.go
@@ -28,6 +28,8 @@ const (
 	ResizedType Type = "Resized"
 	// SnapshottingType indicates whether the disk snapshotting operation is in progress.
 	SnapshottingType Type = "Snapshotting"
+	// StorageclassReady inicates whether the storage class is ready.
+	StorageclassReadyType Type = "StorageclassReady"
 )
 
 type (
@@ -39,6 +41,8 @@ type (
 	ResizedReason = string
 	// SnapshottingReason represents the various reasons for the Snapshotting condition type.
 	SnapshottingReason = string
+	// StorageclassReadyReason represents the various reasons for the Storageclass ready condition type.
+	StorageclassReadyReason = string
 )
 
 const (
@@ -83,4 +87,9 @@ const (
 	Snapshotting SnapshottingReason = "Snapshotting"
 	// SnapshottingNotAvailable indicates that the snapshotting operation is not available for now.
 	SnapshottingNotAvailable SnapshottingReason = "NotAvailable"
+
+	// StorageclassReady indicates that the storage class is ready
+	StorageclassReady StorageclassReadyReason = "StorageclassReady"
+	// StorageclassNotReady indicates that the storage class is not ready
+	StorageclassNotReady StorageclassReadyReason = "StorageclassNotReady"
 )

--- a/api/core/v1alpha2/vdcondition/condition.go
+++ b/api/core/v1alpha2/vdcondition/condition.go
@@ -28,8 +28,8 @@ const (
 	ResizedType Type = "Resized"
 	// SnapshottingType indicates whether the disk snapshotting operation is in progress.
 	SnapshottingType Type = "Snapshotting"
-	// StorageclassReady inicates whether the storage class is ready.
-	StorageclassReadyType Type = "StorageclassReady"
+	// StorageClassReadyType indicates whether the storage class is ready.
+	StorageClassReadyType Type = "StorageClassReady"
 )
 
 type (
@@ -41,8 +41,8 @@ type (
 	ResizedReason = string
 	// SnapshottingReason represents the various reasons for the Snapshotting condition type.
 	SnapshottingReason = string
-	// StorageclassReadyReason represents the various reasons for the Storageclass ready condition type.
-	StorageclassReadyReason = string
+	// StorageClassReadyReason represents the various reasons for the Storageclass ready condition type.
+	StorageClassReadyReason = string
 )
 
 const (
@@ -88,8 +88,8 @@ const (
 	// SnapshottingNotAvailable indicates that the snapshotting operation is not available for now.
 	SnapshottingNotAvailable SnapshottingReason = "NotAvailable"
 
-	// StorageclassReady indicates that the storage class is ready
-	StorageclassReady StorageclassReadyReason = "StorageclassReady"
-	// StorageclassNotReady indicates that the storage class is not ready
-	StorageclassNotReady StorageclassReadyReason = "StorageclassNotReady"
+	// StorageClassReady indicates that the storage class is ready
+	StorageClassReady StorageClassReadyReason = "StorageClassReady"
+	// StorageClassNotReady indicates that the storage class is not ready
+	StorageClassNotReady StorageClassReadyReason = "StorageClassNotReady"
 )

--- a/api/core/v1alpha2/vicondition/condition.go
+++ b/api/core/v1alpha2/vicondition/condition.go
@@ -24,8 +24,8 @@ const (
 	DatasourceReadyType Type = "DatasourceReady"
 	// ReadyType indicates whether the import process succeeded and the `VirtualImage` is ready for use.
 	ReadyType Type = "Ready"
-	// StorageclassReadyType indicates whether the storageclass ready
-	StorageclassReadyType Type = "StorageclassReady"
+	// StorageClassReadyType indicates whether the storageClass ready
+	StorageClassReadyType Type = "StorageClassReady"
 )
 
 type (
@@ -33,8 +33,8 @@ type (
 	DatasourceReadyReason = string
 	// ReadyReason represents the various reasons for the Ready condition type.
 	ReadyReason = string
-	// StorageclassReadyReason represents the various reasons for the StorageclassReady condition type.
-	StorageclassReadyReason = string
+	// StorageClassReadyReason represents the various reasons for the StorageClassReady condition type.
+	StorageClassReadyReason = string
 )
 
 const (
@@ -63,10 +63,10 @@ const (
 	// Lost indicates that the underlying PersistentVolumeClaim has been lost and the `VirtualImage` can no longer be used.
 	Lost ReadyReason = "PVCLost"
 
-	// StorageclassReady indicates that the chosen Storageclass exists.
-	StorageclassReady StorageclassReadyReason = "StorageclassReady"
-	// StorageclassNotReady indicates that the chosen Storageclass not exists.
-	StorageclassNotReady StorageclassReadyReason = "StorageclassNotReady"
+	// StorageClassReady indicates that the chosen StorageClass exists.
+	StorageClassReady StorageClassReadyReason = "StorageClassReady"
+	// StorageClassNotReady indicates that the chosen StorageClass not exists.
+	StorageClassNotReady StorageClassReadyReason = "StorageClassNotReady"
 	// DVCRTypeUsed indicates that the DVCR provisioning chosen.
-	DVCRTypeUsed StorageclassReadyReason = "DVCRTypeUsed"
+	DVCRTypeUsed StorageClassReadyReason = "DVCRTypeUsed"
 )

--- a/api/core/v1alpha2/vicondition/condition.go
+++ b/api/core/v1alpha2/vicondition/condition.go
@@ -33,7 +33,7 @@ type (
 	DatasourceReadyReason = string
 	// ReadyReason represents the various reasons for the Ready condition type.
 	ReadyReason = string
-	// placeholder
+	// StorageclassReadyReason represents the various reasons for the StorageclassReady condition type.
 	StorageclassReadyReason = string
 )
 
@@ -63,10 +63,10 @@ const (
 	// Lost indicates that the underlying PersistentVolumeClaim has been lost and the `VirtualImage` can no longer be used.
 	Lost ReadyReason = "PVCLost"
 
-	// placeholder
+	// StorageclassReady indicates that the chosen Storageclass exists.
 	StorageclassReady StorageclassReadyReason = "StorageclassReady"
-	// placeholder
+	// StorageclassNotReady indicates that the chosen Storageclass not exists.
 	StorageclassNotReady StorageclassReadyReason = "StorageclassNotReady"
-	// placeholder
+	// DVCRTypeUsed indicates that the DVCR provisioning chosen.
 	DVCRTypeUsed StorageclassReadyReason = "DVCRTypeUsed"
 )

--- a/api/core/v1alpha2/vicondition/condition.go
+++ b/api/core/v1alpha2/vicondition/condition.go
@@ -24,6 +24,8 @@ const (
 	DatasourceReadyType Type = "DatasourceReady"
 	// ReadyType indicates whether the import process succeeded and the `VirtualImage` is ready for use.
 	ReadyType Type = "Ready"
+	// StorageclassReadyType indicates whether the storageclass ready
+	StorageclassReadyType Type = "StorageclassReady"
 )
 
 type (
@@ -31,6 +33,8 @@ type (
 	DatasourceReadyReason = string
 	// ReadyReason represents the various reasons for the Ready condition type.
 	ReadyReason = string
+	// placeholder
+	StorageclassReadyReason = string
 )
 
 const (
@@ -58,4 +62,11 @@ const (
 
 	// Lost indicates that the underlying PersistentVolumeClaim has been lost and the `VirtualImage` can no longer be used.
 	Lost ReadyReason = "PVCLost"
+
+	// placeholder
+	StorageclassReady StorageclassReadyReason = "StorageclassReady"
+	// placeholder
+	StorageclassNotReady StorageclassReadyReason = "StorageclassNotReady"
+	// placeholder
+	DVCRTypeUsed StorageclassReadyReason = "DVCRTypeUsed"
 )

--- a/images/virtualization-artifact/hack/dlv.sh
+++ b/images/virtualization-artifact/hack/dlv.sh
@@ -80,6 +80,7 @@ kubectl -n d8-virtualization patch deployment ${deployment} --type='strategic' -
         }
     }
 }'
+sleep 5
 kubectl -n d8-virtualization port-forward deployments/${deployment} 2345:2345
 
 EOF

--- a/images/virtualization-artifact/hack/dlv.sh
+++ b/images/virtualization-artifact/hack/dlv.sh
@@ -80,7 +80,6 @@ kubectl -n d8-virtualization patch deployment ${deployment} --type='strategic' -
         }
     }
 }'
-sleep 5
 kubectl -n d8-virtualization port-forward deployments/${deployment} 2345:2345
 
 EOF

--- a/images/virtualization-artifact/pkg/controller/vd/internal/life_cycle.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/life_cycle.go
@@ -19,7 +19,6 @@ package internal
 import (
 	"context"
 	"fmt"
-	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -111,7 +110,7 @@ func (h LifeCycleHandler) Handle(ctx context.Context, vd *virtv2.VirtualDisk) (r
 			return reconcile.Result{}, fmt.Errorf("failed to sync virtual disk data source %s: %w", ds.Name(), err)
 		}
 		return reconcile.Result{Requeue: requeue}, nil
-	} else {
-		return reconcile.Result{RequeueAfter: 2 * time.Second}, nil
 	}
+
+	return reconcile.Result{}, nil
 }

--- a/images/virtualization-artifact/pkg/controller/vd/internal/life_cycle.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/life_cycle.go
@@ -103,8 +103,8 @@ func (h LifeCycleHandler) Handle(ctx context.Context, vd *virtv2.VirtualDisk) (r
 		}
 	}
 
-	storageclassReadyCondition, ok := service.GetCondition(vdcondition.StorageclassReadyType, vd.Status.Conditions)
-	if ok && storageclassReadyCondition.Status == metav1.ConditionTrue {
+	storageClassReadyCondition, ok := service.GetCondition(vdcondition.StorageClassReadyType, vd.Status.Conditions)
+	if ok && storageClassReadyCondition.Status == metav1.ConditionTrue {
 		requeue, err := ds.Sync(ctx, vd)
 		if err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to sync virtual disk data source %s: %w", ds.Name(), err)

--- a/images/virtualization-artifact/pkg/controller/vd/internal/life_cycle.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/life_cycle.go
@@ -19,10 +19,11 @@ package internal
 import (
 	"context"
 	"fmt"
+	"time"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"time"
 
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vd/internal/source"

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/sources.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/sources.go
@@ -132,19 +132,19 @@ func setPhaseConditionFromStorageError(err error, vd *virtv2.VirtualDisk, condit
 	case err == nil:
 		return false, nil
 	case errors.Is(err, service.ErrStorageProfileNotFound):
-		vd.Status.Phase = virtv2.DiskFailed
+		vd.Status.Phase = virtv2.DiskPending
 		condition.Status = metav1.ConditionFalse
 		condition.Reason = vdcondition.ProvisioningFailed
 		condition.Message = "StorageProfile not found in the cluster: Please check a StorageClass name in the cluster or set a default StorageClass."
 		return true, nil
 	case errors.Is(err, service.ErrStorageClassNotFound):
-		vd.Status.Phase = virtv2.DiskFailed
+		vd.Status.Phase = virtv2.DiskPending
 		condition.Status = metav1.ConditionFalse
 		condition.Reason = vdcondition.ProvisioningFailed
 		condition.Message = "Provided StorageClass not found in the cluster."
 		return true, nil
 	case errors.Is(err, service.ErrDefaultStorageClassNotFound):
-		vd.Status.Phase = virtv2.DiskFailed
+		vd.Status.Phase = virtv2.DiskPending
 		condition.Status = metav1.ConditionFalse
 		condition.Reason = vdcondition.ProvisioningFailed
 		condition.Message = "Default StorageClass not found in the cluster: please provide a StorageClass name or set a default StorageClass."

--- a/images/virtualization-artifact/pkg/controller/vd/internal/storageclass_ready.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/storageclass_ready.go
@@ -30,21 +30,21 @@ import (
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
 )
 
-type StorageclassReadyHandler struct {
+type StorageClassReadyHandler struct {
 	service *service.DiskService
 }
 
-func NewStorageclassReadyHandler(client client.Client) *StorageclassReadyHandler {
-	return &StorageclassReadyHandler{
+func NewStorageClassReadyHandler(client client.Client) *StorageClassReadyHandler {
+	return &StorageClassReadyHandler{
 		service: service.NewDiskService(client, nil, nil),
 	}
 }
 
-func (h StorageclassReadyHandler) Handle(ctx context.Context, vd *virtv2.VirtualDisk) (reconcile.Result, error) {
-	condition, ok := service.GetCondition(vdcondition.StorageclassReadyType, vd.Status.Conditions)
+func (h StorageClassReadyHandler) Handle(ctx context.Context, vd *virtv2.VirtualDisk) (reconcile.Result, error) {
+	condition, ok := service.GetCondition(vdcondition.StorageClassReadyType, vd.Status.Conditions)
 	if !ok {
 		condition = metav1.Condition{
-			Type:   vdcondition.StorageclassReadyType,
+			Type:   vdcondition.StorageClassReadyType,
 			Status: metav1.ConditionUnknown,
 		}
 	}
@@ -65,11 +65,11 @@ func (h StorageclassReadyHandler) Handle(ctx context.Context, vd *virtv2.Virtual
 
 	if sc != nil {
 		condition.Status = metav1.ConditionTrue
-		condition.Reason = vdcondition.StorageclassReady
+		condition.Reason = vdcondition.StorageClassReady
 		condition.Message = "Storage class ready."
 	} else {
 		condition.Status = metav1.ConditionFalse
-		condition.Reason = vdcondition.StorageclassNotReady
+		condition.Reason = vdcondition.StorageClassNotReady
 		condition.Message = fmt.Sprintf("Storage class %q not ready", *vd.Spec.PersistentVolumeClaim.StorageClass)
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vd/internal/storageclass_ready.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/storageclass_ready.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type StorageclassReadyHandler struct {
+	service *service.DiskService
+}
+
+func NewStorageclassReadyHandler(client client.Client) *StorageclassReadyHandler {
+	return &StorageclassReadyHandler{
+		service: service.NewDiskService(client, nil, nil),
+	}
+}
+
+func (h StorageclassReadyHandler) Handle(ctx context.Context, vd *virtv2.VirtualDisk) (reconcile.Result, error) {
+	condition, ok := service.GetCondition(vdcondition.StorageclassReadyType, vd.Status.Conditions)
+	if !ok {
+		condition = metav1.Condition{
+			Type:   vdcondition.StorageclassReadyType,
+			Status: metav1.ConditionUnknown,
+		}
+	}
+
+	defer func() { service.SetCondition(condition, &vd.Status.Conditions) }()
+
+	if vd.DeletionTimestamp != nil {
+		condition.Status = metav1.ConditionUnknown
+		condition.Reason = ""
+		condition.Message = ""
+		return reconcile.Result{}, nil
+	}
+
+	sc, err := h.service.GetStorageClass(ctx, vd.Spec.PersistentVolumeClaim.StorageClass)
+	if err != nil && !errors.Is(err, errors.New("storage class not found")) {
+		return reconcile.Result{}, err
+	}
+
+	if sc != nil {
+		condition.Status = metav1.ConditionTrue
+		condition.Reason = vdcondition.StorageclassReady
+		condition.Message = "Storage class ready."
+	} else {
+		condition.Status = metav1.ConditionFalse
+		condition.Reason = vdcondition.StorageclassNotReady
+		condition.Message = fmt.Sprintf("Storage class %q not ready", *vd.Spec.PersistentVolumeClaim.StorageClass)
+		return reconcile.Result{RequeueAfter: 2 * time.Second}, err
+	}
+
+	return reconcile.Result{}, nil
+}

--- a/images/virtualization-artifact/pkg/controller/vd/internal/storageclass_ready.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/storageclass_ready.go
@@ -22,12 +22,13 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
-	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
-	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
 )
 
 type StorageclassReadyHandler struct {
@@ -59,7 +60,7 @@ func (h StorageclassReadyHandler) Handle(ctx context.Context, vd *virtv2.Virtual
 	}
 
 	sc, err := h.service.GetStorageClass(ctx, vd.Spec.PersistentVolumeClaim.StorageClass)
-	if err != nil && !errors.Is(err, errors.New("storage class not found")) {
+	if err != nil && !errors.Is(err, service.ErrDefaultStorageClassNotFound) && !errors.Is(err, service.ErrStorageClassNotFound) {
 		return reconcile.Result{}, err
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vd/internal/storageclass_ready.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/storageclass_ready.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -72,7 +70,6 @@ func (h StorageclassReadyHandler) Handle(ctx context.Context, vd *virtv2.Virtual
 		condition.Status = metav1.ConditionFalse
 		condition.Reason = vdcondition.StorageclassNotReady
 		condition.Message = fmt.Sprintf("Storage class %q not ready", *vd.Spec.PersistentVolumeClaim.StorageClass)
-		return reconcile.Result{RequeueAfter: 2 * time.Second}, err
 	}
 
 	return reconcile.Result{}, nil

--- a/images/virtualization-artifact/pkg/controller/vd/internal/storageclass_ready.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/storageclass_ready.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"

--- a/images/virtualization-artifact/pkg/controller/vd/vd_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vd/vd_controller.go
@@ -81,6 +81,7 @@ func NewController(
 		internal.NewDeletionHandler(sources),
 		internal.NewAttacheeHandler(mgr.GetClient()),
 		internal.NewStatsHandler(stat, importer, uploader),
+		internal.NewStorageclassReadyHandler(mgr.GetClient()),
 	)
 
 	vdController, err := controller.New(ControllerName, mgr, controller.Options{

--- a/images/virtualization-artifact/pkg/controller/vd/vd_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vd/vd_controller.go
@@ -81,7 +81,7 @@ func NewController(
 		internal.NewDeletionHandler(sources),
 		internal.NewAttacheeHandler(mgr.GetClient()),
 		internal.NewStatsHandler(stat, importer, uploader),
-		internal.NewStorageclassReadyHandler(mgr.GetClient()),
+		internal.NewStorageClassReadyHandler(mgr.GetClient()),
 	)
 
 	vdController, err := controller.New(ControllerName, mgr, controller.Options{

--- a/images/virtualization-artifact/pkg/controller/vd/vd_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vd/vd_controller.go
@@ -74,6 +74,7 @@ func NewController(
 
 	reconciler := NewReconciler(
 		mgr.GetClient(),
+		internal.NewStorageClassReadyHandler(mgr.GetClient()),
 		internal.NewDatasourceReadyHandler(blank, sources),
 		internal.NewLifeCycleHandler(blank, sources, mgr.GetClient()),
 		internal.NewSnapshottingHandler(disk),
@@ -81,7 +82,6 @@ func NewController(
 		internal.NewDeletionHandler(sources),
 		internal.NewAttacheeHandler(mgr.GetClient()),
 		internal.NewStatsHandler(stat, importer, uploader),
-		internal.NewStorageClassReadyHandler(mgr.GetClient()),
 	)
 
 	vdController, err := controller.New(ControllerName, mgr, controller.Options{

--- a/images/virtualization-artifact/pkg/controller/vd/vd_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/vd/vd_reconciler.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	storagev1 "k8s.io/api/storage/v1"
 	"reflect"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/types"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/sources.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/sources.go
@@ -196,13 +196,13 @@ func setPhaseConditionForPVCProvisioningImage(
 		condition.Message = service.CapitalizeFirstLetter(err.Error())
 		return nil
 	case errors.Is(err, service.ErrStorageClassNotFound):
-		vi.Status.Phase = virtv2.ImageProvisioning
+		vi.Status.Phase = virtv2.ImagePending
 		condition.Status = metav1.ConditionFalse
 		condition.Reason = vicondition.ProvisioningFailed
 		condition.Message = "Provided StorageClass not found in the cluster."
 		return nil
 	case errors.Is(err, service.ErrDefaultStorageClassNotFound):
-		vi.Status.Phase = virtv2.ImageProvisioning
+		vi.Status.Phase = virtv2.ImagePending
 		condition.Status = metav1.ConditionFalse
 		condition.Reason = vicondition.ProvisioningFailed
 		condition.Message = "Default StorageClass not found in the cluster: please provide a StorageClass name or set a default StorageClass."
@@ -242,13 +242,13 @@ func setPhaseConditionFromStorageError(err error, vi *virtv2.VirtualImage, condi
 		condition.Message = "StorageProfile not found in the cluster: Please check a StorageClass name in the cluster or set a default StorageClass."
 		return true, nil
 	case errors.Is(err, service.ErrStorageClassNotFound):
-		vi.Status.Phase = virtv2.ImageFailed
+		vi.Status.Phase = virtv2.ImagePending
 		condition.Status = metav1.ConditionFalse
 		condition.Reason = vicondition.ProvisioningFailed
 		condition.Message = "Provided StorageClass not found in the cluster."
 		return true, nil
 	case errors.Is(err, service.ErrDefaultStorageClassNotFound):
-		vi.Status.Phase = virtv2.ImageFailed
+		vi.Status.Phase = virtv2.ImagePending
 		condition.Status = metav1.ConditionFalse
 		condition.Reason = vicondition.ProvisioningFailed
 		condition.Message = "Default StorageClass not found in the cluster: please provide a StorageClass name or set a default StorageClass."

--- a/images/virtualization-artifact/pkg/controller/vi/internal/storageclass_ready.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/storageclass_ready.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -81,7 +79,6 @@ func (h StorageclassReadyHandler) Handle(ctx context.Context, vi *v1alpha2.Virtu
 			condition.Status = metav1.ConditionFalse
 			condition.Reason = vicondition.StorageclassNotReady
 			condition.Message = fmt.Sprintf("Storageclass %q not ready", *vi.Spec.PersistentVolumeClaim.StorageClass)
-			return reconcile.Result{RequeueAfter: 2 * time.Second}, err
 		}
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vi/internal/storageclass_ready.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/storageclass_ready.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+	"fmt"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"time"
+
+	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vicondition"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type StorageclassReadyHandler struct {
+	service *service.DiskService
+}
+
+func (h StorageclassReadyHandler) Name() string {
+	return "StorageclassReadyHandler"
+}
+
+func NewStorageClassReadyHandler(client service.Client) *StorageclassReadyHandler {
+	return &StorageclassReadyHandler{
+		service: service.NewDiskService(client, nil, nil),
+	}
+}
+
+func (h StorageclassReadyHandler) Handle(ctx context.Context, vi *v1alpha2.VirtualImage) (reconcile.Result, error) {
+	condition, ok := service.GetCondition(vicondition.StorageclassReadyType, vi.Status.Conditions)
+	if !ok {
+		condition = metav1.Condition{
+			Type:   vicondition.StorageclassReadyType,
+			Status: metav1.ConditionUnknown,
+		}
+	}
+
+	defer func() { service.SetCondition(condition, &vi.Status.Conditions) }()
+
+	if vi.DeletionTimestamp != nil {
+		condition.Status = metav1.ConditionUnknown
+		condition.Reason = ""
+		condition.Message = ""
+		return reconcile.Result{}, nil
+	}
+
+	switch vi.Spec.Storage {
+	case v1alpha2.StorageContainerRegistry:
+		condition.Status = metav1.ConditionTrue
+		condition.Reason = vicondition.DVCRTypeUsed
+		condition.Message = "Used dvcr storage"
+	case v1alpha2.StorageKubernetes:
+		sc, err := h.service.GetStorageClass(ctx, vi.Spec.PersistentVolumeClaim.StorageClass)
+		if err != nil && !errors.IsNotFound(err) {
+			return reconcile.Result{}, err
+		}
+
+		if sc != nil {
+			condition.Status = metav1.ConditionTrue
+			condition.Reason = vicondition.StorageclassReady
+			condition.Message = "Storageclass ready"
+		} else {
+			condition.Status = metav1.ConditionFalse
+			condition.Reason = vicondition.StorageclassNotReady
+			condition.Message = fmt.Sprintf("Storageclass %q not ready", *vi.Spec.PersistentVolumeClaim.StorageClass)
+			return reconcile.Result{RequeueAfter: 2 * time.Second}, err
+		}
+	}
+
+	return reconcile.Result{}, nil
+}

--- a/images/virtualization-artifact/pkg/controller/vi/internal/storageclass_ready.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/storageclass_ready.go
@@ -44,10 +44,10 @@ func NewStorageClassReadyHandler(client service.Client) *StorageclassReadyHandle
 }
 
 func (h StorageclassReadyHandler) Handle(ctx context.Context, vi *v1alpha2.VirtualImage) (reconcile.Result, error) {
-	condition, ok := service.GetCondition(vicondition.StorageclassReadyType, vi.Status.Conditions)
+	condition, ok := service.GetCondition(vicondition.StorageClassReadyType, vi.Status.Conditions)
 	if !ok {
 		condition = metav1.Condition{
-			Type:   vicondition.StorageclassReadyType,
+			Type:   vicondition.StorageClassReadyType,
 			Status: metav1.ConditionUnknown,
 		}
 	}
@@ -74,11 +74,11 @@ func (h StorageclassReadyHandler) Handle(ctx context.Context, vi *v1alpha2.Virtu
 
 		if sc != nil {
 			condition.Status = metav1.ConditionTrue
-			condition.Reason = vicondition.StorageclassReady
+			condition.Reason = vicondition.StorageClassReady
 			condition.Message = "Storageclass ready"
 		} else {
 			condition.Status = metav1.ConditionFalse
-			condition.Reason = vicondition.StorageclassNotReady
+			condition.Reason = vicondition.StorageClassNotReady
 			condition.Message = fmt.Sprintf("Storageclass %q not ready", *vi.Spec.PersistentVolumeClaim.StorageClass)
 		}
 	}

--- a/images/virtualization-artifact/pkg/controller/vi/internal/storageclass_ready.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/storageclass_ready.go
@@ -18,15 +18,16 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vicondition"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 type StorageclassReadyHandler struct {
@@ -68,7 +69,7 @@ func (h StorageclassReadyHandler) Handle(ctx context.Context, vi *v1alpha2.Virtu
 		condition.Message = "Used dvcr storage"
 	case v1alpha2.StorageKubernetes:
 		sc, err := h.service.GetStorageClass(ctx, vi.Spec.PersistentVolumeClaim.StorageClass)
-		if err != nil && !errors.IsNotFound(err) {
+		if err != nil && !errors.Is(err, service.ErrDefaultStorageClassNotFound) && !errors.Is(err, service.ErrStorageClassNotFound) {
 			return reconcile.Result{}, err
 		}
 

--- a/images/virtualization-artifact/pkg/controller/vi/internal/storageclass_ready.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/storageclass_ready.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 

--- a/images/virtualization-artifact/pkg/controller/vi/vi_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vi/vi_controller.go
@@ -75,6 +75,7 @@ func NewController(
 		internal.NewLifeCycleHandler(sources, mgr.GetClient()),
 		internal.NewDeletionHandler(sources),
 		internal.NewAttacheeHandler(mgr.GetClient()),
+		internal.NewStorageClassReadyHandler(mgr.GetClient()),
 	)
 
 	viController, err := controller.New(ControllerName, mgr, controller.Options{

--- a/images/virtualization-artifact/pkg/controller/vi/vi_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vi/vi_controller.go
@@ -71,11 +71,11 @@ func NewController(
 
 	reconciler := NewReconciler(
 		mgr.GetClient(),
+		internal.NewStorageClassReadyHandler(mgr.GetClient()),
 		internal.NewDatasourceReadyHandler(sources),
 		internal.NewLifeCycleHandler(sources, mgr.GetClient()),
 		internal.NewDeletionHandler(sources),
 		internal.NewAttacheeHandler(mgr.GetClient()),
-		internal.NewStorageClassReadyHandler(mgr.GetClient()),
 	)
 
 	viController, err := controller.New(ControllerName, mgr, controller.Options{

--- a/images/virtualization-artifact/pkg/controller/vi/vi_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/vi/vi_reconciler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	storagev1 "k8s.io/api/storage/v1"
 	"log/slog"
 	"time"
 
@@ -224,6 +225,20 @@ func (r *Reconciler) SetupController(_ context.Context, mgr manager.Manager, ctr
 		},
 	); err != nil {
 		return fmt.Errorf("error setting watch on VDs: %w", err)
+	}
+
+	if err := ctr.Watch(
+		source.Kind(mgr.GetCache(), &storagev1.StorageClass{}),
+		&handler.EnqueueRequestForObject{},
+		predicate.Funcs{
+			CreateFunc: func(e event.CreateEvent) bool {
+				return true
+			},
+			DeleteFunc: func(e event.DeleteEvent) bool { return true },
+			UpdateFunc: func(e event.UpdateEvent) bool { return false },
+		},
+	); err != nil {
+		return fmt.Errorf("error setting watch on storage classes: %w", err)
 	}
 
 	viFromVIEnqueuer := watchers.NewVirtualImageRequestEnqueuer(mgr.GetClient(), &virtv2.VirtualImage{}, virtv2.VirtualImageObjectRefKindVirtualImage)

--- a/images/virtualization-artifact/pkg/controller/vi/vi_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/vi/vi_reconciler.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	storagev1 "k8s.io/api/storage/v1"
 	"log/slog"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/types"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"


### PR DESCRIPTION
## Description
Introduces a readiness condition and validation for StorageClass specified in VirtualImage and VirtualDisk. If the specified StorageClass is not ready, the resource will remain in a pending state.

## Why do we need it, and what problem does it solve?

## What is the expected result?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
