### PR TITLE
fix(vm): check size policy matched condition in reconciler

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
@@ -215,6 +215,11 @@ func (h *SyncKvvmHandler) isWaiting(vm *virtv2.VirtualMachine) bool {
 			if c.Status != metav1.ConditionTrue {
 				return true
 			}
+
+		case vmcondition.TypeSizingPolicyMatched:
+			if c.Status != metav1.ConditionTrue {
+				return true
+			}
 		}
 	}
 	return false

--- a/images/virtualization-artifact/pkg/controller/vm/vm_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vm/vm_controller.go
@@ -62,11 +62,11 @@ func SetupController(
 		internal.NewFilesystemHandler(),
 		internal.NewSnapshottingHandler(client),
 		internal.NewPodHandler(client),
+		internal.NewSizePolicyHandler(),
 		internal.NewSyncKvvmHandler(dvcrSettings, client, recorder),
 		internal.NewSyncMetadataHandler(client),
 		internal.NewLifeCycleHandler(client, recorder),
 		internal.NewStatisticHandler(client),
-		internal.NewSizePolicyHandler(),
 	}
 	r := NewReconciler(client, handlers...)
 


### PR DESCRIPTION
## Description
Check `VirtualMachine` size policy matched condition while syncing `VirtualMachine` state with kubevirt Virtual Machine.

## Why do we need it, and what problem does it solve?

## What is the expected result?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
