### PR TITLE
refactor(kube-api-rewriter): remove prefix from preserved original names in metadata

### DIFF
--- a/images/kube-api-proxy/pkg/rewriter/prefixed_name_rewriter.go
+++ b/images/kube-api-proxy/pkg/rewriter/prefixed_name_rewriter.go
@@ -241,7 +241,7 @@ func (p *PrefixedNameRewriter) isOriginal(name, value string) bool {
 }
 
 func (p *PrefixedNameRewriter) isPreserved(name string) bool {
-	return strings.HasSuffix(name, PreservedPrefix)
+	return strings.HasPrefix(name, PreservedPrefix)
 }
 
 func (p *PrefixedNameRewriter) preserveName(name string) string {


### PR DESCRIPTION

## Description

Use TrimPrefix for remove prefixes.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

virt-handler generates node patches to set labels with kvm capabilities. To run it with original kubevirt, preserving original label names with the prefix was introduced. This patch fix restoring names in the patch rewriter.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?

There should no errors 422 Uprocessable entity in logs.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
