### PR TITLE
feat(vm): notify user if the virtual machine cannot be restarted immediately

### DIFF
--- a/api/core/v1alpha2/events.go
+++ b/api/core/v1alpha2/events.go
@@ -17,42 +17,6 @@ limitations under the License.
 package v1alpha2
 
 const (
-	// ReasonErrUnknownState is event reason that VMI has unexpected state
-	ReasonErrUnknownState = "UnknownState"
-
-	// ReasonErrWrongPVCSize is event reason that PVC has wrong size
-	ReasonErrWrongPVCSize = "WrongPVCSize"
-
-	// ReasonErrImportFailed is event reason that importer/uploader Pod is failed
-	ReasonErrImportFailed = "ImportFailed"
-
-	// ReasonErrGetProgressFailed is event reason about the failure of getting progress.
-	ReasonErrGetProgressFailed = "GetProgressFailed"
-
-	// ReasonIpAddressNotAvailable is event reason that VM cannot use defined ip address.
-	ReasonIpAddressNotAvailable = "IpAddressNotAvailable"
-
-	// ReasonIpAddressNotAssigned is event reason that Ip address is not assigned in the guest VM.
-	ReasonIpAddressNotAssigned = "IpAddressNotAssigned"
-
-	// ReasonCPUModelNotFound is event reason that defined cpu model not found.
-	ReasonCPUModelNotFound = "CPUModelNotFound"
-
-	// ReasonImportSucceeded is event reason that the import is successfully completed
-	ReasonImportSucceeded = "ImportSucceeded"
-
-	// ReasonImportSucceededToPVC is event reason that the import is successfully completed to PVC
-	ReasonImportSucceededToPVC = "ImportSucceededToPVC"
-
-	// ReasonHotplugPostponed is event reason that disk hotplug is not possible at the moment.
-	ReasonHotplugPostponed = "HotplugPostponed"
-
-	// ReasonVMWaitForBlockDevices is event reason that block devices used by VM are not ready yet.
-	ReasonVMWaitForBlockDevices = "WaitForBlockDevices"
-
-	// ReasonUnknownHotPluggedVolume is event reason that volume was hot plugged to VirtualMachineInstance, but it is not a VirtualDisk.
-	ReasonUnknownHotPluggedVolume = "UnknownHotPluggedVolume"
-
 	// ReasonVDAlreadyInUse is event reason that VirtualDisk was not attached to VirtualMachine, because VirtualDisk attached to another VirtualMachine.
 	ReasonVDAlreadyInUse = "VirtualDiskAlreadyInUse"
 	// ReasonVMChangesApplied is event reason that changes applied from VM to underlying KVVM.
@@ -64,14 +28,14 @@ const (
 	// ReasonVMLastAppliedSpecInvalid is event reason that JSON in last-applied-spec annotation is invalid.
 	ReasonVMLastAppliedSpecInvalid = "VMLastAppliedSpecInvalid"
 
-	// ReasonErrUploaderWaitDurationExpired is event reason that uploading time expired.
-	ReasonErrUploaderWaitDurationExpired = "UploaderWaitDurationExpired"
-
 	// ReasonErrVmNotSynced is event reason that vm is not synced.
 	ReasonErrVmNotSynced = "VirtualMachineNotSynced"
 
-	// ReasonErrVMOPNotPermitted is event reason that vmop is not permitted.
-	ReasonErrVMOPNotPermitted = "VirtualMachineOperationNotPermitted"
+	// ReasonErrVmSynced is event reason that vm is synced.
+	ReasonErrVmSynced = "VirtualMachineSynced"
+
+	// ReasonErrRestartAwaitingChanges is event reason indicating that the vm has pending changes requiring a restart.
+	ReasonErrRestartAwaitingChanges = "RestartAwaitingChanges"
 
 	// ReasonErrVMOPFailed is event reason that operation is failed
 	ReasonErrVMOPFailed = "VirtualMachineOperationFailed"

--- a/api/core/v1alpha2/vmcondition/condition.go
+++ b/api/core/v1alpha2/vmcondition/condition.go
@@ -66,11 +66,11 @@ const (
 	ReasonProvisioningReady    Reason = "ProvisioningReady"
 	ReasonProvisioningNotReady Reason = "ProvisioningNotReady"
 
-	ReasonConfigurationApplied           Reason = "ConfigurationApplied"
-	ReasonConfigurationNotApplied        Reason = "ConfigurationNotApplied"
-	ReasonRestartAwaitingChangesExist    Reason = "RestartAwaitingChangesExist"
-	ReasonRestartAwaitingChangesNotExist Reason = "RestartAwaitingChangesNotExist"
-	ReasonRestartNoNeed                  Reason = "NoNeedRestart"
+	ReasonConfigurationApplied    Reason = "ConfigurationApplied"
+	ReasonConfigurationNotApplied Reason = "ConfigurationNotApplied"
+
+	ReasonRestartAwaitingChangesExist Reason = "RestartAwaitingChangesExist"
+	ReasonRestartNoNeed               Reason = "NoNeedRestart"
 
 	ReasonPodStarted    Reason = "PodStarted"
 	ReasonPodNotFound   Reason = "PodNotFound"

--- a/images/dvcr-artifact/pkg/retry/retry.go
+++ b/images/dvcr-artifact/pkg/retry/retry.go
@@ -36,10 +36,10 @@ func Retry(ctx context.Context, f Fn) error {
 	return ExponentialBackoff(ctx, f, defaultBackoff)
 }
 
-// Sleep for 1 then 3 seconds. This should cover networking blips.
+// Sleep for 3^0 then 3^1, 3^2 , ..., 3^7 seconds. This should cover networking blips.
 var defaultBackoff = Backoff{
 	Duration: time.Second,
 	Factor:   3.0,
 	Jitter:   0.1,
-	Steps:    3,
+	Steps:    9,
 }


### PR DESCRIPTION
## Description

1. Refactored SyncKvvmHandler.
2. Added a warning that restarting the virtual machine can be dangerous, as not all dependencies may be ready yet.
3. Fixed the bug with outdated changes in .status.restartAwaitingChanges.
4. Improved error messages for the user.
5. Removed the use of the deprecated conditions.Manager.
6. Retry in importer pod now lasts not for 3 seconds, but for [about 1 minute](https://github.com/deckhouse/virtualization/pull/477/files#diff-7cbd42bcec757d74b1b2159d6a27f8504fbc982f21b77d580adc1ac56ec99b94L39).

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
