### PR TITLE
fix(vm): unsupported guest agent reason wrap

### DIFF
--- a/api/core/v1alpha2/vmcondition/condition.go
+++ b/api/core/v1alpha2/vmcondition/condition.go
@@ -50,6 +50,9 @@ func (r Reason) String() string {
 const (
 	ReasonAgentNotReady Reason = "AgentNotReady"
 
+	ReasonAgentSupported    Reason = "AgentSupported"
+	ReasonAgentNotSupported Reason = "AgentNotSupported"
+
 	ReasonClassReady    Reason = "VirtualMachineClassReady"
 	ReasonClassNotReady Reason = "VirtualMachineClassNotReady"
 

--- a/api/core/v1alpha2/vmcondition/condition.go
+++ b/api/core/v1alpha2/vmcondition/condition.go
@@ -48,10 +48,11 @@ func (r Reason) String() string {
 }
 
 const (
+	ReasonAgentReady    Reason = "AgentReady"
 	ReasonAgentNotReady Reason = "AgentNotReady"
 
-	ReasonAgentSupported    Reason = "AgentSupported"
-	ReasonAgentNotSupported Reason = "AgentNotSupported"
+	ReasonAgentSupported    Reason = "AgentVersionSupported"
+	ReasonAgentNotSupported Reason = "AgentVersionNotSupported"
 
 	ReasonClassReady    Reason = "VirtualMachineClassReady"
 	ReasonClassNotReady Reason = "VirtualMachineClassNotReady"

--- a/images/virtualization-artifact/pkg/controller/vm/internal/agent.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/agent.go
@@ -126,11 +126,13 @@ func (h *AgentHandler) syncAgentVersionNotSupport(vm *virtv2.VirtualMachine, kvv
 	for _, c := range kvvmi.Status.Conditions {
 		if c.Type == virtv1.VirtualMachineInstanceUnsupportedAgent {
 			status := conditionStatus(string(c.Status))
-			//nolint:staticcheck
-			cb.Status(status).Reason(conditions.DeprecatedWrappedString(c.Reason))
-			if status != metav1.ConditionTrue {
-				cb.Message(c.Message)
+			switch status {
+			case metav1.ConditionTrue:
+				cb.Status(status).Reason(vmcondition.ReasonAgentSupported).Message(c.Reason)
+			case metav1.ConditionFalse:
+				cb.Status(status).Reason(vmcondition.ReasonAgentNotSupported).Message(c.Reason)
 			}
+
 			return
 		}
 	}

--- a/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/life_cycle.go
+++ b/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/life_cycle.go
@@ -351,7 +351,6 @@ func (h LifeCycleHandler) ensureVirtualDiskSnapshots(ctx context.Context, vmSnap
 			}
 		}
 
-		//nolint:staticcheck
 		vdSnapshotReady, _ := conditions.GetCondition(vdscondition.VirtualDiskSnapshotReadyType, vdSnapshot.Status.Conditions)
 		if vdSnapshotReady.Reason == vdscondition.VirtualDiskSnapshotFailed.String() || vdSnapshot.Status.Phase == virtv2.VirtualDiskSnapshotPhaseFailed {
 			return nil, fmt.Errorf("the virtual disk snapshot %q is failed: %w. %s", vdSnapshot.Name, ErrCannotTakeSnapshot, vdSnapshotReady.Message)
@@ -449,13 +448,11 @@ func (h LifeCycleHandler) ensureBlockDeviceConsistency(ctx context.Context, vm *
 			return fmt.Errorf("%w: waiting for the virtual disk %q to be %s", ErrVirtualDiskNotReady, vd.Name, virtv2.DiskReady)
 		}
 
-		//nolint:staticcheck
 		ready, _ := conditions.GetCondition(vdcondition.ReadyType, vd.Status.Conditions)
 		if ready.Status != metav1.ConditionTrue {
 			return fmt.Errorf("%w: waiting for the Ready condition of the virtual disk %q to be True", ErrVirtualDiskResizing, vd.Name)
 		}
 
-		//nolint:staticcheck
 		resizingReady, _ := conditions.GetCondition(vdcondition.ResizedType, vd.Status.Conditions)
 		if resizingReady.Reason == vdcondition.InProgress.String() {
 			return fmt.Errorf("%w: waiting for the virtual disk %q to be resized", ErrVirtualDiskResizing, vd.Name)

--- a/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/life_cycle.go
+++ b/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/life_cycle.go
@@ -352,7 +352,7 @@ func (h LifeCycleHandler) ensureVirtualDiskSnapshots(ctx context.Context, vmSnap
 		}
 
 		//nolint:staticcheck
-		vdSnapshotReady, _ := conditions.GetCondition(conditions.DeprecatedWrappedString(vdscondition.VirtualDiskSnapshotReadyType), vdSnapshot.Status.Conditions)
+		vdSnapshotReady, _ := conditions.GetCondition(vdscondition.VirtualDiskSnapshotReadyType, vdSnapshot.Status.Conditions)
 		if vdSnapshotReady.Reason == vdscondition.VirtualDiskSnapshotFailed.String() || vdSnapshot.Status.Phase == virtv2.VirtualDiskSnapshotPhaseFailed {
 			return nil, fmt.Errorf("the virtual disk snapshot %q is failed: %w. %s", vdSnapshot.Name, ErrCannotTakeSnapshot, vdSnapshotReady.Message)
 		}
@@ -450,13 +450,13 @@ func (h LifeCycleHandler) ensureBlockDeviceConsistency(ctx context.Context, vm *
 		}
 
 		//nolint:staticcheck
-		ready, _ := conditions.GetCondition(conditions.DeprecatedWrappedString(vdcondition.ReadyType), vd.Status.Conditions)
+		ready, _ := conditions.GetCondition(vdcondition.ReadyType, vd.Status.Conditions)
 		if ready.Status != metav1.ConditionTrue {
 			return fmt.Errorf("%w: waiting for the Ready condition of the virtual disk %q to be True", ErrVirtualDiskResizing, vd.Name)
 		}
 
 		//nolint:staticcheck
-		resizingReady, _ := conditions.GetCondition(conditions.DeprecatedWrappedString(vdcondition.ResizedType), vd.Status.Conditions)
+		resizingReady, _ := conditions.GetCondition(vdcondition.ResizedType, vd.Status.Conditions)
 		if resizingReady.Reason == vdcondition.InProgress.String() {
 			return fmt.Errorf("%w: waiting for the virtual disk %q to be resized", ErrVirtualDiskResizing, vd.Name)
 		}


### PR DESCRIPTION
## Description
Wrap guest agent conditions reasons

## Why do we need it, and what problem does it solve?
Kubevirt delete VirtualMachineInstanceUnsupportedAgent if its supported, in this case we set incorrect reason and message

## What is the expected result?
Correct guest agent conditions

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
