### PR TITLE
fix(vm): create a kvvm with an optional cpu feature invtsc

### DIFF
--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
@@ -107,9 +107,13 @@ func (b *KVVM) SetCPUModel(class *virtv2.VirtualMachineClass) error {
 	case virtv2.CPUTypeFeatures, virtv2.CPUTypeDiscovery:
 		cpu.Features = make([]virtv1.CPUFeature, len(class.Status.CpuFeatures.Enabled))
 		for i, feature := range class.Status.CpuFeatures.Enabled {
+			policy := "require"
+			if feature == "invtsc" {
+				policy = "optional"
+			}
 			cpu.Features[i] = virtv1.CPUFeature{
 				Name:   feature,
-				Policy: "require",
+				Policy: policy,
 			}
 		}
 	default:


### PR DESCRIPTION
## Description

Use "optional" policy for "invtsc" cpu feature.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

The problem with invtsc feature occurs when vmclass "Discovery" is used or feature is specified explicitly.

When "required" policy set for "invtcs" feature, kubevirt adds nodeSelector to schedule VM to the node with the lowest tsc frequency. This nodeSelector ignores other rules and not what user expects. This PR changes policy to "optional" to respect other rules in the nodeSelector.

Example of the label in the nodeSelector:
```
scheduling.node.virtualization.deckhouse.io/tsc-frequency-3407964000: "true"
```
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?


<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
