### PR TITLE
refactor(ci): run helm-templates validation on related changes only

### DIFF
--- a/.github/workflows/dev_validation.yaml
+++ b/.github/workflows/dev_validation.yaml
@@ -30,6 +30,26 @@ defaults:
     shell: bash
 
 jobs:
+  paths_filter:
+    runs-on: ubuntu-latest
+    name: Filter changed paths
+    outputs:
+      helm_templates: ${{ steps.paths_filter.outputs.helm_templates }}
+    steps:
+      # For pull requests it's not necessary to checkout the code, this action uses Github API.
+      - uses: dorny/paths-filter@v3
+        id: paths_filter
+        with:
+          filters: |
+            helm_templates:
+              - 'crds/**'
+              - 'charts/**'
+              - 'tools/kubeconform/**'
+              - 'templates/**'
+              - .helmignore
+              - Chart.yaml
+              - Taskfile.yaml
+
   no_cyrillic:
     if: "!contains(github.event.pull_request.labels.*.name, 'validation/skip/no_cyrillic')"
     runs-on: ubuntu-latest
@@ -99,8 +119,10 @@ jobs:
         run: |
           task validation:copyright
 
+  # Run helm templates validation on changes in related files and without the skip labels.
   helm_templates:
-    if: "!contains(github.event.pull_request.labels.*.name, 'validation/skip/helm_templates')"
+    needs: paths_filter
+    if: ${{ needs.paths_filter.outputs.helm_templates == 'true' && !contains(github.event.pull_request.labels.*.name, 'validation/skip/helm_templates') }}
     runs-on: ubuntu-latest
     name: Validate helm templates with OpenAPI schemas
     steps:
@@ -110,8 +132,6 @@ jobs:
           version: 3.37.2
 
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Run validation "Helm templates"
         run: |

--- a/.github/workflows/dev_validation.yaml
+++ b/.github/workflows/dev_validation.yaml
@@ -31,6 +31,7 @@ defaults:
 
 jobs:
   paths_filter:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'validation/skip/helm_templates') }}
     runs-on: ubuntu-latest
     name: Filter changed paths
     outputs:


### PR DESCRIPTION
## Description

Add "dorny/paths-filter" action to detect changes in helm templates related files.

## Why do we need it, and what problem does it solve?

No need to run helm templates validation for any change in the repo.

## What is the expected result?

helm templates validation is skipped for changes in Go sourcres.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
