### PR TITLE
test(api): refactor e2e tests

### DIFF
--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -9,6 +9,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.31.0
 	k8s.io/apimachinery v0.31.0
+	k8s.io/utils v0.0.0-20240921022957-49e7df575cb6
 	kubevirt.io/api v1.3.1
 	sigs.k8s.io/controller-runtime v0.19.0
 	sigs.k8s.io/yaml v1.4.0
@@ -38,7 +39,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/openshift/api v0.0.0-20230503133300-8bbcb7ca7183 // indirect
 	github.com/openshift/custom-resource-status v1.1.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
@@ -57,8 +57,7 @@ require (
 	k8s.io/client-go v0.31.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
-	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect
-	kubevirt.io/containerized-data-importer-api v1.57.0-alpha1 // indirect
+	kubevirt.io/containerized-data-importer-api v1.60.3 // indirect
 	kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -154,8 +154,6 @@ github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAl
 github.com/onsi/gomega v1.18.1/go.mod h1:0q+aL8jAiMXy9hbwj2mr5GziHiwhAIQpFmmtT5hitRs=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
 github.com/onsi/gomega v1.34.1/go.mod h1:kU1QgUvBDLXBJq618Xvm2LUX6rSAfRaFRTcdOeDLwwY=
-github.com/openshift/api v0.0.0-20230503133300-8bbcb7ca7183 h1:t/CahSnpqY46sQR01SoS+Jt0jtjgmhgE6lFmRnO4q70=
-github.com/openshift/api v0.0.0-20230503133300-8bbcb7ca7183/go.mod h1:4VWG+W22wrB4HfBL88P40DxLEpSOaiBVxUnfalfJo9k=
 github.com/openshift/custom-resource-status v1.1.2 h1:C3DL44LEbvlbItfd8mT5jWrqPfHnSOQoQf/sypqA6A4=
 github.com/openshift/custom-resource-status v1.1.2/go.mod h1:DB/Mf2oTeiAmVVX1gN+NEqweonAPY0TKUwADizj8+ZA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -367,12 +365,12 @@ k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 h1:BZqlfIlq5YbRMFko6/PM7F
 k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340/go.mod h1:yD4MZYeKMBwQKVht279WycxKyM84kkAx2DPrTXaeb98=
 k8s.io/utils v0.0.0-20210802155522-efc7438f0176/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20211116205334-6203023598ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 h1:pUdcCO1Lk/tbT5ztQWOBi5HBgbBP1J8+AsQnQCKsi8A=
-k8s.io/utils v0.0.0-20240711033017-18e509b52bc8/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+k8s.io/utils v0.0.0-20240921022957-49e7df575cb6 h1:MDF6h2H/h4tbzmtIKTuctcwZmY0tY9mD9fNT47QO6HI=
+k8s.io/utils v0.0.0-20240921022957-49e7df575cb6/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 kubevirt.io/api v1.3.1 h1:MoTNo/zvDlZ44c2ocXLPln8XTaQOeUodiYbEKrTCqv4=
 kubevirt.io/api v1.3.1/go.mod h1:tCn7VAZktEvymk490iPSMPCmKM9UjbbfH2OsFR/IOLU=
-kubevirt.io/containerized-data-importer-api v1.57.0-alpha1 h1:IWo12+ei3jltSN5jQN1xjgakfvRSF3G3Rr4GXVOOy2I=
-kubevirt.io/containerized-data-importer-api v1.57.0-alpha1/go.mod h1:Y/8ETgHS1GjO89bl682DPtQOYEU/1ctPFBz6Sjxm4DM=
+kubevirt.io/containerized-data-importer-api v1.60.3 h1:kQEXi7scpzUa0RPf3/3MKk1Kmem0ZlqqiuK3kDF5L2I=
+kubevirt.io/containerized-data-importer-api v1.60.3/go.mod h1:8mwrkZIdy8j/LmCyKt2wFXbiMavLUIqDaegaIF67CZs=
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90 h1:QMrd0nKP0BGbnxTqakhDZAUhGKxPiPiN5gSDqKUmGGc=
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90/go.mod h1:018lASpFYBsYN6XwmA2TIrPCx6e0gviTd/ZNtSitKgc=
 sigs.k8s.io/controller-runtime v0.19.0 h1:nWVM7aq+Il2ABxwiCizrVDSlmDcshi9llbaFbC0ji/Q=

--- a/tests/e2e/sizing_policy_test.go
+++ b/tests/e2e/sizing_policy_test.go
@@ -74,10 +74,10 @@ var _ = Describe("Sizing policy", Ordered, ContinueOnFailure, func() {
 		notExistingVmClassChanging     = map[string]string{"vm": "not-existing-vmclass-with-changing"}
 		notExistingVmClassCreating     = map[string]string{"vm": "not-existing-vmclass-with-creating"}
 		existingVmClass                = map[string]string{"vm": "existing-vmclass"}
-		testcaseLabel                  = map[string]string{"testcase": "sizing-policy"}
+		testCaseLabel                  = map[string]string{"testcase": "sizing-policy"}
 	)
 
-	Context("Environment preparing", func() {
+	Context("Preparing the environment", func() {
 		vmNotValidSizingPolicyChanging = fmt.Sprintf("%s-vm-%s", namePrefix, notExistingVmClassChanging["vm"])
 		vmNotValidSizingPolicyCreating = fmt.Sprintf("%s-vm-%s", namePrefix, notExistingVmClassCreating["vm"])
 		vmClassDiscovery = fmt.Sprintf("%s-discovery", namePrefix)
@@ -95,7 +95,7 @@ var _ = Describe("Sizing policy", Ordered, ContinueOnFailure, func() {
 		It("checks VIs phases", func() {
 			By(fmt.Sprintf("VIs should be in %s phases", PhaseReady))
 			WaitPhase(kc.ResourceVI, PhaseReady, kc.GetOptions{
-				Labels:    testcaseLabel,
+				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Output:    "jsonpath='{.items[*].metadata.name}'",
 			})
@@ -160,7 +160,7 @@ var _ = Describe("Sizing policy", Ordered, ContinueOnFailure, func() {
 			})
 
 			It("changes VMClassName in VM specification with existing VMClass", func() {
-				mergePatch := fmt.Sprintf("{\"spec\":{\"virtualMachineClassName\":\"%s\"}}", vmClassDiscovery)
+				mergePatch := fmt.Sprintf("{\"spec\":{\"virtualMachineClassName\":%q}}", vmClassDiscovery)
 				MergePatchResource(kc.ResourceVM, vmNotValidSizingPolicyChanging, mergePatch)
 			})
 
@@ -183,7 +183,7 @@ var _ = Describe("Sizing policy", Ordered, ContinueOnFailure, func() {
 			})
 
 			It("changes VMClassName in VM specification with not existing VMClass which have correct prefix for creating", func() {
-				mergePatch := fmt.Sprintf("{\"spec\":{\"virtualMachineClassName\":\"%s\"}}", vmClassDiscoveryCopy)
+				mergePatch := fmt.Sprintf("{\"spec\":{\"virtualMachineClassName\":%q}}", vmClassDiscoveryCopy)
 				MergePatchResource(kc.ResourceVM, vmNotValidSizingPolicyCreating, mergePatch)
 			})
 
@@ -216,7 +216,7 @@ var _ = Describe("Sizing policy", Ordered, ContinueOnFailure, func() {
 	Context(fmt.Sprintf("When virtual machines in phase %s:", PhaseRunning), func() {
 		It("checks sizing policy match", func() {
 			res := kubectl.List(kc.ResourceVM, kc.GetOptions{
-				Labels:    testcaseLabel,
+				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Output:    "jsonpath='{.items[*].metadata.name}'",
 			})

--- a/tests/e2e/testdata/complex-test/kustomization.yaml
+++ b/tests/e2e/testdata/complex-test/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: testcases
 namePrefix: pr-number-or-commit-hash-
 resources:
   - ns.yaml
+  - vmc.yaml
   - cvi
   - vi
   - vd
@@ -14,3 +15,4 @@ labels:
   - includeSelectors: true
     pairs:
       id: pr-number-or-commit-hash
+      testcase: complex-test

--- a/tests/e2e/testdata/complex-test/vd/kustomization.yaml
+++ b/tests/e2e/testdata/complex-test/vd/kustomization.yaml
@@ -8,3 +8,7 @@ resources:
   - ./vd-from-cvi-alpine-registry.yaml
   - ./vd-from-vi-alpine-http.yaml
   - ./vd-from-vi-alpine-registry.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      hasNoConsumer: "complex-test"

--- a/tests/e2e/testdata/complex-test/vm/overlays/vm-a-not-b/kustomization.yaml
+++ b/tests/e2e/testdata/complex-test/vm/overlays/vm-a-not-b/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 patches:
   - path: vm.affinity.patch.yaml
   - path: vm.tolerations.patch.yaml
+  - path: vm.vmclass.patch.yaml
 labels:
   - includeSelectors: true
     pairs:

--- a/tests/e2e/testdata/complex-test/vm/overlays/vm-a-not-b/vm.vmclass.patch.yaml
+++ b/tests/e2e/testdata/complex-test/vm/overlays/vm-a-not-b/vm.vmclass.patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualMachine
+metadata:
+  name: vm
+spec:
+  virtualMachineClassName: affinity-discovery

--- a/tests/e2e/testdata/complex-test/vm/overlays/vm-b-not-a/kustomization.yaml
+++ b/tests/e2e/testdata/complex-test/vm/overlays/vm-b-not-a/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 patches:
   - path: vm.affinity.patch.yaml
   - path: vm.tolerations.patch.yaml
+  - path: vm.vmclass.patch.yaml
 labels:
   - includeSelectors: true
     pairs:

--- a/tests/e2e/testdata/complex-test/vm/overlays/vm-b-not-a/vm.vmclass.patch.yaml
+++ b/tests/e2e/testdata/complex-test/vm/overlays/vm-b-not-a/vm.vmclass.patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualMachine
+metadata:
+  name: vm
+spec:
+  virtualMachineClassName: affinity-discovery

--- a/tests/e2e/testdata/complex-test/vm/overlays/vm-c-and-a/kustomization.yaml
+++ b/tests/e2e/testdata/complex-test/vm/overlays/vm-c-and-a/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 patches:
   - path: vm.affinity.patch.yaml
   - path: vm.tolerations.patch.yaml
+  - path: vm.vmclass.patch.yaml
 labels:
   - includeSelectors: true
     pairs:

--- a/tests/e2e/testdata/complex-test/vm/overlays/vm-c-and-a/vm.vmclass.patch.yaml
+++ b/tests/e2e/testdata/complex-test/vm/overlays/vm-c-and-a/vm.vmclass.patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualMachine
+metadata:
+  name: vm
+spec:
+  virtualMachineClassName: affinity-discovery

--- a/tests/e2e/testdata/complex-test/vmc.yaml
+++ b/tests/e2e/testdata/complex-test/vmc.yaml
@@ -1,0 +1,7 @@
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualMachineClass
+metadata:
+  name: affinity-discovery
+spec:
+  cpu:
+    type: Discovery

--- a/tests/e2e/testdata/connectivity/kustomization.yaml
+++ b/tests/e2e/testdata/connectivity/kustomization.yaml
@@ -10,4 +10,5 @@ configurations:
 labels:
   - includeSelectors: true
     pairs:
-      testcase: pr-number-or-commit-hash
+      id: pr-number-or-commit-hash
+      testcase: vm-connectivity

--- a/tests/e2e/testdata/connectivity/resources/kustomization.yaml
+++ b/tests/e2e/testdata/connectivity/resources/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - vi.yaml
-  - vm1.yaml
-  - vm1-svc.yaml
-  - vm2.yaml
-  - vm2-svc.yaml
+  - vm-connectivity-a.yaml
+  - vm-connectivity-a-svc.yaml
+  - vm-connectivity-b.yaml
+  - vm-connectivity-b-svc.yaml

--- a/tests/e2e/testdata/connectivity/resources/vm-connectivity-a-svc.yaml
+++ b/tests/e2e/testdata/connectivity/resources/vm-connectivity-a-svc.yaml
@@ -2,12 +2,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: vm1
+  name: vm-connectivity-a
   labels:
     vm: linux
+    service: vm-connectivity-a
 spec:
   selector:
-    service: vm1
+    service: vm-connectivity-a
   ports:
     - name: http
       port: 80

--- a/tests/e2e/testdata/connectivity/resources/vm-connectivity-a.yaml
+++ b/tests/e2e/testdata/connectivity/resources/vm-connectivity-a.yaml
@@ -2,7 +2,7 @@
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualDisk
 metadata:
-  name: vm1-vd-from-vi
+  name: vd-connectivity-a
 spec:
   persistentVolumeClaim:
     size: 4Gi
@@ -15,10 +15,10 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualMachine
 metadata:
-  name: vm1
+  name: vm-connectivity-a
   labels:
     vm: linux
-    service: vm1
+    service: vm-connectivity-a
 spec:
   virtualMachineClassName: generic
   runPolicy: AlwaysOn
@@ -32,7 +32,7 @@ spec:
     size: 1Gi
   blockDeviceRefs:
     - kind: VirtualDisk
-      name: vm1-vd-from-vi
+      name: vd-connectivity-a
   provisioning:
     type: UserData
     userData: |

--- a/tests/e2e/testdata/connectivity/resources/vm-connectivity-b-svc.yaml
+++ b/tests/e2e/testdata/connectivity/resources/vm-connectivity-b-svc.yaml
@@ -2,12 +2,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: vm2
+  name: vm-connectivity-b
   labels:
     vm: linux
+    service: vm-connectivity-b
 spec:
   selector:
-    service: vm2
+    service: vm-connectivity-b
   ports:
     - name: http
       port: 80

--- a/tests/e2e/testdata/connectivity/resources/vm-connectivity-b.yaml
+++ b/tests/e2e/testdata/connectivity/resources/vm-connectivity-b.yaml
@@ -2,7 +2,7 @@
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualDisk
 metadata:
-  name: vm2-vd-from-vi
+  name: vd-connectivity-b
 spec:
   persistentVolumeClaim:
     size: 4Gi
@@ -15,10 +15,10 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualMachine
 metadata:
-  name: vm2
+  name: vm-connectivity-b
   labels:
     vm: linux
-    service: vm2
+    service: vm-connectivity-b
 spec:
   virtualMachineClassName: generic
   runPolicy: AlwaysOn
@@ -32,7 +32,7 @@ spec:
     size: 1Gi
   blockDeviceRefs:
     - kind: VirtualDisk
-      name: vm2-vd-from-vi
+      name: vd-connectivity-b
   provisioning:
     type: UserData
     userData: |

--- a/tests/e2e/testdata/vm-disk-attachment/overlays/automatic-with-hotplug/kustomization.yaml
+++ b/tests/e2e/testdata/vm-disk-attachment/overlays/automatic-with-hotplug/kustomization.yaml
@@ -19,7 +19,3 @@ patches:
     target:
       kind: VirtualMachine
       name: vm
-labels:
-  - includeSelectors: true
-    pairs:
-      vm: automatic-with-hotplug-standalone

--- a/tests/e2e/testdata/vm-disk-attachment/overlays/automatic-with-hotplug/vd-attach.yaml
+++ b/tests/e2e/testdata/vm-disk-attachment/overlays/automatic-with-hotplug/vd-attach.yaml
@@ -2,6 +2,8 @@ apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualDisk
 metadata:
   name: vd-attach
+  labels:
+    hasNoConsumer: "vm-disk-attachment"
 spec:
   persistentVolumeClaim:
     size: 100Mi

--- a/tests/e2e/vm_disk_resizing_test.go
+++ b/tests/e2e/vm_disk_resizing_test.go
@@ -39,10 +39,7 @@ type DiskMetaData struct {
 	SizeFromObject *resource.Quantity
 }
 
-var (
-	DiskResizingLabel = map[string]string{"testcase": "disk-resizing"}
-	DiskIdPrefix      = "scsi-0QEMU_QEMU_HARDDISK_"
-)
+const DiskIdPrefix = "scsi-0QEMU_QEMU_HARDDISK_"
 
 func WaitBlockDeviceRefsStatus(namespace string, vms ...string) {
 	GinkgoHelper()
@@ -152,8 +149,10 @@ func GetVirtualMachineDisks(vmName string, config *cfg.Config) (VirtualMachineDi
 }
 
 var _ = Describe("Virtual disk resizing", Ordered, ContinueOnFailure, func() {
+	diskResizingLabel := map[string]string{"testcase": "disk-resizing"}
+
 	Context("When resources are applied:", func() {
-		It("must have no errors", func() {
+		It("result should be succeeded", func() {
 			res := kubectl.Kustomize(conf.TestData.DiskResizing, kc.KustomizeOptions{})
 			Expect(res.WasSuccess()).To(Equal(true), res.StdErr())
 		})
@@ -163,7 +162,7 @@ var _ = Describe("Virtual disk resizing", Ordered, ContinueOnFailure, func() {
 		It("checks VDs phases", func() {
 			By(fmt.Sprintf("VDs should be in %s phases", PhaseReady))
 			WaitPhase(kc.ResourceVD, PhaseReady, kc.GetOptions{
-				Labels:    DiskResizingLabel,
+				Labels:    diskResizingLabel,
 				Namespace: conf.Namespace,
 				Output:    "jsonpath='{.items[*].metadata.name}'",
 			})
@@ -174,7 +173,7 @@ var _ = Describe("Virtual disk resizing", Ordered, ContinueOnFailure, func() {
 		It("checks VMs phases", func() {
 			By(fmt.Sprintf("VMs should be in %s phases", PhaseRunning))
 			WaitPhase(kc.ResourceVM, PhaseRunning, kc.GetOptions{
-				Labels:    DiskResizingLabel,
+				Labels:    diskResizingLabel,
 				Namespace: conf.Namespace,
 				Output:    "jsonpath='{.items[*].metadata.name}'",
 			})
@@ -185,7 +184,7 @@ var _ = Describe("Virtual disk resizing", Ordered, ContinueOnFailure, func() {
 		It("checks VMBDAs phases", func() {
 			By(fmt.Sprintf("VMBDAs should be in %s phases", PhaseAttached))
 			WaitPhase(kc.ResourceVMBDA, PhaseAttached, kc.GetOptions{
-				Labels:    DiskResizingLabel,
+				Labels:    diskResizingLabel,
 				Namespace: conf.Namespace,
 				Output:    "jsonpath='{.items[*].metadata.name}'",
 			})
@@ -199,14 +198,14 @@ var _ = Describe("Virtual disk resizing", Ordered, ContinueOnFailure, func() {
 				vmDisksAfter  VirtualMachineDisks
 				err           error
 			)
-			vmName := fmt.Sprintf("%s-vm-%s", namePrefix, DiskResizingLabel["testcase"])
+			vmName := fmt.Sprintf("%s-vm-%s", namePrefix, diskResizingLabel["testcase"])
 			It("get disks metadata before resizing", func() {
 				vmDisksBefore, err = GetVirtualMachineDisks(vmName, conf)
 				Expect(err).NotTo(HaveOccurred(), err)
 			})
 			It("resizes disks", func() {
 				res := kubectl.List(kc.ResourceVD, kc.GetOptions{
-					Labels:    DiskResizingLabel,
+					Labels:    diskResizingLabel,
 					Namespace: conf.Namespace,
 					Output:    "jsonpath='{.items[*].metadata.name}'",
 				})
@@ -224,28 +223,28 @@ var _ = Describe("Virtual disk resizing", Ordered, ContinueOnFailure, func() {
 			It("checks VDs, VMs and VMBDA phases", func() {
 				By(fmt.Sprintf("VDs should be in %s phases", PhaseReady))
 				WaitPhase(kc.ResourceVD, PhaseReady, kc.GetOptions{
-					Labels:    DiskResizingLabel,
+					Labels:    diskResizingLabel,
 					Namespace: conf.Namespace,
 					Output:    "jsonpath='{.items[*].metadata.name}'",
 				})
 
 				By(fmt.Sprintf("VMs should be in %s phases", PhaseRunning))
 				WaitPhase(kc.ResourceVM, PhaseRunning, kc.GetOptions{
-					Labels:    DiskResizingLabel,
+					Labels:    diskResizingLabel,
 					Namespace: conf.Namespace,
 					Output:    "jsonpath='{.items[*].metadata.name}'",
 				})
 
 				By(fmt.Sprintf("VMBDAs should be in %s phases", PhaseAttached))
 				WaitPhase(kc.ResourceVMBDA, PhaseAttached, kc.GetOptions{
-					Labels:    DiskResizingLabel,
+					Labels:    diskResizingLabel,
 					Namespace: conf.Namespace,
 					Output:    "jsonpath='{.items[*].metadata.name}'",
 				})
 
 				By("BlockDeviceRefsStatus: disks should be attached")
 				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
-					Labels:    DiskResizingLabel,
+					Labels:    diskResizingLabel,
 					Namespace: conf.Namespace,
 					Output:    "jsonpath='{.items[*].metadata.name}'",
 				})


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
- make ginkgo contexts more readable;
- make test cases independent;
- adopt tests to updated API;
- adopt tests for different storage class volume binding modes.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
API was changed and require to adopt tests for running them in development clusters because of E2E cluster has different configuration.
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
E2E tests can be running in development clusters and result should be succeeded.
## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
