### PR TITLE
feat(core, kubevirt): disable kubevirt exportproxy 

### DIFF
--- a/templates/kubevirt/kubevirt.yaml
+++ b/templates/kubevirt/kubevirt.yaml
@@ -29,14 +29,12 @@ spec:
     evictionStrategy: LiveMigrate
     developerConfiguration:
       featureGates:
-      - Macvtap
       - HotplugVolumes
       - GPU
       - Snapshot
       - ExpandDisks
       - Root
       - VMLiveUpdateFeatures
-      - VMExport
       - CPUManager
       - Sidecar
       - VolumeSnapshotDataSource
@@ -66,10 +64,6 @@ spec:
     - resourceType: DaemonSet
       resourceName: virt-handler
       patch: '[{"op":"replace","path":"/spec/template/spec/tolerations","value":{{ $tolerationsAnyNode }}}]'
-      type: json
-    - resourceType: Deployment
-      resourceName: virt-exportproxy
-      patch: '[{"op":"replace","path":"/spec/replicas","value":0}]'
       type: json
     {{- if (include "helm_lib_ha_enabled" .) }}
     - resourceType: Deployment
@@ -102,11 +96,6 @@ spec:
     - resourceName: virt-handler
       resourceType: DaemonSet
       patch: {{ include "kube_api_rewriter.pod_spec_strategic_patch_json" (list . "virt-handler") }}
-      type: strategic
-
-    - resourceName: virt-exportproxy
-      resourceType: Deployment
-      patch: {{ include "kube_api_rewriter.pod_spec_strategic_patch_json" (list . "exportproxy") }}
       type: strategic
 
     # Add rewriter proxy container port to Services used by webhook configurations.
@@ -197,10 +186,6 @@ spec:
       type: strategic
     - resourceType: Deployment
       resourceName: virt-controller
-      patch: {{ include "pod_spec_priotity_class_name_patch" $priorityClassName }}
-      type: strategic
-    - resourceType: Deployment
-      resourceName: virt-exportproxy
       patch: {{ include "pod_spec_priotity_class_name_patch" $priorityClassName }}
       type: strategic
     - resourceType: DaemonSet


### PR DESCRIPTION
## Description

Remove FeatureGate VMExport from kubevirt config.
Remove patches related to exportproxy.

## Why do we need it, and what problem does it solve?

We scaled exportproxy to 0 replicas with patches to disabled unneeded component. Without VMExport feature virt-operator doesn't create Deployment at all.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
