### PR TITLE
feat(vd): Allow change Virtual Disk spec after connect to Virtual Machine while Virtual Disk is not ready

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vd/internal/validators/spec_changes_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/validators/spec_changes_validator.go
@@ -47,21 +47,11 @@ func (v *SpecChangesValidator) ValidateUpdate(_ context.Context, oldVD, newVD *v
 	ready, _ := service.GetCondition(vdcondition.ReadyType, newVD.Status.Conditions)
 	if ready.Status == metav1.ConditionTrue || newVD.Status.Phase == virtv2.DiskReady || newVD.Status.Phase == virtv2.DiskLost || newVD.Status.Phase == virtv2.DiskTerminating {
 		if !reflect.DeepEqual(oldVD.Spec.DataSource, newVD.Spec.DataSource) {
-			return nil, fmt.Errorf("VirtualDisk has already been created: data source cannot be changed after disk is created")
+			return nil, fmt.Errorf("VirtualDisk has already been attached: data source cannot be changed after disk is attached to VirtualMachine")
 		}
 
 		if !reflect.DeepEqual(oldVD.Spec.PersistentVolumeClaim.StorageClass, newVD.Spec.PersistentVolumeClaim.StorageClass) {
-			return nil, fmt.Errorf("VirtualDisk has already been created: storage class cannot be changed after disk is created")
-		}
-	}
-
-	if len(newVD.Status.AttachedToVirtualMachines) > 0 {
-		if !reflect.DeepEqual(oldVD.Spec.DataSource, newVD.Spec.DataSource) {
-			return nil, fmt.Errorf("VirtualDisk has already been attached to the virtual machine: data source cannot be changed after disk is attached")
-		}
-
-		if !reflect.DeepEqual(oldVD.Spec.PersistentVolumeClaim.StorageClass, newVD.Spec.PersistentVolumeClaim.StorageClass) {
-			return nil, fmt.Errorf("VirtualDisk has already been attached to the virtual machine: storage class cannot be changed after disk is attached")
+			return nil, fmt.Errorf("VirtualDisk has already been attached: storage class cannot be changed after disk is attached to VirtualMachine")
 		}
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vd/internal/validators/spec_changes_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/validators/spec_changes_validator.go
@@ -51,7 +51,7 @@ func (v *SpecChangesValidator) ValidateUpdate(_ context.Context, oldVD, newVD *v
 		}
 
 		if !reflect.DeepEqual(oldVD.Spec.PersistentVolumeClaim.StorageClass, newVD.Spec.PersistentVolumeClaim.StorageClass) {
-			return nil, fmt.Errorf("VirtualDisk has already been attached: storage class cannot be changed after disk is attached to VirtualMachine")
+			return nil, fmt.Errorf("VirtualDisk has already been attached: storage class cannot be changed while disk is attached to VirtualMachine")
 		}
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vd/internal/validators/spec_changes_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/validators/spec_changes_validator.go
@@ -47,7 +47,7 @@ func (v *SpecChangesValidator) ValidateUpdate(_ context.Context, oldVD, newVD *v
 	ready, _ := service.GetCondition(vdcondition.ReadyType, newVD.Status.Conditions)
 	if ready.Status == metav1.ConditionTrue || newVD.Status.Phase == virtv2.DiskReady || newVD.Status.Phase == virtv2.DiskLost || newVD.Status.Phase == virtv2.DiskTerminating {
 		if !reflect.DeepEqual(oldVD.Spec.DataSource, newVD.Spec.DataSource) {
-			return nil, fmt.Errorf("VirtualDisk has already been attached: data source cannot be changed after disk is attached to VirtualMachine")
+			return nil, fmt.Errorf("VirtualDisk has already been attached: data source cannot be changed while disk is attached to VirtualMachine")
 		}
 
 		if !reflect.DeepEqual(oldVD.Spec.PersistentVolumeClaim.StorageClass, newVD.Spec.PersistentVolumeClaim.StorageClass) {


### PR DESCRIPTION
## Description
Allow change Virtual Disk spec after connect to Virtual Machine while Virtual Disk is not ready

## Why do we need it, and what problem does it solve?

## What is the expected result?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
