### PR TITLE
refactor(e2e): unix-like loader for Kubernetes connection parameters

### DIFF
--- a/tests/e2e/Taskfile.yaml
+++ b/tests/e2e/Taskfile.yaml
@@ -3,7 +3,6 @@ version: "3"
 silent: true
 
 vars:
-  E2E_CLUSTERTRANSPORT_KUBECONFIG: '{{ .E2E_CLUSTERTRANSPORT_KUBECONFIG | default "$HOME/.kube/config" }}'
   GINKGO_VERSION: "2.20.0"
   VERSION: "v1.0.0"
 
@@ -24,16 +23,15 @@ tasks:
   ginkgo:
     cmds:
       - |
-        v=($(ginkgo version 2>/dev/null)) 
-        if [ "${v[2]}" != "{{ .GINKGO_VERSION }}" ]; then 
-          go install github.com/onsi/ginkgo/v2/ginkgo@v"{{ .GINKGO_VERSION }}" ; 
+        v=($(ginkgo version 2>/dev/null))
+        if [ "${v[2]}" != "{{ .GINKGO_VERSION }}" ]; then
+          go install github.com/onsi/ginkgo/v2/ginkgo@v"{{ .GINKGO_VERSION }}" ;
         fi
   run:
     desc: "Run e2e tests"
     deps:
       - ginkgo
     cmds:
-      - export E2E_CLUSTERTRANSPORT_KUBECONFIG={{.E2E_CLUSTERTRANSPORT_KUBECONFIG}}
       - ginkgo --focus "Virtualization resources" -v
 
   run_local:
@@ -43,7 +41,6 @@ tasks:
       - ginkgo
     cmds:
       - |
-        export E2E_CLUSTERTRANSPORT_KUBECONFIG={{.E2E_CLUSTERTRANSPORT_KUBECONFIG}}
         ginkgo \
           --skip-file vm_test.go \
           --skip-file vm_label_annotation_test.go \
@@ -59,7 +56,6 @@ tasks:
     cmds:
       - |
         {{if .TEST }}
-          export E2E_CLUSTERTRANSPORT_KUBECONFIG={{.E2E_CLUSTERTRANSPORT_KUBECONFIG}}
           ginkgo --focus "{{ .TEST }}" -v
         {{else}}
           echo "Specify test to run"
@@ -67,7 +63,7 @@ tasks:
         {{end}}
 
   fix:ssh_key_perm:
-    desc: "Check and fix rights for ssh keys"
+    desc: "Check and fix permissions for ssh keys"
     cmds:
       - |
         ID_ED=testdata/vm/sshkeys/id_ed

--- a/tests/e2e/config/clustertransport/kube_connection_settings.go
+++ b/tests/e2e/config/clustertransport/kube_connection_settings.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clustertransport
+
+import (
+	"fmt"
+)
+
+type ClusterTransport struct {
+	KubeConfig           string `yaml:"kubeConfig"`
+	Token                string `yaml:"token"`
+	Endpoint             string `yaml:"endpoint"`
+	CertificateAuthority string `yaml:"certificateAuthority"`
+	InsecureTls          bool   `yaml:"insecureTls"`
+}
+
+// KubeConnectionCmdSettings returns environment variables and arguments for kubectl command
+// to connect to the cluster.
+//
+// It uses common UNIX config parameters priority:
+// - First look for a command line parameter (token and endpoint in ClusterTransport).
+// - environment var (CluterTransport.KubeConfig set from E2E_CLUSTERTRANSPORT_KUBECONFIG)
+// - then local config file (kubeConfig from e2e config file).
+// - then global config file (kubectl will use KUBECONFIG env or default config file $HOME/.kube/config).
+func KubeConnectionCmdSettings(conf ClusterTransport) (env, args []string, err error) {
+	// Token and endpoint have the highest priority, use them to specify connection without config file.
+	if conf.Token != "" || conf.Endpoint != "" {
+		if conf.Endpoint == "" {
+			return nil, nil, fmt.Errorf("token is not enough, specify endpoint to connect to cluster")
+		}
+		if conf.Token == "" {
+			return nil, nil, fmt.Errorf("endpoint is not enough, specify token to connect to cluster")
+		}
+		args = []string{
+			fmt.Sprintf("--token=%s", conf.Token),
+			fmt.Sprintf("--server=%s", conf.Endpoint),
+		}
+		if conf.CertificateAuthority != "" {
+			args = append(args, fmt.Sprintf("--certificate-authority=%s", conf.CertificateAuthority))
+		}
+		if conf.InsecureTls {
+			args = append(args, "--insecure-skip-tls-verify=true")
+		}
+
+		return nil, args, nil
+	}
+
+	// Override KUBECONFIG from E2E_CLUSTERTRANSPORT_KUBECONFIG or from e2e config file.
+	if conf.KubeConfig != "" {
+		return []string{
+			fmt.Sprintf("KUBECONFIG=%s", conf.KubeConfig),
+		}, nil, nil
+	}
+
+	// No overrides from the user, let kubectl decide what to use.
+	return nil, nil, nil
+}

