### PR TITLE
feat(vd): requeue for exceeded quota error

### DIFF
--- a/images/virtualization-artifact/pkg/controller/service/disk_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/disk_service.go
@@ -428,6 +428,14 @@ func (s DiskService) GetVolumeSnapshot(ctx context.Context, name, namespace stri
 	return helper.FetchObject(ctx, types.NamespacedName{Name: name, Namespace: namespace}, s.client, &vsv1.VolumeSnapshot{})
 }
 
+func (s DiskService) GetVirtualImage(ctx context.Context, name, namespace string) (*virtv2.VirtualImage, error) {
+	return helper.FetchObject(ctx, types.NamespacedName{Name: name, Namespace: namespace}, s.client, &virtv2.VirtualImage{})
+}
+
+func (s DiskService) GetClusterVirtualImage(ctx context.Context, name string) (*virtv2.ClusterVirtualImage, error) {
+	return helper.FetchObject(ctx, types.NamespacedName{Name: name}, s.client, &virtv2.ClusterVirtualImage{})
+}
+
 func (s DiskService) ListVirtualDiskSnapshots(ctx context.Context, namespace string) ([]virtv2.VirtualDiskSnapshot, error) {
 	var vdSnapshots virtv2.VirtualDiskSnapshotList
 	err := s.client.List(ctx, &vdSnapshots, &client.ListOptions{

--- a/images/virtualization-artifact/pkg/controller/vd/internal/life_cycle.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/life_cycle.go
@@ -103,10 +103,10 @@ func (h LifeCycleHandler) Handle(ctx context.Context, vd *virtv2.VirtualDisk) (r
 		}
 	}
 
-	requeue, err := ds.Sync(ctx, vd)
+	result, err := ds.Sync(ctx, vd)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to sync virtual disk data source %s: %w", ds.Name(), err)
 	}
 
-	return reconcile.Result{Requeue: requeue}, nil
+	return result, nil
 }

--- a/images/virtualization-artifact/pkg/controller/vd/internal/mock.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/mock.go
@@ -10,6 +10,7 @@ import (
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sync"
 )
 
@@ -29,7 +30,7 @@ var _ Handler = &HandlerMock{}
 //			NameFunc: func() string {
 //				panic("mock out the Name method")
 //			},
-//			SyncFunc: func(ctx context.Context, vd *virtv2.VirtualDisk) (bool, error) {
+//			SyncFunc: func(ctx context.Context, vd *virtv2.VirtualDisk) (reconcile.Result, error) {
 //				panic("mock out the Sync method")
 //			},
 //			ValidateFunc: func(ctx context.Context, vd *virtv2.VirtualDisk) error {
