### PR TITLE
refactor(api): unified deletion message when removing cleanup finalizer

### DIFF
--- a/images/virtualization-artifact/pkg/controller/cvi/internal/deletion.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/deletion.go
@@ -23,8 +23,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/deckhouse/virtualization-controller/pkg/controller/cvi/internal/source"
+	"github.com/deckhouse/virtualization-controller/pkg/logger"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
+
+const deletionHandlerName = "DeletionHandler"
 
 type DeletionHandler struct {
 	sources *source.Sources
@@ -37,6 +40,8 @@ func NewDeletionHandler(sources *source.Sources) *DeletionHandler {
 }
 
 func (h DeletionHandler) Handle(ctx context.Context, cvi *virtv2.ClusterVirtualImage) (reconcile.Result, error) {
+	log := logger.FromContext(ctx).With(logger.SlogHandler(deletionHandlerName))
+
 	if cvi.DeletionTimestamp != nil {
 		requeue, err := h.sources.CleanUp(ctx, cvi)
 		if err != nil {
@@ -47,6 +52,7 @@ func (h DeletionHandler) Handle(ctx context.Context, cvi *virtv2.ClusterVirtualI
 			return reconcile.Result{Requeue: true}, nil
 		}
 
+		log.Info("Deletion observed: remove cleanup finalizer from clusterVirtualImage")
 		controllerutil.RemoveFinalizer(cvi, virtv2.FinalizerCVICleanup)
 		return reconcile.Result{}, nil
 	}

--- a/images/virtualization-artifact/pkg/controller/vd/internal/deletion.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/deletion.go
@@ -23,8 +23,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vd/internal/source"
+	"github.com/deckhouse/virtualization-controller/pkg/logger"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
+
+const deletionHandlerName = "DeletionHandler"
 
 type DeletionHandler struct {
 	sources *source.Sources
@@ -37,6 +40,8 @@ func NewDeletionHandler(sources *source.Sources) *DeletionHandler {
 }
 
 func (h DeletionHandler) Handle(ctx context.Context, vd *virtv2.VirtualDisk) (reconcile.Result, error) {
+	log := logger.FromContext(ctx).With(logger.SlogHandler(deletionHandlerName))
+
 	if vd.DeletionTimestamp != nil {
 		requeue, err := h.sources.CleanUp(ctx, vd)
 		if err != nil {
@@ -47,6 +52,7 @@ func (h DeletionHandler) Handle(ctx context.Context, vd *virtv2.VirtualDisk) (re
 			return reconcile.Result{Requeue: true}, nil
 		}
 
+		log.Info("Deletion observed: remove cleanup finalizer from VirtualDisk")
 		controllerutil.RemoveFinalizer(vd, virtv2.FinalizerVDCleanup)
 		return reconcile.Result{}, nil
 	}

--- a/images/virtualization-artifact/pkg/controller/vmbda/internal/deletion.go
+++ b/images/virtualization-artifact/pkg/controller/vmbda/internal/deletion.go
@@ -22,8 +22,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/deckhouse/virtualization-controller/pkg/logger"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
+
+const deletionHandlerName = "DeletionHandler"
 
 type DeletionHandler struct{}
 
@@ -31,8 +34,10 @@ func NewDeletionHandler() *DeletionHandler {
 	return &DeletionHandler{}
 }
 
-func (h DeletionHandler) Handle(_ context.Context, vd *virtv2.VirtualMachineBlockDeviceAttachment) (reconcile.Result, error) {
+func (h DeletionHandler) Handle(ctx context.Context, vd *virtv2.VirtualMachineBlockDeviceAttachment) (reconcile.Result, error) {
+	log := logger.FromContext(ctx).With(logger.SlogHandler(deletionHandlerName))
 	if vd.DeletionTimestamp != nil {
+		log.Info("Deletion observed: remove cleanup finalizer from VirtualMachineBlockDeviceAttachment")
 		controllerutil.RemoveFinalizer(vd, virtv2.FinalizerVMBDACleanup)
 		return reconcile.Result{}, nil
 	}

--- a/images/virtualization-artifact/pkg/controller/vmclass/internal/deletion.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/internal/deletion.go
@@ -68,7 +68,7 @@ func (h *DeletionHandler) Handle(ctx context.Context, s state.VirtualMachineClas
 		h.recorder.Event(changed, corev1.EventTypeWarning, virtv2.ReasonVMClassInUse, msg)
 		return reconcile.Result{RequeueAfter: 60 * time.Second}, nil
 	}
-	h.logger.Info("Delete VmClass, remove protection finalizers")
+	h.logger.Info("Deletion observed: remove cleanup finalizer from VirtualMachineClass")
 	controllerutil.RemoveFinalizer(changed, virtv2.FinalizerVMCleanup)
 	return reconcile.Result{}, nil
 }

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/protection_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/protection_handler.go
@@ -57,7 +57,7 @@ func (h *ProtectionHandler) Handle(ctx context.Context, state state.VMIPState) (
 
 	switch {
 	case len(configuredVms) == 0:
-		log.Debug("Allow VirtualMachineIPAddress deletion")
+		log.Debug("Allow VirtualMachineIPAddress deletion: remove protection finalizer")
 		controllerutil.RemoveFinalizer(vmip, virtv2.FinalizerIPAddressProtection)
 	case vmip.DeletionTimestamp == nil:
 		log.Debug("Protect VirtualMachineIPAddress from deletion")
@@ -67,7 +67,7 @@ func (h *ProtectionHandler) Handle(ctx context.Context, state state.VMIPState) (
 	}
 
 	if vm == nil || vm.DeletionTimestamp != nil {
-		log.Info("VirtualMachineIP is no longer attached to any VM, proceeding with detachment", "VirtualMachineIPName", vmip.Name)
+		log.Info("VirtualMachineIP is no longer attached to any VM: remove cleanup finalizer", "VirtualMachineIPName", vmip.Name)
 		controllerutil.RemoveFinalizer(vmip, virtv2.FinalizerIPAddressCleanup)
 	} else if vmip.GetDeletionTimestamp() == nil {
 		controllerutil.AddFinalizer(vmip, virtv2.FinalizerIPAddressCleanup)

--- a/images/virtualization-artifact/pkg/controller/vmiplease/internal/protection_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmiplease/internal/protection_handler.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vmiplease/internal/state"
+	"github.com/deckhouse/virtualization-controller/pkg/logger"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
@@ -35,6 +36,7 @@ func NewProtectionHandler() *ProtectionHandler {
 }
 
 func (h *ProtectionHandler) Handle(ctx context.Context, state state.VMIPLeaseState) (reconcile.Result, error) {
+	log := logger.FromContext(ctx).With(logger.SlogHandler(ProtectionHandlerName))
 	lease := state.VirtualMachineIPAddressLease()
 
 	vmip, err := state.VirtualMachineIPAddress(ctx)
@@ -45,6 +47,7 @@ func (h *ProtectionHandler) Handle(ctx context.Context, state state.VMIPLeaseSta
 	if vmip != nil {
 		controllerutil.AddFinalizer(lease, virtv2.FinalizerIPAddressLeaseCleanup)
 	} else if lease.GetDeletionTimestamp() == nil {
+		log.Info("Deletion observed: remove cleanup finalizer from VirtualMachineIPAddressLease")
 		controllerutil.RemoveFinalizer(lease, virtv2.FinalizerIPAddressLeaseCleanup)
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vmop/internal/deletion.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/internal/deletion.go
@@ -18,7 +18,6 @@ package internal
 
 import (
 	"context"
-	"fmt"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -59,7 +58,11 @@ func (h DeletionHandler) Handle(ctx context.Context, s state.VMOperationState) (
 	}
 
 	// Remove finalizer when VirtualMachineOperation is in deletion state or not in progress.
-	log.Debug(fmt.Sprintf("Remove cleanup finalier from VMOP: deletion %v, phase %s", changed.DeletionTimestamp != nil, changed.Status.Phase))
+	if changed.DeletionTimestamp != nil {
+		log.Info("Deletion observed: remove cleanup finalizer from VirtualMachineOperation", "phase", changed.Status.Phase)
+	} else {
+		log.Debug("Remove cleanup finalizer from VirtualMachineOperation: not InProgress state", "phase", changed.Status.Phase)
+	}
 	controllerutil.RemoveFinalizer(changed, virtv2.FinalizerVMOPCleanup)
 	return reconcile.Result{}, nil
 }


### PR DESCRIPTION
## Description
- Add log.Info before removing cleanup finalizer.
- Change confusing message "Delete %SOME_RESOURCE%" to "Deletion observed".

## Why do we need it, and what problem does it solve?

"Delete %SOME_RESOURCE%" message leads to a wrong assumption that controller deletes that %SOME_RESOURCE%.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
