### PR TITLE
chore(module): fix doc-ru linter output

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -103,7 +103,7 @@ tasks:
         docker run \
           --rm -it -v "$PWD:/src" docker.io/fl64/d8-doc-ru-linter:v0.0.1-dev0 \
           sh -c \
-            'for crd in /src/crds/*.yaml; do [[ "$(basename "$crd")" =~ ^doc-ru ]] || /d8-doc-ru-linter -s "$crd" -d "/src/crds/doc-ru-$(basename "$crd")" -n /dev/null; done'
+            'for crd in /src/crds/*.yaml; do [[ "$(basename "$crd")" =~ ^doc-ru ]] || (echo ${crd}; /d8-doc-ru-linter -s "$crd" -d "/src/crds/doc-ru-$(basename "$crd")" -n /dev/null); done'
 
   lint:prettier:yaml:
     desc: "Check if yaml files are prettier-formatted."


### PR DESCRIPTION
## Description
Fix output for doc-ru linter

## Why do we need it, and what problem does it solve?
We need to know the name of file with changes

## What is the expected result?
```
/src/crds/clustervirtualimages.yaml # <---
{"count":1,"operations":[{"path":"/spec/versions/v1alpha2/schema/openAPIV3Schema/properties/spec/properties/dataSource/properties/http/properties/insecureSkipVerify","op":"delete"}]}
/src/crds/virtualdisks.yaml # <---
{"count":0,"operations":[]}
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
