### PR TITLE
feat(vm): add specchanges for vmclass

### DIFF
--- a/api/core/v1alpha2/events.go
+++ b/api/core/v1alpha2/events.go
@@ -28,6 +28,9 @@ const (
 	// ReasonVMLastAppliedSpecInvalid is event reason that JSON in last-applied-spec annotation is invalid.
 	ReasonVMLastAppliedSpecInvalid = "VMLastAppliedSpecInvalid"
 
+	// ReasonVMClassLastAppliedSpecInvalid is event reason that JSON in last-applied-spec annotation is invalid.
+	ReasonVMClassLastAppliedSpecInvalid = "VMClassLastAppliedSpecInvalid"
+
 	// ReasonErrVmNotSynced is event reason that vm is not synced.
 	ReasonErrVmNotSynced = "VirtualMachineNotSynced"
 

--- a/api/core/v1alpha2/virtual_machine_class.go
+++ b/api/core/v1alpha2/virtual_machine_class.go
@@ -59,6 +59,11 @@ type VirtualMachineClassList struct {
 	Items []VirtualMachineClass `json:"items"`
 }
 
+type VirtualMachineClassNodePlacement struct {
+	NodeSelector NodeSelector        `json:"nodeSelector,omitempty"`
+	Tolerations  []corev1.Toleration `json:"tolerations,omitempty"`
+}
+
 type VirtualMachineClassSpec struct {
 	NodeSelector NodeSelector `json:"nodeSelector,omitempty"`
 	// Tolerations are the same as `spec.tolerations` in the [Pod](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
@@ -208,7 +213,7 @@ type VirtualMachineClassStatus struct {
 	// +kubebuilder:example={"maxAllocatableResources: {\"cpu\": 1, \"memory\": \"10Gi\"}"}
 	MaxAllocatableResources corev1.ResourceList `json:"maxAllocatableResources,omitempty"`
 	// The latest detailed observations of the VirtualMachineClass resource.
-	Conditions              []metav1.Condition  `json:"conditions,omitempty"`
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 	// The generation last processed by the controller.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }

--- a/api/core/v1alpha2/virtual_machine_class.go
+++ b/api/core/v1alpha2/virtual_machine_class.go
@@ -59,11 +59,6 @@ type VirtualMachineClassList struct {
 	Items []VirtualMachineClass `json:"items"`
 }
 
-type VirtualMachineClassNodePlacement struct {
-	NodeSelector NodeSelector        `json:"nodeSelector,omitempty"`
-	Tolerations  []corev1.Toleration `json:"tolerations,omitempty"`
-}
-
 type VirtualMachineClassSpec struct {
 	NodeSelector NodeSelector `json:"nodeSelector,omitempty"`
 	// Tolerations are the same as `spec.tolerations` in the [Pod](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).

--- a/api/core/v1alpha2/vmcondition/condition.go
+++ b/api/core/v1alpha2/vmcondition/condition.go
@@ -25,6 +25,7 @@ func (t Type) String() string {
 const (
 	TypeIPAddressReady                      Type = "VirtualMachineIPAddressReady"
 	TypeClassReady                          Type = "VirtualMachineClassReady"
+	TypeClassChanged                        Type = "VirtualMachineClassChanged"
 	TypeBlockDevicesReady                   Type = "BlockDevicesReady"
 	TypeRunning                             Type = "Running"
 	TypeMigrating                           Type = "Migrating"
@@ -56,6 +57,7 @@ const (
 
 	ReasonClassReady    Reason = "VirtualMachineClassReady"
 	ReasonClassNotReady Reason = "VirtualMachineClassNotReady"
+	ReasonClassChanged  Reason = "VirtualMachineClassChanged"
 
 	ReasonIPAddressReady        Reason = "VirtualMachineIPAddressReady"
 	ReasonIPAddressNotReady     Reason = "VirtualMachineIPAddressNotReady"

--- a/api/core/v1alpha2/vmcondition/condition.go
+++ b/api/core/v1alpha2/vmcondition/condition.go
@@ -25,7 +25,6 @@ func (t Type) String() string {
 const (
 	TypeIPAddressReady                      Type = "VirtualMachineIPAddressReady"
 	TypeClassReady                          Type = "VirtualMachineClassReady"
-	TypeClassChanged                        Type = "VirtualMachineClassChanged"
 	TypeBlockDevicesReady                   Type = "BlockDevicesReady"
 	TypeRunning                             Type = "Running"
 	TypeMigrating                           Type = "Migrating"
@@ -57,7 +56,6 @@ const (
 
 	ReasonClassReady    Reason = "VirtualMachineClassReady"
 	ReasonClassNotReady Reason = "VirtualMachineClassNotReady"
-	ReasonClassChanged  Reason = "VirtualMachineClassChanged"
 
 	ReasonIPAddressReady        Reason = "VirtualMachineIPAddressReady"
 	ReasonIPAddressNotReady     Reason = "VirtualMachineIPAddressNotReady"
@@ -74,8 +72,9 @@ const (
 	ReasonConfigurationApplied    Reason = "ConfigurationApplied"
 	ReasonConfigurationNotApplied Reason = "ConfigurationNotApplied"
 
-	ReasonRestartAwaitingChangesExist Reason = "RestartAwaitingChangesExist"
-	ReasonRestartNoNeed               Reason = "NoNeedRestart"
+	ReasonRestartAwaitingChangesExist        Reason = "RestartAwaitingChangesExist"
+	ReasonRestartAwaitingVMClassChangesExist Reason = "RestartAwaitingVMClassChangesExist"
+	ReasonRestartNoNeed                      Reason = "NoNeedRestart"
 
 	ReasonPodStarted    Reason = "PodStarted"
 	ReasonPodNotFound   Reason = "PodNotFound"

--- a/images/virtualization-artifact/pkg/common/annotations/annotations.go
+++ b/images/virtualization-artifact/pkg/common/annotations/annotations.go
@@ -60,6 +60,9 @@ const (
 	// AnnVMLastAppliedSpec is an annotation on KVVM. It contains a JSON with VM spec.
 	AnnVMLastAppliedSpec = AnnAPIGroup + "/vm.last-applied-spec"
 
+	// AnnVMClassLastAppliedSpec is an annotation on KVVM. It contains a JSON with VM spec.
+	AnnVMClassLastAppliedSpec = AnnAPIGroup + "/vmclass.last-applied-spec"
+
 	// LastPropagatedVMAnnotationsAnnotation is a marshalled map of previously applied virtual machine annotations.
 	LastPropagatedVMAnnotationsAnnotation = AnnAPIGroup + "/last-propagated-vm-annotations"
 	// LastPropagatedVMLabelsAnnotation is a marshalled map of previously applied virtual machine labels.

--- a/images/virtualization-artifact/pkg/controller/conditions/builder.go
+++ b/images/virtualization-artifact/pkg/controller/conditions/builder.go
@@ -39,6 +39,10 @@ func SetCondition(c Conder, conditions *[]metav1.Condition) {
 	meta.SetStatusCondition(conditions, c.Condition())
 }
 
+func RemoveCondition(conditionType Stringer, conditions *[]metav1.Condition) {
+	meta.RemoveStatusCondition(conditions, conditionType.String())
+}
+
 func GetCondition(condType Stringer, conditions []metav1.Condition) (metav1.Condition, bool) {
 	for _, condition := range conditions {
 		if condition.Type == condType.String() {

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/last_applied_spec.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/last_applied_spec.go
@@ -55,7 +55,7 @@ func SetLastAppliedSpec(kvvm *virtv1.VirtualMachine, vm *v1alpha2.VirtualMachine
 
 // LoadLastAppliedClassSpec loads VMClass spec from JSON in the last-applied-spec annotation.
 func LoadLastAppliedClassSpec(kvvm *virtv1.VirtualMachine) (*v1alpha2.VirtualMachineClassSpec, error) {
-	lastSpecJSON := kvvm.GetAnnotations()[common.AnnVMClassLastAppliedSpec]
+	lastSpecJSON := kvvm.GetAnnotations()[annotations.AnnVMClassLastAppliedSpec]
 	if strings.TrimSpace(lastSpecJSON) == "" {
 		return nil, nil
 	}
@@ -75,6 +75,6 @@ func SetLastAppliedClassSpec(kvvm *virtv1.VirtualMachine, class *v1alpha2.Virtua
 		return fmt.Errorf("convert spec to JSON: %w", err)
 	}
 
-	common.AddAnnotation(kvvm, common.AnnVMClassLastAppliedSpec, string(lastApplied))
+	annotations.AddAnnotation(kvvm, annotations.AnnVMClassLastAppliedSpec, string(lastApplied))
 	return nil
 }

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/last_applied_spec.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/last_applied_spec.go
@@ -52,3 +52,29 @@ func SetLastAppliedSpec(kvvm *virtv1.VirtualMachine, vm *v1alpha2.VirtualMachine
 	annotations.AddAnnotation(kvvm, annotations.AnnVMLastAppliedSpec, string(lastApplied))
 	return nil
 }
+
+// LoadLastAppliedClassSpec loads VMClass spec from JSON in the last-applied-spec annotation.
+func LoadLastAppliedClassSpec(kvvm *virtv1.VirtualMachine) (*v1alpha2.VirtualMachineClassSpec, error) {
+	lastSpecJSON := kvvm.GetAnnotations()[common.AnnVMClassLastAppliedSpec]
+	if strings.TrimSpace(lastSpecJSON) == "" {
+		return nil, nil
+	}
+
+	var spec v1alpha2.VirtualMachineClassSpec
+	err := json.Unmarshal([]byte(lastSpecJSON), &spec)
+	if err != nil {
+		return nil, fmt.Errorf("load spec from JSON: %w", err)
+	}
+	return &spec, nil
+}
+
+// SetLastAppliedClassSpec updates the last-applied-spec annotation with VMClass spec JSON.
+func SetLastAppliedClassSpec(kvvm *virtv1.VirtualMachine, class *v1alpha2.VirtualMachineClass) error {
+	lastApplied, err := json.Marshal(class.Spec)
+	if err != nil {
+		return fmt.Errorf("convert spec to JSON: %w", err)
+	}
+
+	common.AddAnnotation(kvvm, common.AnnVMClassLastAppliedSpec, string(lastApplied))
+	return nil
+}

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
@@ -181,7 +181,7 @@ func (h *SyncKvvmHandler) Handle(ctx context.Context, s state.VirtualMachineStat
 			Reason(vmcondition.ReasonRestartAwaitingChangesExist).
 			Message("Waiting for the user to restart in order to apply the configuration changes.")
 	case classChanged:
-		h.recorder.Event(current, corev1.EventTypeNormal, virtv2.ReasonErrRestartAwaitingChanges, "The virtual machine configuration successfully synced")
+		h.recorder.Event(current, corev1.EventTypeNormal, virtv2.ReasonErrRestartAwaitingChanges, "Restart required to propogate changes from the vmclass spec")
 		cbConfApplied.
 			Status(metav1.ConditionFalse).
 			Reason(vmcondition.ReasonConfigurationNotApplied).

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
@@ -118,6 +118,7 @@ func (h *SyncKvvmHandler) Handle(ctx context.Context, s state.VirtualMachineStat
 		}
 		classChanges := h.detectClassSpecChanges(ctx, &class.Spec, lastClassAppliedSpec)
 		if !classChanges.IsEmpty() {
+			allChanges.Add(classChanges.GetAll()...)
 			classChanged = true
 		}
 	}
@@ -181,7 +182,7 @@ func (h *SyncKvvmHandler) Handle(ctx context.Context, s state.VirtualMachineStat
 			Reason(vmcondition.ReasonRestartAwaitingChangesExist).
 			Message("Waiting for the user to restart in order to apply the configuration changes.")
 	case classChanged:
-		h.recorder.Event(current, corev1.EventTypeNormal, virtv2.ReasonErrRestartAwaitingChanges, "Restart required to propogate changes from the vmclass spec")
+		h.recorder.Event(current, corev1.EventTypeNormal, virtv2.ReasonErrRestartAwaitingChanges, "Restart required to propagate changes from the vmclass spec")
 		cbConfApplied.
 			Status(metav1.ConditionFalse).
 			Reason(vmcondition.ReasonConfigurationNotApplied).

--- a/images/virtualization-artifact/pkg/controller/vm/internal/watcher/vmclass_watcher.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/watcher/vmclass_watcher.go
@@ -18,8 +18,8 @@ package watcher
 
 import (
 	"context"
-	"reflect"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -79,7 +79,9 @@ func (w VirtualMachineClassWatcher) Watch(mgr manager.Manager, ctr controller.Co
 				if !oldOk || !newOk {
 					return false
 				}
-				return !reflect.DeepEqual(oldVMC.Spec.SizingPolicies, newVMC.Spec.SizingPolicies)
+				return !equality.Semantic.DeepEqual(oldVMC.Spec.SizingPolicies, newVMC.Spec.SizingPolicies) ||
+					!equality.Semantic.DeepEqual(oldVMC.Spec.Tolerations, oldVMC.Spec.Tolerations) ||
+					!equality.Semantic.DeepEqual(oldVMC.Spec.NodeSelector, newVMC.Spec.NodeSelector)
 			},
 		},
 	)

--- a/images/virtualization-artifact/pkg/controller/vmchange/compare_test.go
+++ b/images/virtualization-artifact/pkg/controller/vmchange/compare_test.go
@@ -356,7 +356,7 @@ enableParavirtualization: true
 			currentSpec := loadVMSpec(t, tt.currentSpec)
 			desiredSpec := loadVMSpec(t, tt.desiredSpec)
 
-			changes = CompareSpecs(currentSpec, desiredSpec)
+			changes = CompareVMSpecs(currentSpec, desiredSpec)
 
 			defer func() {
 				if t.Failed() {

--- a/images/virtualization-artifact/pkg/controller/vmchange/vmclass_change.go
+++ b/images/virtualization-artifact/pkg/controller/vmchange/vmclass_change.go
@@ -1,0 +1,42 @@
+package vmchange
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+)
+
+func makePathWithClass(path string) string {
+	return fmt.Sprintf("VirtualMachineClass:%s", path)
+}
+
+func compareVmClassNodeSelector(current, desired *v1alpha2.VirtualMachineClassSpec) []FieldChange {
+	isEmpty := func(nodeSelector v1alpha2.NodeSelector) bool {
+		return len(nodeSelector.MatchExpressions) == 0 && len(nodeSelector.MatchLabels) == 0
+	}
+
+	currentValue := NewValue(current.NodeSelector, isEmpty(current.NodeSelector), false)
+	desiredValue := NewValue(desired.NodeSelector, isEmpty(desired.NodeSelector), false)
+
+	return compareValues(
+		makePathWithClass("spec.nodeSelector"),
+		currentValue,
+		desiredValue,
+		reflect.DeepEqual(current.NodeSelector, desired.NodeSelector),
+		ActionRestart,
+	)
+}
+
+func compareVmClassTolerations(current, desired *v1alpha2.VirtualMachineClassSpec) []FieldChange {
+	currentValue := NewValue(current.Tolerations, len(current.Tolerations) == 0, false)
+	desiredValue := NewValue(desired.Tolerations, len(desired.Tolerations) == 0, false)
+
+	return compareValues(
+		makePathWithClass("spec.tolerations"),
+		currentValue,
+		desiredValue,
+		reflect.DeepEqual(current.Tolerations, desired.Tolerations),
+		ActionRestart,
+	)
+}

--- a/images/virtualization-artifact/pkg/controller/vmchange/vmclass_change.go
+++ b/images/virtualization-artifact/pkg/controller/vmchange/vmclass_change.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package vmchange
 
 import (


### PR DESCRIPTION
## Description
- add annotation to save vmclass spec that was used to generate current kvvm.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

We need to detect changes in vmclass to set status that VM needs a restart to apply destructive changes from the vmclass spec.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