@@ -49,7 +50,7 @@ type HandlerMock struct {
 	NameFunc func() string
 
 	// SyncFunc mocks the Sync method.
-	SyncFunc func(ctx context.Context, vd *virtv2.VirtualDisk) (bool, error)
+	SyncFunc func(ctx context.Context, vd *virtv2.VirtualDisk) (reconcile.Result, error)
 
 	// ValidateFunc mocks the Validate method.
 	ValidateFunc func(ctx context.Context, vd *virtv2.VirtualDisk) error
@@ -151,7 +152,7 @@ func (mock *HandlerMock) NameCalls() []struct {
 }
 
 // Sync calls SyncFunc.
-func (mock *HandlerMock) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (bool, error) {
+func (mock *HandlerMock) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (reconcile.Result, error) {
 	if mock.SyncFunc == nil {
 		panic("HandlerMock.SyncFunc: method is nil but Handler.Sync was just called")
 	}

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref.go
@@ -18,37 +18,25 @@ package source
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	common2 "github.com/deckhouse/virtualization-controller/pkg/common"
-	"github.com/deckhouse/virtualization-controller/pkg/controller"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/common"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/supplements"
-	"github.com/deckhouse/virtualization-controller/pkg/imageformat"
-	"github.com/deckhouse/virtualization-controller/pkg/logger"
-	"github.com/deckhouse/virtualization-controller/pkg/sdk/framework/helper"
-	"github.com/deckhouse/virtualization-controller/pkg/util"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
-	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
 )
 
 const objectRefDataSource = "objectref"
 
 type ObjectRefDataSource struct {
-	statService *service.StatService
-	diskService *service.DiskService
-	client      client.Client
-
+	diskService      *service.DiskService
 	vdSnapshotSyncer *ObjectRefVirtualDiskSnapshot
-	viOnPvcSyncer    *ObjectRefVirtualImageOnPvc
+	viDVCRSyncer     *ObjectRefVirtualImageDVCR
+	viPVCSyncer      *ObjectRefVirtualImagePVC
+	cviSyncer        *ObjectRefClusterVirtualImage
 }
 
 func NewObjectRefDataSource(
@@ -57,162 +45,43 @@ func NewObjectRefDataSource(
 	client client.Client,
 ) *ObjectRefDataSource {
 	return &ObjectRefDataSource{
-		statService:      statService,
 		diskService:      diskService,
-		client:           client,
 		vdSnapshotSyncer: NewObjectRefVirtualDiskSnapshot(diskService),
-		viOnPvcSyncer:    NewObjectRefVirtualImageOnPvc(diskService),
+		viDVCRSyncer:     NewObjectRefVirtualImageDVCR(statService, diskService, client),
+		viPVCSyncer:      NewObjectRefVirtualImagePVC(diskService),
+		cviSyncer:        NewObjectRefClusterVirtualImage(statService, diskService, client),
 	}
 }
 
-func (ds ObjectRefDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (bool, error) {
-	log, ctx := logger.GetDataSourceContext(ctx, objectRefDataSource)
-
-	condition, _ := service.GetCondition(vdcondition.ReadyType, vd.Status.Conditions)
-	defer func() { service.SetCondition(condition, &vd.Status.Conditions) }()
+func (ds ObjectRefDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (reconcile.Result, error) {
+	if vd.Spec.DataSource == nil || vd.Spec.DataSource.ObjectRef == nil {
+		return reconcile.Result{}, fmt.Errorf("not object ref data source, please report a bug")
+	}
 
 	switch vd.Spec.DataSource.ObjectRef.Kind {
 	case virtv2.VirtualDiskObjectRefKindVirtualDiskSnapshot:
-		return ds.vdSnapshotSyncer.Sync(ctx, vd, &condition)
+		return ds.vdSnapshotSyncer.Sync(ctx, vd)
+	case virtv2.VirtualDiskObjectRefKindClusterVirtualImage:
+		return ds.cviSyncer.Sync(ctx, vd)
 	case virtv2.VirtualImageKind:
-		viKey := types.NamespacedName{Name: vd.Spec.DataSource.ObjectRef.Name, Namespace: vd.Namespace}
-		vi, err := helper.FetchObject(ctx, viKey, ds.client, &virtv2.VirtualImage{})
+		vi, err := ds.diskService.GetVirtualImage(ctx, vd.Spec.DataSource.ObjectRef.Name, vd.Namespace)
 		if err != nil {
-			return false, fmt.Errorf("unable to get VI %s: %w", viKey, err)
+			return reconcile.Result{}, fmt.Errorf("unable to get VI: %w", err)
 		}
 
 		if vi == nil {
-			return false, fmt.Errorf("VI object ref source %s is nil", vd.Spec.DataSource.ObjectRef.Name)
+			return reconcile.Result{}, fmt.Errorf("VI object ref source %s is nil", vd.Spec.DataSource.ObjectRef.Name)
 		}
 
-		if vi.Spec.Storage == virtv2.StorageKubernetes {
-			return ds.viOnPvcSyncer.Sync(ctx, vd, vi, &condition)
+		switch vi.Spec.Storage {
+		case virtv2.StorageKubernetes:
+			return ds.viPVCSyncer.Sync(ctx, vd)
+		case virtv2.StorageContainerRegistry:
+			return ds.viDVCRSyncer.Sync(ctx, vd)
 		}
 	}
 
-	supgen := supplements.NewGenerator(common.VDShortName, vd.Name, vd.Namespace, vd.UID)
-	dv, err := ds.diskService.GetDataVolume(ctx, supgen)
-	if err != nil {
-		return false, err
-	}
-	pvc, err := ds.diskService.GetPersistentVolumeClaim(ctx, supgen)
-	if err != nil {
-		return false, err
-	}
-
-	switch {
-	case isDiskProvisioningFinished(condition):
-		log.Debug("Disk provisioning finished: clean up")
-
-		setPhaseConditionForFinishedDisk(pvc, &condition, &vd.Status.Phase, supgen)
-
-		// Protect Ready Disk and underlying PVC.
-		err = ds.diskService.Protect(ctx, vd, nil, pvc)
-		if err != nil {
-			return false, err
-		}
-
-		err = ds.diskService.Unprotect(ctx, dv)
-		if err != nil {
-			return false, err
-		}
-
-		return CleanUpSupplements(ctx, vd, ds)
-	case common.AnyTerminating(dv, pvc):
-		log.Info("Waiting for supplements to be terminated")
-	case dv == nil:
-		log.Info("Start import to PVC")
-
-		var dvcrDataSource controller.DVCRDataSource
-		dvcrDataSource, err = controller.NewDVCRDataSourcesForVMD(ctx, vd.Spec.DataSource, vd, ds.client)
-		if err != nil {
-			return false, err
-		}
-
-		if !dvcrDataSource.IsReady() {
-			condition.Status = metav1.ConditionFalse
-			condition.Reason = vdcondition.ProvisioningFailed
-			condition.Message = "Failed to get stats from non-ready datasource: waiting for the DataSource to be ready."
-			return false, nil
-		}
-
-		vd.Status.Progress = "0%"
-		vd.Status.SourceUID = util.GetPointer(dvcrDataSource.GetUID())
-
-		if imageformat.IsISO(dvcrDataSource.GetFormat()) {
-			setPhaseConditionToFailed(&condition, &vd.Status.Phase, ErrISOSourceNotSupported)
-			return false, nil
-		}
-
-		var diskSize resource.Quantity
-		diskSize, err = ds.getPVCSize(vd, dvcrDataSource)
-		if err != nil {
-			setPhaseConditionToFailed(&condition, &vd.Status.Phase, err)
-
-			if errors.Is(err, service.ErrInsufficientPVCSize) {
-				return false, nil
-			}
-
-			return false, err
-		}
-
-		var source *cdiv1.DataVolumeSource
-		source, err = ds.getSource(supgen, dvcrDataSource)
-		if err != nil {
-			return false, err
-		}
-
-		err = ds.diskService.Start(ctx, diskSize, vd.Spec.PersistentVolumeClaim.StorageClass, source, vd, supgen)
-		if updated, err := setPhaseConditionFromStorageError(err, vd, &condition); err != nil || updated {
-			return false, err
-		}
-
-		vd.Status.Phase = virtv2.DiskProvisioning
-		condition.Status = metav1.ConditionFalse
-		condition.Reason = vdcondition.Provisioning
-		condition.Message = "PVC Provisioner not found: create the new one."
-
-		return true, nil
-	case pvc == nil:
-		vd.Status.Phase = virtv2.DiskProvisioning
-		condition.Status = metav1.ConditionFalse
-		condition.Reason = vdcondition.Provisioning
-		condition.Message = "PVC not found: waiting for creation."
-		return true, nil
-	case ds.diskService.IsImportDone(dv, pvc):
-		log.Info("Import has completed", "dvProgress", dv.Status.Progress, "dvPhase", dv.Status.Phase, "pvcPhase", pvc.Status.Phase)
-
-		vd.Status.Phase = virtv2.DiskReady
-		condition.Status = metav1.ConditionTrue
-		condition.Reason = vdcondition.Ready
-		condition.Message = ""
-
-		vd.Status.Progress = "100%"
-		vd.Status.Capacity = ds.diskService.GetCapacity(pvc)
-		vd.Status.Target.PersistentVolumeClaim = dv.Status.ClaimName
-	default:
-		log.Info("Provisioning to PVC is in progress", "dvProgress", dv.Status.Progress, "dvPhase", dv.Status.Phase, "pvcPhase", pvc.Status.Phase)
-
-		vd.Status.Progress = ds.diskService.GetProgress(dv, vd.Status.Progress, service.NewScaleOption(0, 100))
-		vd.Status.Capacity = ds.diskService.GetCapacity(pvc)
-		vd.Status.Target.PersistentVolumeClaim = dv.Status.ClaimName
-
-		err = ds.diskService.Protect(ctx, vd, dv, pvc)
-		if err != nil {
-			return false, err
-		}
-		sc, err := ds.diskService.GetStorageClass(ctx, pvc.Spec.StorageClassName)
-		if updated, err := setPhaseConditionFromStorageError(err, vd, &condition); err != nil || updated {
-			return false, err
-		}
-		if err = setPhaseConditionForPVCProvisioningDisk(ctx, dv, vd, pvc, sc, &condition, ds.diskService); err != nil {
-			return false, err
-		}
-
-		return false, nil
-	}
-
-	return true, nil
+	return reconcile.Result{}, fmt.Errorf("unexpected object ref kind %s, please report a bug", vd.Spec.DataSource.ObjectRef.Kind)
 }
 
 func (ds ObjectRefDataSource) CleanUp(ctx context.Context, vd *virtv2.VirtualDisk) (bool, error) {
@@ -226,95 +95,37 @@ func (ds ObjectRefDataSource) CleanUp(ctx context.Context, vd *virtv2.VirtualDis
 	return requeue, nil
 }
 
-func (ds ObjectRefDataSource) CleanUpSupplements(ctx context.Context, vd *virtv2.VirtualDisk) (bool, error) {
-	supgen := supplements.NewGenerator(common.VDShortName, vd.Name, vd.Namespace, vd.UID)
-
-	requeue, err := ds.diskService.CleanUpSupplements(ctx, supgen)
-	if err != nil {
-		return false, err
-	}
-
-	return requeue, nil
-}
-
 func (ds ObjectRefDataSource) Validate(ctx context.Context, vd *virtv2.VirtualDisk) error {
 	if vd.Spec.DataSource == nil || vd.Spec.DataSource.ObjectRef == nil {
-		return errors.New("object ref missed for data source")
-	}
-
-	if vd.Spec.DataSource.ObjectRef.Kind == virtv2.VirtualDiskObjectRefKindVirtualDiskSnapshot {
-		return ds.vdSnapshotSyncer.Validate(ctx, vd)
-	}
-
-	if vd.Spec.DataSource.ObjectRef.Kind == virtv2.VirtualImageKind {
-		viKey := types.NamespacedName{Name: vd.Spec.DataSource.ObjectRef.Name, Namespace: vd.Namespace}
-		vi, err := helper.FetchObject(ctx, viKey, ds.client, &virtv2.VirtualImage{})
-		if err != nil {
-			return fmt.Errorf("unable to get VI %s: %w", viKey, err)
-		}
-
-		if vi == nil {
-			return NewImageNotReadyError(vd.Spec.DataSource.ObjectRef.Name)
-		}
-
-		if vi.Spec.Storage == virtv2.StorageKubernetes {
-			if vi.Status.Phase != virtv2.ImageReady {
-				return NewImageNotReadyError(vd.Spec.DataSource.ObjectRef.Name)
-			}
-			return nil
-		}
-	}
-
-	dvcrDataSource, err := controller.NewDVCRDataSourcesForVMD(ctx, vd.Spec.DataSource, vd, ds.client)
-	if err != nil {
-		return err
-	}
-
-	if dvcrDataSource.IsReady() {
-		return nil
+		return fmt.Errorf("not object ref data source, please report a bug")
 	}
 
 	switch vd.Spec.DataSource.ObjectRef.Kind {
-	case virtv2.VirtualDiskObjectRefKindVirtualImage:
-		return NewImageNotReadyError(vd.Spec.DataSource.ObjectRef.Name)
+	case virtv2.VirtualDiskObjectRefKindVirtualDiskSnapshot:
+		return ds.vdSnapshotSyncer.Validate(ctx, vd)
 	case virtv2.VirtualDiskObjectRefKindClusterVirtualImage:
-		return NewClusterImageNotReadyError(vd.Spec.DataSource.ObjectRef.Name)
-	default:
-		return fmt.Errorf("unexpected object ref kind: %s", vd.Spec.DataSource.ObjectRef.Kind)
+		return ds.cviSyncer.Validate(ctx, vd)
+	case virtv2.VirtualImageKind:
+		vi, err := ds.diskService.GetVirtualImage(ctx, vd.Spec.DataSource.ObjectRef.Name, vd.Namespace)
+		if err != nil {
+			return fmt.Errorf("unable to get VI: %w", err)
+		}
+
+		if vi == nil {
+			return fmt.Errorf("VI object ref source %s is nil", vd.Spec.DataSource.ObjectRef.Name)
+		}
+
+		switch vi.Spec.Storage {
+		case virtv2.StorageKubernetes:
+			return ds.viPVCSyncer.Validate(ctx, vd)
+		case virtv2.StorageContainerRegistry:
+			return ds.viDVCRSyncer.Validate(ctx, vd)
+		}
 	}
+
+	return fmt.Errorf("unexpected object ref kind %s, please report a bug", vd.Spec.DataSource.ObjectRef.Kind)
 }
 
 func (ds ObjectRefDataSource) Name() string {
 	return objectRefDataSource
-}
-
-func (ds ObjectRefDataSource) getSource(sup *supplements.Generator, dvcrDataSource controller.DVCRDataSource) (*cdiv1.DataVolumeSource, error) {
-	if !dvcrDataSource.IsReady() {
-		return nil, errors.New("dvcr data source is not ready")
-	}
-
-	url := common2.DockerRegistrySchemePrefix + dvcrDataSource.GetTarget()
-	secretName := sup.DVCRAuthSecretForDV().Name
-	certConfigMapName := sup.DVCRCABundleConfigMapForDV().Name
-
-	return &cdiv1.DataVolumeSource{
-		Registry: &cdiv1.DataVolumeSourceRegistry{
-			URL:           &url,
-			SecretRef:     &secretName,
-			CertConfigMap: &certConfigMapName,
-		},
-	}, nil
-}
-
-func (ds ObjectRefDataSource) getPVCSize(vd *virtv2.VirtualDisk, dvcrDataSource controller.DVCRDataSource) (resource.Quantity, error) {
-	if !dvcrDataSource.IsReady() {
-		return resource.Quantity{}, errors.New("dvcr data source is not ready")
-	}
-
-	unpackedSize, err := resource.ParseQuantity(dvcrDataSource.GetSize().UnpackedBytes)
-	if err != nil {
-		return resource.Quantity{}, fmt.Errorf("failed to parse unpacked bytes %s: %w", dvcrDataSource.GetSize().UnpackedBytes, err)
-	}
-
-	return service.GetValidatedPVCSize(vd.Spec.PersistentVolumeClaim.Size, unpackedSize)
 }

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_vi_dvcr.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_vi_dvcr.go
@@ -19,39 +19,49 @@ package source
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	common2 "github.com/deckhouse/virtualization-controller/pkg/common"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/common"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/supplements"
+	"github.com/deckhouse/virtualization-controller/pkg/imageformat"
 	"github.com/deckhouse/virtualization-controller/pkg/logger"
+	"github.com/deckhouse/virtualization-controller/pkg/util"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
 )
 
-const blankDataSource = "blank"
-
-type BlankDataSource struct {
+type ObjectRefVirtualImageDVCR struct {
 	statService *service.StatService
 	diskService *service.DiskService
+	client      client.Client
 }
 
-func NewBlankDataSource(
+func NewObjectRefVirtualImageDVCR(
 	statService *service.StatService,
 	diskService *service.DiskService,
-) *BlankDataSource {
-	return &BlankDataSource{
+	client client.Client,
+) *ObjectRefVirtualImageDVCR {
+	return &ObjectRefVirtualImageDVCR{
 		statService: statService,
 		diskService: diskService,
+		client:      client,
 	}
 }
 
-func (ds BlankDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (reconcile.Result, error) {
-	log, ctx := logger.GetDataSourceContext(ctx, blankDataSource)
+func (ds ObjectRefVirtualImageDVCR) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (reconcile.Result, error) {
+	if vd.Spec.DataSource == nil || vd.Spec.DataSource.ObjectRef == nil {
+		return reconcile.Result{}, errors.New("object ref missed for data source")
+	}
+
+	log, ctx := logger.GetDataSourceContext(ctx, objectRefDataSource)
 
 	condition, _ := service.GetCondition(vdcondition.ReadyType, vd.Status.Conditions)
 	defer func() { service.SetCondition(condition, &vd.Status.Conditions) }()
@@ -64,6 +74,13 @@ func (ds BlankDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (rec
 	pvc, err := ds.diskService.GetPersistentVolumeClaim(ctx, supgen)
 	if err != nil {
 		return reconcile.Result{}, err
+	}
+	vi, err := ds.diskService.GetVirtualImage(ctx, vd.Spec.DataSource.ObjectRef.Name, vd.Namespace)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if vi == nil {
+		return reconcile.Result{}, errors.New("the source virtual image not found")
 	}
 
 	switch {
@@ -90,19 +107,28 @@ func (ds BlankDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (rec
 		log.Info("Start import to PVC")
 
 		vd.Status.Progress = "0%"
+		vd.Status.SourceUID = util.GetPointer(vi.GetUID())
+
+		if imageformat.IsISO(vi.Status.Format) {
+			setPhaseConditionToFailed(&condition, &vd.Status.Phase, ErrISOSourceNotSupported)
+			return reconcile.Result{}, nil
+		}
 
 		var diskSize resource.Quantity
-		diskSize, err = ds.getPVCSize(vd)
+		diskSize, err = ds.getPVCSize(vd, vi.Status.Size)
 		if err != nil {
 			setPhaseConditionToFailed(&condition, &vd.Status.Phase, err)
+
+			if errors.Is(err, service.ErrInsufficientPVCSize) {
+				return reconcile.Result{}, nil
+			}
 
 			return reconcile.Result{}, err
 		}
 
-		source := ds.getSource()
+		source := ds.getSource(supgen, vi)
 
 		err = ds.diskService.Start(ctx, diskSize, vd.Spec.PersistentVolumeClaim.StorageClass, source, vd, supgen)
-
 		if updated, err := setPhaseConditionFromStorageError(err, vd, &condition); err != nil || updated {
 			return reconcile.Result{}, err
 		}
@@ -148,24 +174,31 @@ func (ds BlankDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (rec
 		if err = setPhaseConditionForPVCProvisioningDisk(ctx, dv, vd, pvc, sc, &condition, ds.diskService); err != nil {
 			return reconcile.Result{}, err
 		}
+
 		return reconcile.Result{}, nil
 	}
 
 	return reconcile.Result{Requeue: true}, nil
 }
 
-func (ds BlankDataSource) CleanUp(ctx context.Context, vd *virtv2.VirtualDisk) (bool, error) {
-	supgen := supplements.NewGenerator(common.VDShortName, vd.Name, vd.Namespace, vd.UID)
-
-	requeue, err := ds.diskService.CleanUp(ctx, supgen)
-	if err != nil {
-		return false, err
+func (ds ObjectRefVirtualImageDVCR) Validate(ctx context.Context, vd *virtv2.VirtualDisk) error {
+	if vd.Spec.DataSource == nil || vd.Spec.DataSource.ObjectRef == nil {
+		return errors.New("object ref missed for data source")
 	}
 
-	return requeue, nil
+	vi, err := ds.diskService.GetVirtualImage(ctx, vd.Spec.DataSource.ObjectRef.Name, vd.Namespace)
+	if err != nil {
+		return err
+	}
+
+	if vi == nil || vi.Status.Phase != virtv2.ImageReady || vi.Status.Target.RegistryURL == "" {
+		return NewImageNotReadyError(vd.Spec.DataSource.ObjectRef.Name)
+	}
+
+	return nil
 }
 
-func (ds BlankDataSource) CleanUpSupplements(ctx context.Context, vd *virtv2.VirtualDisk) (reconcile.Result, error) {
+func (ds ObjectRefVirtualImageDVCR) CleanUpSupplements(ctx context.Context, vd *virtv2.VirtualDisk) (reconcile.Result, error) {
 	supgen := supplements.NewGenerator(common.VDShortName, vd.Name, vd.Namespace, vd.UID)
 
 	requeue, err := ds.diskService.CleanUpSupplements(ctx, supgen)
@@ -176,25 +209,25 @@ func (ds BlankDataSource) CleanUpSupplements(ctx context.Context, vd *virtv2.Vir
 	return reconcile.Result{Requeue: requeue}, nil
 }
 
-func (ds BlankDataSource) Validate(_ context.Context, _ *virtv2.VirtualDisk) error {
-	return nil
-}
+func (ds ObjectRefVirtualImageDVCR) getSource(sup *supplements.Generator, vi *virtv2.VirtualImage) *cdiv1.DataVolumeSource {
+	url := common2.DockerRegistrySchemePrefix + vi.Status.Target.RegistryURL
+	secretName := sup.DVCRAuthSecretForDV().Name
+	certConfigMapName := sup.DVCRCABundleConfigMapForDV().Name
 
-func (ds BlankDataSource) Name() string {
-	return blankDataSource
-}
-
-func (ds BlankDataSource) getSource() *cdiv1.DataVolumeSource {
 	return &cdiv1.DataVolumeSource{
-		Blank: &cdiv1.DataVolumeBlankImage{},
+		Registry: &cdiv1.DataVolumeSourceRegistry{
+			URL:           &url,
+			SecretRef:     &secretName,
+			CertConfigMap: &certConfigMapName,
+		},
 	}
 }
 
-func (ds BlankDataSource) getPVCSize(vd *virtv2.VirtualDisk) (resource.Quantity, error) {
-	pvcSize := vd.Spec.PersistentVolumeClaim.Size
-	if pvcSize == nil || pvcSize.IsZero() {
-		return resource.Quantity{}, errors.New("spec.persistentVolumeClaim.size should be set for blank virtual disk")
+func (ds ObjectRefVirtualImageDVCR) getPVCSize(vd *virtv2.VirtualDisk, imageSize virtv2.ImageStatusSize) (resource.Quantity, error) {
+	unpackedSize, err := resource.ParseQuantity(imageSize.UnpackedBytes)
+	if err != nil {
+		return resource.Quantity{}, fmt.Errorf("failed to parse unpacked bytes %s: %w", imageSize.UnpackedBytes, err)
 	}
 
-	return *pvcSize, nil
+	return service.GetValidatedPVCSize(vd.Spec.PersistentVolumeClaim.Size, unpackedSize)
 }

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/registry.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/registry.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	cc "github.com/deckhouse/virtualization-controller/pkg/common"
 	"github.com/deckhouse/virtualization-controller/pkg/common/datasource"
@@ -68,7 +69,7 @@ func NewRegistryDataSource(
 	}
 }
 
-func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (bool, error) {
+func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (reconcile.Result, error) {
 	log, ctx := logger.GetDataSourceContext(ctx, registryDataSource)
 
 	condition, _ := service.GetCondition(vdcondition.ReadyType, vd.Status.Conditions)
@@ -77,15 +78,15 @@ func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (
 	supgen := supplements.NewGenerator(common.VDShortName, vd.Name, vd.Namespace, vd.UID)
 	pod, err := ds.importerService.GetPod(ctx, supgen)
 	if err != nil {
-		return false, err
+		return reconcile.Result{}, err
 	}
 	dv, err := ds.diskService.GetDataVolume(ctx, supgen)
 	if err != nil {
-		return false, err
+		return reconcile.Result{}, err
 	}
 	pvc, err := ds.diskService.GetPersistentVolumeClaim(ctx, supgen)
 	if err != nil {
-		return false, err
+		return reconcile.Result{}, err
 	}
 
 	switch {
@@ -97,18 +98,18 @@ func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (
 		// Protect Ready Disk and underlying PVC.
 		err = ds.diskService.Protect(ctx, vd, nil, pvc)
 		if err != nil {
-			return false, err
+			return reconcile.Result{}, err
 		}
 
 		// Unprotect import time supplements to delete them later.
 		err = ds.importerService.Unprotect(ctx, pod)
 		if err != nil {
-			return false, err
+			return reconcile.Result{}, err
 		}
 
 		err = ds.diskService.Unprotect(ctx, dv)
 		if err != nil {
-			return false, err
+			return reconcile.Result{}, err
 		}
 
 		return CleanUpSupplements(ctx, vd, ds)
@@ -117,17 +118,26 @@ func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (
 	case pod == nil:
 		log.Info("Start import to DVCR")
 
-		envSettings := ds.getEnvSettings(vd, supgen)
-		err = ds.importerService.Start(ctx, envSettings, vd, supgen, datasource.NewCABundleForVMD(vd.Spec.DataSource))
-		var requeue bool
-		requeue, err = setPhaseConditionForImporterStart(&condition, &vd.Status.Phase, err)
-		if err != nil {
-			return false, err
-		}
-
 		vd.Status.Progress = "0%"
 
-		return requeue, nil
+		envSettings := ds.getEnvSettings(vd, supgen)
+		err = ds.importerService.Start(ctx, envSettings, vd, supgen, datasource.NewCABundleForVMD(vd.Spec.DataSource))
+		switch {
+		case err == nil:
+			// OK.
+		case common.ErrQuotaExceeded(err):
+			return setQuotaExceededPhaseCondition(&condition, &vd.Status.Phase, err, vd.CreationTimestamp), nil
+		default:
+			setPhaseConditionToFailed(&condition, &vd.Status.Phase, fmt.Errorf("unexpected error: %w", err))
+			return reconcile.Result{}, err
+		}
+
+		vd.Status.Phase = virtv2.DiskPending
+		condition.Status = metav1.ConditionFalse
+		condition.Reason = vdcondition.WaitForUserUpload
+		condition.Message = "DVCR Provisioner not found: create the new one."
+
+		return reconcile.Result{Requeue: true}, nil
 	case !common.IsPodComplete(pod):
 		log.Info("Provisioning to DVCR is in progress", "podPhase", pod.Status.Phase)
 
@@ -140,14 +150,14 @@ func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (
 				condition.Status = metav1.ConditionFalse
 				condition.Reason = vdcondition.ProvisioningNotStarted
 				condition.Message = service.CapitalizeFirstLetter(err.Error() + ".")
-				return false, nil
+				return reconcile.Result{}, nil
 			case errors.Is(err, service.ErrProvisioningFailed):
 				condition.Status = metav1.ConditionFalse
 				condition.Reason = vdcondition.ProvisioningFailed
 				condition.Message = service.CapitalizeFirstLetter(err.Error() + ".")
-				return false, nil
+				return reconcile.Result{}, nil
 			default:
-				return false, err
+				return reconcile.Result{}, err
 			}
 		}
 
@@ -160,7 +170,7 @@ func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (
 
 		err = ds.importerService.Protect(ctx, pod)
 		if err != nil {
-			return false, err
+			return reconcile.Result{}, err
 		}
 	case dv == nil:
 		log.Info("Start import to PVC")
@@ -174,9 +184,9 @@ func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (
 				condition.Status = metav1.ConditionFalse
 				condition.Reason = vdcondition.ProvisioningFailed
 				condition.Message = service.CapitalizeFirstLetter(err.Error() + ".")
-				return false, nil
+				return reconcile.Result{}, nil
 			default:
-				return false, err
+				return reconcile.Result{}, err
 			}
 		}
 
@@ -184,7 +194,7 @@ func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (
 
 		if imageformat.IsISO(ds.statService.GetFormat(pod)) {
 			setPhaseConditionToFailed(&condition, &vd.Status.Phase, ErrISOSourceNotSupported)
-			return false, nil
+			return reconcile.Result{}, nil
 		}
 
 		var diskSize resource.Quantity
@@ -193,30 +203,30 @@ func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (
 			setPhaseConditionToFailed(&condition, &vd.Status.Phase, err)
 
 			if errors.Is(err, service.ErrInsufficientPVCSize) {
-				return false, nil
+				return reconcile.Result{}, nil
 			}
 
-			return false, err
+			return reconcile.Result{}, err
 		}
 
 		source := ds.getSource(supgen, ds.statService.GetDVCRImageName(pod))
 
 		err = ds.diskService.Start(ctx, diskSize, vd.Spec.PersistentVolumeClaim.StorageClass, source, vd, supgen)
 		if updated, err := setPhaseConditionFromStorageError(err, vd, &condition); err != nil || updated {
-			return false, err
+			return reconcile.Result{}, err
 		}
 		vd.Status.Phase = virtv2.DiskProvisioning
 		condition.Status = metav1.ConditionFalse
 		condition.Reason = vdcondition.Provisioning
 		condition.Message = "PVC Provisioner not found: create the new one."
 
-		return true, nil
+		return reconcile.Result{Requeue: true}, nil
 	case pvc == nil:
 		vd.Status.Phase = virtv2.DiskProvisioning
 		condition.Status = metav1.ConditionFalse
 		condition.Reason = vdcondition.Provisioning
 		condition.Message = "PVC not found: waiting for creation."
-		return true, nil
+		return reconcile.Result{Requeue: true}, nil
 	case ds.diskService.IsImportDone(dv, pvc):
 		log.Info("Import has completed", "dvProgress", dv.Status.Progress, "dvPhase", dv.Status.Phase, "pvcPhase", pvc.Status.Phase)
 
@@ -237,19 +247,19 @@ func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (
 
 		err = ds.diskService.Protect(ctx, vd, dv, pvc)
 		if err != nil {
-			return false, err
+			return reconcile.Result{}, err
 		}
 		sc, err := ds.diskService.GetStorageClass(ctx, pvc.Spec.StorageClassName)
 		if updated, err := setPhaseConditionFromStorageError(err, vd, &condition); err != nil || updated {
-			return false, err
+			return reconcile.Result{}, err
 		}
 		if err = setPhaseConditionForPVCProvisioningDisk(ctx, dv, vd, pvc, sc, &condition, ds.diskService); err != nil {
-			return false, err
+			return reconcile.Result{}, err
 		}
-		return false, nil
+		return reconcile.Result{}, nil
 	}
 
-	return true, nil
+	return reconcile.Result{Requeue: true}, nil
 }
 
 func (ds RegistryDataSource) CleanUp(ctx context.Context, vd *virtv2.VirtualDisk) (bool, error) {
@@ -268,20 +278,20 @@ func (ds RegistryDataSource) CleanUp(ctx context.Context, vd *virtv2.VirtualDisk
 	return importerRequeue || diskRequeue, nil
 }
 
-func (ds RegistryDataSource) CleanUpSupplements(ctx context.Context, vd *virtv2.VirtualDisk) (bool, error) {
+func (ds RegistryDataSource) CleanUpSupplements(ctx context.Context, vd *virtv2.VirtualDisk) (reconcile.Result, error) {
 	supgen := supplements.NewGenerator(common.VDShortName, vd.Name, vd.Namespace, vd.UID)
 
 	importerRequeue, err := ds.importerService.CleanUpSupplements(ctx, supgen)
 	if err != nil {
-		return false, err
+		return reconcile.Result{}, err
 	}
 
 	diskRequeue, err := ds.diskService.CleanUpSupplements(ctx, supgen)
 	if err != nil {
-		return false, err
+		return reconcile.Result{}, err
 	}
 
-	return importerRequeue || diskRequeue, nil
+	return reconcile.Result{Requeue: importerRequeue || diskRequeue}, nil
 }
 
 func (ds RegistryDataSource) Validate(ctx context.Context, vd *virtv2.VirtualDisk) error {

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/upload.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/upload.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	common2 "github.com/deckhouse/virtualization-controller/pkg/common"
 	"github.com/deckhouse/virtualization-controller/pkg/common/datasource"
@@ -62,7 +63,7 @@ func NewUploadDataSource(
 	}
 }
 
-func (ds UploadDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (bool, error) {
+func (ds UploadDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (reconcile.Result, error) {
 	log, ctx := logger.GetDataSourceContext(ctx, uploadDataSource)
 
 	condition, _ := service.GetCondition(vdcondition.ReadyType, vd.Status.Conditions)
@@ -71,23 +72,23 @@ func (ds UploadDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (bo
 	supgen := supplements.NewGenerator(common.VDShortName, vd.Name, vd.Namespace, vd.UID)
 	pod, err := ds.uploaderService.GetPod(ctx, supgen)
 	if err != nil {
-		return false, err
+		return reconcile.Result{}, err
 	}
 	svc, err := ds.uploaderService.GetService(ctx, supgen)
 	if err != nil {
-		return false, err
+		return reconcile.Result{}, err
 	}
 	ing, err := ds.uploaderService.GetIngress(ctx, supgen)
 	if err != nil {
-		return false, err
+		return reconcile.Result{}, err
 	}
 	dv, err := ds.diskService.GetDataVolume(ctx, supgen)
 	if err != nil {
-		return false, err
+		return reconcile.Result{}, err
 	}
 	pvc, err := ds.diskService.GetPersistentVolumeClaim(ctx, supgen)
 	if err != nil {
-		return false, err
+		return reconcile.Result{}, err
 	}
 
 	switch {
@@ -99,18 +100,18 @@ func (ds UploadDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (bo
 		// Protect Ready Disk and underlying PVC.
 		err = ds.diskService.Protect(ctx, vd, nil, pvc)
 		if err != nil {
-			return false, err
+			return reconcile.Result{}, err
 		}
 
 		// Unprotect upload time supplements to delete them later.
 		err = ds.uploaderService.Unprotect(ctx, pod, svc, ing)
 		if err != nil {
-			return false, err
+			return reconcile.Result{}, err
 		}
 
 		err = ds.diskService.Unprotect(ctx, dv)
 		if err != nil {
-			return false, err
+			return reconcile.Result{}, err
 		}
 
 		return CleanUpSupplements(ctx, vd, ds)
@@ -119,17 +120,26 @@ func (ds UploadDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (bo
 	case pod == nil || svc == nil || ing == nil:
 		log.Info("Start import to DVCR")
 
-		envSettings := ds.getEnvSettings(vd, supgen)
-		err = ds.uploaderService.Start(ctx, envSettings, vd, supgen, datasource.NewCABundleForVMD(vd.Spec.DataSource))
-		var requeue bool
-		requeue, err = setPhaseConditionForUploaderStart(&condition, &vd.Status.Phase, err)
-		if err != nil {
-			return false, err
-		}
-
 		vd.Status.Progress = "0%"
 
-		return requeue, nil
+		envSettings := ds.getEnvSettings(vd, supgen)
+		err = ds.uploaderService.Start(ctx, envSettings, vd, supgen, datasource.NewCABundleForVMD(vd.Spec.DataSource))
+		switch {
+		case err == nil:
+			// OK.
+		case common.ErrQuotaExceeded(err):
+			return setQuotaExceededPhaseCondition(&condition, &vd.Status.Phase, err, vd.CreationTimestamp), nil
+		default:
+			setPhaseConditionToFailed(&condition, &vd.Status.Phase, fmt.Errorf("unexpected error: %w", err))
+			return reconcile.Result{}, err
+		}
+
+		vd.Status.Phase = virtv2.DiskPending
+		condition.Status = metav1.ConditionFalse
+		condition.Reason = vdcondition.WaitForUserUpload
+		condition.Message = "DVCR Provisioner not found: create the new one."
+
+		return reconcile.Result{Requeue: true}, nil
 	case !common.IsPodComplete(pod):
 		err = ds.statService.CheckPod(pod)
 		if err != nil {
@@ -140,14 +150,14 @@ func (ds UploadDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (bo
 				condition.Status = metav1.ConditionFalse
 				condition.Reason = vdcondition.ProvisioningNotStarted
 				condition.Message = service.CapitalizeFirstLetter(err.Error() + ".")
-				return false, nil
+				return reconcile.Result{}, nil
 			case errors.Is(err, service.ErrProvisioningFailed):
 				condition.Status = metav1.ConditionFalse
 				condition.Reason = vdcondition.ProvisioningFailed
 				condition.Message = service.CapitalizeFirstLetter(err.Error() + ".")
-				return false, nil
+				return reconcile.Result{}, nil
 			default:
-				return false, err
+				return reconcile.Result{}, err
 			}
 		}
 
@@ -172,7 +182,7 @@ func (ds UploadDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (bo
 				condition.Message = fmt.Sprintf("Waiting for the uploader %q to be ready to process the user's upload.", pod.Name)
 			}
 
-			return true, nil
+			return reconcile.Result{Requeue: true}, nil
 		}
 
 		log.Info("Provisioning to DVCR is in progress", "podPhase", pod.Status.Phase)
@@ -187,7 +197,7 @@ func (ds UploadDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (bo
 
 		err = ds.uploaderService.Protect(ctx, pod, svc, ing)
 		if err != nil {
-			return false, err
+			return reconcile.Result{}, err
 		}
 	case dv == nil:
 		log.Info("Start import to PVC")
@@ -201,9 +211,9 @@ func (ds UploadDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (bo
 				condition.Status = metav1.ConditionFalse
 				condition.Reason = vdcondition.ProvisioningFailed
 				condition.Message = service.CapitalizeFirstLetter(err.Error() + ".")
-				return false, nil
+				return reconcile.Result{}, nil
 			default:
-				return false, err
+				return reconcile.Result{}, err
 			}
 		}
 
@@ -212,7 +222,7 @@ func (ds UploadDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (bo
 
 		if imageformat.IsISO(ds.statService.GetFormat(pod)) {
 			setPhaseConditionToFailed(&condition, &vd.Status.Phase, ErrISOSourceNotSupported)
-			return false, nil
+			return reconcile.Result{}, nil
 		}
 
 		var diskSize resource.Quantity
@@ -221,17 +231,17 @@ func (ds UploadDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (bo
 			setPhaseConditionToFailed(&condition, &vd.Status.Phase, err)
 
 			if errors.Is(err, service.ErrInsufficientPVCSize) {
-				return false, nil
+				return reconcile.Result{}, nil
 			}
 
-			return false, err
+			return reconcile.Result{}, err
 		}
 
 		source := ds.getSource(supgen, ds.statService.GetDVCRImageName(pod))
 
 		err = ds.diskService.Start(ctx, diskSize, vd.Spec.PersistentVolumeClaim.StorageClass, source, vd, supgen)
 		if updated, err := setPhaseConditionFromStorageError(err, vd, &condition); err != nil || updated {
-			return false, err
+			return reconcile.Result{}, err
 		}
 
 		vd.Status.Phase = virtv2.DiskProvisioning
@@ -239,13 +249,13 @@ func (ds UploadDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (bo
 		condition.Reason = vdcondition.Provisioning
 		condition.Message = "PVC Provisioner not found: create the new one."
 
-		return true, nil
+		return reconcile.Result{Requeue: true}, nil
 	case pvc == nil:
 		vd.Status.Phase = virtv2.DiskProvisioning
 		condition.Status = metav1.ConditionFalse
 		condition.Reason = vdcondition.Provisioning
 		condition.Message = "PVC not found: waiting for creation."
-		return true, nil
+		return reconcile.Result{Requeue: true}, nil
 	case ds.diskService.IsImportDone(dv, pvc):
 		log.Info("Import has completed", "dvProgress", dv.Status.Progress, "dvPhase", dv.Status.Phase, "pvcPhase", pvc.Status.Phase)
 
@@ -268,19 +278,19 @@ func (ds UploadDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (bo
 
 		err = ds.diskService.Protect(ctx, vd, dv, pvc)
 		if err != nil {
-			return false, err
+			return reconcile.Result{}, err
 		}
 		sc, err := ds.diskService.GetStorageClass(ctx, pvc.Spec.StorageClassName)
 		if updated, err := setPhaseConditionFromStorageError(err, vd, &condition); err != nil || updated {
-			return false, err
+			return reconcile.Result{}, err
 		}
 		if err = setPhaseConditionForPVCProvisioningDisk(ctx, dv, vd, pvc, sc, &condition, ds.diskService); err != nil {
-			return false, err
+			return reconcile.Result{}, err
 		}
-		return false, nil
+		return reconcile.Result{}, nil
 	}
 
-	return true, nil
+	return reconcile.Result{Requeue: true}, nil
 }
 
 func (ds UploadDataSource) CleanUp(ctx context.Context, vd *virtv2.VirtualDisk) (bool, error) {
@@ -299,20 +309,20 @@ func (ds UploadDataSource) CleanUp(ctx context.Context, vd *virtv2.VirtualDisk) 
 	return uploaderRequeue || diskRequeue, nil
 }
 
-func (ds UploadDataSource) CleanUpSupplements(ctx context.Context, vd *virtv2.VirtualDisk) (bool, error) {
+func (ds UploadDataSource) CleanUpSupplements(ctx context.Context, vd *virtv2.VirtualDisk) (reconcile.Result, error) {
 	supgen := supplements.NewGenerator(common.VDShortName, vd.Name, vd.Namespace, vd.UID)
 
 	uploaderRequeue, err := ds.uploaderService.CleanUpSupplements(ctx, supgen)
 	if err != nil {
-		return false, err
+		return reconcile.Result{}, err
 	}
 
 	diskRequeue, err := ds.diskService.CleanUpSupplements(ctx, supgen)
 	if err != nil {
-		return false, err
+		return reconcile.Result{}, err
 	}
 
-	return uploaderRequeue || diskRequeue, nil
+	return reconcile.Result{Requeue: uploaderRequeue || diskRequeue}, nil
 }
 
 func (ds UploadDataSource) Validate(_ context.Context, _ *virtv2.VirtualDisk) error {


### PR DESCRIPTION
## Description

1. Refactored the virtual disk controller. SourceHandlers now return reconcile.Result. 
2. If a "quota exceeded" error appears, we make additional attempts with a one-minute interval. If after 30 minutes it still doesn't succeed, the phase is set to Failed.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
