### PR TITLE
chore(crds): fix backup.deckhouse.io/cluster-config label

### DIFF
--- a/api/core/v1alpha2/virtual_machine_class.go
+++ b/api/core/v1alpha2/virtual_machine_class.go
@@ -33,7 +33,7 @@ const (
 // A resource cannot be deleted as long as it is used in one of the VMs.
 //
 // +kubebuilder:object:root=true
-// +kubebuilder:metadata:labels={heritage=deckhouse,module=virtualization,backup.deckhouse.io/cluster-config=}
+// +kubebuilder:metadata:labels={heritage=deckhouse,module=virtualization,backup.deckhouse.io/cluster-config=true}
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:categories={virtualization},scope=Cluster,shortName={vmc,vmcs,vmclass,vmclasses},singular=virtualmachineclass
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="VirtualMachineClass phase."

--- a/api/scripts/update-codegen.sh
+++ b/api/scripts/update-codegen.sh
@@ -93,7 +93,7 @@ function generate::crds() {
               if ! [[ " ${ALLOWED_RESOURCE_GEN_CRD[*]} " =~ [[:space:]]$(cat "$file" | yq '.spec.names.kind')[[:space:]] ]]; then
                 continue
               fi
-              cp "$file" "./crds/${file/#"$OUTPUT_BASE/$PREFIX_GROUP"/}"
+              cp "$file" "./crds/$(echo $file | awk -Fio_ '{print $2}')"
           done
 }
 

--- a/crds/clustervirtualimages.yaml
+++ b/crds/clustervirtualimages.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     heritage: deckhouse
     module: virtualization
-    backup.deckhouse.io/cluster-config: ""
+    backup.deckhouse.io/cluster-config: "true"
 spec:
   group: virtualization.deckhouse.io
   scope: Cluster

--- a/crds/virtualmachineclasses.yaml
+++ b/crds/virtualmachineclasses.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
   labels:
-    backup.deckhouse.io/cluster-config: ""
+    backup.deckhouse.io/cluster-config: "true"
     heritage: deckhouse
     module: virtualization
   name: virtualmachineclasses.virtualization.deckhouse.io


### PR DESCRIPTION

## Description
Change backup label from `backup.deckhouse.io/cluster-config=""` to `backup.deckhouse.io/cluster-config="true"` in virtualmachineclass, clustervirtualimage.

## Why do we need it, and what problem does it solve?
Usually, the logic of processing such resources is based on the `"true"` value, not empty string.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
