### PR TITLE
refactor(kube-api-rewriter): add rewriter for Event resources

### DIFF
--- a/images/kube-api-rewriter/pkg/rewriter/events.go
+++ b/images/kube-api-rewriter/pkg/rewriter/events.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rewriter
+
+const (
+	EventKind     = "Event"
+	EventListKind = "EventList"
+)
+
+// RewriteEventOrList rewrites a single Event resource or a list of Events in EventList.
+// The only field need to rewrite is involvedObject:
+//
+//	 {
+//	  "metadata": { "name": "...", "namespace": "...", "managedFields": [...] },
+//	  "involvedObject": {
+//	    "kind": "SomeResource",
+//	    "namespace": "name",
+//	    "name": "ns",
+//	    "uid": "a260fe4f-103a-41c6-996c-d29edb01fbbd",
+//	    "apiVersion": "group.io/v1"
+//	  },
+//	  "type": "...",
+//	  "reason": "...",
+//	  "message": "...",
+//	  "source": {
+//	    "component": "...",
+//	    "host": "..."
+//	  },
+//	  "reportingComponent": "...",
+//	  "reportingInstance": "..."
+//	},
+func RewriteEventOrList(rules *RewriteRules, obj []byte, action Action) ([]byte, error) {
+	return RewriteResourceOrList(obj, EventListKind, func(singleObj []byte) ([]byte, error) {
+		return TransformObject(singleObj, "involvedObject", func(involvedObj []byte) ([]byte, error) {
+			return RewriteAPIVersionAndKind(rules, involvedObj, action)
+		})
+	})
+}

--- a/images/kube-api-rewriter/pkg/rewriter/events_test.go
+++ b/images/kube-api-rewriter/pkg/rewriter/events_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rewriter
+
+import (
+	"bufio"
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestRewriteEvent(t *testing.T) {
+	eventReq := `POST /api/v1/namespaces/vm/events HTTP/1.1
+Host: 127.0.0.1
+
+`
+	eventPayload := `{
+  "kind": "Event",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "some-event-name",
+    "namespace": "vm",
+  },
+  "involvedObject": {
+    "kind": "SomeResource",
+    "namespace": "vm",
+    "name": "some-vm-name",
+    "uid": "ad9f7357-f6b0-4679-8571-042c75ec53fb",
+    "apiVersion": "original.group.io/v1"
+  },
+  "reason": "EventReason",
+  "message": "Event message for some-vm-name",
+  "source": {
+    "component": "some-component",
+    "host": "some-node"
+  },
+  "count": 1000,
+  "type": "Warning",
+  "eventTime": null,
+  "reportingComponent": "some-component",
+  "reportingInstance": "some-node"
+}`
+
+	req, err := http.ReadRequest(bufio.NewReader(bytes.NewBufferString(eventReq + eventPayload)))
+	require.NoError(t, err, "should parse hardcoded http request")
+	require.NotNil(t, req.URL, "should parse url in hardcoded http request")
+
+	rwr := createTestRewriterForCore()
+	targetReq := NewTargetRequest(rwr, req)
+	require.NotNil(t, targetReq, "should get TargetRequest")
+	require.True(t, targetReq.ShouldRewriteRequest(), "should rewrite request")
+	require.True(t, targetReq.ShouldRewriteResponse(), "should rewrite response")
+	// require.Equal(t, origGroup, targetReq.OrigGroup(), "should set proper orig group")
+
+	resultBytes, err := rwr.RewriteJSONPayload(targetReq, []byte(eventPayload), Rename)
+	if err != nil {
+		t.Fatalf("should rename Error without error: %v", err)
+	}
+	if resultBytes == nil {
+		t.Fatalf("should rename Error: %v", err)
+	}
+
+	tests := []struct {
+		path     string
+		expected string
+	}{
+		{`involvedObject.kind`, "PrefixedSomeResource"},
+		{`involvedObject.apiVersion`, "prefixed.resources.group.io/v1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			actual := gjson.GetBytes(resultBytes, tt.path).String()
+			if actual != tt.expected {
+				t.Fatalf("%s value should be %s, got %s", tt.path, tt.expected, actual)
+			}
+		})
+	}
+
+	// Restore.
+	resultBytes, err = rwr.RewriteJSONPayload(targetReq, []byte(eventPayload), Restore)
+	if err != nil {
+		t.Fatalf("should restore PVC without error: %v", err)
+	}
+	if resultBytes == nil {
+		t.Fatalf("should restore PVC: %v", err)
+	}
+
+	tests = []struct {
+		path     string
+		expected string
+	}{
+		{`involvedObject.kind`, "SomeResource"},
+		{`involvedObject.apiVersion`, "original.group.io/v1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			actual := gjson.GetBytes(resultBytes, tt.path).String()
+			if actual != tt.expected {
+				t.Fatalf("%s value should be %s, got %s", tt.path, tt.expected, actual)
+			}
+		})
+	}
+
+}

