### PR TITLE
feat(vi,vd): add custom settings for SC

### DIFF
--- a/api/core/v1alpha2/virtual_image.go
+++ b/api/core/v1alpha2/virtual_image.go
@@ -112,7 +112,7 @@ type VirtualImageStatusTarget struct {
 	// Created image in DVCR.
 	// +kubebuilder:example:="dvcr.<dvcr-namespace>.svc/vi/<image-namespace>/<image-name>:latest"
 	RegistryURL string `json:"registryURL,omitempty"`
-	// Created PersistentVolumeClaim name for Kubernetes storage.
+	// Created PersistentVolumeClaim name for PersistentVolumeClaim storage.
 	PersistentVolumeClaim string `json:"persistentVolumeClaimName,omitempty"`
 }
 
@@ -158,15 +158,23 @@ const (
 // Storage type to store the image for current virtualization setup.
 //
 // * `ContainerRegistry` — use a dedicated deckhouse virtualization container registry (DVCR). In this case, images will be downloaded and injected to a container, then pushed to a DVCR (shipped with the virtualization module).
-// * `Kubernetes` - use a Persistent Volume Claim (PVC).
-// +kubebuilder:validation:Enum:={ContainerRegistry,Kubernetes}
+// * `PersistentVolumeClaim` - use a Persistent Volume Claim (PVC).
+// * `Kubernetes` - Deprecated: Use of this value is discouraged and may be removed in future versions. Use PersistentVolumeClaim instead.
+// +kubebuilder:validation:Enum:={ContainerRegistry,Kubernetes,PersistentVolumeClaim}
 type StorageType string
 
 const (
-	StorageContainerRegistry StorageType = "ContainerRegistry"
-	StorageKubernetes        StorageType = "Kubernetes"
+	StorageContainerRegistry     StorageType = "ContainerRegistry"
+	StoragePersistentVolumeClaim StorageType = "PersistentVolumeClaim"
+
+	// TODO: remove storage type Kubernetes in 2025
+	StorageKubernetes StorageType = "Kubernetes"
 )
 
+// Settings for creating PVCs to store the image with storage type 'PersistentVolumeClaim'.
 type VirtualImagePersistentVolumeClaim struct {
-	StorageClass *string `json:"storageClass,omitempty"`
+	// The name of the StorageClass required by the claim. More info — https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+	//
+	// When creating image with storage type 'PersistentVolumeClaim', the user can specify the required StorageClass to create the image, or not explicitly, in which case the default StorageClass will be used.
+	StorageClass *string `json:"storageClassName,omitempty"`
 }

--- a/api/pkg/apiserver/api/generated/openapi/zz_generated.openapi.go
+++ b/api/pkg/apiserver/api/generated/openapi/zz_generated.openapi.go
@@ -2895,12 +2895,14 @@ func schema_virtualization_api_core_v1alpha2_VirtualImagePersistentVolumeClaim(r
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "Settings for creating PVCs to store the image with storage type 'PersistentVolumeClaim'.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
-					"storageClass": {
+					"storageClassName": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "The name of the StorageClass required by the claim. More info — https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1\n\nWhen creating image with storage type 'PersistentVolumeClaim', the user can specify the required StorageClass to create the image, or not explicitly, in which case the default StorageClass will be used.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -3066,7 +3068,7 @@ func schema_virtualization_api_core_v1alpha2_VirtualImageStatusTarget(ref common
 					},
 					"persistentVolumeClaimName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Created PersistentVolumeClaim name for Kubernetes storage.",
+							Description: "Created PersistentVolumeClaim name for PersistentVolumeClaim storage.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/crds/doc-ru-virtualimages.yaml
+++ b/crds/doc-ru-virtualimages.yaml
@@ -12,6 +12,15 @@ spec:
           properties:
             spec:
               properties:
+                persistentVolumeClaim:
+                  description: |
+                    Настройки для создания PVC для хранения образа с хранилищем типа 'PersistentVolumeClaim'.
+                  properties:
+                    storageClassName:
+                      description: |
+                        Имя StorageClass, требуемого для PersistentVolumeClaim. Дополнительная информация — https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1.
+
+                        При создании образа с хранилищем типа 'PersistentVolumeClaim' пользователь может указать требуемый StorageClass для создания диска, либо не указывать явно и в этом случае будет использован StorageClass доступный по умолчанию.
                 dataSource:
                   description: |
                     Тип источника, из которого будет создан образ.
@@ -86,7 +95,8 @@ spec:
                     Тип хранилища для хранения образа:
 
                     * `ContainerRegistry` — использовать container registry (DVCR). В этом случае образы будут загружаться в контейнер, а затем в DVCR (поставляется с модулем виртуализации).
-                    * `Kubernetes` - использовать Persistent Volume Claim (PVC).
+                    * `Kubernetes` - Устарело: использование этого значения не рекомендуется и может быть удалено в будущих версиях. Используйте тип PersistentVolumeClaim.
+                    * `PersistentVolumeClaim` - использовать Persistent Volume Claim (PVC).
             status:
               properties:
                 conditions:

--- a/crds/virtualimages.yaml
+++ b/crds/virtualimages.yaml
@@ -215,8 +215,15 @@ spec:
                         "self.type == 'ObjectRef' ? has(self.objectRef) && !has(self.http)
                         && !has(self.containerImage) : true"
                 persistentVolumeClaim:
+                  description:
+                    Settings for creating PVCs to store the image with storage
+                    type 'PersistentVolumeClaim'.
                   properties:
-                    storageClass:
+                    storageClassName:
+                      description: |-
+                        The name of the StorageClass required by the claim. More info — https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+
+                        When creating image with storage type 'PersistentVolumeClaim', the user can specify the required StorageClass to create the image, or not explicitly, in which case the default StorageClass will be used.
                       type: string
                   type: object
                 storage:
@@ -225,10 +232,12 @@ spec:
                     Storage type to store the image for current virtualization setup.
 
                     * `ContainerRegistry` — use a dedicated deckhouse virtualization container registry (DVCR). In this case, images will be downloaded and injected to a container, then pushed to a DVCR (shipped with the virtualization module).
-                    * `Kubernetes` - use a Persistent Volume Claim (PVC).
+                    * `PersistentVolumeClaim` - use a Persistent Volume Claim (PVC).
+                    * `Kubernetes` - Deprecated: Use of this value is discouraged and may be removed in future versions. Use PersistentVolumeClaim instead.
                   enum:
                     - ContainerRegistry
                     - Kubernetes
+                    - PersistentVolumeClaim
                   type: string
               required:
                 - dataSource
@@ -399,7 +408,7 @@ spec:
                   properties:
                     persistentVolumeClaimName:
                       description:
-                        Created PersistentVolumeClaim name for Kubernetes
+                        Created PersistentVolumeClaim name for PersistentVolumeClaim
                         storage.
                       type: string
                     registryURL:

--- a/docs/internal/data_source_details.md
+++ b/docs/internal/data_source_details.md
@@ -19,7 +19,7 @@ Additional importer and uploader are implemented to import into DVCR instead PVC
 
 ## Supported storages (destinations)
 
-- Kubernetes - import into PVC.
+- PersistentVolumeClaim - import into PVC.
 - ContainerRegistry - import into DVCR.
 
 ## Possible import paths
@@ -53,7 +53,7 @@ When importing into DVCR, importer Pod expects auth Secret.
 
 Note: CA Bundle for DVCR is not implemented yet, DVCR is an internal Service, we use INSECURE_TLS=true to satisfy rbac-proxy.
 
-#### storage Kubernetes (import into PVC)
+#### storage PersistentVolumeClaim (import into PVC)
 
 When importing into PVC, DataVolume use DVCR as registry source, so it expects auth credentials in the Secret, and ca bundle in the ConfigMap.
 virtualization-controller creates copies of these resources:

--- a/images/virtualization-artifact/cmd/virtualization-controller/main.go
+++ b/images/virtualization-artifact/cmd/virtualization-controller/main.go
@@ -119,6 +119,9 @@ func main() {
 		os.Exit(1)
 	}
 
+	viStorageClassSettings := appconfig.LoadVirtualImageStorageClassSettings()
+	vdStorageClassSettings := appconfig.LoadVirtualDiskStorageClassSettings()
+
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()
 	if err != nil {
@@ -178,11 +181,6 @@ func main() {
 		virtualMachineIPLeasesRetentionDuration = "10m"
 	}
 
-	storageClassForVirtualImageOnPVC := os.Getenv(common.VirtualImageStorageClass)
-	if storageClassForVirtualImageOnPVC == "" {
-		log.Info("virtualImages.storageClassName not found in ModuleConfig, default storage class will be used for images on PVCs.")
-	}
-
 	// Create a new Manager to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, managerOpts)
 	if err != nil {
@@ -211,12 +209,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	if _, err = vd.NewController(ctx, mgr, log, importSettings.ImporterImage, importSettings.UploaderImage, importSettings.Requirements, dvcrSettings); err != nil {
+	if _, err = vd.NewController(ctx, mgr, log, importSettings.ImporterImage, importSettings.UploaderImage, importSettings.Requirements, dvcrSettings, vdStorageClassSettings); err != nil {
 		log.Error(err.Error())
 		os.Exit(1)
 	}
 
-	if _, err = vi.NewController(ctx, mgr, log, importSettings.ImporterImage, importSettings.UploaderImage, importSettings.Requirements, dvcrSettings, storageClassForVirtualImageOnPVC); err != nil {
+	if _, err = vi.NewController(ctx, mgr, log, importSettings.ImporterImage, importSettings.UploaderImage, importSettings.Requirements, dvcrSettings, viStorageClassSettings); err != nil {
 		log.Error(err.Error())
 		os.Exit(1)
 	}

--- a/images/virtualization-artifact/pkg/common/common.go
+++ b/images/virtualization-artifact/pkg/common/common.go
@@ -179,6 +179,14 @@ const (
 
 	// VirtualImageStorageClass is a parameter for configuring the storage class for Virtual Image on PVC.
 	VirtualImageStorageClass = "VIRTUAL_IMAGE_STORAGE_CLASS"
+	// VirtualImageDefaultStorageClass specifies the default storage class for virtual images on PVC when none is specified.
+	VirtualImageDefaultStorageClass = "VIRTUAL_IMAGE_DEFAULT_STORAGE_CLASS"
+	// VirtualImageAllowedStorageClasses is a parameter that lists all allowed storage classes for virtual images on PVC.
+	VirtualImageAllowedStorageClasses = "VIRTUAL_IMAGE_ALLOWED_STORAGE_CLASSES"
+	// VirtualDiskDefaultStorageClass specifies the default storage class for virtual disks when none is specified.
+	VirtualDiskDefaultStorageClass = "VIRTUAL_DISK_DEFAULT_STORAGE_CLASS"
+	// VirtualDiskAllowedStorageClasses is a parameter that lists all allowed storage classes for virtual disks.
+	VirtualDiskAllowedStorageClasses = "VIRTUAL_DISK_ALLOWED_STORAGE_CLASSES"
 
 	DockerRegistrySchemePrefix = "docker://"
 

--- a/images/virtualization-artifact/pkg/config/load_vd_storage_class_settings.go
+++ b/images/virtualization-artifact/pkg/config/load_vd_storage_class_settings.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"os"
+	"strings"
+
+	"github.com/deckhouse/virtualization-controller/pkg/common"
+)
+
+type VirtualDiskStorageClassSettings struct {
+	AllowedStorageClassNames []string
+	DefaultStorageClassName  string
+}
+
+func LoadVirtualDiskStorageClassSettings() VirtualDiskStorageClassSettings {
+	var allowedStorageClassNames []string
+	allowedStorageClassNamesRaw := os.Getenv(common.VirtualDiskAllowedStorageClasses)
+	if allowedStorageClassNamesRaw != "" {
+		allowedStorageClassNames = strings.Split(allowedStorageClassNamesRaw, ",")
+	}
+
+	return VirtualDiskStorageClassSettings{
+		AllowedStorageClassNames: allowedStorageClassNames,
+		DefaultStorageClassName:  os.Getenv(common.VirtualDiskDefaultStorageClass),
+	}
+}

--- a/images/virtualization-artifact/pkg/config/load_vi_storage_class_settings.go
+++ b/images/virtualization-artifact/pkg/config/load_vi_storage_class_settings.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"os"
+	"strings"
+
+	"github.com/deckhouse/virtualization-controller/pkg/common"
+)
+
+type VirtualImageStorageClassSettings struct {
+	AllowedStorageClassNames []string
+	DefaultStorageClassName  string
+	StorageClassName         string
+}
+
+func LoadVirtualImageStorageClassSettings() VirtualImageStorageClassSettings {
+	var allowedStorageClassNames []string
+	allowedStorageClassNamesRaw := os.Getenv(common.VirtualImageAllowedStorageClasses)
+	if allowedStorageClassNamesRaw != "" {
+		allowedStorageClassNames = strings.Split(allowedStorageClassNamesRaw, ",")
+	}
+
+	return VirtualImageStorageClassSettings{
+		AllowedStorageClassNames: allowedStorageClassNames,
+		DefaultStorageClassName:  os.Getenv(common.VirtualImageDefaultStorageClass),
+		StorageClassName:         os.Getenv(common.VirtualImageStorageClass),
+	}
+}

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref.go
@@ -94,7 +94,7 @@ func (ds ObjectRefDataSource) Sync(ctx context.Context, cvi *virtv2.ClusterVirtu
 			return reconcile.Result{}, fmt.Errorf("VI object ref source %s is nil", cvi.Spec.DataSource.ObjectRef.Name)
 		}
 
-		if vi.Spec.Storage == virtv2.StorageKubernetes {
+		if vi.Spec.Storage == virtv2.StorageKubernetes || vi.Spec.Storage == virtv2.StoragePersistentVolumeClaim {
 			return ds.viOnPvcSyncer.Sync(ctx, cvi, vi, cb)
 		}
 	case virtv2.VirtualDiskKind:
@@ -292,7 +292,7 @@ func (ds ObjectRefDataSource) Validate(ctx context.Context, cvi *virtv2.ClusterV
 			return NewImageNotReadyError(cvi.Spec.DataSource.ObjectRef.Name)
 		}
 
-		if vi.Spec.Storage == virtv2.StorageKubernetes {
+		if vi.Spec.Storage == virtv2.StorageKubernetes || vi.Spec.Storage == virtv2.StoragePersistentVolumeClaim {
 			if vi.Status.Phase != virtv2.ImageReady {
 				return NewImageNotReadyError(cvi.Spec.DataSource.ObjectRef.Name)
 			}

--- a/images/virtualization-artifact/pkg/controller/dvcr_data_source.go
+++ b/images/virtualization-artifact/pkg/controller/dvcr_data_source.go
@@ -104,8 +104,8 @@ func NewDVCRDataSourcesForVMI(ctx context.Context, ds virtv2.VirtualImageDataSou
 			}
 
 			if vmi != nil {
-				if vmi.Spec.Storage == virtv2.StorageKubernetes {
-					return DVCRDataSource{}, fmt.Errorf("the DVCR not used for virtual images with storage type 'Kubernetes'")
+				if vmi.Spec.Storage == virtv2.StorageKubernetes || vmi.Spec.Storage == virtv2.StoragePersistentVolumeClaim {
+					return DVCRDataSource{}, fmt.Errorf("the DVCR not used for virtual images with storage type '%s'", vmi.Spec.Storage)
 				}
 
 				dsDVCR.uid = vmi.UID

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
@@ -126,7 +126,8 @@ func ApplyVirtualMachineSpec(
 
 			name := GenerateVMIDiskName(bd.Name)
 			switch vi.Spec.Storage {
-			case virtv2.StorageKubernetes:
+			case virtv2.StorageKubernetes,
+				virtv2.StoragePersistentVolumeClaim:
 				// Attach PVC as ephemeral volume: its data will be restored to initial state on VM restart.
 				if err := kvvm.SetDisk(name, SetDiskOptions{
 					PersistentVolumeClaim: util.GetPointer(vi.Status.Target.PersistentVolumeClaim),

--- a/images/virtualization-artifact/pkg/controller/service/disk_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/disk_service.go
@@ -498,12 +498,12 @@ func (s DiskService) CheckImportProcess(ctx context.Context, dv *cdiv1.DataVolum
 
 func (s DiskService) GetStorageClass(ctx context.Context, storageClassName *string) (*storev1.StorageClass, error) {
 	if storageClassName == nil || *storageClassName == "" {
-		return s.getDefaultStorageClass(ctx)
+		return s.GetDefaultStorageClass(ctx)
 	}
 	return s.getStorageClass(ctx, *storageClassName)
 }
 
-func (s DiskService) getDefaultStorageClass(ctx context.Context) (*storev1.StorageClass, error) {
+func (s DiskService) GetDefaultStorageClass(ctx context.Context) (*storev1.StorageClass, error) {
 	var scs storev1.StorageClassList
 	err := s.client.List(ctx, &scs, &client.ListOptions{})
 	if err != nil {

--- a/images/virtualization-artifact/pkg/controller/service/errors.go
+++ b/images/virtualization-artifact/pkg/controller/service/errors.go
@@ -22,6 +22,7 @@ var (
 	ErrStorageClassNotFound        = errors.New("storage class not found")
 	ErrStorageProfileNotFound      = errors.New("storage profile not found")
 	ErrDefaultStorageClassNotFound = errors.New("default storage class not found")
+	ErrStorageClassNotAllowed      = errors.New("storage class not allowed")
 	ErrDataVolumeNotRunning        = errors.New("pvc importer is not running")
 )
 

--- a/images/virtualization-artifact/pkg/controller/service/vd_storage_class_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/vd_storage_class_service.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"slices"
+
+	storev1 "k8s.io/api/storage/v1"
+
+	"github.com/deckhouse/virtualization-controller/pkg/config"
+)
+
+type VirtualDiskStorageClassService struct {
+	storageClassSettings config.VirtualDiskStorageClassSettings
+}
+
+func NewVirtualDiskStorageClassService(settings config.VirtualDiskStorageClassSettings) *VirtualDiskStorageClassService {
+	return &VirtualDiskStorageClassService{
+		storageClassSettings: settings,
+	}
+}
+
+// GetStorageClass determines the storage class for VD from global settings and resource spec.
+//
+// Global settings contain a default storage class and an array of allowed storageClasses from the ModuleConfig.
+// Storage class is allowed if contained in the "allowed" array.
+//
+// Storage class from the spec has the most priority with fallback to global settings:
+// 1. Return `storageClassName` if specified in the resource spec and allowed by global settings.
+// 2. Return global `defaultStorageClass` if specified.
+// 3. Return cluster-wide default storage class if specified and allowed.
+//
+// Errors:
+// 1. Return error if no storage class is specified.
+// 2. Return error if specified non-empty class is not allowed.
+func (svc *VirtualDiskStorageClassService) GetStorageClass(storageClassFromSpec *string, clusterDefaultStorageClass *storev1.StorageClass) (*string, error) {
+	if svc.storageClassSettings.DefaultStorageClassName == "" && len(svc.storageClassSettings.AllowedStorageClassNames) == 0 {
+		return storageClassFromSpec, nil
+	}
+
+	if storageClassFromSpec != nil && *storageClassFromSpec != "" {
+		if slices.Contains(svc.storageClassSettings.AllowedStorageClassNames, *storageClassFromSpec) {
+			return storageClassFromSpec, nil
+		}
+
+		if svc.storageClassSettings.DefaultStorageClassName != "" && svc.storageClassSettings.DefaultStorageClassName == *storageClassFromSpec {
+			return storageClassFromSpec, nil
+		}
+
+		return nil, ErrStorageClassNotAllowed
+	}
+
+	if svc.storageClassSettings.DefaultStorageClassName != "" {
+		return &svc.storageClassSettings.DefaultStorageClassName, nil
+	}
+
+	if clusterDefaultStorageClass != nil && clusterDefaultStorageClass.Name != "" {
+		if slices.Contains(svc.storageClassSettings.AllowedStorageClassNames, clusterDefaultStorageClass.Name) {
+			return &clusterDefaultStorageClass.Name, nil
+		}
+
+		return nil, ErrStorageClassNotAllowed
+	}
+
+	return nil, ErrStorageClassNotFound
+}

--- a/images/virtualization-artifact/pkg/controller/service/vd_storage_class_service_test.go
+++ b/images/virtualization-artifact/pkg/controller/service/vd_storage_class_service_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	storev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/deckhouse/virtualization-controller/pkg/config"
+)
+
+var _ = Describe("VirtualDiskStorageClassService", func() {
+	var (
+		service                    *VirtualDiskStorageClassService
+		storageClassSettings       config.VirtualDiskStorageClassSettings
+		clusterDefaultStorageClass *storev1.StorageClass
+	)
+
+	BeforeEach(func() {
+		clusterDefaultStorageClass = &storev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "default-cluster-storage"}}
+	})
+
+	Context("when settings are empty", func() {
+		It("returns the storageClassFromSpec", func() {
+			storageClassSettings = config.VirtualDiskStorageClassSettings{}
+			service = NewVirtualDiskStorageClassService(storageClassSettings)
+			sc := ptr.To("requested-storage-class")
+			storageClass, err := service.GetStorageClass(sc, clusterDefaultStorageClass)
+
+			Expect(err).To(BeNil())
+			Expect(storageClass).To(Equal(sc))
+		})
+	})
+
+	Context("when settings are empty and storageClassFromSpec is empty", func() {
+		It("returns the storageClassFromSpec", func() {
+			storageClassSettings = config.VirtualDiskStorageClassSettings{}
+			service = NewVirtualDiskStorageClassService(storageClassSettings)
+
+			storageClass, err := service.GetStorageClass(nil, clusterDefaultStorageClass)
+
+			Expect(err).To(BeNil())
+			Expect(storageClass).To(BeNil())
+		})
+	})
+
+	Context("when settings and clusterDefaultStorageClass are empty", func() {
+		It("returns the storageClassFromSpec", func() {
+			storageClassSettings = config.VirtualDiskStorageClassSettings{}
+			service = NewVirtualDiskStorageClassService(storageClassSettings)
+			sc := ptr.To("requested-storage-class")
+			storageClass, err := service.GetStorageClass(sc, nil)
+
+			Expect(err).To(BeNil())
+			Expect(storageClass).To(Equal(sc))
+		})
+	})
+
+	Context("when AllowedStorageClassNames exist, but DefaultStorageClassName is empty", func() {
+		BeforeEach(func() {
+			storageClassSettings = config.VirtualDiskStorageClassSettings{
+				AllowedStorageClassNames: []string{"allowed-storage-class"},
+				DefaultStorageClassName:  "",
+			}
+			service = NewVirtualDiskStorageClassService(storageClassSettings)
+		})
+
+		It("returns the requested storage class if it's in the allowed list", func() {
+			sc := ptr.To("allowed-storage-class")
+			storageClass, err := service.GetStorageClass(sc, clusterDefaultStorageClass)
+
+			Expect(err).To(BeNil())
+			Expect(storageClass).To(Equal(sc))
+		})
+
+		It("returns an error if the requested storage class is not in the allowed list", func() {
+			_, err := service.GetStorageClass(ptr.To("not-allowed-storage-class"), clusterDefaultStorageClass)
+
+			Expect(err).To(Equal(ErrStorageClassNotAllowed))
+		})
+
+		It("returns an error if storageClassFromSpec is empty", func() {
+			_, err := service.GetStorageClass(nil, clusterDefaultStorageClass)
+
+			Expect(err).To(Equal(ErrStorageClassNotAllowed))
+		})
+	})
+
+	Context("when AllowedStorageClassNames is empty, but DefaultStorageClassName exist", func() {
+		BeforeEach(func() {
+			storageClassSettings = config.VirtualDiskStorageClassSettings{
+				AllowedStorageClassNames: []string{},
+				DefaultStorageClassName:  "default-storage-class",
+			}
+			service = NewVirtualDiskStorageClassService(storageClassSettings)
+		})
+
+		It("returns the default storage class if storageClassFromSpec is empty", func() {
+			storageClass, err := service.GetStorageClass(nil, clusterDefaultStorageClass)
+
+			Expect(err).To(BeNil())
+			Expect(storageClass).To(Equal(ptr.To("default-storage-class")))
+		})
+
+		It("returns the requested storage class if it matches the default storage class", func() {
+			sc := ptr.To("default-storage-class")
+			storageClass, err := service.GetStorageClass(sc, clusterDefaultStorageClass)
+
+			Expect(err).To(BeNil())
+			Expect(storageClass).To(Equal(sc))
+		})
+
+		It("returns an error if the requested storage class does not match the default", func() {
+			_, err := service.GetStorageClass(ptr.To("different-storage-class"), clusterDefaultStorageClass)
+
+			Expect(err).To(Equal(ErrStorageClassNotAllowed))
+		})
+	})
+
+	Context("when both AllowedStorageClassNames and DefaultStorageClassName exist", func() {
+		BeforeEach(func() {
+			storageClassSettings = config.VirtualDiskStorageClassSettings{
+				AllowedStorageClassNames: []string{"allowed-storage-class"},
+				DefaultStorageClassName:  "default-storage-class",
+			}
+			service = NewVirtualDiskStorageClassService(storageClassSettings)
+		})
+
+		It("returns the default storage class if storageClassFromSpec is empty", func() {
+			storageClass, err := service.GetStorageClass(nil, clusterDefaultStorageClass)
+
+			Expect(err).To(BeNil())
+			Expect(storageClass).To(Equal(ptr.To("default-storage-class")))
+		})
+
+		It("returns the requested storage class if it's in the allowed list", func() {
+			sc := ptr.To("allowed-storage-class")
+			storageClass, err := service.GetStorageClass(sc, clusterDefaultStorageClass)
+
+			Expect(err).To(BeNil())
+			Expect(storageClass).To(Equal(sc))
+		})
+
+		It("returns an error if the requested storage class is not in the allowed list", func() {
+			_, err := service.GetStorageClass(ptr.To("not-allowed-storage-class"), clusterDefaultStorageClass)
+
+			Expect(err).To(Equal(ErrStorageClassNotAllowed))
+		})
+	})
+})

--- a/images/virtualization-artifact/pkg/controller/service/vi_storage_class_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/vi_storage_class_service.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"slices"
+
+	storev1 "k8s.io/api/storage/v1"
+
+	"github.com/deckhouse/virtualization-controller/pkg/config"
+)
+
+type VirtualImageStorageClassService struct {
+	storageClassSettings config.VirtualImageStorageClassSettings
+}
+
+func NewVirtualImageStorageClassService(settings config.VirtualImageStorageClassSettings) *VirtualImageStorageClassService {
+	return &VirtualImageStorageClassService{
+		storageClassSettings: settings,
+	}
+}
+
+// GetStorageClass determines the storage class for VI from global settings and resource spec.
+//
+// Global settings contain a default storage class and an array of allowed storageClasses from the ModuleConfig.
+// Storage class is allowed if contained in the "allowed" array.
+//
+// Storage class from the spec has the most priority with fallback to global settings:
+// 1. Return `storageClassName` if specified in the resource spec and allowed by global settings.
+// 2. Return global `defaultStorageClass` if specified.
+// 3. Return cluster-wide default storage class if specified and allowed.
+//
+// Errors:
+// 1. Return error if no storage class is specified.
+// 2. Return error if specified non-empty class is not allowed.
+func (svc *VirtualImageStorageClassService) GetStorageClass(storageClassFromSpec *string, clusterDefaultStorageClass *storev1.StorageClass) (*string, error) {
+	if svc.storageClassSettings.DefaultStorageClassName == "" && len(svc.storageClassSettings.AllowedStorageClassNames) == 0 {
+		if svc.storageClassSettings.StorageClassName == "" {
+			return storageClassFromSpec, nil
+		}
+
+		if storageClassFromSpec == nil || *storageClassFromSpec == "" || *storageClassFromSpec == svc.storageClassSettings.StorageClassName {
+			return &svc.storageClassSettings.StorageClassName, nil
+		}
+
+		return nil, ErrStorageClassNotAllowed
+	}
+
+	if storageClassFromSpec != nil && *storageClassFromSpec != "" {
+		if slices.Contains(svc.storageClassSettings.AllowedStorageClassNames, *storageClassFromSpec) {
+			return storageClassFromSpec, nil
+		}
+
+		if svc.storageClassSettings.DefaultStorageClassName != "" && svc.storageClassSettings.DefaultStorageClassName == *storageClassFromSpec {
+			return storageClassFromSpec, nil
+		}
+
+		return nil, ErrStorageClassNotAllowed
+	}
+
+	if svc.storageClassSettings.DefaultStorageClassName != "" {
+		return &svc.storageClassSettings.DefaultStorageClassName, nil
+	}
+
+	if clusterDefaultStorageClass != nil && clusterDefaultStorageClass.Name != "" {
+		if slices.Contains(svc.storageClassSettings.AllowedStorageClassNames, clusterDefaultStorageClass.Name) {
+			return &clusterDefaultStorageClass.Name, nil
+		}
+
+		return nil, ErrStorageClassNotAllowed
+	}
+
+	return nil, ErrStorageClassNotFound
+}

--- a/images/virtualization-artifact/pkg/controller/service/vi_storage_class_service_test.go
+++ b/images/virtualization-artifact/pkg/controller/service/vi_storage_class_service_test.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	storev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/deckhouse/virtualization-controller/pkg/config"
+)
+
+var _ = Describe("VirtualImageStorageClassService", func() {
+	var (
+		service                    *VirtualImageStorageClassService
+		storageClassSettings       config.VirtualImageStorageClassSettings
+		clusterDefaultStorageClass *storev1.StorageClass
+	)
+
+	BeforeEach(func() {
+		clusterDefaultStorageClass = &storev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "default-cluster-storage"}}
+	})
+
+	Context("when settings are empty", func() {
+		It("returns the storageClassFromSpec", func() {
+			storageClassSettings = config.VirtualImageStorageClassSettings{}
+			service = NewVirtualImageStorageClassService(storageClassSettings)
+			sc := ptr.To("requested-storage-class")
+			storageClass, err := service.GetStorageClass(sc, clusterDefaultStorageClass)
+
+			Expect(err).To(BeNil())
+			Expect(storageClass).To(Equal(sc))
+		})
+	})
+
+	Context("when settings are empty and storageClassFromSpec is empty", func() {
+		It("returns the storageClassFromSpec", func() {
+			storageClassSettings = config.VirtualImageStorageClassSettings{}
+			service = NewVirtualImageStorageClassService(storageClassSettings)
+
+			storageClass, err := service.GetStorageClass(nil, clusterDefaultStorageClass)
+
+			Expect(err).To(BeNil())
+			Expect(storageClass).To(BeNil())
+		})
+	})
+
+	Context("when settings and clusterDefaultStorageClass are empty", func() {
+		It("returns the storageClassFromSpec", func() {
+			storageClassSettings = config.VirtualImageStorageClassSettings{}
+			service = NewVirtualImageStorageClassService(storageClassSettings)
+			sc := ptr.To("requested-storage-class")
+			storageClass, err := service.GetStorageClass(sc, nil)
+
+			Expect(err).To(BeNil())
+			Expect(storageClass).To(Equal(sc))
+		})
+	})
+
+	Context("when settings and clusterDefaultStorageClass are empty, but StorageClassName exist", func() {
+		BeforeEach(func() {
+			storageClassSettings = config.VirtualImageStorageClassSettings{
+				StorageClassName: "storage-class-name",
+			}
+			service = NewVirtualImageStorageClassService(storageClassSettings)
+		})
+
+		It("return the StorageClassName if storageClassFromSpec is empty", func() {
+			storageClass, err := service.GetStorageClass(nil, nil)
+			Expect(err).To(BeNil())
+			Expect(storageClass).To(Equal(&storageClassSettings.StorageClassName))
+		})
+
+		It("return the StorageClassName if storageClassFromSpec equal StorageClassName", func() {
+			storageClass, err := service.GetStorageClass(&storageClassSettings.StorageClassName, nil)
+			Expect(err).To(BeNil())
+			Expect(storageClass).To(Equal(&storageClassSettings.StorageClassName))
+		})
+
+		It("return the err if storageClassFromSpec not equal StorageClassName", func() {
+			sc := ptr.To("requested-storage-class")
+			_, err := service.GetStorageClass(sc, nil)
+			Expect(err).To(Equal(ErrStorageClassNotAllowed))
+		})
+	})
+
+	Context("when AllowedStorageClassNames exist, but DefaultStorageClassName is empty", func() {
+		BeforeEach(func() {
+			storageClassSettings = config.VirtualImageStorageClassSettings{
+				AllowedStorageClassNames: []string{"allowed-storage-class"},
+				DefaultStorageClassName:  "",
+			}
+			service = NewVirtualImageStorageClassService(storageClassSettings)
+		})
+
+		It("returns the requested storage class if it's in the allowed list", func() {
+			sc := ptr.To("allowed-storage-class")
+			storageClass, err := service.GetStorageClass(sc, clusterDefaultStorageClass)
+
+			Expect(err).To(BeNil())
+			Expect(storageClass).To(Equal(sc))
+		})
+
+		It("returns an error if the requested storage class is not in the allowed list", func() {
+			_, err := service.GetStorageClass(ptr.To("not-allowed-storage-class"), clusterDefaultStorageClass)
+
+			Expect(err).To(Equal(ErrStorageClassNotAllowed))
+		})
+
+		It("returns an error if storageClassFromSpec is empty", func() {
+			_, err := service.GetStorageClass(nil, clusterDefaultStorageClass)
+
+			Expect(err).To(Equal(ErrStorageClassNotAllowed))
+		})
+	})
+
+	Context("when AllowedStorageClassNames is empty, but DefaultStorageClassName exist", func() {
+		BeforeEach(func() {
+			storageClassSettings = config.VirtualImageStorageClassSettings{
+				AllowedStorageClassNames: []string{},
+				DefaultStorageClassName:  "default-storage-class",
+			}
+			service = NewVirtualImageStorageClassService(storageClassSettings)
+		})
+
+		It("returns the default storage class if storageClassFromSpec is empty", func() {
+			storageClass, err := service.GetStorageClass(nil, clusterDefaultStorageClass)
+
+			Expect(err).To(BeNil())
+			Expect(storageClass).To(Equal(ptr.To("default-storage-class")))
+		})
+
+		It("returns the requested storage class if it matches the default storage class", func() {
+			sc := ptr.To("default-storage-class")
+			storageClass, err := service.GetStorageClass(sc, clusterDefaultStorageClass)
+
+			Expect(err).To(BeNil())
+			Expect(storageClass).To(Equal(sc))
+		})
+
+		It("returns an error if the requested storage class does not match the default", func() {
+			_, err := service.GetStorageClass(ptr.To("different-storage-class"), clusterDefaultStorageClass)
+
+			Expect(err).To(Equal(ErrStorageClassNotAllowed))
+		})
+	})
+
+	Context("when both AllowedStorageClassNames and DefaultStorageClassName exist", func() {
+		BeforeEach(func() {
+			storageClassSettings = config.VirtualImageStorageClassSettings{
+				AllowedStorageClassNames: []string{"allowed-storage-class"},
+				DefaultStorageClassName:  "default-storage-class",
+			}
+			service = NewVirtualImageStorageClassService(storageClassSettings)
+		})
+
+		It("returns the default storage class if storageClassFromSpec is empty", func() {
+			storageClass, err := service.GetStorageClass(nil, clusterDefaultStorageClass)
+
+			Expect(err).To(BeNil())
+			Expect(storageClass).To(Equal(ptr.To("default-storage-class")))
+		})
+
+		It("returns the requested storage class if it's in the allowed list", func() {
+			sc := ptr.To("allowed-storage-class")
+			storageClass, err := service.GetStorageClass(sc, clusterDefaultStorageClass)
+
+			Expect(err).To(BeNil())
+			Expect(storageClass).To(Equal(sc))
+		})
+
+		It("returns an error if the requested storage class is not in the allowed list", func() {
+			_, err := service.GetStorageClass(ptr.To("not-allowed-storage-class"), clusterDefaultStorageClass)
+
+			Expect(err).To(Equal(ErrStorageClassNotAllowed))
+		})
+	})
+})

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref.go
@@ -43,13 +43,14 @@ func NewObjectRefDataSource(
 	statService *service.StatService,
 	diskService *service.DiskService,
 	client client.Client,
+	storageClassService *service.VirtualDiskStorageClassService,
 ) *ObjectRefDataSource {
 	return &ObjectRefDataSource{
 		diskService:      diskService,
 		vdSnapshotSyncer: NewObjectRefVirtualDiskSnapshot(diskService),
-		viDVCRSyncer:     NewObjectRefVirtualImageDVCR(statService, diskService, client),
-		viPVCSyncer:      NewObjectRefVirtualImagePVC(diskService),
-		cviSyncer:        NewObjectRefClusterVirtualImage(statService, diskService, client),
+		viDVCRSyncer:     NewObjectRefVirtualImageDVCR(statService, diskService, storageClassService, client),
+		viPVCSyncer:      NewObjectRefVirtualImagePVC(diskService, storageClassService),
+		cviSyncer:        NewObjectRefClusterVirtualImage(statService, diskService, storageClassService, client),
 	}
 }
 

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/sources.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/sources.go
@@ -135,6 +135,27 @@ type CheckImportProcess interface {
 	CheckImportProcess(ctx context.Context, dv *cdiv1.DataVolume, pvc *corev1.PersistentVolumeClaim) error
 }
 
+func setConditionFromStorageClassError(err error, cb *conditions.ConditionBuilder) (bool, error) {
+	switch {
+	case err == nil:
+		return false, nil
+	case errors.Is(err, service.ErrStorageClassNotFound):
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(vdcondition.ProvisioningFailed).
+			Message("Provided StorageClass not found in the cluster.")
+		return true, nil
+	case errors.Is(err, service.ErrStorageClassNotAllowed):
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(vdcondition.ProvisioningFailed).
+			Message("Specified StorageClass is not allowed: please check the module settings.")
+		return true, nil
+	default:
+		return false, err
+	}
+}
+
 func setPhaseConditionFromStorageError(err error, vd *virtv2.VirtualDisk, cb *conditions.ConditionBuilder) (bool, error) {
 	switch {
 	case err == nil:

--- a/images/virtualization-artifact/pkg/controller/vi/internal/life_cycle.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/life_cycle.go
@@ -127,7 +127,7 @@ func (h LifeCycleHandler) Handle(ctx context.Context, vi *virtv2.VirtualImage) (
 
 	var result reconcile.Result
 	var err error
-	if vi.Spec.Storage == virtv2.StorageKubernetes {
+	if vi.Spec.Storage == virtv2.StorageKubernetes || vi.Spec.Storage == virtv2.StoragePersistentVolumeClaim {
 		if vi.Status.StorageClassName != "" && storageClassReadyCondition.Status == metav1.ConditionTrue {
 			result, err = ds.StoreToPVC(ctx, vi)
 		}

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/http.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/http.go
@@ -24,7 +24,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -42,11 +41,11 @@ import (
 )
 
 type HTTPDataSource struct {
-	statService        Stat
-	importerService    Importer
-	dvcrSettings       *dvcr.Settings
-	diskService        *service.DiskService
-	storageClassForPVC string
+	statService         Stat
+	importerService     Importer
+	dvcrSettings        *dvcr.Settings
+	diskService         *service.DiskService
+	storageClassService *service.VirtualImageStorageClassService
 }
 
 func NewHTTPDataSource(
@@ -54,14 +53,14 @@ func NewHTTPDataSource(
 	importerService Importer,
 	dvcrSettings *dvcr.Settings,
 	diskService *service.DiskService,
-	storageClassForPVC string,
+	storageClassService *service.VirtualImageStorageClassService,
 ) *HTTPDataSource {
 	return &HTTPDataSource{
-		statService:        statService,
-		importerService:    importerService,
-		dvcrSettings:       dvcrSettings,
-		diskService:        diskService,
-		storageClassForPVC: storageClassForPVC,
+		statService:         statService,
+		importerService:     importerService,
+		dvcrSettings:        dvcrSettings,
+		diskService:         diskService,
+		storageClassService: storageClassService,
 	}
 }
 
@@ -203,6 +202,12 @@ func (ds HTTPDataSource) StoreToPVC(ctx context.Context, vi *virtv2.VirtualImage
 		return reconcile.Result{}, err
 	}
 
+	clusterDefaultSC, _ := ds.diskService.GetDefaultStorageClass(ctx)
+	sc, err := ds.storageClassService.GetStorageClass(vi.Spec.PersistentVolumeClaim.StorageClass, clusterDefaultSC)
+	if updated, err := setConditionFromStorageClassError(err, cb); err != nil || updated {
+		return reconcile.Result{}, err
+	}
+
 	switch {
 	case isDiskProvisioningFinished(condition):
 		log.Info("Image provisioning finished: clean up")
@@ -310,7 +315,7 @@ func (ds HTTPDataSource) StoreToPVC(ctx context.Context, vi *virtv2.VirtualImage
 
 		source := ds.getSource(supgen, ds.statService.GetDVCRImageName(pod))
 
-		err = ds.diskService.StartImmediate(ctx, diskSize, ptr.To(vi.Status.StorageClassName), source, vi, supgen)
+		err = ds.diskService.StartImmediate(ctx, diskSize, sc, source, vi, supgen)
 		if updated, err := setPhaseConditionFromStorageError(err, vi, cb); err != nil || updated {
 			return reconcile.Result{}, err
 		}

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/sources.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/sources.go
@@ -212,6 +212,27 @@ func setPhaseConditionFromPodError(cb *conditions.ConditionBuilder, vi *virtv2.V
 	}
 }
 
+func setConditionFromStorageClassError(err error, cb *conditions.ConditionBuilder) (bool, error) {
+	switch {
+	case err == nil:
+		return false, nil
+	case errors.Is(err, service.ErrStorageClassNotFound):
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(vicondition.ProvisioningFailed).
+			Message("Provided StorageClass not found in the cluster.")
+		return true, nil
+	case errors.Is(err, service.ErrStorageClassNotAllowed):
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(vicondition.ProvisioningFailed).
+			Message("Specified StorageClass is not allowed: please change provided StorageClass name or check the module settings.")
+		return true, nil
+	default:
+		return false, err
+	}
+}
+
 func setPhaseConditionFromStorageError(err error, vi *virtv2.VirtualImage, cb *conditions.ConditionBuilder) (bool, error) {
 	switch {
 	case err == nil:

--- a/images/virtualization-artifact/pkg/controller/vi/internal/storageclass_ready.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/storageclass_ready.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -34,18 +33,16 @@ import (
 )
 
 type StorageClassReadyHandler struct {
-	service                      DiskService
-	storageClassFromModuleConfig string
+	service DiskService
 }
 
 func (h StorageClassReadyHandler) Name() string {
 	return "StorageClassReadyHandler"
 }
 
-func NewStorageClassReadyHandler(diskService DiskService, storageClassFromModuleConfig string) *StorageClassReadyHandler {
+func NewStorageClassReadyHandler(diskService DiskService) *StorageClassReadyHandler {
 	return &StorageClassReadyHandler{
-		service:                      diskService,
-		storageClassFromModuleConfig: storageClassFromModuleConfig,
+		service: diskService,
 	}
 }
 
@@ -77,7 +74,7 @@ func (h StorageClassReadyHandler) Handle(ctx context.Context, vi *virtv2.Virtual
 
 	hasNoStorageClassInSpec := vi.Spec.PersistentVolumeClaim.StorageClass == nil || *vi.Spec.PersistentVolumeClaim.StorageClass == ""
 	hasStorageClassInStatus := vi.Status.StorageClassName != ""
-	storageClassName := h.ActualStorageClass(vi, pvc)
+	var storageClassName *string
 
 	sc, err := h.service.GetStorageClass(ctx, storageClassName)
 	if err != nil && !errors.Is(err, service.ErrDefaultStorageClassNotFound) && !errors.Is(err, service.ErrStorageClassNotFound) {
@@ -112,29 +109,4 @@ func (h StorageClassReadyHandler) Handle(ctx context.Context, vi *virtv2.Virtual
 	}
 
 	return reconcile.Result{}, nil
-}
-
-func (h StorageClassReadyHandler) ActualStorageClass(vi *virtv2.VirtualImage, pvc *corev1.PersistentVolumeClaim) *string {
-	if vi == nil {
-		return nil
-	}
-
-	hasNoStorageClassInSpec := vi.Spec.PersistentVolumeClaim.StorageClass == nil || *vi.Spec.PersistentVolumeClaim.StorageClass == ""
-	useStorageClassFromModuleConfig := hasNoStorageClassInSpec && h.storageClassFromModuleConfig != ""
-	hasStorageClassInStatus := vi.Status.StorageClassName != ""
-
-	var storageClassName *string
-
-	switch {
-	case pvc != nil && pvc.Spec.StorageClassName != nil && *pvc.Spec.StorageClassName != "":
-		storageClassName = pvc.Spec.StorageClassName
-	case hasStorageClassInStatus && hasNoStorageClassInSpec:
-		storageClassName = &vi.Status.StorageClassName
-	case useStorageClassFromModuleConfig:
-		storageClassName = &h.storageClassFromModuleConfig
-	default:
-		storageClassName = vi.Spec.PersistentVolumeClaim.StorageClass
-	}
-
-	return storageClassName
 }

--- a/images/virtualization-artifact/pkg/controller/vi/vi_webhook.go
+++ b/images/virtualization-artifact/pkg/controller/vi/vi_webhook.go
@@ -19,6 +19,7 @@ package vi
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -64,8 +65,14 @@ func (v *Validator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Obj
 	}
 
 	ready, _ := conditions.GetCondition(vicondition.ReadyType, newVI.Status.Conditions)
-	if newVI.Status.Phase == virtv2.ImageReady || ready.Status == metav1.ConditionTrue {
-		return nil, fmt.Errorf("VirtualImage is in the Ready state: spec is immutable now")
+	if ready.Status == metav1.ConditionTrue || newVI.Status.Phase == virtv2.ImageReady || newVI.Status.Phase == virtv2.ImageLost || newVI.Status.Phase == virtv2.ImageTerminating {
+		if !reflect.DeepEqual(oldVI.Spec.DataSource, newVI.Spec.DataSource) {
+			return nil, fmt.Errorf("VirtualImage has already been created: data source cannot be changed after disk is created")
+		}
+
+		if !reflect.DeepEqual(oldVI.Spec.PersistentVolumeClaim.StorageClass, newVI.Spec.PersistentVolumeClaim.StorageClass) {
+			return nil, fmt.Errorf("VirtualImage has already been created: storage class cannot be changed after disk is created")
+		}
 	}
 
 	return nil, nil

--- a/openapi/config-values.yaml
+++ b/openapi/config-values.yaml
@@ -179,14 +179,47 @@ properties:
   virtualImages:
     type: object
     description: |
-      Configuring storage class for virtual images. If the this setting is not specified,
-      the default storage class will be used.
-    required: [storageClassName]
+      Configuring storage class for virtual images on PVC.
     properties:
       storageClassName:
+        deprecated: true
+        x-doc-deprecated: true
         type: string
         description: |
-          Specifies the name of the storage class to be used for virtual images.
+          Since the parameter has been deprecated, use the `defaultStorageClassName` parameter.
+      defaultStorageClassName:
+        type: string
+        description: |
+          Specifies the name of the default storage class to be used for virtual images on PVC.
+      allowedStorageClassSelector:
+        type: object
+        description: |
+          Selector for allowed storage classes to be used for virtual images on PVC.
+        properties:
+          matchNames:
+            type: array
+            items:
+              type: string
+            x-examples: ["sc-1", "sc-2"]
+  virtualDisks:
+    type: object
+    description: |
+      Configuring storage class for virtual disks.
+    properties:
+      defaultStorageClassName:
+        type: string
+        description: |
+          Specifies the name of the default storage class to be used for virtual disks.
+      allowedStorageClassSelector:
+        type: object
+        description: |
+          Selector for allowed storage classes to be used for virtual disks.
+        properties:
+          matchNames:
+            type: array
+            items:
+              type: string
+            x-examples: ["sc-1", "sc-2"]
   logLevel:
     type: string
     description: |

--- a/openapi/doc-ru-config-values.yaml
+++ b/openapi/doc-ru-config-values.yaml
@@ -91,13 +91,43 @@ properties:
   virtualImages:
     type: object
     description: |
-      Настройка класса хранения для виртуальных образов. Если это значение не указано,
-      будет использоваться класс хранения по умолчанию.
+      Настройка класса хранения для виртуальных образов на PVC.
     properties:
       storageClassName:
         type: string
         description: |
-          Указывает имя класса хранения, который будет использоваться для виртуальных образов.
+          Поскольку этот параметр был устаревшим, используйте параметр `defaultStorageClassName`.
+      defaultStorageClassName:
+        type: string
+        description: |
+          Указывает имя класса хранения по умолчанию, который будет использоваться для виртуальных образов на PVC.
+      allowedStorageClassSelector:
+        type: object
+        description: |
+          Селектор разрешенных классов хранения, которые можно использовать для виртуальных образов на PVC.
+        properties:
+          matchNames:
+            type: array
+            items:
+              type: string
+  virtualDisks:
+    type: object
+    description: |
+      Настройка класса хранения для виртуальных дисков.
+    properties:
+      defaultStorageClassName:
+        type: string
+        description: |
+          Указывает имя класса хранения по умолчанию, который будет использоваться для виртуальных дисков.
+      allowedStorageClassSelector:
+        type: object
+        description: |
+          Селектор разрешенных классов хранения, используемых для виртуальных дисков.
+        properties:
+          matchNames:
+            type: array
+            items:
+              type: string
   logLevel:
     type: string
     description: |

--- a/templates/virtualization-controller/_helpers.tpl
+++ b/templates/virtualization-controller/_helpers.tpl
@@ -33,6 +33,20 @@
 {{- if (hasKey .Values.virtualization "virtualImages") }}
 - name: VIRTUAL_IMAGE_STORAGE_CLASS
   value: {{ .Values.virtualization.virtualImages.storageClassName }}
+- name: VIRTUAL_IMAGE_DEFAULT_STORAGE_CLASS
+  value: {{ .Values.virtualization.virtualImages.defaultStorageClassName }}
+{{- if (hasKey .Values.virtualization.virtualImages "allowedStorageClassSelector") }}
+- name: VIRTUAL_IMAGE_ALLOWED_STORAGE_CLASSES
+  value: {{ join "," .Values.virtualization.virtualImages.allowedStorageClassSelector.matchNames | quote }}
+{{- end }}
+{{- end }}
+{{- if (hasKey .Values.virtualization "virtualDisks") }}
+- name: VIRTUAL_DISK_DEFAULT_STORAGE_CLASS
+  value: {{ .Values.virtualization.virtualDisks.defaultStorageClassName }}
+{{- if (hasKey .Values.virtualization.virtualDisks "allowedStorageClassSelector") }}
+- name: VIRTUAL_DISK_ALLOWED_STORAGE_CLASSES
+  value: {{ join "," .Values.virtualization.virtualDisks.allowedStorageClassSelector.matchNames | quote }}
+{{- end }}
 {{- end }}
 - name: VIRTUAL_MACHINE_IP_LEASES_RETENTION_DURATION
   value: "10m"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This update introduces customizable settings in module `Virtualization` for managing storage classes related to `VirtualImages` and `VirtualDisks`. The new feature allows for specifying allowed and default storage class names for both `VirtualImages` and `VirtualDisks`.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
