### PR TITLE
fix(vi): hide dvcr url in pvc stored vi

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/upload.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/upload.go
@@ -160,7 +160,6 @@ func (ds UploadDataSource) StoreToPVC(ctx context.Context, vi *virtv2.VirtualIma
 				condition.Reason = vicondition.WaitForUserUpload
 				condition.Message = "Waiting for the user upload."
 
-				vi.Status.Target.RegistryURL = ds.statService.GetDVCRImageName(pod)
 				vi.Status.ImageUploadURLs = &virtv2.ImageUploadURLs{
 					External:  ds.uploaderService.GetExternalURL(ctx, ing),
 					InCluster: ds.uploaderService.GetInClusterURL(ctx, svc),


### PR DESCRIPTION
## Description
Do not show DVCR URL in PVC stored VirtualImage in status.

## Why do we need it, and what problem does it solve?
We don't need to see intermediate DVCR URL in PVC stored VirtualImage.

## What is the expected result?
Correct status of VirtualImage.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
