### PR TITLE
fix(kube-api-rewriter): fix discovery and ValidatingAdmissionPolicy rewrite

### DIFF
--- a/images/kube-api-proxy/Taskfile.dist.yaml
+++ b/images/kube-api-proxy/Taskfile.dist.yaml
@@ -8,7 +8,7 @@ includes:
     optional: true
 
 vars:
-  DevImage: "localhost:5000/$USER/kube-api-proxy:latest"
+  DevImage: "${DevImage:-localhost:5000/$USER/kube-api-proxy:latest}"
 
 tasks:
   default:
@@ -24,13 +24,41 @@ tasks:
   dev:deploy:
     desc: "apply manifest with proxy and test-controller"
     cmds:
+      - task: dev:__deploy
+        vars:
+          CTR_COMMAND: "['./proxy']"
+
+  dev:deploy-with-dlv:
+    desc: "apply manifest with proxy with dlv and test-controller"
+    cmds:
+      - task: dev:__deploy
+        vars:
+          CTR_COMMAND: "['./dlv', '--listen=:2345', '--headless=true', '--continue', '--log=true', '--log-output=debugger,debuglineerr,gdbwire,lldbout,rpc', '--accept-multiclient', '--api-version=2', 'exec', './proxy']"
+
+  dev:__deploy:
+    internal: true
+    cmds:
       - |
         if ! kubectl get no 2>&1 >/dev/null ; then
           echo Restart cluster connection
           exit 1
         fi
       - |
-        cat local/proxy.yaml | IMAGE={{.DevImage}} envsubst | kubectl -n kproxy apply -f -
+        kubectl get ns kproxy &>/dev/null || kubectl create ns kproxy
+        kubectl apply -f - <<EOF
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: deckhouse-registry
+          namespace: kproxy
+        type: $(kubectl get secrets deckhouse-registry -n d8-system -ojsonpath='{.type}')
+        data: $(kubectl get secrets deckhouse-registry -n d8-system -ojsonpath='{.data}')
+        EOF
+        cat local/proxy.yaml | CTR_COMMAND="{{.CTR_COMMAND}}" IMAGE="{{.DevImage}}" envsubst | kubectl -n kproxy apply -f -
+
+  dev:undeploy:
+    desc: "delete manifest with proxy and test-controller"
+    cmd: kubectl delete ns kproxy
 
   dev:restart:
     desc: "restart deployment"

--- a/images/kube-api-proxy/local/Dockerfile
+++ b/images/kube-api-proxy/local/Dockerfile
@@ -1,5 +1,7 @@
 # Go builder.
-FROM golang:1.21-alpine3.19 AS builder
+FROM golang:1.22-alpine3.19 AS builder
+
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
 # Cache-friendly download of go dependencies.
 ADD go.mod go.sum /app/
@@ -12,7 +14,7 @@ RUN GOOS=linux \
     go build -o proxy ./cmd/kube-api-proxy
 
 # Go builder.
-FROM golang:1.21-alpine3.19 AS builder-test-controller
+FROM golang:1.22-alpine3.19 AS builder-test-controller
 
 # Cache-friendly download of go dependencies.
 ADD local/test-controller/go.mod local/test-controller/go.sum /app/
@@ -28,8 +30,9 @@ FROM alpine:3.19
 RUN apk --no-cache add ca-certificates bash sed tini curl && \
     kubectlArch=linux/amd64 && \
     echo "Download kubectl for ${kubectlArch}" && \
-    wget https://storage.googleapis.com/kubernetes-release/release/v1.27.5/bin/${kubectlArch}/kubectl -O /bin/kubectl && \
+    wget https://storage.googleapis.com/kubernetes-release/release/v1.30.0/bin/${kubectlArch}/kubectl -O /bin/kubectl && \
     chmod +x /bin/kubectl
+COPY --from=builder /go/bin/dlv /
 COPY --from=builder /app/proxy /
 COPY --from=builder-test-controller /app/test-controller /
 ADD local/proxy.kubeconfig /

--- a/images/kube-api-proxy/local/proxy.yaml
+++ b/images/kube-api-proxy/local/proxy.yaml
@@ -23,19 +23,10 @@ spec:
       imagePullSecrets:
         - name: "deckhouse-registry"
       containers:
