### PR TITLE
test(api): add force interrupting flag to perfomance test tool

### DIFF
--- a/tests/performance/shatal/README.md
+++ b/tests/performance/shatal/README.md
@@ -36,6 +36,8 @@ count: 100
 # The flag to show debug level logs. 
 # Corresponds to the DEBUG environment variable.
 debug: true
+# The flag to enable force interrupting mode
+forceInterruption: false
 drainer:
   # The flag to enable node draining.
   # Corresponds to the DRAINER_ENABLED environment variable.

--- a/tests/performance/shatal/config.yaml
+++ b/tests/performance/shatal/config.yaml
@@ -4,6 +4,7 @@ namespace: "default"
 interval: "5s"
 count: 100
 debug: true
+forceInterruption: false
 drainer:
   enabled: true
   interval: "10s"

--- a/tests/performance/shatal/internal/config/config.go
+++ b/tests/performance/shatal/internal/config/config.go
@@ -23,17 +23,18 @@ import (
 )
 
 type Config struct {
-	Kubeconfig      string          `yaml:"kubeconfigBase64" env:"KUBECONFIG_BASE64" env-required:""`
-	ResourcesPrefix string          `yaml:"resourcesPrefix" env:"RESOURCES_PREFIX" env-default:"performance"`
-	Namespace       string          `yaml:"namespace" env:"NAMESPACE" env-default:"default"`
-	Interval        time.Duration   `yaml:"interval" env:"INTERVAL" env-default:"5s"`
-	Count           int             `yaml:"count" env:"COUNT"`
-	Debug           bool            `yaml:"debug" env:"DEBUG" env-default:"false"`
-	Drainer         DrainerFeature  `yaml:"drainer"`
-	Creator         CreatorFeature  `yaml:"creator"`
-	Deleter         DeleterFeature  `yaml:"deleter"`
-	Modifier        ModifierFeature `yaml:"modifier"`
-	Nothing         NothingFeature  `yaml:"nothing"`
+	Kubeconfig        string          `yaml:"kubeconfigBase64" env:"KUBECONFIG_BASE64" env-required:""`
+	ResourcesPrefix   string          `yaml:"resourcesPrefix" env:"RESOURCES_PREFIX" env-default:"performance"`
+	Namespace         string          `yaml:"namespace" env:"NAMESPACE" env-default:"default"`
+	Interval          time.Duration   `yaml:"interval" env:"INTERVAL" env-default:"5s"`
+	Count             int             `yaml:"count" env:"COUNT"`
+	Debug             bool            `yaml:"debug" env:"DEBUG" env-default:"false"`
+	Drainer           DrainerFeature  `yaml:"drainer"`
+	Creator           CreatorFeature  `yaml:"creator"`
+	Deleter           DeleterFeature  `yaml:"deleter"`
+	Modifier          ModifierFeature `yaml:"modifier"`
+	Nothing           NothingFeature  `yaml:"nothing"`
+	ForceInterruption bool            `yaml:"forceInterruption"`
 }
 
 type DrainerFeature struct {


### PR DESCRIPTION
## Description
Add force interrupting flag to config of perfomance test toll `Shatal`.

## Why do we need it, and what problem does it solve?

## What is the expected result?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