--- a/images/kube-api-rewriter/pkg/rewriter/rbac_test.go
+++ b/images/kube-api-rewriter/pkg/rewriter/rbac_test.go
@@ -94,7 +94,7 @@ func TestRenameRoleRule(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resBytes, err := renameRoleRule(rwr.Rules, []byte(tt.rule))
+			resBytes, err := RenameResourceRule(rwr.Rules, []byte(tt.rule))
 			require.NoError(t, err, "should rename rule")
 
 			actual := string(resBytes)
@@ -174,7 +174,7 @@ func TestRestoreRoleRule(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resBytes, err := restoreRoleRule(rwr.Rules, []byte(tt.rule))
+			resBytes, err := RestoreResourceRule(rwr.Rules, []byte(tt.rule))
 			require.NoError(t, err, "should rename rule")
 
 			actual := string(resBytes)

--- a/images/kube-api-rewriter/pkg/rewriter/rule_rewriter.go
+++ b/images/kube-api-rewriter/pkg/rewriter/rule_rewriter.go
@@ -265,6 +265,9 @@ func (rw *RuleBasedRewriter) RewriteJSONPayload(_ *TargetRequest, obj []byte, ac
 		ValidatingWebhookConfigurationListKind:
 		rwrBytes, err = RewriteValidatingOrList(rw.Rules, obj, action)
 
+	case EventKind, EventListKind:
+		rwrBytes, err = RewriteEventOrList(rw.Rules, obj, action)
+
 	case ClusterRoleKind, ClusterRoleListKind:
 		rwrBytes, err = RewriteClusterRoleOrList(rw.Rules, obj, action)
 

--- a/images/kube-api-rewriter/pkg/rewriter/target_request.go
+++ b/images/kube-api-rewriter/pkg/rewriter/target_request.go
@@ -297,7 +297,8 @@ func shouldRewriteResource(resourceType string) bool {
 		"controllerrevisions",
 		"apiservices",
 		"validatingadmissionpolicybindings",
-		"validatingadmissionpolicies":
+		"validatingadmissionpolicies",
+		"events":
 		return true
 	}
 


### PR DESCRIPTION
## Description

- Add rewriter for Event resources
- Combine similar rewriters RewriteApiGroupAndKind and RewriteApiVersionAndKind into RewriteGVK with group version field argument.
- Fix rbac_test after renames in #475

## Why do we need it, and what problem does it solve?

- Stop confusing API consumers.
- Make `kubectl describe intvirtvmi/name` to display events.

## What is the expected result?

Before:

```
$ kubectl -n ns describe intvirtvmi/vm-name
...
Events:             <none>
```

After:
```
$ kubectl -n ns describe intvirtvmi/vm-name
...

  Type    Reason            Age   From                         Message
  ----    ------            ----  ----                         -------
  Normal  SuccessfulCreate  25m   disruptionbudget-controller  Created PodDisruptionBudget kubevirt-internal-virtualization-disruption-budget-76t76
  Normal  SuccessfulCreate  25m   virtualmachine-controller    Created virtual machine pod virt-launcher-vm-name-nf6vz
  Normal  Created           25m   virt-handler                 VirtualMachineInstance defined.
  Normal  Started           25m   virt-handler                 VirtualMachineInstance started.

```

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
