### PR TITLE
fix(vmop): patch /metadata/labels for reconciled object

### DIFF
--- a/images/virtualization-artifact/pkg/common/patch/patch.go
+++ b/images/virtualization-artifact/pkg/common/patch/patch.go
@@ -25,6 +25,7 @@ const (
 	PatchReplaceOp = "replace"
 	PatchAddOp     = "add"
 	PatchRemoveOp  = "remove"
+	PatchTestOp    = "test"
 )
 
 type JsonPatch struct {


### PR DESCRIPTION

## Description

- Make Update method detect changes in annotations and labels.
- Change metadata with JSON patch using test+replace technique.

## Why do we need it, and what problem does it solve?

Reconciler should be able to change more metadata field in the changed object.

Also, fix label update for the vmop reconciler.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
