### PR TITLE
fix(vm): unfreeze fs after snapshot

### DIFF
--- a/images/virtualization-artifact/pkg/controller/service/snapshot_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/snapshot_service.go
@@ -105,7 +105,9 @@ func (s *SnapshotService) CanUnfreeze(ctx context.Context, vdSnapshotName string
 
 		_, ok := vdByName[vdSnapshot.Spec.VirtualDiskName]
 		if ok {
-			return false, nil
+			if vdSnapshot.Status.Phase != virtv2.VirtualDiskSnapshotPhaseReady && vdSnapshot.Status.Phase != virtv2.VirtualDiskSnapshotPhaseFailed {
+				return false, nil
+			}
 		}
 	}
 
@@ -119,7 +121,9 @@ func (s *SnapshotService) CanUnfreeze(ctx context.Context, vdSnapshotName string
 
 	for _, vmSnapshot := range vmSnapshots.Items {
 		if vmSnapshot.Spec.VirtualMachineName == vm.Name {
-			return false, nil
+			if vmSnapshot.Status.Phase != virtv2.VirtualMachineSnapshotPhaseReady && vmSnapshot.Status.Phase != virtv2.VirtualMachineSnapshotPhaseFailed {
+				return false, nil
+			}
 		}
 	}
 

--- a/images/virtualization-artifact/pkg/controller/service/snapshot_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/snapshot_service.go
@@ -104,10 +104,11 @@ func (s *SnapshotService) CanUnfreeze(ctx context.Context, vdSnapshotName string
 		}
 
 		_, ok := vdByName[vdSnapshot.Spec.VirtualDiskName]
-		if ok {
-			if vdSnapshot.Status.Phase != virtv2.VirtualDiskSnapshotPhaseReady && vdSnapshot.Status.Phase != virtv2.VirtualDiskSnapshotPhaseFailed {
-				return false, nil
-			}
+		if ok &&
+			vdSnapshot.Status.Phase != virtv2.VirtualDiskSnapshotPhaseReady &&
+			vdSnapshot.Status.Phase != virtv2.VirtualDiskSnapshotPhaseFailed &&
+			vdSnapshot.Status.Phase != virtv2.VirtualDiskSnapshotPhaseTerminating {
+			return false, nil
 		}
 	}
 
@@ -120,10 +121,11 @@ func (s *SnapshotService) CanUnfreeze(ctx context.Context, vdSnapshotName string
 	}
 
 	for _, vmSnapshot := range vmSnapshots.Items {
-		if vmSnapshot.Spec.VirtualMachineName == vm.Name {
-			if vmSnapshot.Status.Phase != virtv2.VirtualMachineSnapshotPhaseReady && vmSnapshot.Status.Phase != virtv2.VirtualMachineSnapshotPhaseFailed {
-				return false, nil
-			}
+		if vmSnapshot.Spec.VirtualMachineName == vm.Name &&
+			vmSnapshot.Status.Phase != virtv2.VirtualMachineSnapshotPhaseReady &&
+			vmSnapshot.Status.Phase != virtv2.VirtualMachineSnapshotPhaseFailed &&
+			vmSnapshot.Status.Phase != virtv2.VirtualMachineSnapshotPhaseTerminating {
+			return false, nil
 		}
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/life_cycle.go
+++ b/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/life_cycle.go
@@ -82,6 +82,16 @@ func (h LifeCycleHandler) Handle(ctx context.Context, vdSnapshot *virtv2.Virtual
 	switch vdSnapshot.Status.Phase {
 	case "":
 		vdSnapshot.Status.Phase = virtv2.VirtualDiskSnapshotPhasePending
+
+	case virtv2.VirtualDiskSnapshotPhaseFailed:
+		vdSnapshotCondition, _ := conditions.GetCondition(vdscondition.VirtualDiskSnapshotReadyType, vdSnapshot.Status.Conditions)
+
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(conditions.CommonReason(vdSnapshotCondition.Reason)).
+			Message(vdSnapshotCondition.Message)
+
+		return reconcile.Result{}, nil
 	case virtv2.VirtualDiskSnapshotPhaseReady:
 		if vs == nil || vs.Status == nil || vs.Status.ReadyToUse == nil || !*vs.Status.ReadyToUse {
 			vdSnapshot.Status.Phase = virtv2.VirtualDiskSnapshotPhaseFailed

--- a/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/life_cycle.go
+++ b/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/life_cycle.go
@@ -72,6 +72,15 @@ func (h LifeCycleHandler) Handle(ctx context.Context, vmSnapshot *virtv2.Virtual
 	switch vmSnapshot.Status.Phase {
 	case "":
 		vmSnapshot.Status.Phase = virtv2.VirtualMachineSnapshotPhasePending
+	case virtv2.VirtualMachineSnapshotPhaseFailed:
+		vmSnapshotCondition, _ := conditions.GetCondition(vmscondition.VirtualMachineSnapshotReadyType, vmSnapshot.Status.Conditions)
+
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(conditions.CommonReason(vmSnapshotCondition.Reason)).
+			Message(vmSnapshotCondition.Message)
+
+		return reconcile.Result{}, nil
 	case virtv2.VirtualMachineSnapshotPhaseReady:
 		// Ensure vd snapshots aren't lost.
 		var lostVDSnapshots []string


### PR DESCRIPTION
## Description
Unfreeze vm fs after snapshot

## Why do we need it, and what problem does it solve?
Currently, with multiple disks and their snapshots, we do not unfreeze the fs

## What is the expected result?
fs unfreeze after all snapshots done

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
