### PR TITLE
fix(vmbda): fix block device attached count condition processing

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vmbda/internal/block_device_limiter.go
+++ b/images/virtualization-artifact/pkg/controller/vmbda/internal/block_device_limiter.go
@@ -52,7 +52,7 @@ func (h *BlockDeviceLimiter) Handle(ctx context.Context, vmbda *virtv2.VirtualMa
 		return reconcile.Result{}, nil
 	}
 
-	if blockDeviceAttachedCount > common.VmBlockDeviceAttachedLimit {
+	if blockDeviceAttachedCount <= common.VmBlockDeviceAttachedLimit {
 		cb.
 			Status(metav1.ConditionTrue).
 			Reason(vmbdacondition.CapacityAvailable).


### PR DESCRIPTION
## Description
Fix `VirtualMachineBlockDeviceAttachement` block device attached count condition processing.

## Why do we need it, and what problem does it solve?

## What is the expected result?

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
