### PR TITLE
fix(cvi,vi,vd): use default http port for uploader service

### DIFF
--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -172,7 +172,7 @@ d8 k get cvi some-image -o jsonpath="{.status.imageUploadURLs}"  | jq
 
 # {
 #   "external":"https://virtualization.example.com/upload/g2OuLgRhdAWqlJsCMyNvcdt4o5ERIwmm",
-#   "inCluster":"http://10.222.165.239"
+#   "inCluster":"http://10.222.165.239/upload"
 # }
 ```
 

--- a/docs/ADMIN_GUIDE_RU.md
+++ b/docs/ADMIN_GUIDE_RU.md
@@ -175,7 +175,7 @@ d8 k get cvi some-image -o jsonpath="{.status.imageUploadURLs}"  | jq
 
 # {
 #   "external":"https://virtualization.example.com/upload/g2OuLgRhdAWqlJsCMyNvcdt4o5ERIwmm",
-#   "inCluster":"http://10.222.165.239"
+#   "inCluster":"http://10.222.165.239/upload"
 # }
 ```
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -327,7 +327,7 @@ d8 k get vi some-image -o jsonpath="{.status.imageUploadURLs}"  | jq
 
 # {
 #   "external":"https://virtualization.example.com/upload/g2OuLgRhdAWqlJsCMyNvcdt4o5ERIwmm",
-#   "inCluster":"http://10.222.165.239"
+#   "inCluster":"http://10.222.165.239/upload"
 # }
 ```
 

--- a/docs/USER_GUIDE_RU.md
+++ b/docs/USER_GUIDE_RU.md
@@ -335,7 +335,7 @@ d8 k get vi some-image -o jsonpath="{.status.imageUploadURLs}"  | jq
 
 # {
 #   "external":"https://virtualization.example.com/upload/g2OuLgRhdAWqlJsCMyNvcdt4o5ERIwmm",
-#   "inCluster":"http://10.222.165.239"
+#   "inCluster":"http://10.222.165.239/upload"
 # }
 ```
 

--- a/images/virtualization-artifact/pkg/common/common.go
+++ b/images/virtualization-artifact/pkg/common/common.go
@@ -36,6 +36,8 @@ const (
 	UploaderContainerName = "uploader"
 	// UploaderPortName provides a constant to use as a port name for uploader Service
 	UploaderPortName = "uploader"
+	// UploaderPort provides a constant to use as a port for uploader Service
+	UploaderPort = 80
 	// UploaderIngressHostVar is a env variable
 	UploaderIngressHostVar = "UPLOADER_INGRESS_HOST"
 	// UploaderIngressTLSSecretVar is a env variable

--- a/images/virtualization-artifact/pkg/controller/service/uploader_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/uploader_service.go
@@ -26,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/deckhouse/virtualization-controller/pkg/common"
 	"github.com/deckhouse/virtualization-controller/pkg/common/datasource"
 	cc "github.com/deckhouse/virtualization-controller/pkg/controller/common"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/supplements"
@@ -203,20 +202,12 @@ func (s UploaderService) GetExternalURL(ctx context.Context, ing *netv1.Ingress)
 }
 
 func (s UploaderService) GetInClusterURL(ctx context.Context, svc *corev1.Service) string {
-	var port int32
-
-	for _, svcPort := range svc.Spec.Ports {
-		if svcPort.Name == common.UploaderPortName {
-			port = svcPort.Port
-		}
-	}
-
-	if port == 0 || svc.Spec.ClusterIP == "" {
-		logger.FromContext(ctx).Error("unexpected spec of the service, please report a bug", "port", port, "clusterIP", svc.Spec.ClusterIP)
+	if svc.Spec.ClusterIP == "" {
+		logger.FromContext(ctx).Error("unexpected empty cluster ip, please report a bug", "clusterIP", svc.Spec.ClusterIP)
 		return ""
 	}
 
-	return fmt.Sprintf("http://%s:%d/upload", svc.Spec.ClusterIP, port)
+	return fmt.Sprintf("http://%s/upload", svc.Spec.ClusterIP)
 }
 
 func (s UploaderService) getPodSettings(ownerRef *metav1.OwnerReference, sup *supplements.Generator) *uploader.PodSettings {

--- a/images/virtualization-artifact/pkg/controller/uploader/uploader_ingress.go
+++ b/images/virtualization-artifact/pkg/controller/uploader/uploader_ingress.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/deckhouse/virtualization-controller/pkg/common"
 	cc "github.com/deckhouse/virtualization-controller/pkg/controller/common"
 	"github.com/deckhouse/virtualization-controller/pkg/sdk/framework/helper"
 	"github.com/deckhouse/virtualization-controller/pkg/util"
@@ -99,7 +100,7 @@ func (i *Ingress) makeSpec() *netv1.Ingress {
 										Service: &netv1.IngressServiceBackend{
 											Name: i.Settings.ServiceName,
 											Port: netv1.ServiceBackendPort{
-												Number: 443,
+												Number: common.UploaderPort,
 											},
 										},
 									},

--- a/images/virtualization-artifact/pkg/controller/uploader/uploader_service.go
+++ b/images/virtualization-artifact/pkg/controller/uploader/uploader_service.go
@@ -76,7 +76,7 @@ func (s *Service) makeSpec() *corev1.Service {
 				{
 					Name:     common.UploaderPortName,
 					Protocol: "TCP",
-					Port:     443,
+					Port:     common.UploaderPort,
 					TargetPort: intstr.IntOrString{
 						Type:   intstr.Int,
 						IntVal: 8444,


### PR DESCRIPTION
## Description

Use default http port for uploader service

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
