### PR TITLE
feat(cdi): configure clone strategy of storage profile

### DIFF
--- a/images/cdi-artifact/patches/019-optimize-csi-clone.patch
+++ b/images/cdi-artifact/patches/019-optimize-csi-clone.patch
@@ -1,0 +1,30 @@
+diff --git a/pkg/controller/clone/csi-clone.go b/pkg/controller/clone/csi-clone.go
+index cbaff4c0d..e66a708cd 100644
+--- a/pkg/controller/clone/csi-clone.go
++++ b/pkg/controller/clone/csi-clone.go
+@@ -103,9 +103,10 @@ func (p *CSIClonePhase) createClaim(ctx context.Context) (*corev1.PersistentVolu
+ 		Name: sourceClaim.Name,
+ 	}
+ 
+-	sourceSize := sourceClaim.Status.Capacity[corev1.ResourceStorage]
+-	p.Log.V(3).Info("setting desired pvc request size to", "restoreSize", sourceSize)
+-	desiredClaim.Spec.Resources.Requests[corev1.ResourceStorage] = sourceSize
++	// With csi-clone, it's possible to specify the same or a larger capacity for the target pvc immediately, with no need to postpone resizing.
++	// sourceSize := sourceClaim.Status.Capacity[corev1.ResourceStorage]
++	// p.Log.V(3).Info("setting desired pvc request size to", "restoreSize", sourceSize)
++	// desiredClaim.Spec.Resources.Requests[corev1.ResourceStorage] = sourceSize
+ 
+ 	cc.AddAnnotation(desiredClaim, cc.AnnPopulatorKind, cdiv1.VolumeCloneSourceRef)
+ 	if p.OwnershipLabel != "" {
+diff --git a/pkg/storagecapabilities/storagecapabilities.go b/pkg/storagecapabilities/storagecapabilities.go
+index 11862364e..1d4fb97f2 100644
+--- a/pkg/storagecapabilities/storagecapabilities.go
++++ b/pkg/storagecapabilities/storagecapabilities.go
+@@ -144,6 +144,7 @@ var CloneStrategyByProvisionerKey = map[string]cdiv1.CDICloneStrategy{
+ 	"hspc.csi.hitachi.com":                     cdiv1.CloneStrategyCsiClone,
+ 	"csi.hpe.com":                              cdiv1.CloneStrategyCsiClone,
+ 	"spectrumscale.csi.ibm.com":                cdiv1.CloneStrategyCsiClone,
++	"rbd.csi.ceph.com":                         cdiv1.CloneStrategyCsiClone,
+ 	"rook-ceph.rbd.csi.ceph.com":               cdiv1.CloneStrategyCsiClone,
+ 	"openshift-storage.rbd.csi.ceph.com":       cdiv1.CloneStrategyCsiClone,
+ 	"cephfs.csi.ceph.com":                      cdiv1.CloneStrategyCsiClone,

--- a/images/cdi-artifact/patches/README.md
+++ b/images/cdi-artifact/patches/README.md
@@ -76,3 +76,8 @@ This is necessary for ensuring that the metrics can be accessed only by Promethe
 Currently covered metrics:
 - cdi-controller
 - cdi-deployment
+
+#### `019-optimize-csi-clone.patch`
+
+Cloning PVC to PVC for provisioner `rbd.csi.ceph.com` now works via csi-clone instead of snapshot.
+With csi-clone, it's possible to specify the same or a larger capacity for the target pvc immediately, with no need to postpone resizing.


### PR DESCRIPTION
## Description

1. Cloning PVC to PVC for provisioner `rbd.csi.ceph.com` now works via `csi-clone` instead of `snapshot`.
2. With `csi-clone`, it's possible to specify the same or a larger capacity for the target PVC immediately, with no need to postpone resizing.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
