### PR TITLE
feat: add webhook for validating module config virtualization

### DIFF
--- a/hooks/module_config_validator.py
+++ b/hooks/module_config_validator.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+#
+# Copyright 2024 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Callable
+from deckhouse import hook
+from lib.hooks.hook import Hook
+from ipaddress import ip_network,ip_address,IPv4Network,IPv4Address
+import common
+
+
+class ModuleConfigValidateHook(Hook):
+    KIND="ModuleConfig"
+    API_VERSION="deckhouse.io/v1alpha1"
+    SNAPSHOT_MODULE_CONFIG = "module-config"
+    SNAPSHOT_NODES = "nodes"
+
+    def __init__(self, module_name: str):
+        self.module_name = module_name
+        self.queue = f"/modules/{self.module_name}/{self.SNAPSHOT_MODULE_CONFIG}"
+
+    def generate_config(self) -> dict:
+        """executeHookOnEvent is empty because we need only execute at module start."""
+        return {
+            "configVersion": "v1",
+            "kubernetes": [
+                {
+                    "name": self.SNAPSHOT_MODULE_CONFIG,
+                    "executeHookOnSynchronization": True,
+                    "executeHookOnEvent": [],
+                    "apiVersion": self.API_VERSION,
+                    "kind": self.KIND,
+                    "nameSelector": {
+                        "matchNames": [self.module_name]
+                    },
+                    "group": "main",
+                    "jqFilter": '{"cidrs": .spec.settings.virtualMachineCIDRs}',
+                    "queue": self.queue,
+                    "keepFullObjectsInMemory": False
+                },
+                {
+                    "name": self.SNAPSHOT_NODES,
+                    "executeHookOnSynchronization": True,
+                    "executeHookOnEvent": [],
+                    "apiVersion": "v1",
+                    "kind": "Node",
+                    "group": "main",
+                    "jqFilter": '{"addresses": .status.addresses}',
+                    "queue": self.queue,
+                    "keepFullObjectsInMemory": False
+                }
+            ]
+        }
+
+    def check_overlaps_cidrs(networks: list[IPv4Network]) -> None:
+        """Check for overlapping CIDRs in a list of networks."""
+        for i, net1 in enumerate(networks):
+            for net2 in networks[i + 1:]:
+                if net1.overlaps(net2):
+                    raise ValueError(f"Overlapping CIDRs {net1} and {net2}")
+
+    def check_node_addresses_overlap(networks: list[IPv4Network], node_addresses: list[IPv4Address]) -> None:
+        """Check if node addresses overlap with any subnet."""
+        for addr in node_addresses:
+            for net in networks:
+                if addr in net:
+                    raise ValueError(f"Node address {addr} overlaps with subnet {net}")
+
+    def reconcile(self) -> Callable[[hook.Context], None]:
+        def r(ctx: hook.Context):
+            cidrs: list[IPv4Network] = [
+                ip_network(c)
+                for c in ctx.snapshots.get(self.SNAPSHOT_MODULE_CONFIG, [{}])[0]
+                .get("filterResult", {})
+                .get("cidrs", [])
+            ]
+            self.check_overlaps_cidrs(cidrs)
+
+            node_addresses: list[IPv4Address] = [
+                ip_address(addr["address"])
+                for snap in ctx.snapshots.get(self.SNAPSHOT_NODES, [])
+                for addr in (snap.get("filterResult", {}).get("addresses") or [])
+                if addr.get("type") in {"InternalIP", "ExternalIP"}
+            ]
+            self.check_node_addresses_overlap(cidrs, node_addresses)
+
+        return r
+
+
+if __name__ == "__main__":
+    h = ModuleConfigValidateHook(common.MODULE_NAME)
+    h.run()

