### PR TITLE
refactor(vm): wrap KVMI ready reasons

### DIFF
--- a/api/core/v1alpha2/vmcondition/condition.go
+++ b/api/core/v1alpha2/vmcondition/condition.go
@@ -103,4 +103,9 @@ const (
 
 	ReasonBlockDeviceCapacityAvailable Reason = "BlockDeviceCapacityAvailable"
 	ReasonBlockDeviceCapacityReached   Reason = "BlockDeviceCapacityReached"
+
+	ReasonPodTerminatingReason      Reason = "PodTerminating"
+	ReasonPodNotExistsReason        Reason = "PodNotExists"
+	ReasonPodConditionMissingReason Reason = "PodConditionMissing"
+	ReasonGuestNotRunningReason     Reason = "GuestNotRunning"
 )

--- a/images/virtualization-artifact/pkg/controller/conditions/stringer.go
+++ b/images/virtualization-artifact/pkg/controller/conditions/stringer.go
@@ -29,14 +29,3 @@ func (cr CommonReason) String() string {
 const (
 	ReasonUnknown CommonReason = "Unknown"
 )
-
-// Deprecated: avoid using this wrapper.
-// TODO: get rid of this wrapper.
-type DeprecatedWrappedString string
-
-func (s DeprecatedWrappedString) String() string {
-	if s == "" {
-		return "Unknown"
-	}
-	return string(s)
-}

--- a/images/virtualization-artifact/pkg/controller/vm/internal/lifecycle.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/lifecycle.go
@@ -265,16 +265,8 @@ func (h *LifeCycleHandler) syncRunning(vm *virtv2.VirtualMachine, kvvm *virtv1.V
 		}
 		for _, c := range kvvmi.Status.Conditions {
 			if c.Type == virtv1.VirtualMachineInstanceReady {
-				var reason conditions.Stringer
-				if r, ok := mapReasons[c.Reason]; ok {
-					reason = r
-				} else {
-					//nolint:staticcheck
-					reason = conditions.DeprecatedWrappedString(c.Reason)
-				}
-
 				cb.Status(conditionStatus(string(c.Status))).
-					Reason(reason).
+					Reason(getKVMIReadyReason(c.Reason)).
 					Message(c.Message)
 				conditions.SetCondition(cb, &vm.Status.Conditions)
 				return

--- a/images/virtualization-artifact/pkg/controller/vm/internal/lifecycle.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/lifecycle.go
@@ -265,9 +265,16 @@ func (h *LifeCycleHandler) syncRunning(vm *virtv2.VirtualMachine, kvvm *virtv1.V
 		}
 		for _, c := range kvvmi.Status.Conditions {
 			if c.Type == virtv1.VirtualMachineInstanceReady {
-				cb.Status(conditionStatus(string(c.Status))).
+				var reason conditions.Stringer
+				if r, ok := mapReasons[c.Reason]; ok {
+					reason = r
+				} else {
 					//nolint:staticcheck
-					Reason(conditions.DeprecatedWrappedString(c.Reason)).
+					reason = conditions.DeprecatedWrappedString(c.Reason)
+				}
+
+				cb.Status(conditionStatus(string(c.Status))).
+					Reason(reason).
 					Message(c.Message)
 				conditions.SetCondition(cb, &vm.Status.Conditions)
 				return

--- a/images/virtualization-artifact/pkg/controller/vm/internal/util.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/util.go
@@ -133,6 +133,17 @@ var mapPhases = map[virtv1.VirtualMachinePrintableStatus]virtv2.MachinePhase{
 
 const kvvmEmptyPhase virtv1.VirtualMachinePrintableStatus = ""
 
+var mapReasons = map[string]vmcondition.Reason{
+	// PodTerminatingReason indicates on the Ready condition on the VMI if the underlying pod is terminating
+	virtv1.PodTerminatingReason: vmcondition.ReasonPodTerminatingReason,
+	// PodNotExistsReason indicates on the Ready condition on the VMI if the underlying pod does not exist
+	virtv1.PodNotExistsReason: vmcondition.ReasonPodNotExistsReason,
+	// PodConditionMissingReason indicates on the Ready condition on the VMI if the underlying pod does not report a Ready condition
+	virtv1.PodConditionMissingReason: vmcondition.ReasonPodConditionMissingReason,
+	// GuestNotRunningReason indicates on the Ready condition on the VMI if the underlying guest VM is not running
+	virtv1.GuestNotRunningReason: vmcondition.ReasonGuestNotRunningReason,
+}
+
 func isPodStartedError(phase virtv1.VirtualMachinePrintableStatus) bool {
 	return slices.Contains([]virtv1.VirtualMachinePrintableStatus{
 		virtv1.VirtualMachineStatusErrImagePull,

--- a/images/virtualization-artifact/pkg/controller/vm/internal/util.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/util.go
@@ -133,6 +133,18 @@ var mapPhases = map[virtv1.VirtualMachinePrintableStatus]virtv2.MachinePhase{
 
 const kvvmEmptyPhase virtv1.VirtualMachinePrintableStatus = ""
 
+func getKVMIReadyReason(kvmiReason string) conditions.Stringer {
+	if r, ok := mapReasons[kvmiReason]; ok {
+		return r
+	}
+
+	if kvmiReason == "" {
+		return conditions.ReasonUnknown
+	}
+
+	return conditions.CommonReason(kvmiReason)
+}
+
 var mapReasons = map[string]vmcondition.Reason{
 	// PodTerminatingReason indicates on the Ready condition on the VMI if the underlying pod is terminating
 	virtv1.PodTerminatingReason: vmcondition.ReasonPodTerminatingReason,


### PR DESCRIPTION
## Description
Wrap reason for VirtualMachineInstanceReady condition

## Why do we need it, and what problem does it solve?
Remove deprecated code

## What is the expected result?
Same behavior, but with our types

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
