### PR TITLE
refactor(ci): change image to base-alt-p11 for virt-api virt-operator, add sysctl to virt-handler

### DIFF
--- a/images/virt-api/werf.inc.yaml
+++ b/images/virt-api/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ $.ImageName }}
-from: {{ .Images.DISTROLESS_ALT_P11 }}
+fromImage: base-alt-p11
 import:
 - image: virt-artifact
   add: /kubevirt-binaries/
@@ -12,8 +12,6 @@ import:
   add: /kubevirt-config-files/
   to: /etc
   includePaths:
-  - passwd
-  - group
   - .version
   before: setup
 # Source https://github.com/kubevirt/kubevirt/blob/v1.3.1/cmd/virt-api/BUILD.bazel

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -1,27 +1,8 @@
 ---
 # Source https://github.com/kubevirt/kubevirt/blob/v1.3.1/hack/dockerized#L15
-# {{- $builderImage := "quay.io/kubevirt/builder:2408151859-735f25dde" }}
 {{- $version := "1.3.1" }}
-# {{- $goVersion := "1.22.7" }}
+{{- $goVersion := "1.22.7" }}
 
-# Update Go version in builder to prevent CVEs in kubevirt components.
-# image: {{ $.ImageName }}-builder
-# final: false
-# from: {{ $builderImage }}
-# shell:
-#   install:
-#   - export GIMME_GO_VERSION={{ $goVersion }}
-#   - |
-#     rm -rf /gimme && \
-#     mkdir -p /gimme && curl -sL \
-#       https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | \
-#     HOME=/gimme bash > /etc/profile.d/gimme.sh
-#   - export PATH=`echo $PATH | tr ":" "\n" | grep -v "go" | tr "\n" ":"`
-#   - source /etc/profile.d/gimme.sh && go version
-# docker:
-#   ENV:
-#     GIMME_GO_VERSION: "{{ $goVersion }}"
-# ---
 image: {{ $.ImageName }}
 final: false
 fromImage: base-alt-p11

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -1,27 +1,27 @@
 ---
 # Source https://github.com/kubevirt/kubevirt/blob/v1.3.1/hack/dockerized#L15
-{{- $builderImage := "quay.io/kubevirt/builder:2408151859-735f25dde" }}
+# {{- $builderImage := "quay.io/kubevirt/builder:2408151859-735f25dde" }}
 {{- $version := "1.3.1" }}
-{{- $goVersion := "1.22.7" }}
+# {{- $goVersion := "1.22.7" }}
 
 # Update Go version in builder to prevent CVEs in kubevirt components.
-image: {{ $.ImageName }}-builder
-final: false
-from: {{ $builderImage }}
-shell:
-  install:
-  - export GIMME_GO_VERSION={{ $goVersion }}
-  - |
-    rm -rf /gimme && \
-    mkdir -p /gimme && curl -sL \
-      https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | \
-    HOME=/gimme bash > /etc/profile.d/gimme.sh
-  - export PATH=`echo $PATH | tr ":" "\n" | grep -v "go" | tr "\n" ":"`
-  - source /etc/profile.d/gimme.sh && go version
-docker:
-  ENV:
-    GIMME_GO_VERSION: "{{ $goVersion }}"
----
+# image: {{ $.ImageName }}-builder
+# final: false
+# from: {{ $builderImage }}
+# shell:
+#   install:
+#   - export GIMME_GO_VERSION={{ $goVersion }}
+#   - |
+#     rm -rf /gimme && \
+#     mkdir -p /gimme && curl -sL \
+#       https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | \
+#     HOME=/gimme bash > /etc/profile.d/gimme.sh
+#   - export PATH=`echo $PATH | tr ":" "\n" | grep -v "go" | tr "\n" ":"`
+#   - source /etc/profile.d/gimme.sh && go version
+# docker:
+#   ENV:
+#     GIMME_GO_VERSION: "{{ $goVersion }}"
+# ---
 image: {{ $.ImageName }}
 final: false
 fromImage: base-alt-p11
@@ -119,13 +119,13 @@ shell:
     - echo ============== Build virt-chroot ======================
     - go build -o /kubevirt-binaries/virt-chroot ./cmd/virt-chroot/
     
-    - echo ============== Build virt-exportproxy ================
+    - echo ============== Build virt-exportproxy =================
     - go build -o /kubevirt-binaries/virt-exportproxy ./cmd/virt-exportproxy/
     
     - echo ============== Build virt-exportserver ================
     - go build -o /kubevirt-binaries/virt-exportserver ./cmd/virt-exportserver/
    
-    - echo ============== Build virt-controller ====================
+    - echo ============== Build virt-controller ==================
     - go build -o /kubevirt-binaries/virt-controller ./cmd/virt-controller/
     
     - echo ============== Build virt-operator ====================

--- a/images/virt-handler/werf.inc.yaml
+++ b/images/virt-handler/werf.inc.yaml
@@ -7,6 +7,7 @@ shell:
   - |
     apt-get update && apt-get install --yes \
     acl \