-        - name: proxy-only
-          image: "${IMAGE}"
-          imagePullPolicy: Always
-          command:
-            - /proxy
-          env:
-            - name: CLIENT_PROXY_PORT
-              value: "23916"
         - name: proxy
           image: "${IMAGE}"
           imagePullPolicy: Always
-          command:
-            - /proxy
+          command: ${CTR_COMMAND}
           env:
             - name: WEBHOOK_ADDRESS
               value: "https://127.0.0.1:9443"

--- a/images/kube-api-proxy/pkg/rewriter/admission_configuration.go
+++ b/images/kube-api-proxy/pkg/rewriter/admission_configuration.go
@@ -30,7 +30,7 @@ func RewriteValidatingOrList(rules *RewriteRules, obj []byte, action Action) ([]
 		return RewriteResourceOrList(obj, ValidatingWebhookConfigurationListKind, func(singleObj []byte) ([]byte, error) {
 			return RewriteArray(singleObj, "webhooks", func(webhook []byte) ([]byte, error) {
 				return RewriteArray(webhook, "rules", func(item []byte) ([]byte, error) {
-					return renameRoleRule(rules, item)
+					return RenameResourceRule(rules, item)
 				})
 			})
 		})
@@ -38,7 +38,7 @@ func RewriteValidatingOrList(rules *RewriteRules, obj []byte, action Action) ([]
 	return RewriteResourceOrList(obj, ValidatingWebhookConfigurationListKind, func(singleObj []byte) ([]byte, error) {
 		return RewriteArray(singleObj, "webhooks", func(webhook []byte) ([]byte, error) {
 			return RewriteArray(webhook, "rules", func(item []byte) ([]byte, error) {
-				return restoreRoleRule(rules, item)
+				return RestoreResourceRule(rules, item)
 			})
 		})
 	})
@@ -49,7 +49,7 @@ func RewriteMutatingOrList(rules *RewriteRules, obj []byte, action Action) ([]by
 		return RewriteResourceOrList(obj, MutatingWebhookConfigurationListKind, func(singleObj []byte) ([]byte, error) {
 			return RewriteArray(singleObj, "webhooks", func(webhook []byte) ([]byte, error) {
 				return RewriteArray(webhook, "rules", func(item []byte) ([]byte, error) {
-					return renameRoleRule(rules, item)
+					return RenameResourceRule(rules, item)
 				})
 			})
 		})
@@ -57,7 +57,7 @@ func RewriteMutatingOrList(rules *RewriteRules, obj []byte, action Action) ([]by
 	return RewriteResourceOrList(obj, MutatingWebhookConfigurationListKind, func(singleObj []byte) ([]byte, error) {
 		return RewriteArray(singleObj, "webhooks", func(webhook []byte) ([]byte, error) {
 			return RewriteArray(webhook, "rules", func(item []byte) ([]byte, error) {
-				return restoreRoleRule(rules, item)
+				return RestoreResourceRule(rules, item)
 			})
 		})
 	})
@@ -72,7 +72,7 @@ func RenameWebhookConfigurationPatch(rules *RewriteRules, obj []byte) ([]byte, e
 	return TransformPatch(obj, func(mergePatch []byte) ([]byte, error) {
 		return RewriteArray(mergePatch, "webhooks", func(webhook []byte) ([]byte, error) {
 			return RewriteArray(webhook, "rules", func(item []byte) ([]byte, error) {
-				return restoreRoleRule(rules, item)
+				return RestoreResourceRule(rules, item)
 			})
 		})
 	}, func(jsonPatch []byte) ([]byte, error) {
@@ -80,7 +80,7 @@ func RenameWebhookConfigurationPatch(rules *RewriteRules, obj []byte) ([]byte, e
 		if path == "/webhooks" {
 			return RewriteArray(jsonPatch, "value", func(webhook []byte) ([]byte, error) {
 				return RewriteArray(webhook, "rules", func(item []byte) ([]byte, error) {
-					return renameRoleRule(rules, item)
+					return RenameResourceRule(rules, item)
 				})
 			})
 		}

--- a/images/kube-api-proxy/pkg/rewriter/admission_policy.go
+++ b/images/kube-api-proxy/pkg/rewriter/admission_policy.go
@@ -1,0 +1,128 @@
+package rewriter
+
+const (
+	ValidatingAdmissionPolicyKind            = "ValidatingAdmissionPolicy"
+	ValidatingAdmissionPolicyListKind        = "ValidatingAdmissionPolicyList"
+	ValidatingAdmissionPolicyBindingKind     = "ValidatingAdmissionPolicyBinding"
+	ValidatingAdmissionPolicyBindingListKind = "ValidatingAdmissionPolicyBindingList"
+)
+
+func RewriteValidatingAdmissionPolicyOrList(rules *RewriteRules, obj []byte, action Action) ([]byte, error) {
+	if action == Rename {
+		return RewriteResourceOrList(obj, ValidatingAdmissionPolicyListKind, func(singleObj []byte) ([]byte, error) {
+			return RewriteArray(singleObj, "spec.matchConstraints.resourceRules", func(item []byte) ([]byte, error) {
+				return renameResourceRules(rules, item)
+			})
+		})
+	}
+	return RewriteResourceOrList(obj, ValidatingAdmissionPolicyListKind, func(singleObj []byte) ([]byte, error) {
+		return RewriteArray(singleObj, "spec.matchConstraints.resourceRules", func(item []byte) ([]byte, error) {
+			return restoreResourceRules(rules, item)
+		})
+	})
+}
+
+func RewriteValidatingAdmissionPolicyBindingOrList(rules *RewriteRules, obj []byte, action Action) ([]byte, error) {
+	if action == Rename {
+		return RewriteResourceOrList(obj, ValidatingAdmissionPolicyBindingListKind, func(singleObj []byte) ([]byte, error) {
+			return RewriteArray(singleObj, "spec.matchResources.resourceRules", func(item []byte) ([]byte, error) {
+				return renameResourceRules(rules, item)
+			})
+		})
+	}
+	return RewriteResourceOrList(obj, ValidatingAdmissionPolicyBindingListKind, func(singleObj []byte) ([]byte, error) {
+		return RewriteArray(singleObj, "spec.matchResources.resourceRules", func(item []byte) ([]byte, error) {
+			return restoreResourceRules(rules, item)
+		})
+	})
+}
+
+// renameValidatingAdmissionPolicyBinding renames apiGroups and resources in a single resourceRule.
+// Rule examples:
+//	resourceRules:
+//	- apiGroups:
+//	    - ""
+//	  apiVersions:
+//      - '*'
+//    operations:
+//      - '*'
+//    resources:
+//      - nodes
+//    scope: '*'
+
+func renameResourceRules(rules *RewriteRules, obj []byte) ([]byte, error) {
+	var err error
+
+	renameResources := false
+	obj, err = TransformArrayOfStrings(obj, "apiGroups", func(apiGroup string) string {
+		if rules.HasGroup(apiGroup) {
+			renameResources = true
+			return rules.RenameApiVersion(apiGroup)
+		}
+		if apiGroup == "*" {
+			renameResources = true
+		}
+		return apiGroup
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Do not rename resources for unknown group.
+	if !renameResources {
+		return obj, nil
+	}
+
+	return TransformArrayOfStrings(obj, "resources", func(resourceType string) string {
+		if resourceType == "*" || resourceType == "" {
+			return resourceType
+		}
+
+		// Rename if there is rule for resourceType.
+		_, resRule := rules.GroupResourceRules(resourceType)
+		if resRule != nil {
+			return rules.RenameResource(resourceType)
+		}
+		return resourceType
+	})
+}
+
+func restoreResourceRules(rules *RewriteRules, obj []byte) ([]byte, error) {
+	var err error
+
+	restoreResources := false
+	obj, err = TransformArrayOfStrings(obj, "apiGroups", func(apiGroup string) string {
+		if rules.IsRenamedGroup(apiGroup) {
+			restoreResources = true
+			return rules.RestoreApiVersion(apiGroup)
+		}
+		if apiGroup == "*" {
+			restoreResources = true
+		}
+		return apiGroup
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Do not rename resources for unknown group.
+	if !restoreResources {
+		return obj, nil
+	}
+
+	return TransformArrayOfStrings(obj, "resources", func(resourceType string) string {
+		if resourceType == "*" || resourceType == "" {
+			return resourceType
+		}
+		// Get rules for resource by restored resourceType.
+		originalResourceType := rules.RestoreResource(resourceType)
+		_, resRule := rules.GroupResourceRules(originalResourceType)
+		if resRule != nil {
+			// NOTE: subresource not trimmed.
+			return originalResourceType
+		}
+
+		// No rules for resourceType, return as-is
+		return resourceType
+	})
+}

--- a/images/kube-api-proxy/pkg/rewriter/admission_policy.go
+++ b/images/kube-api-proxy/pkg/rewriter/admission_policy.go
@@ -23,37 +23,7 @@ const (
 	ValidatingAdmissionPolicyBindingListKind = "ValidatingAdmissionPolicyBindingList"
 )
 
-func RewriteValidatingAdmissionPolicyOrList(rules *RewriteRules, obj []byte, action Action) ([]byte, error) {
-	if action == Rename {
-		return RewriteResourceOrList(obj, ValidatingAdmissionPolicyListKind, func(singleObj []byte) ([]byte, error) {
-			return RewriteArray(singleObj, "spec.matchConstraints.resourceRules", func(item []byte) ([]byte, error) {
-				return renameResourceRules(rules, item)
-			})
-		})
-	}
-	return RewriteResourceOrList(obj, ValidatingAdmissionPolicyListKind, func(singleObj []byte) ([]byte, error) {
-		return RewriteArray(singleObj, "spec.matchConstraints.resourceRules", func(item []byte) ([]byte, error) {
-			return restoreResourceRules(rules, item)
-		})
-	})
-}
-
-func RewriteValidatingAdmissionPolicyBindingOrList(rules *RewriteRules, obj []byte, action Action) ([]byte, error) {
-	if action == Rename {
-		return RewriteResourceOrList(obj, ValidatingAdmissionPolicyBindingListKind, func(singleObj []byte) ([]byte, error) {
-			return RewriteArray(singleObj, "spec.matchResources.resourceRules", func(item []byte) ([]byte, error) {
-				return renameResourceRules(rules, item)
-			})
-		})
-	}
-	return RewriteResourceOrList(obj, ValidatingAdmissionPolicyBindingListKind, func(singleObj []byte) ([]byte, error) {
-		return RewriteArray(singleObj, "spec.matchResources.resourceRules", func(item []byte) ([]byte, error) {
-			return restoreResourceRules(rules, item)
-		})
-	})
-}
-
-// renameValidatingAdmissionPolicyBinding renames apiGroups and resources in a single resourceRule.
+// renames apiGroups and resources in a single resourceRule.
 // Rule examples:
 //	resourceRules:
 //	- apiGroups:
@@ -66,79 +36,32 @@ func RewriteValidatingAdmissionPolicyBindingOrList(rules *RewriteRules, obj []by
 //      - nodes
 //    scope: '*'
 
-func renameResourceRules(rules *RewriteRules, obj []byte) ([]byte, error) {
-	var err error
-
-	renameResources := false
-	obj, err = TransformArrayOfStrings(obj, "apiGroups", func(apiGroup string) string {
-		if rules.HasGroup(apiGroup) {
-			renameResources = true
-			return rules.RenameApiVersion(apiGroup)
-		}
-		if apiGroup == "*" {
-			renameResources = true
-		}
-		return apiGroup
-	})
-	if err != nil {
-		return nil, err
+func RewriteValidatingAdmissionPolicyOrList(rules *RewriteRules, obj []byte, action Action) ([]byte, error) {
+	if action == Rename {
+		return RewriteResourceOrList(obj, ValidatingAdmissionPolicyListKind, func(singleObj []byte) ([]byte, error) {
+			return RewriteArray(singleObj, "spec.matchConstraints.resourceRules", func(item []byte) ([]byte, error) {
+				return RenameResourceRule(rules, item)
+			})
+		})
 	}
-
-	// Do not rename resources for unknown group.
-	if !renameResources {
-		return obj, nil
-	}
-
-	return TransformArrayOfStrings(obj, "resources", func(resourceType string) string {
-		if resourceType == "*" || resourceType == "" {
-			return resourceType
-		}
-
-		// Rename if there is rule for resourceType.
-		_, resRule := rules.GroupResourceRules(resourceType)
-		if resRule != nil {
-			return rules.RenameResource(resourceType)
-		}
-		return resourceType
+	return RewriteResourceOrList(obj, ValidatingAdmissionPolicyListKind, func(singleObj []byte) ([]byte, error) {
+		return RewriteArray(singleObj, "spec.matchConstraints.resourceRules", func(item []byte) ([]byte, error) {
+			return RestoreResourceRule(rules, item)
+		})
 	})
 }
 
-func restoreResourceRules(rules *RewriteRules, obj []byte) ([]byte, error) {
-	var err error
-
-	restoreResources := false
-	obj, err = TransformArrayOfStrings(obj, "apiGroups", func(apiGroup string) string {
-		if rules.IsRenamedGroup(apiGroup) {
-			restoreResources = true
-			return rules.RestoreApiVersion(apiGroup)
-		}
-		if apiGroup == "*" {
-			restoreResources = true
-		}
-		return apiGroup
-	})
-	if err != nil {
-		return nil, err
+func RewriteValidatingAdmissionPolicyBindingOrList(rules *RewriteRules, obj []byte, action Action) ([]byte, error) {
+	if action == Rename {
+		return RewriteResourceOrList(obj, ValidatingAdmissionPolicyBindingListKind, func(singleObj []byte) ([]byte, error) {
+			return RewriteArray(singleObj, "spec.matchResources.resourceRules", func(item []byte) ([]byte, error) {
+				return RenameResourceRule(rules, item)
+			})
+		})
 	}
-
-	// Do not rename resources for unknown group.
-	if !restoreResources {
-		return obj, nil
-	}
-
-	return TransformArrayOfStrings(obj, "resources", func(resourceType string) string {
-		if resourceType == "*" || resourceType == "" {
-			return resourceType
-		}
-		// Get rules for resource by restored resourceType.
-		originalResourceType := rules.RestoreResource(resourceType)
-		_, resRule := rules.GroupResourceRules(originalResourceType)
-		if resRule != nil {
-			// NOTE: subresource not trimmed.
-			return originalResourceType
-		}
-
-		// No rules for resourceType, return as-is
-		return resourceType
+	return RewriteResourceOrList(obj, ValidatingAdmissionPolicyBindingListKind, func(singleObj []byte) ([]byte, error) {
+		return RewriteArray(singleObj, "spec.matchResources.resourceRules", func(item []byte) ([]byte, error) {
+			return RestoreResourceRule(rules, item)
+		})
 	})
 }

--- a/images/kube-api-proxy/pkg/rewriter/admission_policy.go
+++ b/images/kube-api-proxy/pkg/rewriter/admission_policy.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package rewriter
 
 const (

--- a/images/kube-api-proxy/pkg/rewriter/rbac.go
+++ b/images/kube-api-proxy/pkg/rewriter/rbac.go
@@ -35,13 +35,13 @@ func RewriteClusterRoleOrList(rules *RewriteRules, obj []byte, action Action) ([
 	if action == Rename {
 		return RewriteResourceOrList(obj, ClusterRoleListKind, func(singleObj []byte) ([]byte, error) {
 			return RewriteArray(singleObj, "rules", func(item []byte) ([]byte, error) {
-				return renameRoleRule(rules, item)
+				return RenameResourceRule(rules, item)
 			})
 		})
 	}
 	return RewriteResourceOrList(obj, ClusterRoleListKind, func(singleObj []byte) ([]byte, error) {
 		return RewriteArray(singleObj, "rules", func(item []byte) ([]byte, error) {
-			return restoreRoleRule(rules, item)
+			return RestoreResourceRule(rules, item)
 		})
 	})
 }
@@ -50,18 +50,18 @@ func RewriteRoleOrList(rules *RewriteRules, obj []byte, action Action) ([]byte, 
 	if action == Rename {
 		return RewriteResourceOrList(obj, RoleListKind, func(singleObj []byte) ([]byte, error) {
 			return RewriteArray(singleObj, "rules", func(item []byte) ([]byte, error) {
-				return renameRoleRule(rules, item)
+				return RenameResourceRule(rules, item)
 			})
 		})
 	}
 	return RewriteResourceOrList(obj, RoleListKind, func(singleObj []byte) ([]byte, error) {
 		return RewriteArray(singleObj, "rules", func(item []byte) ([]byte, error) {
-			return restoreRoleRule(rules, item)
+			return RestoreResourceRule(rules, item)
 		})
 	})
 }
 
-// renameRoleRule renames apiGroups and resources in a single rule.
+// RenameResourceRule renames apiGroups and resources in a single rule.
 // Rule examples:
 //   - apiGroups:
 //   - original.group.io
@@ -80,7 +80,7 @@ func RewriteRoleOrList(rules *RewriteRules, obj []byte, action Action) ([]byte, 
 //   - watch
 //   - list
 //   - create
-func renameRoleRule(rules *RewriteRules, obj []byte) ([]byte, error) {
+func RenameResourceRule(rules *RewriteRules, obj []byte) ([]byte, error) {
 	var err error
 
 	renameResources := false
@@ -117,8 +117,8 @@ func renameRoleRule(rules *RewriteRules, obj []byte) ([]byte, error) {
 	})
 }
 
-// restoreRoleRule restores apiGroups and resources in a single rule.
-func restoreRoleRule(rules *RewriteRules, obj []byte) ([]byte, error) {
+// RestoreResourceRule restores apiGroups and resources in a single rule.
+func RestoreResourceRule(rules *RewriteRules, obj []byte) ([]byte, error) {
 	var err error
 
 	restoreResources := false

--- a/images/kube-api-proxy/pkg/rewriter/rule_rewriter.go
+++ b/images/kube-api-proxy/pkg/rewriter/rule_rewriter.go
@@ -290,6 +290,10 @@ func (rw *RuleBasedRewriter) RewriteJSONPayload(_ *TargetRequest, obj []byte, ac
 	case ServiceMonitorKind, ServiceMonitorListKind:
 		rwrBytes, err = RewriteServiceMonitorOrList(rw.Rules, obj, action)
 
+	case ValidatingAdmissionPolicyBindingKind, ValidatingAdmissionPolicyBindingListKind:
+		rwrBytes, err = RewriteValidatingAdmissionPolicyBindingOrList(rw.Rules, obj, action)
+	case ValidatingAdmissionPolicyKind, ValidatingAdmissionPolicyListKind:
+		rwrBytes, err = RewriteValidatingAdmissionPolicyOrList(rw.Rules, obj, action)
 	default:
 		// TODO Add rw.Rules.IsKnownKind() to rewrite only known kinds.
 		rwrBytes, err = RewriteCustomResourceOrList(rw.Rules, obj, action)

--- a/images/kube-api-proxy/pkg/rewriter/rule_rewriter_test.go
+++ b/images/kube-api-proxy/pkg/rewriter/rule_rewriter_test.go
@@ -216,6 +216,12 @@ func TestRewriteAPIEndpoint(t *testing.T) {
 			"/apis/apps/v1/deployments",
 			"labelSelector=replacedlabelgroup.io+notin+%28renamedLabelValue%2Cvalue-one%29&limit=500",
 		},
+		{
+			"labelSelector label name and renamed values for validating admission policy binding",
+			"/apis/admissionregistration.k8s.io/v1/validatingadmissionpolicybindings?labelSelector=labelgroup.io+notin+%28value-one%2ClabelValueToRename%29&limit=500",
+			"/apis/admissionregistration.k8s.io/v1/validatingadmissionpolicybindings",
+			"labelSelector=replacedlabelgroup.io+notin+%28renamedLabelValue%2Cvalue-one%29&limit=500",
+		},
 	}
 
 	for _, tt := range tests {

--- a/images/kube-api-proxy/pkg/rewriter/target_request.go
+++ b/images/kube-api-proxy/pkg/rewriter/target_request.go
@@ -295,7 +295,9 @@ func shouldRewriteResource(resourceType string) bool {
 		"servicemonitors",
 		"poddisruptionbudgets",
 		"controllerrevisions",
-		"apiservices":
+		"apiservices",
+		"validatingadmissionpolicybindings",
+		"validatingadmissionpolicies":
 		return true
 	}
 


### PR DESCRIPTION
## Description

- Fix array construction for discovery rewrite in v1.30.
- Add rewriting for ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding.

## Why do we need it, and what problem does it solve?

Make kube-api-rewriter compatible with Kubernetes 1.29+
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?

Module works in Kubernetes 1.29+
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
