### PR TITLE
refactor(cdi): Remove categories from cluster scoped CRD InternalVirtualizationCDI

### DIFF
--- a/crds/embedded/cdi.yaml
+++ b/crds/embedded/cdi.yaml
@@ -9,8 +9,6 @@ metadata:
 spec:
   group: cdi.internal.virtualization.deckhouse.io
   names:
-    categories:
-      - intvirt
     kind: InternalVirtualizationCDI
     listKind: InternalVirtualizationCDIList
     plural: internalvirtualizationcdis


### PR DESCRIPTION

## Description

Remove spec.names.categories for Cluster scoped CRD "InternalVirtualizationCDI".

## Why do we need it, and what problem does it solve?

- It is confusing that CDI config is listed when namespaced objects are requested (kubectl -n vmns get intvirt)
- Original CRD "CDI" has no categories.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
