### PR TITLE
fix(cdi): change clone strategy fot sds provisioners

### DIFF
--- a/images/cdi-artifact/patches/021-fallback-to-host-clone-for-lvm-thick.patch
+++ b/images/cdi-artifact/patches/021-fallback-to-host-clone-for-lvm-thick.patch
@@ -1,0 +1,692 @@
+diff --git a/cmd/cdi-controller/controller.go b/cmd/cdi-controller/controller.go
+index 0f78f9ab5..1d74be0b4 100644
+--- a/cmd/cdi-controller/controller.go
++++ b/cmd/cdi-controller/controller.go
+@@ -8,6 +8,7 @@ import (
+ 	"os"
+ 	"strconv"
+ 
++	rcsiv1 "github.com/deckhouse/sds-replicated-volume/api/v1alpha1"
+ 	"github.com/kelseyhightower/envconfig"
+ 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
+ 	ocpconfigv1 "github.com/openshift/api/config/v1"
+@@ -78,6 +79,7 @@ var (
+ 		imagev1.Install,
+ 		ocpconfigv1.Install,
+ 		routev1.Install,
++		rcsiv1.AddToScheme,
+ 	}
+ )
+ 
+diff --git a/go.mod b/go.mod
+index d7b79b6fd..fcc671287 100644
+--- a/go.mod
++++ b/go.mod
+@@ -79,6 +79,7 @@ require (
+ 	github.com/containers/ocicrypt v1.2.0 // indirect
+ 	github.com/containers/storage v1.55.0 // indirect
+ 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
++	github.com/deckhouse/sds-replicated-volume/api v0.0.0-20241206095502-b096856636cd // indirect
+ 	github.com/distribution/reference v0.6.0 // indirect
+ 	github.com/docker/distribution v2.8.3+incompatible // indirect
+ 	github.com/docker/docker v27.1.1+incompatible // indirect
+diff --git a/go.sum b/go.sum
+index b5e6a41fb..90924be61 100644
+--- a/go.sum
++++ b/go.sum
+@@ -881,6 +881,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
+ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
+ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+ github.com/davecgh/go-xdr v0.0.0-20161123171359-e6a2ba005892/go.mod h1:CTDl0pzVzE5DEzZhPfvhY/9sPFMQIxaJ9VAMs9AagrE=
++github.com/deckhouse/sds-replicated-volume/api v0.0.0-20241206095502-b096856636cd h1:MJzcWolbjy6SnZs9NMhvAq4KZdWRSQNIjcM9h+qGXa0=
++github.com/deckhouse/sds-replicated-volume/api v0.0.0-20241206095502-b096856636cd/go.mod h1:6yz0RtbkLVJtK2DeuvgfaqBZRl5V5ax1WsfPF5pbnvo=
+ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+ github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
+diff --git a/pkg/controller/storageprofile-controller.go b/pkg/controller/storageprofile-controller.go
+index c66a79983..5a44bf1ac 100644
+--- a/pkg/controller/storageprofile-controller.go
++++ b/pkg/controller/storageprofile-controller.go
+@@ -194,6 +194,16 @@ func (r *StorageProfileReconciler) reconcileCloneStrategy(sc *storagev1.StorageC
+ 		strategy = knownStrategy
+ 	}
+ 
++	if overrider, ok := storagecapabilities.GetCloneStrategyOverrider(sc); ok {
++		strategyToUse, err := overrider(context.TODO(), r.client, sc)
++		if err != nil {
++			r.log.Error(fmt.Errorf("override clone strategy: %w", err), "StorageClass.Name", sc.Name, "oldStrategy", strategy, "newStrategy", cdiv1.CloneStrategyHostAssisted)
++			strategy = cdiv1.CloneStrategyHostAssisted
++		} else {
++			strategy = strategyToUse
++		}
++	}
++
+ 	if strategy == cdiv1.CloneStrategySnapshot && snapClass == "" {
+ 		r.log.Info("No VolumeSnapshotClass found for storage class, falling back to host assisted cloning", "StorageClass.Name", sc.Name)
+ 		return &hostAssistedStrategy
+diff --git a/pkg/operator/resources/cluster/controller.go b/pkg/operator/resources/cluster/controller.go
+index 2760dd201..732bdb2f5 100644
+--- a/pkg/operator/resources/cluster/controller.go
++++ b/pkg/operator/resources/cluster/controller.go
+@@ -42,6 +42,20 @@ func createControllerClusterRoleBinding(namespace string) *rbacv1.ClusterRoleBin
+ 
+ func getControllerClusterPolicyRules() []rbacv1.PolicyRule {
+ 	return []rbacv1.PolicyRule{
++		{
++			APIGroups: []string{
++				"storage.deckhouse.io",
++			},
++			Resources: []string{
++				"replicatedstorageclasses",
++				"replicatedstoragepools",
++			},
++			Verbs: []string{
++				"get",
++				"list",
++				"watch",
++			},
++		},
+ 		{
+ 			APIGroups: []string{
+ 				"",
+diff --git a/pkg/storagecapabilities/storagecapabilities.go b/pkg/storagecapabilities/storagecapabilities.go
+index 11862364e..ec037f910 100644
+--- a/pkg/storagecapabilities/storagecapabilities.go
++++ b/pkg/storagecapabilities/storagecapabilities.go
+@@ -4,10 +4,13 @@ package storagecapabilities
+ 
+ import (
+ 	"context"
++	"fmt"
+ 	"strings"
+ 
++	rcsiv1 "github.com/deckhouse/sds-replicated-volume/api/v1alpha1"
+ 	v1 "k8s.io/api/core/v1"
+ 	storagev1 "k8s.io/api/storage/v1"
++	"k8s.io/apimachinery/pkg/types"
+ 	storagehelpers "k8s.io/component-helpers/storage/volume"
+ 
+ 	"sigs.k8s.io/controller-runtime/pkg/client"
+@@ -135,6 +138,13 @@ var SourceFormatsByProvisionerKey = map[string]cdiv1.DataImportCronSourceFormat{
+ 	"csi.trident.netapp.io/ontap-san":    cdiv1.DataImportCronSourceFormatSnapshot,
+ }
+ 
++type CloneStrategyOverrider func(context.Context, client.Client, *storagev1.StorageClass) (cdiv1.CDICloneStrategy, error)
++
++var CloneStrategyOverriderByProvisionerKey = map[string]CloneStrategyOverrider{
++	"replicated.csi.storage.deckhouse.io": replicatedSCICloneStrategyOverrider,
++	"local.csi.storage.deckhouse.io": localSCICloneStrategyOverrider,
++}
++
+ // CloneStrategyByProvisionerKey defines the advised clone strategy for a provisioner
+ var CloneStrategyByProvisionerKey = map[string]cdiv1.CDICloneStrategy{
+ 	"csi-vxflexos.dellemc.com":                 cdiv1.CloneStrategyCsiClone,
+@@ -206,6 +216,41 @@ func GetAdvisedCloneStrategy(sc *storagev1.StorageClass) (cdiv1.CDICloneStrategy
+ 	return strategy, found
+ }
+ 
++// GetCloneStrategyOverrider finds and returns the clone strategy overrider.
++func GetCloneStrategyOverrider(sc *storagev1.StorageClass) (CloneStrategyOverrider, bool) {
++	provisionerKey := storageProvisionerKey(sc)
++	overrider, found := CloneStrategyOverriderByProvisionerKey[provisionerKey]
++	return overrider, found
++}
++
++func replicatedSCICloneStrategyOverrider(ctx context.Context, c client.Client, sc *storagev1.StorageClass) (cdiv1.CDICloneStrategy, error) {
++	var rsc rcsiv1.ReplicatedStorageClass
++	err := c.Get(ctx, types.NamespacedName{Name: sc.Name}, &rsc)
++	if err != nil {
++		return "", fmt.Errorf("failed to get replicated storage class %q: %w", sc.Name,err)
++	}
++
++	var rsp rcsiv1.ReplicatedStoragePool
++	err = c.Get(ctx, types.NamespacedName{Name: rsc.Spec.StoragePool}, &rsp)
++	if err != nil {
++		return "", fmt.Errorf("failed to get replicated storage pool %q: %w", rsc.Spec.StoragePool, err)
++	}
++
++	if rsp.Spec.Type == "LVMThin" {
++		return cdiv1.CloneStrategySnapshot, nil
++	}
++
++	return cdiv1.CloneStrategyHostAssisted, nil
++}
++
++func localSCICloneStrategyOverrider(_ context.Context, _ client.Client, sc *storagev1.StorageClass) (cdiv1.CDICloneStrategy, error) {
++	if sc.Parameters["local.csi.storage.deckhouse.io/lvm-type"] == "Thin" {
++		return cdiv1.CloneStrategySnapshot, nil
++	}
++
++	return cdiv1.CloneStrategyHostAssisted, nil
++}
++
+ func capabilitiesForNoProvisioner(cl client.Client, sc *storagev1.StorageClass) ([]StorageCapabilities, bool) {
+ 	pvs := &v1.PersistentVolumeList{}
+ 	err := cl.List(context.TODO(), pvs)
+diff --git a/vendor/github.com/deckhouse/sds-replicated-volume/api/LICENSE b/vendor/github.com/deckhouse/sds-replicated-volume/api/LICENSE
+new file mode 100644
+index 000000000..261eeb9e9
+--- /dev/null
++++ b/vendor/github.com/deckhouse/sds-replicated-volume/api/LICENSE
+@@ -0,0 +1,201 @@
++                                 Apache License
++                           Version 2.0, January 2004
++                        http://www.apache.org/licenses/
++
++   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
++
++   1. Definitions.
++
++      "License" shall mean the terms and conditions for use, reproduction,
++      and distribution as defined by Sections 1 through 9 of this document.
++
++      "Licensor" shall mean the copyright owner or entity authorized by
++      the copyright owner that is granting the License.
++
++      "Legal Entity" shall mean the union of the acting entity and all
++      other entities that control, are controlled by, or are under common
++      control with that entity. For the purposes of this definition,
++      "control" means (i) the power, direct or indirect, to cause the
++      direction or management of such entity, whether by contract or
++      otherwise, or (ii) ownership of fifty percent (50%) or more of the
++      outstanding shares, or (iii) beneficial ownership of such entity.
++
++      "You" (or "Your") shall mean an individual or Legal Entity
++      exercising permissions granted by this License.
++
++      "Source" form shall mean the preferred form for making modifications,
++      including but not limited to software source code, documentation
++      source, and configuration files.
++
++      "Object" form shall mean any form resulting from mechanical
++      transformation or translation of a Source form, including but
++      not limited to compiled object code, generated documentation,
++      and conversions to other media types.
++
++      "Work" shall mean the work of authorship, whether in Source or
++      Object form, made available under the License, as indicated by a
++      copyright notice that is included in or attached to the work
++      (an example is provided in the Appendix below).
++
++      "Derivative Works" shall mean any work, whether in Source or Object
++      form, that is based on (or derived from) the Work and for which the
++      editorial revisions, annotations, elaborations, or other modifications
++      represent, as a whole, an original work of authorship. For the purposes
++      of this License, Derivative Works shall not include works that remain
++      separable from, or merely link (or bind by name) to the interfaces of,
++      the Work and Derivative Works thereof.
++
++      "Contribution" shall mean any work of authorship, including
++      the original version of the Work and any modifications or additions
++      to that Work or Derivative Works thereof, that is intentionally
++      submitted to Licensor for inclusion in the Work by the copyright owner
++      or by an individual or Legal Entity authorized to submit on behalf of
++      the copyright owner. For the purposes of this definition, "submitted"
++      means any form of electronic, verbal, or written communication sent
++      to the Licensor or its representatives, including but not limited to
++      communication on electronic mailing lists, source code control systems,
++      and issue tracking systems that are managed by, or on behalf of, the
++      Licensor for the purpose of discussing and improving the Work, but
++      excluding communication that is conspicuously marked or otherwise
++      designated in writing by the copyright owner as "Not a Contribution."
++
++      "Contributor" shall mean Licensor and any individual or Legal Entity
++      on behalf of whom a Contribution has been received by Licensor and
++      subsequently incorporated within the Work.
++
++   2. Grant of Copyright License. Subject to the terms and conditions of
++      this License, each Contributor hereby grants to You a perpetual,
++      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
++      copyright license to reproduce, prepare Derivative Works of,
++      publicly display, publicly perform, sublicense, and distribute the
++      Work and such Derivative Works in Source or Object form.
++
++   3. Grant of Patent License. Subject to the terms and conditions of
++      this License, each Contributor hereby grants to You a perpetual,
++      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
++      (except as stated in this section) patent license to make, have made,
++      use, offer to sell, sell, import, and otherwise transfer the Work,
++      where such license applies only to those patent claims licensable
++      by such Contributor that are necessarily infringed by their
++      Contribution(s) alone or by combination of their Contribution(s)
++      with the Work to which such Contribution(s) was submitted. If You
++      institute patent litigation against any entity (including a
++      cross-claim or counterclaim in a lawsuit) alleging that the Work
++      or a Contribution incorporated within the Work constitutes direct
++      or contributory patent infringement, then any patent licenses
++      granted to You under this License for that Work shall terminate
++      as of the date such litigation is filed.
++
++   4. Redistribution. You may reproduce and distribute copies of the
++      Work or Derivative Works thereof in any medium, with or without
++      modifications, and in Source or Object form, provided that You
++      meet the following conditions:
++
++      (a) You must give any other recipients of the Work or
++          Derivative Works a copy of this License; and
++
++      (b) You must cause any modified files to carry prominent notices
++          stating that You changed the files; and
++
++      (c) You must retain, in the Source form of any Derivative Works
++          that You distribute, all copyright, patent, trademark, and
++          attribution notices from the Source form of the Work,
++          excluding those notices that do not pertain to any part of
++          the Derivative Works; and
++
++      (d) If the Work includes a "NOTICE" text file as part of its
++          distribution, then any Derivative Works that You distribute must
++          include a readable copy of the attribution notices contained
++          within such NOTICE file, excluding those notices that do not
++          pertain to any part of the Derivative Works, in at least one
++          of the following places: within a NOTICE text file distributed
++          as part of the Derivative Works; within the Source form or
++          documentation, if provided along with the Derivative Works; or,
++          within a display generated by the Derivative Works, if and
++          wherever such third-party notices normally appear. The contents
++          of the NOTICE file are for informational purposes only and
++          do not modify the License. You may add Your own attribution
++          notices within Derivative Works that You distribute, alongside
++          or as an addendum to the NOTICE text from the Work, provided
++          that such additional attribution notices cannot be construed
++          as modifying the License.
++
++      You may add Your own copyright statement to Your modifications and
++      may provide additional or different license terms and conditions
++      for use, reproduction, or distribution of Your modifications, or
++      for any such Derivative Works as a whole, provided Your use,
++      reproduction, and distribution of the Work otherwise complies with
++      the conditions stated in this License.
++
++   5. Submission of Contributions. Unless You explicitly state otherwise,
++      any Contribution intentionally submitted for inclusion in the Work
++      by You to the Licensor shall be under the terms and conditions of
++      this License, without any additional terms or conditions.
++      Notwithstanding the above, nothing herein shall supersede or modify
++      the terms of any separate license agreement you may have executed
++      with Licensor regarding such Contributions.
++
++   6. Trademarks. This License does not grant permission to use the trade
++      names, trademarks, service marks, or product names of the Licensor,
++      except as required for reasonable and customary use in describing the
++      origin of the Work and reproducing the content of the NOTICE file.
++
++   7. Disclaimer of Warranty. Unless required by applicable law or
++      agreed to in writing, Licensor provides the Work (and each
++      Contributor provides its Contributions) on an "AS IS" BASIS,
++      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
++      implied, including, without limitation, any warranties or conditions
++      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
++      PARTICULAR PURPOSE. You are solely responsible for determining the
++      appropriateness of using or redistributing the Work and assume any
++      risks associated with Your exercise of permissions under this License.
++
++   8. Limitation of Liability. In no event and under no legal theory,
++      whether in tort (including negligence), contract, or otherwise,
++      unless required by applicable law (such as deliberate and grossly
++      negligent acts) or agreed to in writing, shall any Contributor be
++      liable to You for damages, including any direct, indirect, special,
++      incidental, or consequential damages of any character arising as a
++      result of this License or out of the use or inability to use the
++      Work (including but not limited to damages for loss of goodwill,
++      work stoppage, computer failure or malfunction, or any and all
++      other commercial damages or losses), even if such Contributor
++      has been advised of the possibility of such damages.
++
++   9. Accepting Warranty or Additional Liability. While redistributing
++      the Work or Derivative Works thereof, You may choose to offer,
++      and charge a fee for, acceptance of support, warranty, indemnity,
++      or other liability obligations and/or rights consistent with this
++      License. However, in accepting such obligations, You may act only
++      on Your own behalf and on Your sole responsibility, not on behalf
++      of any other Contributor, and only if You agree to indemnify,
++      defend, and hold each Contributor harmless for any liability
++      incurred by, or claims asserted against, such Contributor by reason
++      of your accepting any such warranty or additional liability.
++
++   END OF TERMS AND CONDITIONS
++
++   APPENDIX: How to apply the Apache License to your work.
++
++      To apply the Apache License to your work, attach the following
++      boilerplate notice, with the fields enclosed by brackets "[]"
++      replaced with your own identifying information. (Don't include
++      the brackets!)  The text should be enclosed in the appropriate
++      comment syntax for the file format. We also recommend that a
++      file or class name and description of purpose be included on the
++      same "printed page" as the copyright notice for easier
++      identification within third-party archives.
++
++   Copyright [yyyy] [name of copyright owner]
++
++   Licensed under the Apache License, Version 2.0 (the "License");
++   you may not use this file except in compliance with the License.
++   You may obtain a copy of the License at
++
++       http://www.apache.org/licenses/LICENSE-2.0
++
++   Unless required by applicable law or agreed to in writing, software
++   distributed under the License is distributed on an "AS IS" BASIS,
++   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++   See the License for the specific language governing permissions and
++   limitations under the License.
+diff --git a/vendor/github.com/deckhouse/sds-replicated-volume/api/v1alpha1/register.go b/vendor/github.com/deckhouse/sds-replicated-volume/api/v1alpha1/register.go
+new file mode 100644
+index 000000000..2bb3b779f
+--- /dev/null
++++ b/vendor/github.com/deckhouse/sds-replicated-volume/api/v1alpha1/register.go
+@@ -0,0 +1,50 @@
++/*
++Copyright 2023 Flant JSC
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package v1alpha1
++
++import (
++	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
++	"k8s.io/apimachinery/pkg/runtime"
++	"k8s.io/apimachinery/pkg/runtime/schema"
++)
++
++const (
++	APIGroup   = "storage.deckhouse.io"
++	APIVersion = "v1alpha1" // v1alpha1
++)
++
++// SchemeGroupVersion is group version used to register these objects
++var (
++	SchemeGroupVersion = schema.GroupVersion{
++		Group:   APIGroup,
++		Version: APIVersion,
++	}
++	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
++	AddToScheme   = SchemeBuilder.AddToScheme
++)
++
++// Adds the list of known types to Scheme.
++func addKnownTypes(scheme *runtime.Scheme) error {
++	scheme.AddKnownTypes(SchemeGroupVersion,
++		&ReplicatedStorageClass{},
++		&ReplicatedStorageClassList{},
++		&ReplicatedStoragePool{},
++		&ReplicatedStoragePoolList{},
++	)
++	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
++	return nil
++}
+diff --git a/vendor/github.com/deckhouse/sds-replicated-volume/api/v1alpha1/replicated_storage_class.go b/vendor/github.com/deckhouse/sds-replicated-volume/api/v1alpha1/replicated_storage_class.go
+new file mode 100644
+index 000000000..ef19e9662
+--- /dev/null
++++ b/vendor/github.com/deckhouse/sds-replicated-volume/api/v1alpha1/replicated_storage_class.go
+@@ -0,0 +1,47 @@
++/*
++Copyright 2023 Flant JSC
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package v1alpha1
++
++import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
++
++type ReplicatedStorageClass struct {
++	metav1.TypeMeta   `json:",inline"`
++	metav1.ObjectMeta `json:"metadata,omitempty"`
++	Spec              ReplicatedStorageClassSpec   `json:"spec"`
++	Status            ReplicatedStorageClassStatus `json:"status,omitempty"`
++}
++
++// ReplicatedStorageClassList contains a list of empty block device
++type ReplicatedStorageClassList struct {
++	metav1.TypeMeta `json:",inline"`
++	metav1.ListMeta `json:"metadata"`
++	Items           []ReplicatedStorageClass `json:"items"`
++}
++
++type ReplicatedStorageClassSpec struct {
++	StoragePool   string   `json:"storagePool"`
++	ReclaimPolicy string   `json:"reclaimPolicy"`
++	Replication   string   `json:"replication"`
++	VolumeAccess  string   `json:"volumeAccess"`
++	Topology      string   `json:"topology"`
++	Zones         []string `json:"zones"`
++}
++
++type ReplicatedStorageClassStatus struct {
++	Phase  string `json:"phase,omitempty"`
++	Reason string `json:"reason,omitempty"`
++}
+diff --git a/vendor/github.com/deckhouse/sds-replicated-volume/api/v1alpha1/replicated_storage_pool.go b/vendor/github.com/deckhouse/sds-replicated-volume/api/v1alpha1/replicated_storage_pool.go
+new file mode 100644
+index 000000000..7f62c514b
+--- /dev/null
++++ b/vendor/github.com/deckhouse/sds-replicated-volume/api/v1alpha1/replicated_storage_pool.go
+@@ -0,0 +1,48 @@
++/*
++Copyright 2023 Flant JSC
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package v1alpha1
++
++import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
++
++type ReplicatedStoragePool struct {
++	metav1.TypeMeta   `json:",inline"`
++	metav1.ObjectMeta `json:"metadata,omitempty"`
++	Spec              ReplicatedStoragePoolSpec   `json:"spec"`
++	Status            ReplicatedStoragePoolStatus `json:"status,omitempty"`
++}
++
++type ReplicatedStoragePoolSpec struct {
++	Type            string                                 `json:"type"`
++	LVMVolumeGroups []ReplicatedStoragePoolLVMVolumeGroups `json:"lvmVolumeGroups"`
++}
++
++type ReplicatedStoragePoolLVMVolumeGroups struct {
++	Name         string `json:"name"`
++	ThinPoolName string `json:"thinPoolName"`
++}
++
++type ReplicatedStoragePoolStatus struct {
++	Phase  string `json:"phase"`
++	Reason string `json:"reason"`
++}
++
++// ReplicatedStoragePoolList contains a list of ReplicatedStoragePool
++type ReplicatedStoragePoolList struct {
++	metav1.TypeMeta `json:",inline"`
++	metav1.ListMeta `json:"metadata"`
++	Items           []ReplicatedStoragePool `json:"items"`
++}
+diff --git a/vendor/github.com/deckhouse/sds-replicated-volume/api/v1alpha1/zz_generated.deepcopy.go b/vendor/github.com/deckhouse/sds-replicated-volume/api/v1alpha1/zz_generated.deepcopy.go
+new file mode 100644
+index 000000000..eba4474e0
+--- /dev/null
++++ b/vendor/github.com/deckhouse/sds-replicated-volume/api/v1alpha1/zz_generated.deepcopy.go
+@@ -0,0 +1,137 @@
++/*
++Copyright 2023 Flant JSC
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package v1alpha1
++
++import "k8s.io/apimachinery/pkg/runtime"
++
++// --------------- replicated storage class
++
++// DeepCopyInto is an autogenerated deepcopy function, copying the receiver, writing into out. in must be non-nil.
++func (in *ReplicatedStorageClass) DeepCopyInto(out *ReplicatedStorageClass) {
++	*out = *in
++	out.TypeMeta = in.TypeMeta
++	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
++}
++
++// DeepCopy is an autogenerated deepcopy function, copying the receiver, creating a new EmptyBlockDevice.
++func (in *ReplicatedStorageClass) DeepCopy() *ReplicatedStorageClass {
++	if in == nil {
++		return nil
++	}
++	out := new(ReplicatedStorageClass)
++	in.DeepCopyInto(out)
++	return out
++}
++
++// DeepCopyObject is an autogenerated deepcopy function, copying the receiver, creating a new runtime.Object.
++func (in *ReplicatedStorageClass) DeepCopyObject() runtime.Object {
++	if c := in.DeepCopy(); c != nil {
++		return c
++	}
++	return nil
++}
++
++// DeepCopyInto is an autogenerated deepcopy function, copying the receiver, writing into out. in must be non-nil.
++func (in *ReplicatedStorageClassList) DeepCopyInto(out *ReplicatedStorageClassList) {
++	*out = *in
++	out.TypeMeta = in.TypeMeta
++	in.ListMeta.DeepCopyInto(&out.ListMeta)
++	if in.Items != nil {
++		in, out := &in.Items, &out.Items
++		*out = make([]ReplicatedStorageClass, len(*in))
++		for i := range *in {
++			(*in)[i].DeepCopyInto(&(*out)[i])
++		}
++	}
++}
++
++// DeepCopy is an autogenerated deepcopy function, copying the receiver, creating a new GuestbookList.
++func (in *ReplicatedStorageClassList) DeepCopy() *ReplicatedStorageClassList {
++	if in == nil {
++		return nil
++	}
++	out := new(ReplicatedStorageClassList)
++	in.DeepCopyInto(out)
++	return out
++}
++
++// DeepCopyObject is an autogenerated deepcopy function, copying the receiver, creating a new runtime.Object.
++func (in *ReplicatedStorageClassList) DeepCopyObject() runtime.Object {
++	if c := in.DeepCopy(); c != nil {
++		return c
++	}
++	return nil
++}
++
++// --------------- replicated storage pool
++
++// DeepCopyInto is an autogenerated deepcopy function, copying the receiver, writing into out. in must be non-nil.
++func (in *ReplicatedStoragePool) DeepCopyInto(out *ReplicatedStoragePool) {
++	*out = *in
++	out.TypeMeta = in.TypeMeta
++	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
++}
++
++// DeepCopy is an autogenerated deepcopy function, copying the receiver, creating a new EmptyBlockDevice.
++func (in *ReplicatedStoragePool) DeepCopy() *ReplicatedStoragePool {
++	if in == nil {
++		return nil
++	}
++	out := new(ReplicatedStoragePool)
++	in.DeepCopyInto(out)
++	return out
++}
++
++// DeepCopyObject is an autogenerated deepcopy function, copying the receiver, creating a new runtime.Object.
++func (in *ReplicatedStoragePool) DeepCopyObject() runtime.Object {
++	if c := in.DeepCopy(); c != nil {
++		return c
++	}
++	return nil
++}
++
++// DeepCopyInto is an autogenerated deepcopy function, copying the receiver, writing into out. in must be non-nil.
++func (in *ReplicatedStoragePoolList) DeepCopyInto(out *ReplicatedStoragePoolList) {
++	*out = *in
++	out.TypeMeta = in.TypeMeta
++	in.ListMeta.DeepCopyInto(&out.ListMeta)
++	if in.Items != nil {
++		in, out := &in.Items, &out.Items
++		*out = make([]ReplicatedStoragePool, len(*in))
++		for i := range *in {
++			(*in)[i].DeepCopyInto(&(*out)[i])
++		}
++	}
++}
++
++// DeepCopy is an autogenerated deepcopy function, copying the receiver, creating a new GuestbookList.
++func (in *ReplicatedStoragePoolList) DeepCopy() *ReplicatedStoragePoolList {
++	if in == nil {
++		return nil
++	}
++	out := new(ReplicatedStoragePoolList)
++	in.DeepCopyInto(out)
++	return out
++}
++
++// DeepCopyObject is an autogenerated deepcopy function, copying the receiver, creating a new runtime.Object.
++func (in *ReplicatedStoragePoolList) DeepCopyObject() runtime.Object {
++	if c := in.DeepCopy(); c != nil {
++		return c
++	}
++	return nil
++}
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index 87f48ccdd..746961d58 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -167,6 +167,9 @@ github.com/coreos/go-semver/semver
+ # github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
+ ## explicit
+ github.com/davecgh/go-spew/spew
++# github.com/deckhouse/sds-replicated-volume/api v0.0.0-20241206095502-b096856636cd
++## explicit; go 1.22.2
++github.com/deckhouse/sds-replicated-volume/api/v1alpha1
+ # github.com/distribution/reference v0.6.0
+ ## explicit; go 1.20
+ github.com/distribution/reference

--- a/images/cdi-artifact/patches/README.md
+++ b/images/cdi-artifact/patches/README.md
@@ -85,3 +85,9 @@ With csi-clone, it's possible to specify the same or a larger capacity for the t
 #### `020-manage-provisioner-tolerations.patch`
 
 Add annotation to manage provisioner tolerations to avoid unschedulable error.
+
+#### `021-fallback-to-host-clone-for-lvm-thick.patch`
+
+When cloning from PVC to PVC, it's necessary to select a cloning strategy. By default, the cloning strategy `snapshot` is selected.
+However, `replicated.csi.storage.deckhouse.io` and `local.csi.storage.deckhouse.io` can create snapshots only when using LVM Thin.
+To avoid errors, for LVM Thick, it's necessary to use `copy` cloning strategy (`csi-clone` is also unavailable since the CSI itself creates a snapshot when using `csi-clone`).

--- a/templates/cdi/cdi-operator/rbac-for-us.yaml
+++ b/templates/cdi/cdi-operator/rbac-for-us.yaml
@@ -279,6 +279,15 @@ rules:
   verbs:
     - '*'
 - apiGroups:
+    - storage.deckhouse.io
+  resources:
+    - replicatedstorageclasses
+    - replicatedstoragepools
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
     - snapshot.storage.k8s.io
   resources:
     - volumesnapshots
@@ -585,4 +594,4 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: d8:rbac-proxy 
+  name: d8:rbac-proxy


### PR DESCRIPTION
## Description

When cloning from PVC to PVC, it's necessary to select a cloning strategy. By default, the cloning strategy `snapshot` is selected.

However, `replicated.csi.storage.deckhouse.io` and `local.csi.storage.deckhouse.io` can create snapshots only when using LVM Thin.

To avoid errors, for LVM Thick, it's necessary to use `copy` cloning strategy (`csi-clone` is also unavailable since the CSI itself creates a snapshot when using `csi-clone`).


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
