### PR TITLE
chore(module): helm templates cleanup

### DIFF
--- a/templates/kubevirt/service-monitor.yaml
+++ b/templates/kubevirt/service-monitor.yaml
@@ -8,13 +8,6 @@ metadata:
   {{- include "helm_lib_module_labels" (list $ (dict "prometheus" "main")) | nindent 2 }}
 spec:
   endpoints:
-  - bearerTokenSecret:
-      key: token
-      name: prometheus-token
-    path: /metrics
-    port: metrics
-spec:
-  endpoints:
     - bearerTokenSecret:
         key: token
         name: prometheus-token
@@ -226,13 +219,5 @@ spec:
   selector:
     matchLabels:
       prometheus.kubevirt.internal.virtualization.deckhouse.io: "true"
-    scheme: https
-    tlsConfig:
-      insecureSkipVerify: true
-  namespaceSelector:
-    matchNames:
-    - d8-{{ .Chart.Name }}
-  selector:
-    matchLabels:
-      prometheus.kubevirt.internal.virtualization.deckhouse.io: "true"
+
 {{- end }}

--- a/templates/pre-delete-hook/job.yaml
+++ b/templates/pre-delete-hook/job.yaml
@@ -12,7 +12,6 @@ spec:
   template:
     metadata:
       name: virtualization-pre-delete-hook
-      labels:
       {{- include "helm_lib_module_labels" (list . (dict "app" "virtualization-pre-delete-hook")) | nindent 6 }}
     spec:
       restartPolicy: Never

--- a/templates/virtualization-controller/service-metrics.yaml
+++ b/templates/virtualization-controller/service-metrics.yaml
@@ -7,9 +7,7 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "virtualization-controller")) | nindent 2 }}
 spec:
   ports:
-    - type: ClusterIP
-      clusterIP: None
-      name: metrics
+    - name: metrics
       port: 8080
       protocol: TCP
       targetPort: metrics


### PR DESCRIPTION
## Description

Remove field dublicates in resources.

## Why do we need it, and what problem does it solve?

kubeconform report before:

```
ERROR     Job virtualization-pre-delete-hook
  error unmarshalling resource: error converting YAML to JSON: yaml: unmarshal errors:
    line 21: key "labels" already set in map
ERROR     ServiceMonitor virtualization-virt-handler
  error unmarshalling resource: error converting YAML to JSON: yaml: unmarshal errors:
    line 235: key "namespaceSelector" already set in map
    line 238: key "selector" already set in map
    line 19: key "spec" already set in map
INVALID   Service virtualization-controller-metrics
  - /spec/ports/0:
      additionalProperties 'clusterIP', 'type' not allowed
------- Summary -------
      valid: 97
    skipped: 0
  no schema: 0
     errors: 2
    invalid: 1
```

kubeconform report after:
```
...
VALID     Job virtualization-pre-delete-hook
VALID     Service virtualization-controller-metrics
VALID     ServiceMonitor virtualization-virt-handler
...
------- Summary -------
      valid: 100
    skipped: 0
  no schema: 0
     errors: 0
    invalid: 0

```
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
