### PR TITLE
refactor(vmop): change vm label from name to uid

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vmop/internal/lifecycle.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/internal/lifecycle.go
@@ -70,7 +70,7 @@ func (h LifecycleHandler) Handle(ctx context.Context, s state.VMOperationState) 
 
 	// Initialize new VMOP resource: set label with vm name, set phase to Pending and all conditions to Unknown.
 	if changed.Status.Phase == "" {
-		cc.AddLabel(changed, cc.LabelVirtualMachineName, changed.Spec.VirtualMachine)
+		cc.AddLabel(changed, cc.LabelVirtualMachineUID, string(changed.GetUID()))
 		changed.Status.Phase = virtv2.VMOPPhasePending
 		// Add all conditions in unknown state.
 		conditions.SetCondition(


### PR DESCRIPTION

## Description

- VM name may exceed 63 characters limit on the label value
- UID is more robust for the purpose to get all related VMOPs.
- UID is already set for VMIP resources.


## Why do we need it, and what problem does it solve?

We need a way to fetch all VMOPs related to a particular VM (think of UI).

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
