### PR TITLE
refactor(ci): switch from merge commit to head sha commit in builds

### DIFF
--- a/.github/workflows/dev_module_build-on-self-hosted-runner.yml
+++ b/.github/workflows/dev_module_build-on-self-hosted-runner.yml
@@ -134,6 +134,8 @@ jobs:
           version: 3.37.2
 
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Run lint virtualization-controller
         run: |
@@ -177,6 +179,8 @@ jobs:
           version: 3.37.2
 
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Run test hooks
         run: |
@@ -196,6 +200,7 @@ jobs:
     runs-on: [self-hosted, ci-testing]
     env:
       MODULES_MODULE_TAG: ${{needs.set_vars.outputs.modules_module_tag}}
+      WERF_VIRTUAL_MERGE: 0
     steps:
       - name: Print vars
         run: |
@@ -208,6 +213,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Remove unwanted software
         uses: ./.github/actions/remove-unwanted-software

--- a/.github/workflows/dev_module_build-on-self-hosted-runner.yml
+++ b/.github/workflows/dev_module_build-on-self-hosted-runner.yml
@@ -135,6 +135,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Run lint virtualization-controller

--- a/.github/workflows/dev_module_build.yml
+++ b/.github/workflows/dev_module_build.yml
@@ -32,6 +32,7 @@ on:
     branches:
       - main
       - pre-alpha
+      # - refactor/ci/pullrequest-head-sha
 
 defaults:
   run:
@@ -121,6 +122,8 @@ jobs:
           version: 3.37.2
 
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Run lint virtualization-controller
         run: |
@@ -158,6 +161,8 @@ jobs:
           version: 3.37.2
 
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Run test hooks
         run: |
@@ -174,6 +179,7 @@ jobs:
     needs: set_vars
     env:
       MODULES_MODULE_TAG: ${{needs.set_vars.outputs.modules_module_tag}}
+      WERF_VIRTUAL_MERGE: 0
     steps:
       - name: Print vars
         run: |
@@ -186,10 +192,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Remove unwanted software
         uses: ./.github/actions/remove-unwanted-software
 
       - uses: deckhouse/modules-actions/setup@v1
 
+      - name: Echo
+        run: |
+          echo "HEAD SHA ${{ github.event.pull_request.head.sha }}"
       - uses: deckhouse/modules-actions/build@v1

--- a/.github/workflows/dev_module_build.yml
+++ b/.github/workflows/dev_module_build.yml
@@ -26,6 +26,10 @@ env:
 
 on:
   workflow_dispatch:
+    inputs:
+      pr_number:
+        required: false
+        type: number
   pull_request:
     types: [opened, reopened, synchronize]
   push:
@@ -53,8 +57,14 @@ jobs:
         run: |
           if [[ "${{ github.ref_name }}" == 'pre-alpha' || "${{ github.ref_name }}" == 'main' ]]; then
             MODULES_MODULE_TAG="${{ github.ref_name }}"
-          else
+          elif [[ -n "${{ github.event.pull_request.number }}" ]]; then
             MODULES_MODULE_TAG="pr${{ github.event.pull_request.number }}"
+          elif [[ -n "${{ github.event.inputs.pr_number }}" ]]; then
+            MODULES_MODULE_TAG="pr${{ github.event.inputs.pr_number }}"
+          else
+            echo "Cannot set MODULES_MODULE_TAG variable"
+            echo "Exit"
+            exit 1
           fi
 
           echo "MODULES_MODULE_TAG=$MODULES_MODULE_TAG" >> "$GITHUB_OUTPUT"
@@ -122,7 +132,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Run lint virtualization-controller
         run: |
@@ -140,7 +150,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Lint yaml with prettier
         run: task -p lint:prettier:yaml
@@ -161,7 +171,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Run test hooks
         run: |
@@ -191,7 +201,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Remove unwanted software
         uses: ./.github/actions/remove-unwanted-software

--- a/.github/workflows/dev_module_build.yml
+++ b/.github/workflows/dev_module_build.yml
@@ -32,7 +32,6 @@ on:
     branches:
       - main
       - pre-alpha
-      # - refactor/ci/pullrequest-head-sha
 
 defaults:
   run:
@@ -199,7 +198,4 @@ jobs:
 
       - uses: deckhouse/modules-actions/setup@v1
 
-      - name: Echo
-        run: |
-          echo "HEAD SHA ${{ github.event.pull_request.head.sha }}"
       - uses: deckhouse/modules-actions/build@v1

--- a/.github/workflows/dev_module_build.yml
+++ b/.github/workflows/dev_module_build.yml
@@ -27,7 +27,7 @@ env:
 on:
   workflow_dispatch:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, reopened, synchronize]
   push:
     branches:
       - main

--- a/.github/workflows/dev_validation.yaml
+++ b/.github/workflows/dev_validation.yaml
@@ -48,6 +48,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Run validation "No cyrillic"
         run: |
@@ -71,6 +72,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Run validation "Doc changes"
         run: |
@@ -94,6 +96,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Run validation "Copyright"
         run: |


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Switch from Merge commit to HEAD SHA to prevent rebuilding images that have not been modified in the current branch
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Improve CI/CD

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