--- a/images/virtualization-artifact/cmd/virtualization-controller/main.go
+++ b/images/virtualization-artifact/cmd/virtualization-controller/main.go
@@ -40,6 +40,8 @@ import (
 	appconfig "github.com/deckhouse/virtualization-controller/pkg/config"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/cvi"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/indexer"
+	mc "github.com/deckhouse/virtualization-controller/pkg/controller/moduleconfig"
+	mcapi "github.com/deckhouse/virtualization-controller/pkg/controller/moduleconfig/api"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vd"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vdsnapshot"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vi"
@@ -166,6 +168,7 @@ func main() {
 		cdiv1beta1.AddToScheme,
 		virtv1.AddToScheme,
 		vsv1.AddToScheme,
+		mcapi.AddToScheme,
 	} {
 		err = f(scheme)
 		if err != nil {
@@ -301,6 +304,11 @@ func main() {
 		os.Exit(1)
 	}
 	if err = vmop.SetupGC(mgr, vmopLogger, gcSettings.VMOP); err != nil {
+		log.Error(err.Error())
+		os.Exit(1)
+	}
+
+	if err = mc.SetupWebhookWithManager(mgr); err != nil {
 		log.Error(err.Error())
 		os.Exit(1)
 	}

--- a/images/virtualization-artifact/pkg/controller/moduleconfig/api/deep_copy.go
+++ b/images/virtualization-artifact/pkg/controller/moduleconfig/api/deep_copy.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import "k8s.io/apimachinery/pkg/runtime"
+
+func (in *ModuleConfig) DeepCopyInto(out *ModuleConfig) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	in.Spec.DeepCopyInto(&out.Spec)
+	out.Status = in.Status
+}
+
+func (in *ModuleConfig) DeepCopy() *ModuleConfig {
+	if in == nil {
+		return nil
+	}
+	out := new(ModuleConfig)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *ModuleConfig) DeepCopyObject() runtime.Object {
+	if c := in.DeepCopy(); c != nil {
+		return c
+	}
+	return nil
+}
+
+func (in *ModuleConfigList) DeepCopyInto(out *ModuleConfigList) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]ModuleConfig, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+}
+
+func (in *ModuleConfigList) DeepCopy() *ModuleConfigList {
+	if in == nil {
+		return nil
+	}
+	out := new(ModuleConfigList)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *ModuleConfigList) DeepCopyObject() runtime.Object {
+	if c := in.DeepCopy(); c != nil {
+		return c
+	}
+	return nil
+}
+
+func (in *ModuleConfigSpec) DeepCopyInto(out *ModuleConfigSpec) {
+	*out = *in
+	in.Settings.DeepCopyInto(&out.Settings)
+	if in.Enabled != nil {
+		in, out := &in.Enabled, &out.Enabled
+		*out = new(bool)
+		**out = **in
+	}
+}
+
+func (in *ModuleConfigSpec) DeepCopy() *ModuleConfigSpec {
+	if in == nil {
+		return nil
+	}
+	out := new(ModuleConfigSpec)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *ModuleConfigStatus) DeepCopyInto(out *ModuleConfigStatus) {
+	*out = *in
+}
+
+func (in *ModuleConfigStatus) DeepCopy() *ModuleConfigStatus {
+	if in == nil {
+		return nil
+	}
+	out := new(ModuleConfigStatus)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (v *SettingsValues) DeepCopy() *SettingsValues {
+	nmap := make(map[string]interface{}, len(*v))
+
+	for key, value := range *v {
+		nmap[key] = value
+	}
+
+	vv := SettingsValues(nmap)
+
+	return &vv
+}
+
+func (v SettingsValues) DeepCopyInto(out *SettingsValues) {
+	{
+		v := &v
+		clone := v.DeepCopy()
+		*out = *clone
+		return
+	}
+}

--- a/images/virtualization-artifact/pkg/controller/moduleconfig/api/moduleconfig.go
+++ b/images/virtualization-artifact/pkg/controller/moduleconfig/api/moduleconfig.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var _ runtime.Object = (*ModuleConfig)(nil)
+
+// ModuleConfig is a configuration for module or for global config values.
+type ModuleConfig struct {
+	metav1.TypeMeta `json:",inline"`
+	// +optional
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec ModuleConfigSpec `json:"spec"`
+
+	Status ModuleConfigStatus `json:"status,omitempty"`
+}
+
+// SettingsValues empty interface in needed to handle DeepCopy generation. DeepCopy does not work with unnamed empty interfaces
+type SettingsValues map[string]interface{}
+
+type ModuleConfigSpec struct {
+	Version  int            `json:"version,omitempty"`
+	Settings SettingsValues `json:"settings,omitempty"`
+	Enabled  *bool          `json:"enabled,omitempty"`
+}
+
+type ModuleConfigStatus struct {
+	Version string `json:"version"`
+	Message string `json:"message"`
+}
+
+// ModuleConfigList is a list of ModuleConfig resources
+type ModuleConfigList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata"`
+
+	Items []ModuleConfig `json:"items"`
+}