--- a/tests/e2e/executor/executor.go
+++ b/tests/e2e/executor/executor.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 )
 
@@ -76,8 +77,27 @@ func (e CMDExecutor) makeCMD(ctx context.Context, command string, stdout, stderr
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
-	cmd.Env = e.env
+	cmd.Env = mergeEnvs(cmd.Environ(), e.env)
 	return cmd
+}
+
+func mergeEnvs(curr []string, override []string) []string {
+	envMap := make(map[string]string)
+
+	for _, currEnv := range curr {
+		envName, envValue, _ := strings.Cut(currEnv, "=")
+		envMap[envName] = envValue
+	}
+	for _, newEnv := range override {
+		envName, envValue, _ := strings.Cut(newEnv, "=")
+		envMap[envName] = envValue
+	}
+
+	res := make([]string, 0, len(envMap))
+	for name, val := range envMap {
+		res = append(res, fmt.Sprintf("%s=%s", name, val))
+	}
+	return res
 }
 
 type CMDExecutor struct {

--- a/tests/e2e/kubectl/kubectl.go
+++ b/tests/e2e/kubectl/kubectl.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/deckhouse/virtualization/tests/e2e/config/clustertransport"
 	"github.com/deckhouse/virtualization/tests/e2e/executor"
 )
 
