### PR TITLE
fix(vm): fix the virtual machine matching with the virtual machine class during validation when no sizing policy is provided

### DIFF
--- a/images/virtualization-artifact/pkg/controller/service/size_policy_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/size_policy_service.go
@@ -24,7 +24,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
 const (
@@ -39,7 +39,7 @@ func NewSizePolicyService() *SizePolicyService {
 	return &SizePolicyService{}
 }
 
-func (s *SizePolicyService) CheckVMMatchedSizePolicy(vm *v1alpha2.VirtualMachine, vmClass *v1alpha2.VirtualMachineClass) error {
+func (s *SizePolicyService) CheckVMMatchedSizePolicy(vm *virtv2.VirtualMachine, vmClass *virtv2.VirtualMachineClass) error {
 	// check if no sizing policy requirements setted
 	if len(vmClass.Spec.SizingPolicies) == 0 {
 		return nil
@@ -66,7 +66,7 @@ func (s *SizePolicyService) CheckVMMatchedSizePolicy(vm *v1alpha2.VirtualMachine
 	return nil
 }
 
-func getVMSizePolicy(vm *v1alpha2.VirtualMachine, vmClass *v1alpha2.VirtualMachineClass) *v1alpha2.SizingPolicy {
+func getVMSizePolicy(vm *virtv2.VirtualMachine, vmClass *virtv2.VirtualMachineClass) *virtv2.SizingPolicy {
 	for _, sp := range vmClass.Spec.SizingPolicies {
 		if vm.Spec.CPU.Cores >= sp.Cores.Min && vm.Spec.CPU.Cores <= sp.Cores.Max {
 			return sp.DeepCopy()
@@ -76,7 +76,7 @@ func getVMSizePolicy(vm *v1alpha2.VirtualMachine, vmClass *v1alpha2.VirtualMachi
 	return nil
 }
 
-func validateCoreFraction(vm *v1alpha2.VirtualMachine, sp *v1alpha2.SizingPolicy) (errorsArray []error) {
+func validateCoreFraction(vm *virtv2.VirtualMachine, sp *virtv2.SizingPolicy) (errorsArray []error) {
 	if sp.CoreFractions == nil {
 		return
 	}
@@ -102,7 +102,7 @@ func validateCoreFraction(vm *v1alpha2.VirtualMachine, sp *v1alpha2.SizingPolicy
 	return
 }
 
-func validateMemory(vm *v1alpha2.VirtualMachine, sp *v1alpha2.SizingPolicy) (errorsArray []error) {
+func validateMemory(vm *virtv2.VirtualMachine, sp *virtv2.SizingPolicy) (errorsArray []error) {
 	if sp.Memory == nil || sp.Memory.Max.IsZero() {
 		return
 	}
@@ -135,7 +135,7 @@ func validateMemory(vm *v1alpha2.VirtualMachine, sp *v1alpha2.SizingPolicy) (err
 	return
 }
 
-func validatePerCoreMemory(vm *v1alpha2.VirtualMachine, sp *v1alpha2.SizingPolicy) (errorsArray []error) {
+func validatePerCoreMemory(vm *virtv2.VirtualMachine, sp *virtv2.SizingPolicy) (errorsArray []error) {
 	if sp.Memory == nil || sp.Memory.PerCore.Max.IsZero() {
 		return
 	}

--- a/images/virtualization-artifact/pkg/controller/service/size_policy_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/size_policy_service.go
@@ -40,7 +40,7 @@ func NewSizePolicyService() *SizePolicyService {
 }
 
 func (s *SizePolicyService) CheckVMMatchedSizePolicy(vm *virtv2.VirtualMachine, vmClass *virtv2.VirtualMachineClass) error {
-	// check if no sizing policy requirements set
+	// check if no sizing policy requirements are set.
 	if len(vmClass.Spec.SizingPolicies) == 0 {
 		return nil
 	}

--- a/images/virtualization-artifact/pkg/controller/service/size_policy_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/size_policy_service.go
@@ -40,7 +40,7 @@ func NewSizePolicyService() *SizePolicyService {
 }
 
 func (s *SizePolicyService) CheckVMMatchedSizePolicy(vm *virtv2.VirtualMachine, vmClass *virtv2.VirtualMachineClass) error {
-	// check if no sizing policy requirements setted
+	// check if no sizing policy requirements set
 	if len(vmClass.Spec.SizingPolicies) == 0 {
 		return nil
 	}

--- a/images/virtualization-artifact/pkg/controller/service/size_policy_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/size_policy_service.go
@@ -40,7 +40,7 @@ func NewSizePolicyService() *SizePolicyService {
 }
 
 func (s *SizePolicyService) CheckVMMatchedSizePolicy(vm *virtv2.VirtualMachine, vmClass *virtv2.VirtualMachineClass) error {
-	// check if no sizing policy requirements are set.
+	// check if no sizing policy requirements are set
 	if len(vmClass.Spec.SizingPolicies) == 0 {
 		return nil
 	}

--- a/images/virtualization-artifact/pkg/controller/service/size_policy_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/size_policy_service.go
@@ -40,6 +40,11 @@ func NewSizePolicyService() *SizePolicyService {
 }
 
 func (s *SizePolicyService) CheckVMMatchedSizePolicy(vm *v1alpha2.VirtualMachine, vmClass *v1alpha2.VirtualMachineClass) error {
+	// check if no sizing policy requirements setted
+	if len(vmClass.Spec.SizingPolicies) == 0 {
+		return nil
+	}
+
 	sizePolicy := getVMSizePolicy(vm, vmClass)
 	if sizePolicy == nil {
 		return fmt.Errorf(

--- a/images/virtualization-artifact/pkg/controller/service/size_policy_service_test.go
+++ b/images/virtualization-artifact/pkg/controller/service/size_policy_service_test.go
@@ -491,46 +491,6 @@ var _ = Describe("SizePolicyService", func() {
 		})
 	})
 
-	Context("when VM's per core memory step is incorrect", func() {
-		// Virtual machine with an incorrect per-core memory step
-		vm := &v1alpha2.VirtualMachine{
-			Spec: v1alpha2.VirtualMachineSpec{
-				VirtualMachineClassName: "vmclasstest",
-				CPU:                     v1alpha2.CPUSpec{Cores: 2, CoreFraction: "10%"},
-				Memory:                  v1alpha2.MemorySpec{Size: resource.MustParse("4001Mi")},
-			},
-		}
-
-		BeforeEach(func() {
-			// Set mock VM class data with invalid per-core memory step policies for the VM
-			vmClass = &v1alpha2.VirtualMachineClass{
-				Spec: v1alpha2.VirtualMachineClassSpec{
-					SizingPolicies: []v1alpha2.SizingPolicy{
-						{
-							Cores: &v1alpha2.SizingPolicyCores{Min: 1, Max: 4},
-							Memory: &v1alpha2.SizingPolicyMemory{
-								Step: resource.MustParse("1Gi"),
-								PerCore: v1alpha2.SizingPolicyMemoryPerCore{
-									MemoryMinMax: v1alpha2.MemoryMinMax{
-										Min: resource.MustParse("1Gi"),
-										Max: resource.MustParse("3Gi"),
-									},
-								},
-							},
-						},
-					},
-				},
-			}
-		})
-
-		It("should fail validation due to non-matching per core memory step", func() {
-			service := service.NewSizePolicyService()
-			err := service.CheckVMMatchedSizePolicy(vm, vmClass)
-			// Expect an error because the per-core memory size does not match the step policy
-			Expect(err).ShouldNot(BeNil())
-		})
-	})
-
 	Context("When size policy not provided", func() {
 		vm := &v1alpha2.VirtualMachine{
 			Spec: v1alpha2.VirtualMachineSpec{
@@ -539,7 +499,7 @@ var _ = Describe("SizePolicyService", func() {
 				Memory:                  v1alpha2.MemorySpec{Size: resource.MustParse("4001Mi")},
 			},
 		}
-		vmClass = &v1alpha2.VirtualMachineClass{}
+		vmClass := &v1alpha2.VirtualMachineClass{}
 
 		It("should pass validation cause no requirements", func() {
 			service := service.NewSizePolicyService()

--- a/images/virtualization-artifact/pkg/controller/service/size_policy_service_test.go
+++ b/images/virtualization-artifact/pkg/controller/service/size_policy_service_test.go
@@ -22,33 +22,29 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
-	v1alpha2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
 var _ = Describe("SizePolicyService", func() {
-	var vmClass *v1alpha2.VirtualMachineClass
-
 	Context("when VM's class has no valid size policy", func() {
 		// Virtual machine with non-matching CPU parameters
-		vm := &v1alpha2.VirtualMachine{
-			Spec: v1alpha2.VirtualMachineSpec{
+		vm := &virtv2.VirtualMachine{
+			Spec: virtv2.VirtualMachineSpec{
 				VirtualMachineClassName: "vmclasstest",
-				CPU:                     v1alpha2.CPUSpec{Cores: 5, CoreFraction: "10%"},
+				CPU:                     virtv2.CPUSpec{Cores: 5, CoreFraction: "10%"},
 			},
 		}
 
-		BeforeEach(func() {
-			// Initialize a virtual machine class with policies that do not match the VM's parameters
-			vmClass = &v1alpha2.VirtualMachineClass{
-				Spec: v1alpha2.VirtualMachineClassSpec{
-					SizingPolicies: []v1alpha2.SizingPolicy{
-						{
-							Cores: &v1alpha2.SizingPolicyCores{Min: 1, Max: 4},
-						},
+		// Initialize a virtual machine class with policies that do not match the VM's parameters
+		vmClass := &virtv2.VirtualMachineClass{
+			Spec: virtv2.VirtualMachineClassSpec{
+				SizingPolicies: []virtv2.SizingPolicy{
+					{
+						Cores: &virtv2.SizingPolicyCores{Min: 1, Max: 4},
 					},
 				},
-			}
-		})
+			},
+		}
 
 		It("should fail validation due to invalid size policy", func() {
 			service := service.NewSizePolicyService()
@@ -60,25 +56,23 @@ var _ = Describe("SizePolicyService", func() {
 
 	Context("when VM's class has correct policy without memory requirements", func() {
 		// Virtual machine with appropriate CPU parameters and no memory requirements
-		vm := &v1alpha2.VirtualMachine{
-			Spec: v1alpha2.VirtualMachineSpec{
+		vm := &virtv2.VirtualMachine{
+			Spec: virtv2.VirtualMachineSpec{
 				VirtualMachineClassName: "vmclasstest",
-				CPU:                     v1alpha2.CPUSpec{Cores: 1, CoreFraction: "10%"},
+				CPU:                     virtv2.CPUSpec{Cores: 1, CoreFraction: "10%"},
 			},
 		}
 
-		BeforeEach(func() {
-			// Set mock VM class data with valid policies for the VM without memory requirements
-			vmClass = &v1alpha2.VirtualMachineClass{
-				Spec: v1alpha2.VirtualMachineClassSpec{
-					SizingPolicies: []v1alpha2.SizingPolicy{
-						{
-							Cores: &v1alpha2.SizingPolicyCores{Min: 1, Max: 4},
-						},
+		// Set mock VM class data with valid policies for the VM without memory requirements
+		vmClass := &virtv2.VirtualMachineClass{
+			Spec: virtv2.VirtualMachineClassSpec{
+				SizingPolicies: []virtv2.SizingPolicy{
+					{
+						Cores: &virtv2.SizingPolicyCores{Min: 1, Max: 4},
 					},
 				},
-			}
-		})
+			},
+		}
 
 		It("should pass validation due to lack of memory requirements", func() {
 			service := service.NewSizePolicyService()
@@ -90,32 +84,30 @@ var _ = Describe("SizePolicyService", func() {
 
 	Context("when VM's memory does not match with policy", func() {
 		// Virtual machine with non-matching memory parameters
-		vm := &v1alpha2.VirtualMachine{
-			Spec: v1alpha2.VirtualMachineSpec{
+		vm := &virtv2.VirtualMachine{
+			Spec: virtv2.VirtualMachineSpec{
 				VirtualMachineClassName: "vmclasstest",
-				CPU:                     v1alpha2.CPUSpec{Cores: 1, CoreFraction: "10%"},
-				Memory:                  v1alpha2.MemorySpec{Size: resource.MustParse("1Gi")},
+				CPU:                     virtv2.CPUSpec{Cores: 1, CoreFraction: "10%"},
+				Memory:                  virtv2.MemorySpec{Size: resource.MustParse("1Gi")},
 			},
 		}
 
-		BeforeEach(func() {
-			// Set mock VM class data with policies that match memory requirements for the VM
-			vmClass = &v1alpha2.VirtualMachineClass{
-				Spec: v1alpha2.VirtualMachineClassSpec{
-					SizingPolicies: []v1alpha2.SizingPolicy{
-						{
-							Cores: &v1alpha2.SizingPolicyCores{Min: 1, Max: 4},
-							Memory: &v1alpha2.SizingPolicyMemory{
-								MemoryMinMax: v1alpha2.MemoryMinMax{
-									Min: resource.MustParse("512Mi"),
-									Max: resource.MustParse("2Gi"),
-								},
+		// Set mock VM class data with policies that match memory requirements for the VM
+		vmClass := &virtv2.VirtualMachineClass{
+			Spec: virtv2.VirtualMachineClassSpec{
+				SizingPolicies: []virtv2.SizingPolicy{
+					{
+						Cores: &virtv2.SizingPolicyCores{Min: 1, Max: 4},
+						Memory: &virtv2.SizingPolicyMemory{
+							MemoryMinMax: virtv2.MemoryMinMax{
+								Min: resource.MustParse("512Mi"),
+								Max: resource.MustParse("2Gi"),
 							},
 						},
 					},
 				},
-			}
-		})
+			},
+		}
 
 		It("should pass validation due to matching memory size", func() {
 			service := service.NewSizePolicyService()
@@ -127,32 +119,30 @@ var _ = Describe("SizePolicyService", func() {
 
 	Context("when VM's memory matches the policy", func() {
 		// Virtual machine with matching memory parameters
-		vm := &v1alpha2.VirtualMachine{
-			Spec: v1alpha2.VirtualMachineSpec{
+		vm := &virtv2.VirtualMachine{
+			Spec: virtv2.VirtualMachineSpec{
 				VirtualMachineClassName: "vmclasstest",
-				CPU:                     v1alpha2.CPUSpec{Cores: 1, CoreFraction: "10%"},
-				Memory:                  v1alpha2.MemorySpec{Size: resource.MustParse("2Gi")},
+				CPU:                     virtv2.CPUSpec{Cores: 1, CoreFraction: "10%"},
+				Memory:                  virtv2.MemorySpec{Size: resource.MustParse("2Gi")},
 			},
 		}
 
-		BeforeEach(func() {
-			// Set mock VM class data with valid memory policies for the VM
-			vmClass = &v1alpha2.VirtualMachineClass{
-				Spec: v1alpha2.VirtualMachineClassSpec{
-					SizingPolicies: []v1alpha2.SizingPolicy{
-						{
-							Cores: &v1alpha2.SizingPolicyCores{Min: 1, Max: 4},
-							Memory: &v1alpha2.SizingPolicyMemory{
-								MemoryMinMax: v1alpha2.MemoryMinMax{
-									Min: resource.MustParse("1Gi"),
-									Max: resource.MustParse("3Gi"),
-								},
+		// Set mock VM class data with valid memory policies for the VM
+		vmClass := &virtv2.VirtualMachineClass{
+			Spec: virtv2.VirtualMachineClassSpec{
+				SizingPolicies: []virtv2.SizingPolicy{
+					{
+						Cores: &virtv2.SizingPolicyCores{Min: 1, Max: 4},
+						Memory: &virtv2.SizingPolicyMemory{
+							MemoryMinMax: virtv2.MemoryMinMax{
+								Min: resource.MustParse("1Gi"),
+								Max: resource.MustParse("3Gi"),
 							},
 						},
 					},
 				},
-			}
-		})
+			},
+		}
 
 		It("should pass validation due to matched memory size", func() {
 			service := service.NewSizePolicyService()
@@ -164,27 +154,25 @@ var _ = Describe("SizePolicyService", func() {
 
 	Context("when class policy has empty memory requirements", func() {
 		// Virtual machine with memory size that matches an empty memory requirement policy
-		vm := &v1alpha2.VirtualMachine{
-			Spec: v1alpha2.VirtualMachineSpec{
+		vm := &virtv2.VirtualMachine{
+			Spec: virtv2.VirtualMachineSpec{
 				VirtualMachineClassName: "vmclasstest",
-				CPU:                     v1alpha2.CPUSpec{Cores: 1, CoreFraction: "10%"},
-				Memory:                  v1alpha2.MemorySpec{Size: resource.MustParse("2Gi")},
+				CPU:                     virtv2.CPUSpec{Cores: 1, CoreFraction: "10%"},
+				Memory:                  virtv2.MemorySpec{Size: resource.MustParse("2Gi")},
 			},
 		}
 
-		BeforeEach(func() {
-			vmClass = &v1alpha2.VirtualMachineClass{
-				Spec: v1alpha2.VirtualMachineClassSpec{
-					// No specific memory policies defined
-					SizingPolicies: []v1alpha2.SizingPolicy{
-						{
-							Cores:  &v1alpha2.SizingPolicyCores{Min: 1, Max: 4},
-							Memory: &v1alpha2.SizingPolicyMemory{},
-						},
+		vmClass := &virtv2.VirtualMachineClass{
+			Spec: virtv2.VirtualMachineClassSpec{
+				// No specific memory policies defined
+				SizingPolicies: []virtv2.SizingPolicy{
+					{
+						Cores:  &virtv2.SizingPolicyCores{Min: 1, Max: 4},
+						Memory: &virtv2.SizingPolicyMemory{},
 					},
 				},
-			}
-		})
+			},
+		}
 
 		It("should pass validation due to lack of memory requirements", func() {
 			service := service.NewSizePolicyService()
@@ -196,34 +184,32 @@ var _ = Describe("SizePolicyService", func() {
 
 	Context("when VM's memory is correct per core", func() {
 		// Virtual machine with memory size that adheres to per-core memory policies
-		vm := &v1alpha2.VirtualMachine{
-			Spec: v1alpha2.VirtualMachineSpec{
+		vm := &virtv2.VirtualMachine{
+			Spec: virtv2.VirtualMachineSpec{
 				VirtualMachineClassName: "vmclasstest",
-				CPU:                     v1alpha2.CPUSpec{Cores: 2, CoreFraction: "10%"},
-				Memory:                  v1alpha2.MemorySpec{Size: resource.MustParse("4Gi")},
+				CPU:                     virtv2.CPUSpec{Cores: 2, CoreFraction: "10%"},
+				Memory:                  virtv2.MemorySpec{Size: resource.MustParse("4Gi")},
 			},
 		}
 
-		BeforeEach(func() {
-			vmClass = &v1alpha2.VirtualMachineClass{
-				Spec: v1alpha2.VirtualMachineClassSpec{
-					// Setting policies with per-core memory requirements
-					SizingPolicies: []v1alpha2.SizingPolicy{
-						{
-							Cores: &v1alpha2.SizingPolicyCores{Min: 1, Max: 4},
-							Memory: &v1alpha2.SizingPolicyMemory{
-								PerCore: v1alpha2.SizingPolicyMemoryPerCore{
-									MemoryMinMax: v1alpha2.MemoryMinMax{
-										Min: resource.MustParse("1Gi"),
-										Max: resource.MustParse("3Gi"),
-									},
+		vmClass := &virtv2.VirtualMachineClass{
+			Spec: virtv2.VirtualMachineClassSpec{
+				// Setting policies with per-core memory requirements
+				SizingPolicies: []virtv2.SizingPolicy{
+					{
+						Cores: &virtv2.SizingPolicyCores{Min: 1, Max: 4},
+						Memory: &virtv2.SizingPolicyMemory{
+							PerCore: virtv2.SizingPolicyMemoryPerCore{
+								MemoryMinMax: virtv2.MemoryMinMax{
+									Min: resource.MustParse("1Gi"),
+									Max: resource.MustParse("3Gi"),
 								},
 							},
 						},
 					},
 				},
-			}
-		})
+			},
+		}
 
 		It("should pass validation due to matched per-core memory size", func() {
 			service := service.NewSizePolicyService()
@@ -235,34 +221,32 @@ var _ = Describe("SizePolicyService", func() {
 
 	Context("when VM's memory is incorrect per core", func() {
 		// Virtual machine with incorrect per-core memory size
-		vm := &v1alpha2.VirtualMachine{
-			Spec: v1alpha2.VirtualMachineSpec{
+		vm := &virtv2.VirtualMachine{
+			Spec: virtv2.VirtualMachineSpec{
 				VirtualMachineClassName: "vmclasstest",
-				CPU:                     v1alpha2.CPUSpec{Cores: 4, CoreFraction: "10%"},
-				Memory:                  v1alpha2.MemorySpec{Size: resource.MustParse("4Gi")},
+				CPU:                     virtv2.CPUSpec{Cores: 4, CoreFraction: "10%"},
+				Memory:                  virtv2.MemorySpec{Size: resource.MustParse("4Gi")},
 			},
 		}
 
-		BeforeEach(func() {
-			// Set mock VM class data with invalid per-core memory policies for the VM
-			vmClass = &v1alpha2.VirtualMachineClass{
-				Spec: v1alpha2.VirtualMachineClassSpec{
-					SizingPolicies: []v1alpha2.SizingPolicy{
-						{
-							Cores: &v1alpha2.SizingPolicyCores{Min: 1, Max: 4},
-							Memory: &v1alpha2.SizingPolicyMemory{
-								PerCore: v1alpha2.SizingPolicyMemoryPerCore{
-									MemoryMinMax: v1alpha2.MemoryMinMax{
-										Min: resource.MustParse("2Gi"),
-										Max: resource.MustParse("3Gi"),
-									},
+		// Set mock VM class data with invalid per-core memory policies for the VM
+		vmClass := &virtv2.VirtualMachineClass{
+			Spec: virtv2.VirtualMachineClassSpec{
+				SizingPolicies: []virtv2.SizingPolicy{
+					{
+						Cores: &virtv2.SizingPolicyCores{Min: 1, Max: 4},
+						Memory: &virtv2.SizingPolicyMemory{
+							PerCore: virtv2.SizingPolicyMemoryPerCore{
+								MemoryMinMax: virtv2.MemoryMinMax{
+									Min: resource.MustParse("2Gi"),
+									Max: resource.MustParse("3Gi"),
 								},
 							},
 						},
 					},
 				},
-			}
-		})
+			},
+		}
 
 		It("should fail validation due to non-matching per-core memory size", func() {
 			service := service.NewSizePolicyService()
@@ -274,27 +258,25 @@ var _ = Describe("SizePolicyService", func() {
 
 	Context("when VM's core fraction is correct", func() {
 		// Virtual machine with a correct core fraction
-		vm := &v1alpha2.VirtualMachine{
-			Spec: v1alpha2.VirtualMachineSpec{
+		vm := &virtv2.VirtualMachine{
+			Spec: virtv2.VirtualMachineSpec{
 				VirtualMachineClassName: "vmclasstest",
-				CPU:                     v1alpha2.CPUSpec{Cores: 1, CoreFraction: "10%"},
-				Memory:                  v1alpha2.MemorySpec{Size: resource.MustParse("2Gi")},
+				CPU:                     virtv2.CPUSpec{Cores: 1, CoreFraction: "10%"},
+				Memory:                  virtv2.MemorySpec{Size: resource.MustParse("2Gi")},
 			},
 		}
 
-		BeforeEach(func() {
-			// Set mock VM class data with valid core fraction policies for the VM
-			vmClass = &v1alpha2.VirtualMachineClass{
-				Spec: v1alpha2.VirtualMachineClassSpec{
-					SizingPolicies: []v1alpha2.SizingPolicy{
-						{
-							Cores:         &v1alpha2.SizingPolicyCores{Min: 1, Max: 4},
-							CoreFractions: []v1alpha2.CoreFractionValue{10, 25, 50, 100},
-						},
+		// Set mock VM class data with valid core fraction policies for the VM
+		vmClass := &virtv2.VirtualMachineClass{
+			Spec: virtv2.VirtualMachineClassSpec{
+				SizingPolicies: []virtv2.SizingPolicy{
+					{
+						Cores:         &virtv2.SizingPolicyCores{Min: 1, Max: 4},
+						CoreFractions: []virtv2.CoreFractionValue{10, 25, 50, 100},
 					},
 				},
-			}
-		})
+			},
+		}
 
 		It("should pass validation due to matching core fraction", func() {
 			service := service.NewSizePolicyService()
@@ -306,27 +288,25 @@ var _ = Describe("SizePolicyService", func() {
 
 	Context("when VM's core fraction is incorrect", func() {
 		// Virtual machine with an incorrect core fraction
-		vm := &v1alpha2.VirtualMachine{
-			Spec: v1alpha2.VirtualMachineSpec{
+		vm := &virtv2.VirtualMachine{
+			Spec: virtv2.VirtualMachineSpec{
 				VirtualMachineClassName: "vmclasstest",
-				CPU:                     v1alpha2.CPUSpec{Cores: 1, CoreFraction: "11%"},
-				Memory:                  v1alpha2.MemorySpec{Size: resource.MustParse("2Gi")},
+				CPU:                     virtv2.CPUSpec{Cores: 1, CoreFraction: "11%"},
+				Memory:                  virtv2.MemorySpec{Size: resource.MustParse("2Gi")},
 			},
 		}
 
-		BeforeEach(func() {
-			// Set mock VM class data with valid core fraction policies for the VM
-			vmClass = &v1alpha2.VirtualMachineClass{
-				Spec: v1alpha2.VirtualMachineClassSpec{
-					SizingPolicies: []v1alpha2.SizingPolicy{
-						{
-							Cores:         &v1alpha2.SizingPolicyCores{Min: 1, Max: 4},
-							CoreFractions: []v1alpha2.CoreFractionValue{10, 25, 50, 100},
-						},
+		// Set mock VM class data with valid core fraction policies for the VM
+		vmClass := &virtv2.VirtualMachineClass{
+			Spec: virtv2.VirtualMachineClassSpec{
+				SizingPolicies: []virtv2.SizingPolicy{
+					{
+						Cores:         &virtv2.SizingPolicyCores{Min: 1, Max: 4},
+						CoreFractions: []virtv2.CoreFractionValue{10, 25, 50, 100},
 					},
 				},
-			}
-		})
+			},
+		}
 
 		It("should fail validation due to non-matching core fraction", func() {
 			service := service.NewSizePolicyService()
@@ -338,33 +318,31 @@ var _ = Describe("SizePolicyService", func() {
 
 	Context("when VM's memory step is correct", func() {
 		// Virtual machine with a correct memory step
-		vm := &v1alpha2.VirtualMachine{
-			Spec: v1alpha2.VirtualMachineSpec{
+		vm := &virtv2.VirtualMachine{
+			Spec: virtv2.VirtualMachineSpec{
 				VirtualMachineClassName: "vmclasstest",
-				CPU:                     v1alpha2.CPUSpec{Cores: 2, CoreFraction: "10%"},
-				Memory:                  v1alpha2.MemorySpec{Size: resource.MustParse("2Gi")},
+				CPU:                     virtv2.CPUSpec{Cores: 2, CoreFraction: "10%"},
+				Memory:                  virtv2.MemorySpec{Size: resource.MustParse("2Gi")},
 			},
 		}
 
-		BeforeEach(func() {
-			// Set mock VM class data with valid memory step policies for the VM
-			vmClass = &v1alpha2.VirtualMachineClass{
-				Spec: v1alpha2.VirtualMachineClassSpec{
-					SizingPolicies: []v1alpha2.SizingPolicy{
-						{
-							Cores: &v1alpha2.SizingPolicyCores{Min: 1, Max: 4},
-							Memory: &v1alpha2.SizingPolicyMemory{
-								Step: resource.MustParse("1Gi"),
-								MemoryMinMax: v1alpha2.MemoryMinMax{
-									Min: resource.MustParse("1Gi"),
-									Max: resource.MustParse("3Gi"),
-								},
+		// Set mock VM class data with valid memory step policies for the VM
+		vmClass := &virtv2.VirtualMachineClass{
+			Spec: virtv2.VirtualMachineClassSpec{
+				SizingPolicies: []virtv2.SizingPolicy{
+					{
+						Cores: &virtv2.SizingPolicyCores{Min: 1, Max: 4},
+						Memory: &virtv2.SizingPolicyMemory{
+							Step: resource.MustParse("1Gi"),
+							MemoryMinMax: virtv2.MemoryMinMax{
+								Min: resource.MustParse("1Gi"),
+								Max: resource.MustParse("3Gi"),
 							},
 						},
 					},
 				},
-			}
-		})
+			},
+		}
 
 		It("should pass validation due to matched memory step", func() {
 			service := service.NewSizePolicyService()
@@ -376,33 +354,31 @@ var _ = Describe("SizePolicyService", func() {
 
 	Context("when VM's memory step is incorrect", func() {
 		// Virtual machine with an incorrect memory step
-		vm := &v1alpha2.VirtualMachine{
-			Spec: v1alpha2.VirtualMachineSpec{
+		vm := &virtv2.VirtualMachine{
+			Spec: virtv2.VirtualMachineSpec{
 				VirtualMachineClassName: "vmclasstest",
-				CPU:                     v1alpha2.CPUSpec{Cores: 2, CoreFraction: "10%"},
-				Memory:                  v1alpha2.MemorySpec{Size: resource.MustParse("2001Mi")},
+				CPU:                     virtv2.CPUSpec{Cores: 2, CoreFraction: "10%"},
+				Memory:                  virtv2.MemorySpec{Size: resource.MustParse("2001Mi")},
 			},
 		}
 
-		BeforeEach(func() {
-			// Set mock VM class data with invalid memory step policies for the VM
-			vmClass = &v1alpha2.VirtualMachineClass{
-				Spec: v1alpha2.VirtualMachineClassSpec{
-					SizingPolicies: []v1alpha2.SizingPolicy{
-						{
-							Cores: &v1alpha2.SizingPolicyCores{Min: 1, Max: 4},
-							Memory: &v1alpha2.SizingPolicyMemory{
-								Step: resource.MustParse("1Gi"),
-								MemoryMinMax: v1alpha2.MemoryMinMax{
-									Min: resource.MustParse("1Gi"),
-									Max: resource.MustParse("3Gi"),
-								},
+		// Set mock VM class data with invalid memory step policies for the VM
+		vmClass := &virtv2.VirtualMachineClass{
+			Spec: virtv2.VirtualMachineClassSpec{
+				SizingPolicies: []virtv2.SizingPolicy{
+					{
+						Cores: &virtv2.SizingPolicyCores{Min: 1, Max: 4},
+						Memory: &virtv2.SizingPolicyMemory{
+							Step: resource.MustParse("1Gi"),
+							MemoryMinMax: virtv2.MemoryMinMax{
+								Min: resource.MustParse("1Gi"),
+								Max: resource.MustParse("3Gi"),
 							},
 						},
 					},
 				},
-			}
-		})
+			},
+		}
 
 		It("should fail validation due to non-matching memory step", func() {
 			service := service.NewSizePolicyService()
@@ -414,34 +390,32 @@ var _ = Describe("SizePolicyService", func() {
 
 	Context("when VM's per core memory step is correct", func() {
 		// Virtual machine with a correct per-core memory step
-		vm := &v1alpha2.VirtualMachine{
-			Spec: v1alpha2.VirtualMachineSpec{
+		vm := &virtv2.VirtualMachine{
+			Spec: virtv2.VirtualMachineSpec{
 				VirtualMachineClassName: "vmclasstest",
-				CPU:                     v1alpha2.CPUSpec{Cores: 2, CoreFraction: "10%"},
-				Memory:                  v1alpha2.MemorySpec{Size: resource.MustParse("4Gi")},
+				CPU:                     virtv2.CPUSpec{Cores: 2, CoreFraction: "10%"},
+				Memory:                  virtv2.MemorySpec{Size: resource.MustParse("4Gi")},
 			},
 		}
 
-		BeforeEach(func() {
-			vmClass = &v1alpha2.VirtualMachineClass{
-				Spec: v1alpha2.VirtualMachineClassSpec{
-					SizingPolicies: []v1alpha2.SizingPolicy{
-						{
-							Cores: &v1alpha2.SizingPolicyCores{Min: 1, Max: 4},
-							Memory: &v1alpha2.SizingPolicyMemory{
-								Step: resource.MustParse("1Gi"),
-								PerCore: v1alpha2.SizingPolicyMemoryPerCore{
-									MemoryMinMax: v1alpha2.MemoryMinMax{
-										Min: resource.MustParse("1Gi"),
-										Max: resource.MustParse("3Gi"),
-									},
+		vmClass := &virtv2.VirtualMachineClass{
+			Spec: virtv2.VirtualMachineClassSpec{
+				SizingPolicies: []virtv2.SizingPolicy{
+					{
+						Cores: &virtv2.SizingPolicyCores{Min: 1, Max: 4},
+						Memory: &virtv2.SizingPolicyMemory{
+							Step: resource.MustParse("1Gi"),
+							PerCore: virtv2.SizingPolicyMemoryPerCore{
+								MemoryMinMax: virtv2.MemoryMinMax{
+									Min: resource.MustParse("1Gi"),
+									Max: resource.MustParse("3Gi"),
 								},
 							},
 						},
 					},
 				},
-			}
-		})
+			},
+		}
 
 		It("should pass validation due to match per core memory step", func() {
 			service := service.NewSizePolicyService()
@@ -453,35 +427,33 @@ var _ = Describe("SizePolicyService", func() {
 
 	Context("when VM's per core memory step is incorrect", func() {
 		// Virtual machine with an incorrect per-core memory step
-		vm := &v1alpha2.VirtualMachine{
-			Spec: v1alpha2.VirtualMachineSpec{
+		vm := &virtv2.VirtualMachine{
+			Spec: virtv2.VirtualMachineSpec{
 				VirtualMachineClassName: "vmclasstest",
-				CPU:                     v1alpha2.CPUSpec{Cores: 2, CoreFraction: "10%"},
-				Memory:                  v1alpha2.MemorySpec{Size: resource.MustParse("4001Mi")},
+				CPU:                     virtv2.CPUSpec{Cores: 2, CoreFraction: "10%"},
+				Memory:                  virtv2.MemorySpec{Size: resource.MustParse("4001Mi")},
 			},
 		}
 
-		BeforeEach(func() {
-			// Set mock VM class data with invalid per-core memory step policies for the VM
-			vmClass = &v1alpha2.VirtualMachineClass{
-				Spec: v1alpha2.VirtualMachineClassSpec{
-					SizingPolicies: []v1alpha2.SizingPolicy{
-						{
-							Cores: &v1alpha2.SizingPolicyCores{Min: 1, Max: 4},
-							Memory: &v1alpha2.SizingPolicyMemory{
-								Step: resource.MustParse("1Gi"),
-								PerCore: v1alpha2.SizingPolicyMemoryPerCore{
-									MemoryMinMax: v1alpha2.MemoryMinMax{
-										Min: resource.MustParse("1Gi"),
-										Max: resource.MustParse("3Gi"),
-									},
+		// Set mock VM class data with invalid per-core memory step policies for the VM
+		vmClass := &virtv2.VirtualMachineClass{
+			Spec: virtv2.VirtualMachineClassSpec{
+				SizingPolicies: []virtv2.SizingPolicy{
+					{
+						Cores: &virtv2.SizingPolicyCores{Min: 1, Max: 4},
+						Memory: &virtv2.SizingPolicyMemory{
+							Step: resource.MustParse("1Gi"),
+							PerCore: virtv2.SizingPolicyMemoryPerCore{
+								MemoryMinMax: virtv2.MemoryMinMax{
+									Min: resource.MustParse("1Gi"),
+									Max: resource.MustParse("3Gi"),
 								},
 							},
 						},
 					},
 				},
-			}
-		})
+			},
+		}
 
 		It("should fail validation due to non-matching per core memory step", func() {
 			service := service.NewSizePolicyService()
@@ -492,14 +464,14 @@ var _ = Describe("SizePolicyService", func() {
 	})
 
 	Context("When size policy not provided", func() {
-		vm := &v1alpha2.VirtualMachine{
-			Spec: v1alpha2.VirtualMachineSpec{
+		vm := &virtv2.VirtualMachine{
+			Spec: virtv2.VirtualMachineSpec{
 				VirtualMachineClassName: "vmclasstest",
-				CPU:                     v1alpha2.CPUSpec{Cores: 2, CoreFraction: "10%"},
-				Memory:                  v1alpha2.MemorySpec{Size: resource.MustParse("4001Mi")},
+				CPU:                     virtv2.CPUSpec{Cores: 2, CoreFraction: "10%"},
+				Memory:                  virtv2.MemorySpec{Size: resource.MustParse("4001Mi")},
 			},
 		}
-		vmClass := &v1alpha2.VirtualMachineClass{}
+		vmClass := &virtv2.VirtualMachineClass{}
 
 		It("should pass validation cause no requirements", func() {
 			service := service.NewSizePolicyService()


### PR DESCRIPTION
## Description
Fix Virtual Machine validation of matching Virtual Machine Class requirements when no Sizing Policy not provided.

## Why do we need it, and what problem does it solve?
Virtual Machines was failing validation when no sizing policy provided. That's incorrect behavior.

## What is the expected result?
Correct validation process)

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
