### PR TITLE
chore(logger): different loggers for controllers

### DIFF
--- a/images/virtualization-artifact/pkg/controller/cvi/cvi_controller.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/cvi_controller.go
@@ -56,8 +56,6 @@ func NewController(
 	dvcr *dvcr.Settings,
 	ns string,
 ) (controller.Controller, error) {
-	log = log.With(logger.SlogController(ControllerName))
-
 	stat := service.NewStatService(log)
 	protection := service.NewProtectionService(mgr.GetClient(), virtv2.FinalizerCVIProtection)
 	importer := service.NewImporterService(dvcr, mgr.GetClient(), importerImage, requirements, PodPullPolicy, PodVerbose, ControllerName, protection)

--- a/images/virtualization-artifact/pkg/controller/vd/vd_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vd/vd_controller.go
@@ -52,15 +52,13 @@ type Condition interface {
 func NewController(
 	ctx context.Context,
 	mgr manager.Manager,
-	lg *log.Logger,
+	log *log.Logger,
 	importerImage string,
 	uploaderImage string,
 	requirements corev1.ResourceRequirements,
 	dvcr *dvcr.Settings,
 	storageClassSettings config.VirtualDiskStorageClassSettings,
 ) (controller.Controller, error) {
-	log := lg.With(logger.SlogController(ControllerName))
-
 	stat := service.NewStatService(log)
 	protection := service.NewProtectionService(mgr.GetClient(), virtv2.FinalizerVDProtection)
 	importer := service.NewImporterService(dvcr, mgr.GetClient(), importerImage, requirements, PodPullPolicy, PodVerbose, ControllerName, protection)
@@ -110,7 +108,7 @@ func NewController(
 		return nil, err
 	}
 
-	vdcolelctor.SetupCollector(mgr.GetCache(), metrics.Registry, lg)
+	vdcolelctor.SetupCollector(mgr.GetCache(), metrics.Registry, log)
 
 	log.Info("Initialized VirtualDisk controller", "image", importerImage)
 

--- a/images/virtualization-artifact/pkg/controller/vdsnapshot/vdsnapshot_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vdsnapshot/vdsnapshot_controller.go
@@ -41,8 +41,6 @@ func NewController(
 	log *log.Logger,
 	virtClient kubeclient.Client,
 ) (controller.Controller, error) {
-	log = log.With(logger.SlogController(ControllerName))
-
 	protection := service.NewProtectionService(mgr.GetClient(), virtv2.FinalizerVDSnapshotProtection)
 	freezer := service.NewSnapshotService(virtClient, mgr.GetClient(), protection)
 

--- a/images/virtualization-artifact/pkg/controller/vi/vi_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vi/vi_controller.go
@@ -57,8 +57,6 @@ func NewController(
 	dvcr *dvcr.Settings,
 	storageClassSettings config.VirtualImageStorageClassSettings,
 ) (controller.Controller, error) {
-	log = log.With(logger.SlogController(ControllerName))
-
 	stat := service.NewStatService(log)
 	protection := service.NewProtectionService(mgr.GetClient(), virtv2.FinalizerVIProtection)
 	importer := service.NewImporterService(dvcr, mgr.GetClient(), importerImage, requirements, PodPullPolicy, PodVerbose, ControllerName, protection)

--- a/images/virtualization-artifact/pkg/controller/vm/vm_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vm/vm_controller.go
@@ -37,17 +37,16 @@ import (
 )
 
 const (
-	controllerName = "vm-controller"
+	ControllerName = "vm-controller"
 )
 
 func SetupController(
 	ctx context.Context,
 	mgr manager.Manager,
-	lg *log.Logger,
+	log *log.Logger,
 	dvcrSettings *dvcr.Settings,
 ) error {
-	log := lg.With(logger.SlogController(controllerName))
-	recorder := mgr.GetEventRecorderFor(controllerName)
+	recorder := mgr.GetEventRecorderFor(ControllerName)
 	mgrCache := mgr.GetCache()
 	client := mgr.GetClient()
 	blockDeviceService := service.NewBlockDeviceService(client)
@@ -70,7 +69,7 @@ func SetupController(
 	}
 	r := NewReconciler(client, handlers...)
 
-	c, err := controller.New(controllerName, mgr, controller.Options{
+	c, err := controller.New(ControllerName, mgr, controller.Options{
 		Reconciler:       r,
 		RecoverPanic:     ptr.To(true),
 		LogConstructor:   logger.NewConstructor(log),
@@ -91,7 +90,7 @@ func SetupController(
 		return err
 	}
 
-	vmmetrics.SetupCollector(mgrCache, metrics.Registry, lg)
+	vmmetrics.SetupCollector(mgrCache, metrics.Registry, log)
 
 	log.Info("Initialized VirtualMachine controller")
 	return nil

--- a/images/virtualization-artifact/pkg/controller/vmbda/vmbda_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vmbda/vmbda_controller.go
@@ -42,8 +42,6 @@ func NewController(
 	lg *log.Logger,
 	ns string,
 ) (controller.Controller, error) {
-	log := lg.With(logger.SlogController(ControllerName))
-
 	attacher := service.NewAttachmentService(mgr.GetClient(), ns)
 	blockDeviceService := service.NewBlockDeviceService(mgr.GetClient())
 
@@ -59,7 +57,7 @@ func NewController(
 	vmbdaController, err := controller.New(ControllerName, mgr, controller.Options{
 		Reconciler:       reconciler,
 		RecoverPanic:     ptr.To(true),
-		LogConstructor:   logger.NewConstructor(log),
+		LogConstructor:   logger.NewConstructor(lg),
 		CacheSyncTimeout: 10 * time.Minute,
 	})
 	if err != nil {
@@ -73,7 +71,7 @@ func NewController(
 
 	if err = builder.WebhookManagedBy(mgr).
 		For(&virtv2.VirtualMachineBlockDeviceAttachment{}).
-		WithValidator(NewValidator(attacher, blockDeviceService, log)).
+		WithValidator(NewValidator(attacher, blockDeviceService, lg)).
 		Complete(); err != nil {
 		return nil, err
 	}

--- a/images/virtualization-artifact/pkg/controller/vmclass/vmclass_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/vmclass_controller.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	controllerName = "vmclass-controller"
+	ControllerName = "vmclass-controller"
 )
 
 func NewController(
@@ -41,9 +41,7 @@ func NewController(
 	controllerNamespace string,
 	log *log.Logger,
 ) (controller.Controller, error) {
-	log = log.With(logger.SlogController(controllerName))
-
-	recorder := mgr.GetEventRecorderFor(controllerName)
+	recorder := mgr.GetEventRecorderFor(ControllerName)
 	client := mgr.GetClient()
 	handlers := []Handler{
 		internal.NewDeletionHandler(client, recorder, log),
@@ -52,7 +50,7 @@ func NewController(
 	}
 	r := NewReconciler(controllerNamespace, client, handlers...)
 
-	c, err := controller.New(controllerName, mgr, controller.Options{
+	c, err := controller.New(ControllerName, mgr, controller.Options{
 		Reconciler:       r,
 		RecoverPanic:     ptr.To(true),
 		LogConstructor:   logger.NewConstructor(log),

--- a/images/virtualization-artifact/pkg/controller/vmip/vmip_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/vmip_controller.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	controllerName = "vmip-controller"
+	ControllerName = "vmip-controller"
 )
 
 func NewController(
@@ -42,9 +42,7 @@ func NewController(
 	log *log.Logger,
 	virtualMachineCIDRs []string,
 ) (controller.Controller, error) {
-	log = log.With(logger.SlogController(controllerName))
-
-	recorder := mgr.GetEventRecorderFor(controllerName)
+	recorder := mgr.GetEventRecorderFor(ControllerName)
 	ipService := service.NewIpAddressService(log, virtualMachineCIDRs)
 
 	handlers := []Handler{
@@ -58,7 +56,7 @@ func NewController(
 		return nil, err
 	}
 
-	c, err := controller.New(controllerName, mgr, controller.Options{
+	c, err := controller.New(ControllerName, mgr, controller.Options{
 		Reconciler:       r,
 		RecoverPanic:     ptr.To(true),
 		LogConstructor:   logger.NewConstructor(log),

--- a/images/virtualization-artifact/pkg/controller/vmiplease/vmiplease_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vmiplease/vmiplease_controller.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	controllerName = "vmiplease-controller"
+	ControllerName = "vmiplease-controller"
 )
 
 func NewController(
@@ -41,7 +41,6 @@ func NewController(
 	log *log.Logger,
 	retentionDurationStr string,
 ) (controller.Controller, error) {
-	log = log.With(logger.SlogController(controllerName))
 	retentionDuration, err := time.ParseDuration(retentionDurationStr)
 	if err != nil {
 		log.Error("Failed to parse retention duration", "err", err)
@@ -56,7 +55,7 @@ func NewController(
 
 	r := NewReconciler(mgr.GetClient(), handlers...)
 
-	c, err := controller.New(controllerName, mgr, controller.Options{
+	c, err := controller.New(ControllerName, mgr, controller.Options{
 		Reconciler:       r,
 		RecoverPanic:     ptr.To(true),
 		LogConstructor:   logger.NewConstructor(log),

--- a/images/virtualization-artifact/pkg/controller/vmop/vmop_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/vmop_controller.go
@@ -37,18 +37,16 @@ import (
 )
 
 const (
-	controllerName = "vmop-controller"
+	ControllerName = "vmop-controller"
 )
 
 func SetupController(
 	ctx context.Context,
 	mgr manager.Manager,
 	virtClient kubeclient.Client,
-	lg *log.Logger,
+	log *log.Logger,
 ) error {
-	log := lg.With(logger.SlogController(controllerName))
-
-	recorder := mgr.GetEventRecorderFor(controllerName)
+	recorder := mgr.GetEventRecorderFor(ControllerName)
 	client := mgr.GetClient()
 	vmopSrv := service.NewVMOperationService(mgr.GetClient(), virtClient)
 
@@ -60,7 +58,7 @@ func SetupController(
 
 	reconciler := NewReconciler(client, handlers...)
 
-	vmopController, err := controller.New(controllerName, mgr, controller.Options{
+	vmopController, err := controller.New(ControllerName, mgr, controller.Options{
 		Reconciler:       reconciler,
 		RateLimiter:      workqueue.NewItemExponentialFailureRateLimiter(time.Second, 32*time.Second),
 		RecoverPanic:     ptr.To(true),
@@ -83,7 +81,7 @@ func SetupController(
 		return err
 	}
 
-	vmopcolelctor.SetupCollector(mgr.GetCache(), metrics.Registry, lg)
+	vmopcolelctor.SetupCollector(mgr.GetCache(), metrics.Registry, log)
 
 	log.Info("Initialized VirtualMachineOperation controller")
 	return nil

--- a/images/virtualization-artifact/pkg/controller/vmop/vmop_webhook.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/vmop_webhook.go
@@ -29,7 +29,7 @@ import (
 
 func NewValidator(log *log.Logger) *Validator {
 	return &Validator{
-		log: log.With("controller", controllerName).With("webhook", "validation"),
+		log: log.With("controller", ControllerName).With("webhook", "validation"),
 	}
 }
 

--- a/images/virtualization-artifact/pkg/controller/vmrestore/vmrestore_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vmrestore/vmrestore_controller.go
@@ -39,8 +39,6 @@ func NewController(
 	mgr manager.Manager,
 	log *log.Logger,
 ) error {
-	log = log.With(logger.SlogController(ControllerName))
-
 	reconciler := NewReconciler(
 		mgr.GetClient(),
 		internal.NewVirtualMachineSnapshotReadyToUseHandler(mgr.GetClient()),

--- a/images/virtualization-artifact/pkg/controller/vmsnapshot/vmsnapshot_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vmsnapshot/vmsnapshot_controller.go
@@ -42,8 +42,6 @@ func NewController(
 	log *log.Logger,
 	virtClient kubeclient.Client,
 ) error {
-	log = log.With(logger.SlogController(ControllerName))
-
 	protection := service.NewProtectionService(mgr.GetClient(), virtv2.FinalizerVMSnapshotProtection)
 	snapshotter := service.NewSnapshotService(virtClient, mgr.GetClient(), protection)
 

--- a/images/virtualization-artifact/pkg/logger/logger.go
+++ b/images/virtualization-artifact/pkg/logger/logger.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -46,6 +47,23 @@ func NewLogger(level, output string, debugVerbosity int) *log.Logger {
 		Level:  detectLogLevel(level, debugVerbosity),
 		Output: detectLogOutput(output),
 	})
+}
+
+func NewControllerLogger(controllerName, level, output string, debugVerbosity int, controllerDebugList []string) *log.Logger {
+	slogLevel := detectLogLevel(level, debugVerbosity)
+
+	if slices.Contains(controllerDebugList, controllerName) {
+		if debugVerbosity != 0 {
+			slogLevel = slog.Level(-1 * debugVerbosity)
+		} else {
+			slogLevel = log.LevelDebug.Level()
+		}
+	}
+
+	return log.NewLogger(log.Options{
+		Level:  slogLevel,
+		Output: detectLogOutput(output),
+	}).With(SlogController(controllerName))
 }
 
 func detectLogLevel(level string, debugVerbosity int) slog.Level {


### PR DESCRIPTION
## Description
Adding ability to enable debug log mode in specific controllers

## Why do we need it, and what problem does it solve?
Debug logs only for specific controllers

## What is the expected result?
New ENV LOG_DEBUG_CONTROLLER_LIST with lists of controllers to be logged in DEBAG mode, multiple controllers must be separated by comma, names must be taken from ControllerName

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