--- a/images/virtualization-artifact/pkg/controller/moduleconfig/api/register.go
+++ b/images/virtualization-artifact/pkg/controller/moduleconfig/api/register.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const (
+	Version   = "v1alpha1"
+	GroupName = "deckhouse.io"
+)
+
+// SchemeGroupVersion is group version used to register these objects
+var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: Version}
+
+// Resource takes an unqualified resource and returns a Group qualified GroupResource
+func Resource(resource string) schema.GroupResource {
+	return SchemeGroupVersion.WithResource(resource).GroupResource()
+}
+
+var (
+	// SchemeBuilder tbd
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	// AddToScheme tbd
+	AddToScheme = SchemeBuilder.AddToScheme
+)
+
+// Adds the list of known types to api.Scheme.
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(SchemeGroupVersion,
+		&ModuleConfig{},
+		&ModuleConfigList{},
+	)
+
+	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+	return nil
+}

--- a/images/virtualization-artifact/pkg/controller/moduleconfig/cidrs_validator.go
+++ b/images/virtualization-artifact/pkg/controller/moduleconfig/cidrs_validator.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package moduleconfig
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	mcapi "github.com/deckhouse/virtualization-controller/pkg/controller/moduleconfig/api"
+)
+
+type cidrsValidator struct {
+	client client.Client
+}
+
+func newCIDRsValidator(client client.Client) *cidrsValidator {
+	return &cidrsValidator{
+		client: client,
+	}
+}
+
+func (v cidrsValidator) ValidateUpdate(ctx context.Context, _, newMC *mcapi.ModuleConfig) (admission.Warnings, error) {
+	CIDRs, err := parseCIDRs(newMC.Spec.Settings)
+	if err != nil {
+		return admission.Warnings{}, err
+	}
+
+	err = checkOverlapsCIDRs(CIDRs)
+	if err != nil {
+		return admission.Warnings{}, err
+	}
+
+	err = v.checkNodeSubnets(ctx, CIDRs)
+	if err != nil {
+		return admission.Warnings{}, err
+	}
+
+	return admission.Warnings{}, nil
+}
+
+func (v cidrsValidator) checkNodeSubnets(ctx context.Context, excludedPrefixes []netip.Prefix) error {
+	nodes := &corev1.NodeList{}
+	err := v.client.List(ctx, nodes)
+	if err != nil {
+		return fmt.Errorf("internal error: unable to retrieve nodes at the moment, please try again later. Details: %w", err)
+	}
+	return checkNodeAddressesOverlap(nodes.Items, excludedPrefixes)
+}

