### PR TITLE
feat(cvi): namespace validation for vi/vd ObjectRef

### DIFF
--- a/crds/clustervirtualimages.yaml
+++ b/crds/clustervirtualimages.yaml
@@ -158,7 +158,7 @@ spec:
                         - rule: "self.kind == 'VirtualImage' || self.kind == 'VirtualDisk' ? has(self.__namespace__) : true"
                           message: The namespace is required for VirtualDisk and VirtualImage
                         - rule: "self.kind == 'VirtualImage' || self.kind == 'VirtualDisk' ? has(self.__namespace__) && size(self.__namespace__) > 0 : true"
-                          message: The namespace name must not be empty
+                          message: The namespace is required for VirtualDisk and VirtualImage
                         - rule: "self.kind == 'VirtualImage' || self.kind == 'VirtualDisk' ? has(self.__namespace__) && size(self.__namespace__) < 64 : true"
                           message: "The namespace must be no longer than 63 characters."
                       properties:

--- a/crds/clustervirtualimages.yaml
+++ b/crds/clustervirtualimages.yaml
@@ -155,8 +155,6 @@ spec:
                         Use an existing `VirtualImage`, `ClusterVirtualImage` or `VirtualDisk` to create an image.
                       required: ["kind", "name"]
                       x-kubernetes-validations:
-                        - rule: "self.kind == 'VirtualImage' || self.kind == 'VirtualDisk' ? has(self.__namespace__) : true"
-                          message: The namespace is required for VirtualDisk and VirtualImage
                         - rule: "self.kind == 'VirtualImage' || self.kind == 'VirtualDisk' ? has(self.__namespace__) && size(self.__namespace__) > 0 : true"
                           message: The namespace is required for VirtualDisk and VirtualImage
                         - rule: "self.kind == 'VirtualImage' || self.kind == 'VirtualDisk' ? has(self.__namespace__) && size(self.__namespace__) < 64 : true"

--- a/crds/clustervirtualimages.yaml
+++ b/crds/clustervirtualimages.yaml
@@ -154,6 +154,13 @@ spec:
                       description: |
                         Use an existing `VirtualImage`, `ClusterVirtualImage` or `VirtualDisk` to create an image.
                       required: ["kind", "name"]
+                      x-kubernetes-validations:
+                        - rule: "self.kind == 'VirtualImage' || self.kind == 'VirtualDisk' ? has(self.__namespace__) : true"
+                          message: The namespace is required for VirtualDisk and VirtualImage
+                        - rule: "self.kind == 'VirtualImage' || self.kind == 'VirtualDisk' ? has(self.__namespace__) && size(self.__namespace__) > 0 : true"
+                          message: The namespace name must not be empty
+                        - rule: "self.kind == 'VirtualImage' || self.kind == 'VirtualDisk' ? has(self.__namespace__) && size(self.__namespace__) < 64 : true"
+                          message: "The namespace must be no longer than 63 characters."
                       properties:
                         kind:
                           type: string


### PR DESCRIPTION
## Description
Currently, when specifying ObjectRef in ClusterVirtualImage to namespace scoped VirtualDisk and VirtualImage resources lack validation for the presence of namespace, its minimum and maximum lengths

## Why do we need it, and what problem does it solve?
If namespace is absent, ObjectRef cannot be found and its presence and correctness must be validated in the manifest.

## What is the expected result?
Adding validation of namespace presence, its minimum and maximum length, but only for ObjectRefs like VirtualImage and VirtualDisk.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
