### PR TITLE
fix(template): add missing fields to kube-rbac-proxy

### DIFF
--- a/templates/kube-rbac-proxy/_helpers.tpl
+++ b/templates/kube-rbac-proxy/_helpers.tpl
@@ -9,6 +9,9 @@
     runAsGroup: 65534
   {{- end }}
   image: {{ include "helm_lib_module_common_image" (list $ctx "kubeRbacProxy") }}
+  imagePullPolicy: IfNotPresent
+  terminationMessagePath: /dev/termination-log
+  terminationMessagePolicy: File
   args:
   - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):{{ $settings.listenPort | default "8082" }}"
   - "--v={{ $settings.logLevel | default "2" }}"
@@ -18,6 +21,7 @@
   - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
     valueFrom:
       fieldRef:
+        apiVersion: v1
         fieldPath: status.podIP
   - name: KUBE_RBAC_PROXY_CONFIG
     value: |


### PR DESCRIPTION
## Description

Explicitly set default fields in the customization patch for kube-rbac-proxy.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

Prevent infinite patching of cdi-apiserver and cdi-deployment by the cdi-operator. cdi-operator don't respect default values from Kubernetes API.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
