### PR TITLE
chore(dev): run dlv build task on m1 mac

### DIFF
--- a/images/virtualization-artifact/hack/dlv.sh
+++ b/images/virtualization-artifact/hack/dlv.sh
@@ -52,7 +52,7 @@ function build_apiserver {
 function build {
     local dockerfile=$1
     cd "$ROOT"
-    docker build -f "./images/virtualization-artifact/hack/$dockerfile" -t "${IMAGE}" .
+    docker build -f "./images/virtualization-artifact/hack/$dockerfile" -t "${IMAGE}" --platform=linux/x86_64 .
 }
 
 function push {


### PR DESCRIPTION
## Description
Running the task ```dlv:build-push`` doesn't work on macs with Apple processor

## Why do we need it, and what problem does it solve?
Running the ``dlv:build-push`` task on macs with Apple processor does not work due to running docker build with the default platform

## What is the expected result?
Running the ``dlv:build-push`` task with specified linux/x86_64 platform

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