--- a/images/virtualization-artifact/pkg/controller/moduleconfig/moduleconfig_webhook.go
+++ b/images/virtualization-artifact/pkg/controller/moduleconfig/moduleconfig_webhook.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package moduleconfig
+
+import (
+	"log/slog"
+
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
+	mcapi "github.com/deckhouse/virtualization-controller/pkg/controller/moduleconfig/api"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/validator"
+)
+
+const moduleConfigName = "virtualization"
+
+func SetupWebhookWithManager(mgr manager.Manager) error {
+	moduleConfigValidator := NewModuleConfigValidator(mgr.GetClient())
+	if err := builder.WebhookManagedBy(mgr).
+		For(&mcapi.ModuleConfig{}).
+		WithValidator(moduleConfigValidator).
+		Complete(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func NewModuleConfigValidator(client client.Client) *validator.Validator[*mcapi.ModuleConfig] {
+	logger := log.Default().With(slog.String("validator", "moduleconfig"))
+
+	cidrs := newCIDRsValidator(client)
+	reduceCIDRs := newRemoveCIDRsValidator(client)
+
+	return validator.NewValidator[*mcapi.ModuleConfig](logger).
+		WithPredicate(&validator.Predicate[*mcapi.ModuleConfig]{
+			Update: func(oldMC, newMC *mcapi.ModuleConfig) bool {
+				return newMC.GetName() == moduleConfigName &&
+					oldMC.GetGeneration() != newMC.GetGeneration()
+			},
+		}).
+		WithUpdateValidators(cidrs, reduceCIDRs)
+}

--- a/images/virtualization-artifact/pkg/controller/moduleconfig/remove_cidrs_validator.go
+++ b/images/virtualization-artifact/pkg/controller/moduleconfig/remove_cidrs_validator.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package moduleconfig
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/deckhouse/virtualization-controller/pkg/common/ip"
+	mcapi "github.com/deckhouse/virtualization-controller/pkg/controller/moduleconfig/api"
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+)
+
+type removeCIDRsValidator struct {
+	client client.Client
+}
+
+func newRemoveCIDRsValidator(client client.Client) *removeCIDRsValidator {
+	return &removeCIDRsValidator{
+		client: client,
+	}
+}
+
+func (v removeCIDRsValidator) ValidateUpdate(ctx context.Context, oldMC, newMC *mcapi.ModuleConfig) (admission.Warnings, error) {
+	oldCIDRs, err := parseCIDRs(oldMC.Spec.Settings)
+	if err != nil {
+		return admission.Warnings{}, err
+	}
+	newCIDRs, err := parseCIDRs(newMC.Spec.Settings)
+	if err != nil {
+		return admission.Warnings{}, err
+	}
+
+	var validateCIDRs []netip.Prefix
+
+loop:
+	for _, oldCIDR := range oldCIDRs {
+		for _, newCIDR := range newCIDRs {
+			if isEqualCIDRs(oldCIDR, newCIDR) {
+				continue loop
+			}
+		}
+		validateCIDRs = append(validateCIDRs, oldCIDR)
+	}
+
+	if len(validateCIDRs) == 0 {
+		return nil, nil
+	}
+
+	leases := &virtv2.VirtualMachineIPAddressLeaseList{}
+	if err := v.client.List(ctx, leases); err != nil {
+		return nil, fmt.Errorf("failed to list VirtualMachineIPAddressLeases: %w", err)
+	}
+
+	for _, lease := range leases.Items {
+		leaseIP, err := netip.ParseAddr(ip.LeaseNameToIP(lease.Name))
+		if err != nil {
+			continue
+		}
+		for _, CIDR := range validateCIDRs {
+			if CIDR.Contains(leaseIP) {
+				return nil, fmt.Errorf("virtualMachineCIDRs item %q can't be removed: VirtualMachineIPAddressLease/%s holds IP address from this network", CIDR, lease.GetName())
+			}
+		}
+	}
+
+	return nil, nil
+}

--- a/images/virtualization-artifact/pkg/controller/moduleconfig/util.go
+++ b/images/virtualization-artifact/pkg/controller/moduleconfig/util.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package moduleconfig
+
+import (
+	"fmt"
+	"net/netip"
+
+	corev1 "k8s.io/api/core/v1"
+
+	mcapi "github.com/deckhouse/virtualization-controller/pkg/controller/moduleconfig/api"
+)
+
+const virtualMachineCIDRs = "virtualMachineCIDRs"
+
+func isEqualCIDRs(a, b netip.Prefix) bool {
+	return a.Addr() == b.Addr() && a.Bits() == b.Bits()
+}
+
+func checkOverlapsCIDRs(prefixes []netip.Prefix) error {
+	for i := 0; i < len(prefixes); i++ {
+		for j := i + 1; j < len(prefixes); j++ {
+			if prefixes[i].Overlaps(prefixes[j]) {
+				return fmt.Errorf("subnets must not overlap, but there is an overlap between CIDRs %v and %v. Please adjust the configuration to resolve this issue", prefixes[i], prefixes[j])
+			}
+		}
+	}
+	return nil
+}
+
+func checkNodeAddressesOverlap(nodes []corev1.Node, excludedPrefixes []netip.Prefix) error {
+	for _, node := range nodes {
+		for _, address := range node.Status.Addresses {
+			if address.Type == corev1.NodeInternalIP || address.Type == corev1.NodeExternalIP {
+				ip, err := netip.ParseAddr(address.Address)
+				if err != nil {
+					// No way to detect if invalid address is in excludedPrefixes, just ignore the error and move on.
+					continue
+				}
+
+				for _, prefix := range excludedPrefixes {
+					if prefix.Contains(ip) {
+						return fmt.Errorf("subnet %s is invalid, it should not contain addresses assigned to nodes: got node %s with IP %s", prefix, node.GetName(), ip)
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func parseCIDRs(settings mcapi.SettingsValues) ([]netip.Prefix, error) {
+	raw := settings[virtualMachineCIDRs].([]interface{})
+	CIDRs, err := convertToStringSlice(raw)
+	if err != nil {
+		return nil, err
+	}
+	parsedCIDRs := make([]netip.Prefix, len(CIDRs))
+	for i, CIDR := range CIDRs {
+		parsedCIDR, err := netip.ParsePrefix(CIDR)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse CIDR %s: %w", CIDR, err)
+		}
+		parsedCIDRs[i] = parsedCIDR
+	}
+	return parsedCIDRs, nil
+}
+
+func convertToStringSlice(input []interface{}) ([]string, error) {
+	result := make([]string, len(input))
+	for i, v := range input {
+		strVal, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("failed to convert value %v to a string", v)
+		}
+		result[i] = strVal
+	}
+	return result, nil
+}

--- a/images/virtualization-artifact/pkg/controller/validator/validator.go
+++ b/images/virtualization-artifact/pkg/controller/validator/validator.go
@@ -1,0 +1,229 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validator
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
+	"github.com/deckhouse/virtualization-controller/pkg/logger"
+)
+
+type CreateValidator[T client.Object] interface {
+	ValidateCreate(ctx context.Context, obj T) (admission.Warnings, error)
+}
+
+type UpdateValidator[T client.Object] interface {
+	ValidateUpdate(ctx context.Context, oldObj, newObj T) (admission.Warnings, error)
+}
+
+type DeleteValidator[T client.Object] interface {
+	ValidateDelete(ctx context.Context, obj T) (admission.Warnings, error)
+}
+
+type (
+	PredicateCreateFunc[T client.Object] func(obj T) bool
+	PredicateUpdateFunc[T client.Object] func(oldObj, newObj T) bool
+	PredicateDeleteFunc[T client.Object] func(obj T) bool
+)
+
+type Predicate[T client.Object] struct {
+	Create PredicateCreateFunc[T]
+	Update PredicateUpdateFunc[T]
+	Delete PredicateDeleteFunc[T]
+}
+
+var _ admission.CustomValidator = &Validator[client.Object]{}
+
+type Validator[T client.Object] struct {
+	create []CreateValidator[T]
+	update []UpdateValidator[T]
+	delete []DeleteValidator[T]
+
+	predicate *Predicate[T]
+
+	log *log.Logger
+}
+
+func NewValidator[T client.Object](log *log.Logger) *Validator[T] {
+	return &Validator[T]{log: log}
+}
+
+func (v *Validator[T]) WithCreateValidators(validators ...CreateValidator[T]) *Validator[T] {
+	v.create = append(v.create, validators...)
+	return v
+}
+
+func (v *Validator[T]) WithUpdateValidators(validators ...UpdateValidator[T]) *Validator[T] {
+	v.update = append(v.update, validators...)
+	return v
+}
+
+func (v *Validator[T]) WithDeleteValidators(validators ...DeleteValidator[T]) *Validator[T] {
+	v.delete = append(v.delete, validators...)
+	return v
+}
+
+func (v *Validator[T]) WithPredicate(predicate *Predicate[T]) *Validator[T] {
+	v.predicate = predicate
+	return v
+}
+
+func (v *Validator[T]) ValidateCreate(ctx context.Context, obj runtime.Object) (w admission.Warnings, err error) {
+	if len(v.create) == 0 {
+		err = fmt.Errorf("misconfigured webhook rules: create operation not implemented")
+		v.log.Error("Ensure the correctness of ValidatingWebhookConfiguration", logger.SlogErr(err))
+		return nil, nil
+	}
+	defer func() {
+		if err != nil {
+			v.logErr(err)
+		}
+	}()
+
+	o, err := v.newObject(obj)
+	if err != nil {
+		return nil, err
+	}
+	if !v.needCreateValidate(o) {
+		return nil, nil
+	}
+
+	var warnings admission.Warnings
+
+	for _, validator := range v.create {
+		warn, err := validator.ValidateCreate(ctx, o)
+		if err != nil {
+			return nil, err
+		}
+		warnings = append(warnings, warn...)
+	}
+
+	return warnings, nil
+}
+
+func (v *Validator[T]) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (w admission.Warnings, err error) {
+	if len(v.update) == 0 {
+		err = fmt.Errorf("misconfigured webhook rules: update operation not implemented")
+		v.log.Error("Ensure the correctness of ValidatingWebhookConfiguration", logger.SlogErr(err))
+		return nil, nil
+	}
+	defer func() {
+		if err != nil {
+			v.logErr(err)
+		}
+	}()
+
+	oldO, err := v.newObject(oldObj)
+	if err != nil {
+		return nil, err
+	}
+	newO, err := v.newObject(newObj)
+	if err != nil {
+		return nil, err
+	}
+	if !v.needUpdateValidate(oldO, newO) {
+		return nil, nil
+	}
+	var warnings admission.Warnings
+
+	for _, validator := range v.update {
+		warn, err := validator.ValidateUpdate(ctx, oldO, newO)
+		if err != nil {
+			return nil, err
+		}
+		warnings = append(warnings, warn...)
+	}
+
+	return warnings, nil
+}
+
+func (v *Validator[T]) ValidateDelete(ctx context.Context, obj runtime.Object) (w admission.Warnings, err error) {
+	if len(v.delete) == 0 {
+		err = fmt.Errorf("misconfigured webhook rules: delete operation not implemented")
+		v.log.Error("Ensure the correctness of ValidatingWebhookConfiguration", logger.SlogErr(err))
+		return nil, nil
+	}
+	defer func() {
+		if err != nil {
+			v.logErr(err)
+		}
+	}()
+
+	o, err := v.newObject(obj)
+	if err != nil {
+		return nil, err
+	}
+	if !v.needDeleteValidate(o) {
+		return nil, nil
+	}
+
+	var warnings admission.Warnings
+
+	for _, validator := range v.delete {
+		warn, err := validator.ValidateDelete(ctx, o)
+		if err != nil {
+			return nil, err
+		}
+		warnings = append(warnings, warn...)
+	}
+
+	return warnings, nil
+}
+
+func (v *Validator[T]) newObject(obj runtime.Object) (T, error) {
+	newObj, ok := obj.(T)
+	if !ok {
+		var empty T
+		return empty, fmt.Errorf("expected a new %T but got a %T", empty, newObj)
+	}
+	return newObj, nil
+}
+
+func (v *Validator[T]) needCreateValidate(obj T) bool {
+	if v.predicate != nil && v.predicate.Create != nil {
+		return v.predicate.Create(obj)
+	}
+	return true
+}
+
+func (v *Validator[T]) needUpdateValidate(oldObj, newObj T) bool {
+	if v.predicate != nil && v.predicate.Update != nil {
+		return v.predicate.Update(oldObj, newObj)
+	}
+	return true
+}
+
+func (v *Validator[T]) needDeleteValidate(obj T) bool {
+	if v.predicate != nil && v.predicate.Delete != nil {
+		return v.predicate.Delete(obj)
+	}
+	return true
+}
+
+func (v *Validator[T]) logErr(err error) {
+	var empty T
+	v.log.Error(
+		fmt.Sprintf("An error occurred while processing %T", empty),
+		logger.SlogErr(err),
+	)
+}

--- a/templates/virtualization-controller/validation-webhook.yaml
+++ b/templates/virtualization-controller/validation-webhook.yaml
@@ -207,3 +207,25 @@ webhooks:
         {{ .Values.virtualization.internal.controller.cert.ca }}
     admissionReviewVersions: ["v1"]
     sideEffects: None
+  - name: "moduleconfig.virtualization-controller.validate.d8-virtualization"
+    rules:
+      - apiGroups: ["deckhouse.io"]
+        apiVersions: ["v1alpha1"]
+        operations: ["UPDATE"]
+        resources: ["moduleconfigs"]
+        scope: "Cluster"
+    clientConfig:
+      service:
+        namespace: d8-{{ .Chart.Name }}
+        name: virtualization-controller
+        path: /validate-deckhouse-io-v1alpha1-moduleconfig
+        port: 443
+      caBundle: |
+        {{ .Values.virtualization.internal.controller.cert.ca }}
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
+    {{- if semverCompare ">=1.27.0" .Values.global.clusterConfiguration.kubernetesVersion }}
+    matchConditions:
+      - name: 'match-virtualization'
+        expression: 'request.name == "virtualization"'
+    {{- end }}


### PR DESCRIPTION
## Description
Add a webhook for ModuleConfig Virtualization
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
It is forbidden to delete used CIDRs
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