+    systemd-sysctl-common \
     nftables \
     qemu-img==9.0.2-alt2 \
     xorriso==1.5.6-alt1

--- a/images/virt-handler/werf.inc.yaml
+++ b/images/virt-handler/werf.inc.yaml
@@ -7,7 +7,7 @@ shell:
   - |
     apt-get update && apt-get install --yes \
     acl \
-    systemd-sysctl-common \
+    procps \
     nftables \
     qemu-img==9.0.2-alt2 \
     xorriso==1.5.6-alt1

--- a/images/virt-operator/werf.inc.yaml
+++ b/images/virt-operator/werf.inc.yaml
@@ -3,6 +3,10 @@ image: {{ $.ImageName }}
 from: {{ .Images.DISTROLESS_ALT_P11 }}
 import:
 - image: base-alt-p11
+  add: /bin
+  to: /bin
+  before: setup
+- image: base-alt-p11
   add: /home
   to: /home
   includePaths:

--- a/images/virt-operator/werf.inc.yaml
+++ b/images/virt-operator/werf.inc.yaml
@@ -1,22 +1,29 @@
 ---
 image: {{ $.ImageName }}
-from: {{ .Images.DISTROLESS_ALT_P11 }}
+fromImage: base-alt-p11
+# from: {{ .Images.DISTROLESS_ALT_P11 }}
 import:
-- image: base-alt-p11
-  add: /bin
-  to: /bin
-  before: setup
-- image: base-alt-p11
-  add: /home
-  to: /home
-  includePaths:
-  - nonroot-user
-  excludePaths:
-  - nonroot-user/.c*
-  - nonroot-user/.x*
-  - nonroot-user/.ssh
-  - nonroot-user/.l*
-  before: setup
+# - image: base-alt-p11
+#   add: /
+#   to: /
+#   before: setup
+#   includePaths:
+#   - bin
+#   - lib64/libreadline*
+#   - lib64/libtinfo.so*
+#   - usr/lib64/libreadline*
+#   - usr/lib64/libtinfo.so*
+# - image: base-alt-p11
+#   add: /home
+#   to: /home
+#   includePaths:
+#   - nonroot-user
+#   excludePaths:
+#   - nonroot-user/.c*
+#   - nonroot-user/.x*
+#   - nonroot-user/.ssh
+#   - nonroot-user/.l*
+#   before: setup
 - image: virt-artifact
   add: /kubevirt-binaries/
   to: /usr/bin
@@ -29,8 +36,8 @@ import:
   add: /kubevirt-config-files/
   to: /etc
   includePaths:
-  - passwd
-  - group
+  # - passwd
+  # - group
   - .version
   before: setup
 # Source https://github.com/kubevirt/kubevirt/blob/v1.3.1/cmd/virt-operator/BUILD.bazel

--- a/images/virt-operator/werf.inc.yaml
+++ b/images/virt-operator/werf.inc.yaml
@@ -1,29 +1,7 @@
 ---
 image: {{ $.ImageName }}
 fromImage: base-alt-p11
-# from: {{ .Images.DISTROLESS_ALT_P11 }}
 import:
-# - image: base-alt-p11
-#   add: /
-#   to: /
-#   before: setup
-#   includePaths:
-#   - bin
-#   - lib64/libreadline*
-#   - lib64/libtinfo.so*
-#   - usr/lib64/libreadline*
-#   - usr/lib64/libtinfo.so*
-# - image: base-alt-p11
-#   add: /home
-#   to: /home
-#   includePaths:
-#   - nonroot-user
-#   excludePaths:
-#   - nonroot-user/.c*
-#   - nonroot-user/.x*
-#   - nonroot-user/.ssh
-#   - nonroot-user/.l*
-#   before: setup
 - image: virt-artifact
   add: /kubevirt-binaries/
   to: /usr/bin
@@ -36,8 +14,6 @@ import:
   add: /kubevirt-config-files/
   to: /etc
   includePaths:
-  # - passwd
-  # - group
   - .version
   before: setup
 # Source https://github.com/kubevirt/kubevirt/blob/v1.3.1/cmd/virt-operator/BUILD.bazel

--- a/images/virt-operator/werf.inc.yaml
+++ b/images/virt-operator/werf.inc.yaml
@@ -2,6 +2,17 @@
 image: {{ $.ImageName }}
 from: {{ .Images.DISTROLESS_ALT_P11 }}
 import:
+- image: base-alt-p11
+  add: /home
+  to: /home
+  includePaths:
+  - nonroot-user
+  excludePaths:
+  - nonroot-user/.c*
+  - nonroot-user/.x*
+  - nonroot-user/.ssh
+  - nonroot-user/.l*
+  before: setup
 - image: virt-artifact
   add: /kubevirt-binaries/
   to: /usr/bin


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix virt-operator and virt-api: `warning: could not resolve current working directory: stat .: permission denied`
Add `sysctl` to virt-handler image


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
