### PR TITLE
chore(core): add cleanup-error-pods.patch

### DIFF
--- a/images/virt-artifact/patches/022-cleanup-error-pods.patch
+++ b/images/virt-artifact/patches/022-cleanup-error-pods.patch
@@ -53,7 +53,7 @@ index 19de1a1921..7f101e4710 100644
 +		if pod.Status.Phase != k8sv1.PodFailed {
 +			continue
 +		}
-+		if strings.Contains(pod.GetName(), "virt-launcher") {
++		if !strings.Contains(pod.GetName(), "virt-launcher") {
 +			continue
 +		}
 +		errorPods = append(errorPods, pod)

--- a/images/virt-artifact/patches/022-cleanup-error-pods.patch
+++ b/images/virt-artifact/patches/022-cleanup-error-pods.patch
@@ -1,0 +1,79 @@
+diff --git a/pkg/virt-controller/watch/vmi.go b/pkg/virt-controller/watch/vmi.go
+index 19de1a1921..7f101e4710 100644
+--- a/pkg/virt-controller/watch/vmi.go
++++ b/pkg/virt-controller/watch/vmi.go
+@@ -19,15 +19,19 @@
+ package watch
+ 
+ import (
++	"cmp"
+ 	"context"
+ 	"encoding/json"
+ 	"errors"
+ 	"fmt"
+ 	"maps"
++	"slices"
+ 	"sort"
+ 	"strings"
+ 	"time"
+ 
++	"k8s.io/utils/ptr"
++
+ 	"kubevirt.io/kubevirt/pkg/virt-controller/network"
+ 
+ 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
+@@ -1048,6 +1052,9 @@ func (c *VMIController) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod,
+ 		log.Log.Reason(err).Errorf("failed to delete orphaned attachment pods %s: %v", controller.VirtualMachineInstanceKey(vmi), err)
+ 		// do not return; just log the error
+ 	}
++	if err := c.deleteErrorPods(context.Background(), vmi, 3); err != nil {
++		return &syncErrorImpl{fmt.Errorf("failed to delete error pods: %v", err), controller.FailedDeletePodReason}
++	}
+ 
+ 	err := c.backendStorage.CreateIfNeededAndUpdateVolumeStatus(vmi)
+ 	if err != nil {
+@@ -1178,6 +1185,44 @@ func (c *VMIController) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod,
+ 	return nil
+ }
+ 
++func getAge(obj v1.Object) time.Duration {
++	return time.Since(obj.GetCreationTimestamp().Time).Truncate(time.Second)
++}
++
++func (c *VMIController) deleteErrorPods(ctx context.Context, vmi *virtv1.VirtualMachineInstance, keepCount int) error {
++	pods, err := c.listPodsFromNamespace(vmi.GetNamespace())
++	if err != nil {
++		return fmt.Errorf("failed to list pods from namespace %s: %v", vmi.GetNamespace(), err)
++	}
++	var errorPods []*k8sv1.Pod
++	for _, pod := range pods {
++		if !controller.IsControlledBy(pod, vmi) {
++			continue
++		}
++		if pod.Status.Phase != k8sv1.PodFailed {
++			continue
++		}
++		if strings.Contains(pod.GetName(), "virt-launcher") {
++			continue
++		}
++		errorPods = append(errorPods, pod)
++	}
++	if len(errorPods) <= keepCount {
++		return nil
++	}
++	slices.SortFunc(errorPods, func(a, b *k8sv1.Pod) int {
++		return cmp.Compare(getAge(a), getAge(b))
++	})
++
++	for _, pod := range errorPods[keepCount:] {
++		err = c.clientset.CoreV1().Pods(vmi.GetNamespace()).Delete(ctx, pod.GetName(), v1.DeleteOptions{GracePeriodSeconds: ptr.To[int64](0)})
++		if err != nil {
++			return fmt.Errorf("failed to delete pod %s: %v", pod.GetName(), err)
++		}
++	}
++	return nil
++}
++
+ func (c *VMIController) handleSyncDataVolumes(vmi *virtv1.VirtualMachineInstance, dataVolumes []*cdiv1.DataVolume) (bool, bool, syncError) {
+ 
+ 	ready := true

--- a/images/virt-artifact/patches/README.md
+++ b/images/virt-artifact/patches/README.md
@@ -72,4 +72,9 @@ We're changing the raw format for disks to qcow2 for all images created on the f
 Additionally, kubevirt can create images on an empty PVC. We're changing this behavior as well, altering the format of the created disk to qcow2. This is achieved using qemu-img.
 
 #### `022-cleanup-error-pods.patch`
-After unsuccessful migrations, so many pods will remain in the failure phase. Clear them by saving the last 3.
+
+Cleanup stale Pods owned by the VMI, keep only last 3 in the Failed phase.
+
+Why we need it?
+
+Unsuccessful migrations may leave a lot of Pods. These huge lists reduce performance on virtualization-controller and cdi-deployment restarts.

--- a/images/virt-artifact/patches/README.md
+++ b/images/virt-artifact/patches/README.md
@@ -70,3 +70,6 @@ Support format qcow2 for pvc with filesystem mode.
 When generating XML for libvirt, we utilize converters that translate the virtual machine instance specification into a Domain. We're making a slight adjustment to this process.
 We're changing the raw format for disks to qcow2 for all images created on the file system. These values are hardcoded as we can't determine the disk format used by the virtual machine through qemu-img.
 Additionally, kubevirt can create images on an empty PVC. We're changing this behavior as well, altering the format of the created disk to qcow2. This is achieved using qemu-img.
+
+#### `022-cleanup-error-pods.patch`
+After unsuccessful migrations, so many pods will remain in the failure phase. Clear them by saving the last 3.


### PR DESCRIPTION
## Description
add cleanup-error-pods.patch

## Why do we need it, and what problem does it solve?
After unsuccessful migrations, so many pods will remain in the failure phase. Clear them by saving the last 3.


## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
