### PR TITLE
feat(ci): send nightly e2e test to loop

### DIFF
--- a/.github/workflows/nightly_e2e_tests_main.yaml
+++ b/.github/workflows/nightly_e2e_tests_main.yaml
@@ -71,3 +71,5 @@ jobs:
         working-directory: ./tests/e2e/
         run: |
           task run:ci -v
+        env:
+          LOOP_WEBHOOK_URL: ${{ secrets.LOOP_WEBHOOK_URL }}

--- a/tests/e2e/Taskfile.yaml
+++ b/tests/e2e/Taskfile.yaml
@@ -54,11 +54,42 @@ tasks:
       - d8
     cmds:
       - |
-        ginkgo \
+        RESULT=$(ginkgo \
           --skip-file vm_test.go \
           --skip-file ipam_test.go \
           --skip-file disks_test.go \
-          -v
+          --no-color \
+          -v | grep --color=never \|)
+
+        if [[ $RESULT == SUCCESS!* ]]; then
+          RESULT_STATUS=":white_check_mark: SUCCESS!"
+        elif [[ $RESULT == FAIL!* ]]; then
+          RESULT_STATUS=":x: FAIL!"
+        else
+          RESULT_STATUS=":question: UNKNOWN"
+        fi
+        DATE=$(date +"%Y-%m-%d")
+
+        PASSED=$(echo "$RESULT" | grep -oP '\d+(?= Passed)')
+        FAILED=$(echo "$RESULT" | grep -oP '\d+(?= Failed)')
+        PENDING=$(echo "$RESULT" | grep -oP '\d+(?= Pending)')
+        SKIPPED=$(echo "$RESULT" | grep -oP '\d+(?= Skipped)')
+
+        SUMMARY="
+        ### :dvp: **DVP $DATE Nightly e2e Tests**
+
+        **Branch:** \`$GITHUB_REF\`
+        **Status: $RESULT_STATUS**
+
+        - ${PASSED:-0} Passed
+        - ${FAILED:-0} Failed
+        - ${PENDING:-0} Pending
+        - ${SKIPPED:-0} Skipped
+
+        [:link: GitHub Actions Output]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)
+        "
+        curl -XPOST -H 'Content-Type: application/json' -d "{\"text\": \"${SUMMARY}\"}" $LOOP_WEBHOOK_URL
+        
 
   run:
     desc: "Run e2e tests"

--- a/tests/e2e/Taskfile.yaml
+++ b/tests/e2e/Taskfile.yaml
@@ -89,7 +89,6 @@ tasks:
         [:link: GitHub Actions Output]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)
         "
         curl -XPOST -H 'Content-Type: application/json' -d "{\"text\": \"${SUMMARY}\"}" $LOOP_WEBHOOK_URL
-        
 
   run:
     desc: "Run e2e tests"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Send message to LOOP on nightly e2e test runs.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
We need this to have a better view of nightly e2e tests' results.
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Messages would be sent to LOOP every night on every e2e test.
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
