### PR TITLE
feat(vi-vd): get newest default StorageClass

### DIFF
--- a/images/virtualization-artifact/pkg/controller/service/disk_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/disk_service.go
@@ -26,7 +26,6 @@ import (
 	"strconv"
 	"strings"
 
-	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 	vsv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
 	storev1 "k8s.io/api/storage/v1"
@@ -45,6 +44,7 @@ import (
 	"github.com/deckhouse/virtualization-controller/pkg/dvcr"
 	"github.com/deckhouse/virtualization-controller/pkg/sdk/framework/helper"
 	"github.com/deckhouse/virtualization-controller/pkg/util"
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
 type DiskService struct {

--- a/images/virtualization-artifact/pkg/controller/service/disk_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/disk_service.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 	vsv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
 	storev1 "k8s.io/api/storage/v1"
@@ -44,7 +45,6 @@ import (
 	"github.com/deckhouse/virtualization-controller/pkg/dvcr"
 	"github.com/deckhouse/virtualization-controller/pkg/sdk/framework/helper"
 	"github.com/deckhouse/virtualization-controller/pkg/util"
-	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
 type DiskService struct {
@@ -511,9 +511,9 @@ func (s DiskService) getDefaultStorageClass(ctx context.Context) (*storev1.Stora
 	}
 
 	var defaultClasses []*storev1.StorageClass
-	for _, sc := range scs.Items {
-		if sc.Annotations[common.AnnDefaultStorageClass] == "true" {
-			defaultClasses = append(defaultClasses, &sc)
+	for idx := range scs.Items {
+		if scs.Items[idx].Annotations[common.AnnDefaultStorageClass] == "true" {
+			defaultClasses = append(defaultClasses, &scs.Items[idx])
 		}
 	}
 

--- a/images/virtualization-artifact/pkg/controller/service/disk_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/disk_service.go
@@ -510,10 +510,10 @@ func (s DiskService) getDefaultStorageClass(ctx context.Context) (*storev1.Stora
 		return nil, err
 	}
 
-	defaultClasses := []storev1.StorageClass{}
+	var defaultClasses []*storev1.StorageClass
 	for _, sc := range scs.Items {
 		if sc.Annotations[common.AnnDefaultStorageClass] == "true" {
-			defaultClasses = append(defaultClasses, sc)
+			defaultClasses = append(defaultClasses, &sc)
 		}
 	}
 
@@ -530,7 +530,7 @@ func (s DiskService) getDefaultStorageClass(ctx context.Context) (*storev1.Stora
 		return defaultClasses[i].CreationTimestamp.UnixNano() > defaultClasses[j].CreationTimestamp.UnixNano()
 	})
 
-	return nil, ErrDefaultStorageClassNotFound
+	return defaultClasses[0], nil
 }
 
 func (s DiskService) getStorageClass(ctx context.Context, storageClassName string) (*storev1.StorageClass, error) {

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -253,9 +253,9 @@ func GetDefaultStorageClass() (*storagev1.StorageClass, error) {
 	}
 
 	var defaultClasses []*storagev1.StorageClass
-	for _, sc := range scList.Items {
-		if sc.Annotations["storageclass.kubernetes.io/is-default-class"] == "true" {
-			defaultClasses = append(defaultClasses, &sc)
+	for idx := range scList.Items {
+		if scList.Items[idx].Annotations["storageclass.kubernetes.io/is-default-class"] == "true" {
+			defaultClasses = append(defaultClasses, &scList.Items[idx])
 		}
 	}
 

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -252,11 +252,10 @@ func GetDefaultStorageClass() (*storagev1.StorageClass, error) {
 		return nil, err
 	}
 
-	defaultClasses := []storagev1.StorageClass{}
+	var defaultClasses []*storagev1.StorageClass
 	for _, sc := range scList.Items {
-		isDefault, ok := sc.Annotations["storageclass.kubernetes.io/is-default-class"]
-		if ok && isDefault == "true" {
-			defaultClasses = append(defaultClasses, sc)
+		if sc.Annotations["storageclass.kubernetes.io/is-default-class"] == "true" {
+			defaultClasses = append(defaultClasses, &sc)
 		}
 	}
 
@@ -273,7 +272,7 @@ func GetDefaultStorageClass() (*storagev1.StorageClass, error) {
 		return defaultClasses[i].CreationTimestamp.UnixNano() > defaultClasses[j].CreationTimestamp.UnixNano()
 	})
 
-	return nil, fmt.Errorf("Default StorageClass not found in the cluster: please set a default StorageClass.")
+	return defaultClasses[0], nil
 }
 
 func toIPNet(prefix netip.Prefix) *net.IPNet {


### PR DESCRIPTION
## Description
Align the method for getting the default StorageClass with how the default StorageClass is defined in k8s

## Why do we need it, and what problem does it solve?
Currently if there are multiple default StorageClasses, we take the random one, the behavior in k8s is different, the last annotated default StorageClass is taken

## What is the expected result?
Take the last annotated default StorageClass


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