@@ -124,39 +125,23 @@ type KubectlConf struct {
 }
 
 func NewKubectl(conf KubectlConf) (*KubectlCMD, error) {
-	envs := make([]string, 2)
-	if home, found := os.LookupEnv("HOME"); found {
-		envs[0] = "HOME=" + home
-	} else {
-		return nil, fmt.Errorf("env HOME not found")
+	if _, found := os.LookupEnv("HOME"); !found {
+		return nil, fmt.Errorf("HOME environment variable shoule be set")
 	}
-	if path, found := os.LookupEnv("PATH"); found {
-		envs[1] = "PATH=" + path
-	} else {
-		return nil, fmt.Errorf("env PATH not found")
+	if _, found := os.LookupEnv("PATH"); !found {
+		return nil, fmt.Errorf("PATH environment variable shoule be set")
 	}
-	if conf.KubeConfig != "" {
-		envs = append(envs, "KUBECONFIG="+conf.KubeConfig)
-		e := executor.NewExecutor(envs)
-		return &KubectlCMD{
-			Executor: e,
-			cmd:      Cmd,
-		}, nil
+
+	connEnvs, connArgs, err := clustertransport.KubeConnectionCmdSettings(clustertransport.ClusterTransport(conf))
+
+	if err != nil {
+		return nil, fmt.Errorf("load connection config: %w", err)
 	}
-	if conf.Token == "" || conf.Endpoint == "" {
-		return nil, fmt.Errorf("not found creds for connect to cluster")
-	}
-	cmd := fmt.Sprintf("%s --token=%s --server=%s", Cmd, conf.Token, conf.Endpoint)
-	if conf.CertificateAuthority != "" {
-		cmd = fmt.Sprintf("%s --certificate-authority=%s", cmd, conf.CertificateAuthority)
-	}
-	if conf.InsecureTls {
-		cmd = fmt.Sprintf("%s --insecure-skip-tls-verify=%t", cmd, true)
-	}
-	e := executor.NewExecutor([]string{})
+
+	e := executor.NewExecutor(connEnvs)
 	return &KubectlCMD{
 		Executor: e,
-		cmd:      cmd,
+		cmd:      strings.Join(append([]string{Cmd}, connArgs...), " "),
 	}, nil
 }
 


### PR DESCRIPTION
## Description

Parameters priority from highest to lowest:

- Direct settings in e2e config file: token and endpoint.
- Kube config in e2e config file or from E2E_CLUSTERTRANSPORT_KUBECONFIG Fallback to kubectl behaviour:
- KUBECONFIG environment variable
- Default config location $HOME/.kube/config

Remove default config location from taskfile, kubectl and d8 executors should decide what to use.

Executor env is now inherited with override from conf.


## Why do we need it, and what problem does it solve?

KUBECONFIG env is now works.

## What is the expected result?

1. Set KUBECONFIG  to cluster without Deckhouse.

```
$ TEST="Virtual machine migration" task run_one

2024/10/18 11:06:29 error: the server doesn't have a resource type "moduleconfigs"

Ginkgo ran 1 suite in 9.789374666s

Test Suite Failed
task: Failed to run task "run_one": exit status 1
```

2. Set KUBECONFIG cluster with virtualization module, but ssh tunnel is down.

```
$ TEST="Virtual machine migration" task run_one
2024/10/18 11:07:02 E1018 11:07:02.966987   21627 memcache.go:265] couldn't get current server API group list: Get "https://127.0.0.1:6445/api?timeout=32s": dial tcp 127.0.0.1:6445: connect: connection refused
E1018 11:07:02.967472   21627 memcache.go:265] couldn't get current server API group list: Get "https://127.0.0.1:6445/api?timeout=32s": dial tcp 127.0.0.1:6445: connect: connection refused
E1018 11:07:02.968470   21627 memcache.go:265] couldn't get current server API group list: Get "https://127.0.0.1:6445/api?timeout=32s": dial tcp 127.0.0.1:6445: connect: connection refused
E1018 11:07:02.968740   21627 memcache.go:265] couldn't get current server API group list: Get "https://127.0.0.1:6445/api?timeout=32s": dial tcp 127.0.0.1:6445: connect: connection refused
E1018 11:07:02.969783   21627 memcache.go:265] couldn't get current server API group list: Get "https://127.0.0.1:6445/api?timeout=32s": dial tcp 127.0.0.1:6445: connect: connection refused
E1018 11:07:02.970003   21627 memcache.go:265] couldn't get current server API group list: Get "https://127.0.0.1:6445/api?timeout=32s": dial tcp 127.0.0.1:6445: connect: connection refused
E1018 11:07:02.971132   21627 memcache.go:265] couldn't get current server API group list: Get "https://127.0.0.1:6445/api?timeout=32s": dial tcp 127.0.0.1:6445: connect: connection refused
The connection to the server 127.0.0.1:6445 was refused - did you specify the right host or port?

Ginkgo ran 1 suite in 7.835066033s

Test Suite Failed
task: Failed to run task "run_one": exit status 1
```

3. Tunnel is up:

``
$ TEST="Virtual machine migration" task run_one
  Starting test suite
Running Suite: Tests - /Users/diafour/Projects/deckhouse/virtualization-controller/tests/e2e
============================================================================================
Random Seed: 1729238854

Will run 7 of 230 specs
...
Ran 7 of 230 Specs in 89.772 seconds
SUCCESS! -- 7 Passed | 0 Failed | 0 Pending | 223 Skipped
PASS

Ginkgo ran 1 suite in 2m48.498105018s
Test Suite Passed
```


4. unset KUBECONFIG, set E2E_CLUSTERTRANSPORT_KUBECONFIG override:

```
$ cp $KUBECONFIG ./local-e2e-test-kubeconfig
$ unset KUBECONFIG
$ set | grep 'KUBECONFIG\|TEST'
E2E_CLUSTERTRANSPORT_KUBECONFIG=./local-e2e-test-kubeconfig
TEST='Virtual machine migration'
$ task run_one
  Starting test suite
Running Suite: Tests - /Users/diafour/Projects/deckhouse/virtualization-controller/tests/e2e
============================================================================================
Random Seed: 1729239578

Will run 7 of 230 specs
...
Ran 7 of 230 Specs in 87.057 seconds
SUCCESS! -- 7 Passed | 0 Failed | 0 Pending | 223 Skipped
PASS

Ginkgo ran 1 suite in 2m47.810759717s
Test Suite Passed
```


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
