### PR TITLE
test(api): add resource deletion step in e2e test cases

### DIFF
--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -230,21 +230,16 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 		})
 
 		Context("When test is complited:", func() {
-			It("tries to delete used resources", func() {
-				kustimizationFile := fmt.Sprintf("%s/%s", conf.TestData.ComplexTest, "kustomization.yaml")
-				err := kustomize.ExcludeResource(kustimizationFile, "ns.yaml")
-				Expect(err).NotTo(HaveOccurred(), "cannot exclude namespace from clean up operation:\n%s", err)
-				res := kubectl.Delete(kc.DeleteOptions{
-					Filename:       []string{conf.TestData.ComplexTest},
-					FilenameOption: kc.Kustomize,
+			It("deletes test case resources", func() {
+				DeleteTestCaseResources(ResourcesToDelete{
+					KustomizationDir: conf.TestData.ComplexTest,
+					AdditionalResources: []AdditionalResource{
+						{
+							kc.ResourceKubevirtVMIM,
+							testCaseLabel,
+						},
+					},
 				})
-				Expect(res.Error()).NotTo(HaveOccurred(), "cmd: %s\nstderr: %s", res.GetCmd(), res.StdErr())
-				res = kubectl.Delete(kc.DeleteOptions{
-					Labels:    testCaseLabel,
-					Namespace: conf.Namespace,
-					Resource:  kc.ResourceKubevirtVMIM,
-				})
-				Expect(res.Error()).NotTo(HaveOccurred(), "cmd: %s\nstderr: %s", res.GetCmd(), res.StdErr())
 			})
 		})
 	})

--- a/tests/e2e/disks_test.go
+++ b/tests/e2e/disks_test.go
@@ -75,7 +75,10 @@ var _ = Describe("Disks", ginkgoutil.CommonE2ETestDecorators(), func() {
 	Context("CVI", func() {
 		AfterAll(func() {
 			By("Removing resources for cvi tests")
-			kubectl.Delete(conf.Disks.CviTestDataDir, kc.DeleteOptions{})
+			kubectl.Delete(kc.DeleteOptions{
+				Filename:       []string{conf.Disks.CviTestDataDir},
+				FilenameOption: kc.Filename,
+			})
 		})
 		When("http source", func() {
 			filepath := cviPath("/cvi_http.yaml")
@@ -104,8 +107,10 @@ var _ = Describe("Disks", ginkgoutil.CommonE2ETestDecorators(), func() {
 		When("upload", func() {
 			AfterAll(func() {
 				By("Removing support resources for cvi upload test")
-				kubectl.DeleteResource(kc.ResourcePod, UploadHelpPod, kc.DeleteOptions{
+				kubectl.Delete(kc.DeleteOptions{
+					Filename:  []string{UploadHelpPod},
 					Namespace: conf.Namespace,
+					Resource:  kc.ResourcePod,
 				})
 			})
 			filepath := cviPath("/cvi_upload.yaml")
@@ -116,7 +121,10 @@ var _ = Describe("Disks", ginkgoutil.CommonE2ETestDecorators(), func() {
 	Context("VI", func() {
 		AfterAll(func() {
 			By("Removing resources for vi tests")
-			kubectl.Delete(conf.Disks.ViTestDataDir, kc.DeleteOptions{})
+			kubectl.Delete(kc.DeleteOptions{
+				Filename:       []string{conf.Disks.ViTestDataDir},
+				FilenameOption: kc.Filename,
+			})
 		})
 		When("http source", func() {
 			filepath := viPath("/vi_http.yaml")
@@ -145,8 +153,10 @@ var _ = Describe("Disks", ginkgoutil.CommonE2ETestDecorators(), func() {
 		When("upload", func() {
 			AfterAll(func() {
 				By("Removing support resources for vi upload test")
-				kubectl.DeleteResource(kc.ResourcePod, UploadHelpPod, kc.DeleteOptions{
+				kubectl.Delete(kc.DeleteOptions{
+					Filename:  []string{UploadHelpPod},
 					Namespace: conf.Namespace,
+					Resource:  kc.ResourcePod,
 				})
 			})
 			filepath := viPath("/vi_upload.yaml")
@@ -157,7 +167,10 @@ var _ = Describe("Disks", ginkgoutil.CommonE2ETestDecorators(), func() {
 	Context("VD", func() {
 		AfterAll(func() {
 			By("Removing resources for vd tests")
-			kubectl.Delete(conf.Disks.VdTestDataDir, kc.DeleteOptions{})
+			kubectl.Delete(kc.DeleteOptions{
+				Filename:       []string{conf.Disks.VdTestDataDir},
+				FilenameOption: kc.Filename,
+			})
 		})
 		When("http source", func() {
 			filepath := vdPath("/vd_http.yaml")
@@ -197,8 +210,10 @@ var _ = Describe("Disks", ginkgoutil.CommonE2ETestDecorators(), func() {
 		When("upload", func() {
 			AfterAll(func() {
 				By("Removing support resources for vd upload test")
-				kubectl.DeleteResource(kc.ResourcePod, UploadHelpPod, kc.DeleteOptions{
+				kubectl.Delete(kc.DeleteOptions{
+					Filename:  []string{UploadHelpPod},
 					Namespace: conf.Namespace,
+					Resource:  kc.ResourcePod,
 				})
 			})
 			filepath := vdPath("/vd_upload.yaml")

--- a/tests/e2e/ipam_test.go
+++ b/tests/e2e/ipam_test.go
@@ -34,7 +34,10 @@ var _ = Describe("Ipam", func() {
 	Context("VirtualMachineIPAddressClaim", ginkgoutil.CommonE2ETestDecorators(), func() {
 		AfterAll(func() {
 			By("Removing resources for vmip tests")
-			kubectl.Delete(conf.Ipam.TestDataDir, kc.DeleteOptions{})
+			kubectl.Delete(kc.DeleteOptions{
+				Filename:       []string{conf.Ipam.TestDataDir},
+				FilenameOption: kc.Filename,
+			})
 		})
 		GetLeaseNameFromClaim := func(manifestClaim string) string {
 			res := kubectl.Get(manifestClaim, kc.GetOptions{Output: "jsonpath={.spec.virtualMachineIPAddressLeaseName}"})
@@ -42,7 +45,10 @@ var _ = Describe("Ipam", func() {
 			return res.StdOut()
 		}
 		DeleteVMIP := func(manifest string) {
-			res := kubectl.Delete(manifest, kc.DeleteOptions{})
+			res := kubectl.Delete(kc.DeleteOptions{
+				Filename:       []string{manifest},
+				FilenameOption: kc.Filename,
+			})
 			Expect(res.Error()).NotTo(HaveOccurred(), "failed delete vmip from file %s.\n%s", manifest, res.StdErr())
 		}
 		When("reclaimPolicy Delete", func() {
@@ -65,7 +71,11 @@ var _ = Describe("Ipam", func() {
 				CheckField(kc.ResourceVMIPLease, leaseName, "jsonpath={'.status.phase'}", PhaseBound)
 				DeleteVMIP(filepath)
 				CheckField(kc.ResourceVMIPLease, leaseName, "jsonpath={'.status.phase'}", PhaseReleased)
-				kubectl.DeleteResource(kc.ResourceVMIPLease, leaseName, kc.DeleteOptions{Namespace: conf.Namespace})
+				kubectl.Delete(kc.DeleteOptions{
+					Filename:  []string{leaseName},
+					Namespace: conf.Namespace,
+					Resource:  kc.ResourceVMIPLease,
+				})
 			})
 		})
 	})

--- a/tests/e2e/sizing_policy_test.go
+++ b/tests/e2e/sizing_policy_test.go
@@ -248,20 +248,11 @@ var _ = Describe("Sizing policy", ginkgoutil.CommonE2ETestDecorators(), func() {
 	})
 
 	Context("When test is complited:", func() {
-		It("tries to delete used resources", func() {
-			kustomizationFile := fmt.Sprintf("%s/%s", conf.TestData.SizingPolicy, "kustomization.yaml")
-			err := kustomize.ExcludeResource(kustomizationFile, "ns.yaml")
-			Expect(err).NotTo(HaveOccurred(), "cannot exclude namespace from clean up operation:\n%s", err)
-			res := kubectl.Delete(kc.DeleteOptions{
-				Filename:       []string{conf.TestData.SizingPolicy},
-				FilenameOption: kc.Kustomize,
+		It("deletes test case resources", func() {
+			DeleteTestCaseResources(ResourcesToDelete{
+				KustomizationDir: conf.TestData.SizingPolicy,
+				Files:            []string{newVmClassFilePath},
 			})
-			Expect(res.Error()).NotTo(HaveOccurred(), "cmd: %s\nstderr: %s", res.GetCmd(), res.StdErr())
-			res = kubectl.Delete(kc.DeleteOptions{
-				Filename:       []string{newVmClassFilePath},
-				FilenameOption: kc.Filename,
-			})
-			Expect(res.Error()).NotTo(HaveOccurred(), "cmd: %s\nstderr: %s", res.GetCmd(), res.StdErr())
 		})
 	})
 })

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -73,7 +73,10 @@ func ItApplyFromFile(filepath string) {
 func ApplyFromFile(filepath string) {
 	GinkgoHelper()
 	fmt.Printf("Apply file %s\n", filepath)
-	res := kubectl.Apply(filepath, kc.ApplyOptions{})
+	res := kubectl.Apply(kc.ApplyOptions{
+		Filename:       []string{filepath},
+		FilenameOption: kc.Filename,
+	})
 	Expect(res.Error()).NotTo(HaveOccurred(), "apply failed for file %s\n%s", filepath, res.StdErr())
 }
 

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -408,3 +408,54 @@ func GetPhaseByVolumeBindingMode(c *Config) string {
 		return PhaseReady
 	}
 }
+
+// Test data templates does not contain this resources, but this resources are created in test case.
+type AdditionalResource struct {
+	Resource kc.Resource
+	Labels   map[string]string
+}
+
+// KustomizationDir - `kubectl delete --kustomize <dir>`
+//
+// AdditionalResources - for each resource `kubectl delete <resource> <labels>`
+//
+// Files - `kubectl delete --filename <files>`
+type ResourcesToDelete struct {
+	KustomizationDir    string
+	AdditionalResources []AdditionalResource
+	Files               []string
+}
+
+// This function checks that all resources in test case can be deleted correctly.
+func DeleteTestCaseResources(resources ResourcesToDelete) {
+	By("Response on deletion request should be successful")
+	errMessage := "cannot delete test case resources"
+	kustimizationFile := fmt.Sprintf("%s/%s", resources.KustomizationDir, "kustomization.yaml")
+	err := kustomize.ExcludeResource(kustimizationFile, "ns.yaml")
+	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("%s\nkustomizationDir: %s\nstderr: %s", errMessage, resources.KustomizationDir, err))
+
+	if resources.KustomizationDir != "" {
+		res := kubectl.Delete(kc.DeleteOptions{
+			Filename:       []string{resources.KustomizationDir},
+			FilenameOption: kc.Kustomize,
+		})
+		Expect(res.Error()).NotTo(HaveOccurred(), fmt.Sprintf("%s\nkustomizationDir: %s\ncmd: %s\nstderr: %s", errMessage, resources.KustomizationDir, res.GetCmd(), res.StdErr()))
+	}
+
+	for _, r := range resources.AdditionalResources {
+		res := kubectl.Delete(kc.DeleteOptions{
+			Labels:    r.Labels,
+			Namespace: conf.Namespace,
+			Resource:  r.Resource,
+		})
+		Expect(res.Error()).NotTo(HaveOccurred(), fmt.Sprintf("%s\ncmd: %s\nstderr: %s", errMessage, res.GetCmd(), res.StdErr()))
+	}
+
+	if len(resources.Files) != 0 {
+		res := kubectl.Delete(kc.DeleteOptions{
+			Filename:       resources.Files,
+			FilenameOption: kc.Filename,
+		})
+		Expect(res.Error()).NotTo(HaveOccurred(), fmt.Sprintf("%s\ncmd: %s\nstderr: %s", errMessage, res.GetCmd(), res.StdErr()))
+	}
+}

--- a/tests/e2e/vm_configuration_test.go
+++ b/tests/e2e/vm_configuration_test.go
@@ -92,7 +92,10 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 
 	Context("When resources are applied:", func() {
 		It("result should be succeeded", func() {
-			res := kubectl.Kustomize(conf.TestData.VmConfiguration, kc.KustomizeOptions{})
+			res := kubectl.Apply(kc.ApplyOptions{
+				Filename:       []string{conf.TestData.VmConfiguration},
+				FilenameOption: kc.Kustomize,
+			})
 			Expect(res.WasSuccess()).To(Equal(true), res.StdErr())
 		})
 	})
@@ -247,6 +250,19 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 				vms := strings.Split(res.StdOut(), " ")
 				CheckCPUCoresNumberFromVirtualMachine("2", vms...)
 			})
+		})
+	})
+
+	Context("When test is complited:", func() {
+		It("tries to delete used resources", func() {
+			kustimizationFile := fmt.Sprintf("%s/%s", conf.TestData.VmConfiguration, "kustomization.yaml")
+			err := kustomize.ExcludeResource(kustimizationFile, "ns.yaml")
+			Expect(err).NotTo(HaveOccurred(), "cannot exclude namespace from clean up operation:\n%s", err)
+			res := kubectl.Delete(kc.DeleteOptions{
+				Filename:       []string{conf.TestData.VmConfiguration},
+				FilenameOption: kc.Kustomize,
+			})
+			Expect(res.Error()).NotTo(HaveOccurred(), "cmd: %s\nstderr: %s", res.GetCmd(), res.StdErr())
 		})
 	})
 })

--- a/tests/e2e/vm_configuration_test.go
+++ b/tests/e2e/vm_configuration_test.go
@@ -254,15 +254,10 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 	})
 
 	Context("When test is complited:", func() {
-		It("tries to delete used resources", func() {
-			kustimizationFile := fmt.Sprintf("%s/%s", conf.TestData.VmConfiguration, "kustomization.yaml")
-			err := kustomize.ExcludeResource(kustimizationFile, "ns.yaml")
-			Expect(err).NotTo(HaveOccurred(), "cannot exclude namespace from clean up operation:\n%s", err)
-			res := kubectl.Delete(kc.DeleteOptions{
-				Filename:       []string{conf.TestData.VmConfiguration},
-				FilenameOption: kc.Kustomize,
+		It("deletes test case resources", func() {
+			DeleteTestCaseResources(ResourcesToDelete{
+				KustomizationDir: conf.TestData.VmConfiguration,
 			})
-			Expect(res.Error()).NotTo(HaveOccurred(), "cmd: %s\nstderr: %s", res.GetCmd(), res.StdErr())
 		})
 	})
 })

--- a/tests/e2e/vm_disk_attachment_test.go
+++ b/tests/e2e/vm_disk_attachment_test.go
@@ -247,15 +247,16 @@ var _ = Describe("Virtual disk attachment", ginkgoutil.CommonE2ETestDecorators()
 	})
 
 	Context("When test is complited:", func() {
-		It("tries to delete used resources", func() {
-			kustimizationFile := fmt.Sprintf("%s/%s", conf.TestData.VmDiskAttachment, "kustomization.yaml")
-			err := kustomize.ExcludeResource(kustimizationFile, "ns.yaml")
-			Expect(err).NotTo(HaveOccurred(), "cannot exclude namespace from clean up operation:\n%s", err)
-			res := kubectl.Delete(kc.DeleteOptions{
-				Filename:       []string{conf.TestData.VmDiskAttachment},
-				FilenameOption: kc.Kustomize,
+		It("deletes test case resources", func() {
+			DeleteTestCaseResources(ResourcesToDelete{
+				KustomizationDir: conf.TestData.VmDiskAttachment,
+				AdditionalResources: []AdditionalResource{
+					{
+						Resource: kc.ResourceVMBDA,
+						Labels:   testCaseLabel,
+					},
+				},
 			})
-			Expect(res.Error()).NotTo(HaveOccurred(), "cmd: %s\nstderr: %s", res.GetCmd(), res.StdErr())
 		})
 	})
 })

--- a/tests/e2e/vm_disk_attachment_test.go
+++ b/tests/e2e/vm_disk_attachment_test.go
@@ -51,8 +51,10 @@ func AttachVirtualDisk(virtualMachine, virtualDisk string, labels map[string]str
 	err := CreateVMBDAManifest(vmbdaFilePath, virtualMachine, virtualDisk, labels)
 	Expect(err).NotTo(HaveOccurred(), err)
 
-	res := kubectl.Apply(vmbdaFilePath, kc.ApplyOptions{
-		Namespace: conf.Namespace,
+	res := kubectl.Apply(kc.ApplyOptions{
+		Filename:       []string{vmbdaFilePath},
+		FilenameOption: kc.Filename,
+		Namespace:      conf.Namespace,
 	})
 	Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
 }
@@ -122,8 +124,22 @@ var _ = Describe("Virtual disk attachment", ginkgoutil.CommonE2ETestDecorators()
 
 	Context("When resources are applied:", func() {
 		It("result should be succeeded", func() {
-			res := kubectl.Kustomize(conf.TestData.VmDiskAttachment, kc.KustomizeOptions{})
+			res := kubectl.Apply(kc.ApplyOptions{
+				Filename:       []string{conf.TestData.VmDiskAttachment},
+				FilenameOption: kc.Kustomize,
+			})
 			Expect(res.WasSuccess()).To(Equal(true), res.StdErr())
+		})
+	})
+
+	Context("When virtual images are applied:", func() {
+		It("checks VIs phases", func() {
+			By(fmt.Sprintf("VIs should be in %s phases", PhaseReady))
+			WaitPhaseByLabel(kc.ResourceVI, PhaseReady, kc.WaitOptions{
+				Labels:    testCaseLabel,
+				Namespace: conf.Namespace,
+				Timeout:   MaxWaitTimeout,
+			})
 		})
 	})
 
@@ -202,8 +218,10 @@ var _ = Describe("Virtual disk attachment", ginkgoutil.CommonE2ETestDecorators()
 				}).WithTimeout(Timeout).WithPolling(Interval).ShouldNot(HaveOccurred(), "virtual machine: %s", vmName)
 			})
 			It("detaches virtual disk", func() {
-				res := kubectl.DeleteResource(kc.ResourceVMBDA, vmbdaName, kc.DeleteOptions{
+				res := kubectl.Delete(kc.DeleteOptions{
+					Filename:  []string{vmbdaName},
 					Namespace: conf.Namespace,
+					Resource:  kc.ResourceVMBDA,
 				})
 				Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
 			})
@@ -225,6 +243,19 @@ var _ = Describe("Virtual disk attachment", ginkgoutil.CommonE2ETestDecorators()
 					return len(disksAfter.BlockDevices), nil
 				}).WithTimeout(Timeout).WithPolling(Interval).Should(Equal(diskCountBefore-1), "comparing error: 'after' must be equal 'before - 1'")
 			})
+		})
+	})
+
+	Context("When test is complited:", func() {
+		It("tries to delete used resources", func() {
+			kustimizationFile := fmt.Sprintf("%s/%s", conf.TestData.VmDiskAttachment, "kustomization.yaml")
+			err := kustomize.ExcludeResource(kustimizationFile, "ns.yaml")
+			Expect(err).NotTo(HaveOccurred(), "cannot exclude namespace from clean up operation:\n%s", err)
+			res := kubectl.Delete(kc.DeleteOptions{
+				Filename:       []string{conf.TestData.VmDiskAttachment},
+				FilenameOption: kc.Kustomize,
+			})
+			Expect(res.Error()).NotTo(HaveOccurred(), "cmd: %s\nstderr: %s", res.GetCmd(), res.StdErr())
 		})
 	})
 })

--- a/tests/e2e/vm_disk_resizing_test.go
+++ b/tests/e2e/vm_disk_resizing_test.go
@@ -159,12 +159,26 @@ func GetVirtualMachineDisks(vmName string, config *cfg.Config) (VirtualMachineDi
 }
 
 var _ = Describe("Virtual disk resizing", ginkgoutil.CommonE2ETestDecorators(), func() {
-	diskResizingLabel := map[string]string{"testcase": "disk-resizing"}
+	testCaseLabel := map[string]string{"testcase": "disk-resizing"}
 
 	Context("When resources are applied:", func() {
 		It("result should be succeeded", func() {
-			res := kubectl.Kustomize(conf.TestData.DiskResizing, kc.KustomizeOptions{})
+			res := kubectl.Apply(kc.ApplyOptions{
+				Filename:       []string{conf.TestData.DiskResizing},
+				FilenameOption: kc.Kustomize,
+			})
 			Expect(res.WasSuccess()).To(Equal(true), res.StdErr())
+		})
+	})
+
+	Context("When virtual images are applied:", func() {
+		It("checks VIs phases", func() {
+			By(fmt.Sprintf("VIs should be in %s phases", PhaseReady))
+			WaitPhaseByLabel(kc.ResourceVI, PhaseReady, kc.WaitOptions{
+				Labels:    testCaseLabel,
+				Namespace: conf.Namespace,
+				Timeout:   MaxWaitTimeout,
+			})
 		})
 	})
 
@@ -172,7 +186,7 @@ var _ = Describe("Virtual disk resizing", ginkgoutil.CommonE2ETestDecorators(), 
 		It("checks VDs phases", func() {
 			By(fmt.Sprintf("VDs should be in %s phases", PhaseReady))
 			WaitPhaseByLabel(kc.ResourceVD, PhaseReady, kc.WaitOptions{
-				Labels:    diskResizingLabel,
+				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,
 			})
@@ -183,7 +197,7 @@ var _ = Describe("Virtual disk resizing", ginkgoutil.CommonE2ETestDecorators(), 
 		It("checks VMs phases", func() {
 			By(fmt.Sprintf("VMs should be in %s phases", PhaseRunning))
 			WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, kc.WaitOptions{
-				Labels:    diskResizingLabel,
+				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,
 			})
@@ -194,7 +208,7 @@ var _ = Describe("Virtual disk resizing", ginkgoutil.CommonE2ETestDecorators(), 
 		It("checks VMBDAs phases", func() {
 			By(fmt.Sprintf("VMBDAs should be in %s phases", PhaseAttached))
 			WaitPhaseByLabel(kc.ResourceVMBDA, PhaseAttached, kc.WaitOptions{
-				Labels:    diskResizingLabel,
+				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,
 			})
@@ -208,14 +222,14 @@ var _ = Describe("Virtual disk resizing", ginkgoutil.CommonE2ETestDecorators(), 
 				vmDisksAfter  VirtualMachineDisks
 				err           error
 			)
-			vmName := fmt.Sprintf("%s-vm-%s", namePrefix, diskResizingLabel["testcase"])
+			vmName := fmt.Sprintf("%s-vm-%s", namePrefix, testCaseLabel["testcase"])
 			It("get disks metadata before resizing", func() {
 				vmDisksBefore, err = GetVirtualMachineDisks(vmName, conf)
 				Expect(err).NotTo(HaveOccurred(), err)
 			})
 			It("resizes disks", func() {
 				res := kubectl.List(kc.ResourceVD, kc.GetOptions{
-					Labels:    diskResizingLabel,
+					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Output:    "jsonpath='{.items[*].metadata.name}'",
 				})
@@ -233,28 +247,28 @@ var _ = Describe("Virtual disk resizing", ginkgoutil.CommonE2ETestDecorators(), 
 			It("checks VDs, VMs and VMBDA phases", func() {
 				By(fmt.Sprintf("VDs should be in %s phases", PhaseReady))
 				WaitPhaseByLabel(kc.ResourceVD, PhaseReady, kc.WaitOptions{
-					Labels:    diskResizingLabel,
+					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
 				})
 
 				By(fmt.Sprintf("VMs should be in %s phases", PhaseRunning))
 				WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, kc.WaitOptions{
-					Labels:    diskResizingLabel,
+					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
 				})
 
 				By(fmt.Sprintf("VMBDAs should be in %s phases", PhaseAttached))
 				WaitPhaseByLabel(kc.ResourceVMBDA, PhaseAttached, kc.WaitOptions{
-					Labels:    diskResizingLabel,
+					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
 				})
 
 				By("BlockDeviceRefsStatus: disks should be attached")
 				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
-					Labels:    diskResizingLabel,
+					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Output:    "jsonpath='{.items[*].metadata.name}'",
 				})
@@ -276,6 +290,19 @@ var _ = Describe("Virtual disk resizing", ginkgoutil.CommonE2ETestDecorators(), 
 					Expect(compareSizeByLsblk).To(BeTrue(), "size by lsblk before must be lower than size after: before: %d, after: %d", sizeByLsblkBefore, sizeByLsblkAfter)
 				}
 			})
+		})
+	})
+
+	Context("When test is complited:", func() {
+		It("tries to delete used resources", func() {
+			kustimizationFile := fmt.Sprintf("%s/%s", conf.TestData.DiskResizing, "kustomization.yaml")
+			err := kustomize.ExcludeResource(kustimizationFile, "ns.yaml")
+			Expect(err).NotTo(HaveOccurred(), "cannot exclude namespace from clean up operation:\n%s", err)
+			res := kubectl.Delete(kc.DeleteOptions{
+				Filename:       []string{conf.TestData.DiskResizing},
+				FilenameOption: kc.Kustomize,
+			})
+			Expect(res.Error()).NotTo(HaveOccurred(), "cmd: %s\nstderr: %s", res.GetCmd(), res.StdErr())
 		})
 	})
 })

--- a/tests/e2e/vm_disk_resizing_test.go
+++ b/tests/e2e/vm_disk_resizing_test.go
@@ -294,15 +294,10 @@ var _ = Describe("Virtual disk resizing", ginkgoutil.CommonE2ETestDecorators(), 
 	})
 
 	Context("When test is complited:", func() {
-		It("tries to delete used resources", func() {
-			kustimizationFile := fmt.Sprintf("%s/%s", conf.TestData.DiskResizing, "kustomization.yaml")
-			err := kustomize.ExcludeResource(kustimizationFile, "ns.yaml")
-			Expect(err).NotTo(HaveOccurred(), "cannot exclude namespace from clean up operation:\n%s", err)
-			res := kubectl.Delete(kc.DeleteOptions{
-				Filename:       []string{conf.TestData.DiskResizing},
-				FilenameOption: kc.Kustomize,
+		It("deletes test case resources", func() {
+			DeleteTestCaseResources(ResourcesToDelete{
+				KustomizationDir: conf.TestData.DiskResizing,
 			})
-			Expect(res.Error()).NotTo(HaveOccurred(), "cmd: %s\nstderr: %s", res.GetCmd(), res.StdErr())
 		})
 	})
 })

--- a/tests/e2e/vm_label_annotation_test.go
+++ b/tests/e2e/vm_label_annotation_test.go
@@ -89,11 +89,20 @@ var _ = Describe("Label and Annotation", ginkgoutil.CommonE2ETestDecorators(), f
 			return nil
 		})
 		if err != nil || len(files) == 0 {
-			kubectl.Delete(imageManifest, kc.DeleteOptions{})
-			kubectl.Delete(conf.VM.TestDataDir, kc.DeleteOptions{})
+			kubectl.Delete(kc.DeleteOptions{
+				Filename:       []string{imageManifest},
+				FilenameOption: kc.Filename,
+			})
+			kubectl.Delete(kc.DeleteOptions{
+				Filename:       []string{conf.VM.TestDataDir},
+				FilenameOption: kc.Filename,
+			})
 		} else {
 			for _, f := range files {
-				kubectl.Delete(f, kc.DeleteOptions{})
+				kubectl.Delete(kc.DeleteOptions{
+					Filename:       []string{f},
+					FilenameOption: kc.Filename,
+				})
 			}
 		}
 	})
@@ -112,7 +121,10 @@ var _ = Describe("Label and Annotation", ginkgoutil.CommonE2ETestDecorators(), f
 
 		AfterAll(func() {
 			By("Delete manifest")
-			kubectl.Delete(vmManifest, kc.DeleteOptions{})
+			kubectl.Delete(kc.DeleteOptions{
+				Filename:       []string{vmManifest},
+				FilenameOption: kc.Filename,
+			})
 		})
 
 		Describe(fmt.Sprintf("Add label %s=%s", labelName, labelValue), func() {
@@ -194,7 +206,10 @@ var _ = Describe("Label and Annotation", ginkgoutil.CommonE2ETestDecorators(), f
 
 		AfterAll(func() {
 			By("Delete manifest")
-			kubectl.Delete(vmManifest, kc.DeleteOptions{})
+			kubectl.Delete(kc.DeleteOptions{
+				Filename:       []string{vmManifest},
+				FilenameOption: kc.Filename,
+			})
 		})
 
 		Describe(fmt.Sprintf("Add annotation %s=%s", annotationName, annotationValue), func() {

--- a/tests/e2e/vm_migration_test.go
+++ b/tests/e2e/vm_migration_test.go
@@ -164,21 +164,16 @@ var _ = Describe("Virtual machine migration", ginkgoutil.CommonE2ETestDecorators
 	})
 
 	Context("When test is complited:", func() {
-		It("tries to delete used resources", func() {
-			kustimizationFile := fmt.Sprintf("%s/%s", conf.TestData.VmMigration, "kustomization.yaml")
-			err := kustomize.ExcludeResource(kustimizationFile, "ns.yaml")
-			Expect(err).NotTo(HaveOccurred(), "cannot exclude namespace from clean up operation:\n%s", err)
-			res := kubectl.Delete(kc.DeleteOptions{
-				Filename:       []string{conf.TestData.VmMigration},
-				FilenameOption: kc.Kustomize,
+		It("deletes test case resources", func() {
+			DeleteTestCaseResources(ResourcesToDelete{
+				KustomizationDir: conf.TestData.VmMigration,
+				AdditionalResources: []AdditionalResource{
+					{
+						Resource: kc.ResourceKubevirtVMIM,
+						Labels:   testCaseLabel,
+					},
+				},
 			})
-			Expect(res.Error()).NotTo(HaveOccurred(), "cmd: %s\nstderr: %s", res.GetCmd(), res.StdErr())
-			res = kubectl.Delete(kc.DeleteOptions{
-				Labels:    testCaseLabel,
-				Namespace: conf.Namespace,
-				Resource:  kc.ResourceKubevirtVMIM,
-			})
-			Expect(res.Error()).NotTo(HaveOccurred(), "cmd: %s\nstderr: %s", res.GetCmd(), res.StdErr())
 		})
 	})
 })

--- a/tests/e2e/vm_test.go
+++ b/tests/e2e/vm_test.go
@@ -66,11 +66,20 @@ var _ = Describe("VM", ginkgoutil.CommonE2ETestDecorators(), func() {
 			return nil
 		})
 		if err != nil || len(files) == 0 {
-			kubectl.Delete(imageManifest, kc.DeleteOptions{})
-			kubectl.Delete(conf.VM.TestDataDir, kc.DeleteOptions{})
+			kubectl.Delete(kc.DeleteOptions{
+				Filename:       []string{imageManifest},
+				FilenameOption: kc.Filename,
+			})
+			kubectl.Delete(kc.DeleteOptions{
+				Filename:       []string{conf.VM.TestDataDir},
+				FilenameOption: kc.Filename,
+			})
 		} else {
 			for _, f := range files {
-				kubectl.Delete(f, kc.DeleteOptions{})
+				kubectl.Delete(kc.DeleteOptions{
+					Filename:       []string{f},
+					FilenameOption: kc.Filename,
+				})
 			}
 		}
 	})
@@ -93,7 +102,10 @@ var _ = Describe("VM", ginkgoutil.CommonE2ETestDecorators(), func() {
 
 	Context("Boot", func() {
 		AfterAll(func() {
-			kubectl.Delete(vmPath("boot/"), kc.DeleteOptions{})
+			kubectl.Delete(kc.DeleteOptions{
+				Filename:       []string{vmPath("boot/")},
+				FilenameOption: kc.Filename,
+			})
 		})
 		Test := func(manifest string) {
 			GinkgoHelper()
@@ -152,7 +164,10 @@ var _ = Describe("VM", ginkgoutil.CommonE2ETestDecorators(), func() {
 		})
 		AfterAll(func() {
 			By("Delete manifest")
-			kubectl.Delete(manifest, kc.DeleteOptions{})
+			kubectl.Delete(kc.DeleteOptions{
+				Filename:       []string{manifest},
+				FilenameOption: kc.Filename,
+			})
 		})
 		When("On to AlwaysOff", func() {
 			It("Patch runpolicy to AlwaysOff", func() {
@@ -229,7 +244,10 @@ var _ = Describe("VM", ginkgoutil.CommonE2ETestDecorators(), func() {
 		}
 		AfterAll(func() {
 			By("Delete manifests")
-			kubectl.Delete(vmPath("provisioning/"), kc.DeleteOptions{})
+			kubectl.Delete(kc.DeleteOptions{
+				Filename:       []string{vmPath("provisioning/")},
+				FilenameOption: kc.Filename,
+			})
 		})
 		When("UserData", func() {
 			manifest := vmPath("provisioning/vm_provisioning_useradata.yaml")
@@ -293,7 +311,10 @@ var _ = Describe("VM", ginkgoutil.CommonE2ETestDecorators(), func() {
 		}
 		AfterAll(func() {
 			By("Delete manifests")
-			kubectl.Delete(vmPath("resources/"), kc.DeleteOptions{})
+			kubectl.Delete(kc.DeleteOptions{
+				Filename:       []string{vmPath("resources/")},
+				FilenameOption: kc.Filename,
+			})
 		})
 		When("Corefraction 100", func() {
 			manifest := vmPath("resources/vm_100.yaml")
@@ -335,7 +356,10 @@ var _ = Describe("VM", ginkgoutil.CommonE2ETestDecorators(), func() {
 		})
 		AfterAll(func() {
 			By("Delete manifests")
-			kubectl.Delete(manifest, kc.DeleteOptions{})
+			kubectl.Delete(kc.DeleteOptions{
+				Filename:       []string{manifest},
+				FilenameOption: kc.Filename,
+			})
 		})
 		When("Compare priorityClassNames", func() {
 			It("Compare priorityClassNames", func() {
@@ -369,7 +393,10 @@ var _ = Describe("VM", ginkgoutil.CommonE2ETestDecorators(), func() {
 		})
 		AfterAll(func() {
 			By("Delete manifest")
-			kubectl.Delete(manifest, kc.DeleteOptions{})
+			kubectl.Delete(kc.DeleteOptions{
+				Filename:       []string{manifest},
+				FilenameOption: kc.Filename,
+			})
 		})
 		When("Compare periods", func() {
 			It("Compare periods", func() {


### PR DESCRIPTION
- exclude namespace in resource deletion step;
- refactor `apply` and `delete` kubectl commands;
- handle errors in clean up phase;
- add resource deletion step in each test case.

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
When test case is completed it's resources should be deleted.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
To catch errors when virtualization resources cannot be deleted correctly.
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
All resources in E2E tests should be deleted correctly in each test case. 
## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
