### PR TITLE
refactor(core): add replace expressions for validating admission policy patch

### DIFF
--- a/images/virt-artifact/patches/023-replace-expressions-for-validating-admission-policy.patch
+++ b/images/virt-artifact/patches/023-replace-expressions-for-validating-admission-policy.patch
@@ -1,0 +1,36 @@
+diff --git a/pkg/virt-operator/resource/generate/components/validatingadmissionpolicy.go b/pkg/virt-operator/resource/generate/components/validatingadmissionpolicy.go
+index 5fefec2304..20914e8bf6 100644
+--- a/pkg/virt-operator/resource/generate/components/validatingadmissionpolicy.go
++++ b/pkg/virt-operator/resource/generate/components/validatingadmissionpolicy.go
+@@ -117,7 +117,7 @@ func NewHandlerV1ValidatingAdmissionPolicy(virtHandlerServiceAccount string) *ad
+ 			Variables: []admissionregistrationv1.Variable{
+ 				{
+ 					Name:       "oldNonKubevirtLabels",
+-					Expression: `oldObject.metadata.labels.filter(k, !k.contains("kubevirt.io") && k != "cpumanager")`,
++					Expression: `oldObject.metadata.labels.filter(k, !k.contains("kubevirt") && k != "cpumanager")`,
+ 				},
+ 				{
+ 					Name:       "oldLabels",
+@@ -125,7 +125,7 @@ func NewHandlerV1ValidatingAdmissionPolicy(virtHandlerServiceAccount string) *ad
+ 				},
+ 				{
+ 					Name:       "newNonKubevirtLabels",
+-					Expression: `object.metadata.labels.filter(k, !k.contains("kubevirt.io") && k != "cpumanager")`,
++					Expression: `object.metadata.labels.filter(k, !k.contains("kubevirt") && k != "cpumanager")`,
+ 				},
+ 				{
+ 					Name:       "newLabels",
+@@ -133,11 +133,11 @@ func NewHandlerV1ValidatingAdmissionPolicy(virtHandlerServiceAccount string) *ad
+ 				},
+ 				{
+ 					Name:       "oldNonKubevirtAnnotations",
+-					Expression: `oldObject.metadata.annotations.filter(k, !k.contains("kubevirt.io"))`,
++					Expression: `oldObject.metadata.annotations.filter(k, !k.contains("kubevirt"))`,
+ 				},
+ 				{
+ 					Name:       "newNonKubevirtAnnotations",
+-					Expression: `object.metadata.annotations.filter(k, !k.contains("kubevirt.io"))`,
++					Expression: `object.metadata.annotations.filter(k, !k.contains("kubevirt"))`,
+ 				},
+ 				{
+ 					Name:       "oldAnnotations",

--- a/images/virt-artifact/patches/README.md
+++ b/images/virt-artifact/patches/README.md
@@ -78,3 +78,8 @@ Cleanup stale Pods owned by the VMI, keep only last 3 in the Failed phase.
 Why we need it?
 
 Unsuccessful migrations may leave a lot of Pods. These huge lists reduce performance on virtualization-controller and cdi-deployment restarts.
+
+#### `023-replace-expressions-for-validating-admission-policy.patch`
+
+Replace the expressions for the ValidatingAdmissionPolicy kubevirt-node-restriction-policy.
+This is necessary because of the kube-api-rewriter that changes the labels.


### PR DESCRIPTION
## Description
add replace expressions for validating admission policy patch
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Replace the expressions for the ValidatingAdmissionPolicy kubevirt-node-restriction-policy.
This is necessary because of the kube-api-rewriter that changes the labels.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
