### PR TITLE
feat(vm): disable serial console log

### DIFF
--- a/templates/kubevirt/kubevirt.yaml
+++ b/templates/kubevirt/kubevirt.yaml
@@ -37,6 +37,8 @@ spec:
       - CPUManager
       - Sidecar
       - VolumeSnapshotDataSource
+    virtualMachineOptions:
+      disableSerialConsoleLog: {}
   customizeComponents:
     flags:
       api: {}


### PR DESCRIPTION
## Description

Disable creating of `guest-console-log` container for a virtual machine pod. 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
