### PR TITLE
fix(kubevirt, core): inject-placement-anynode

### DIFF
--- a/images/virt-artifact/patches/028-inject-placement-anynode.patch
+++ b/images/virt-artifact/patches/028-inject-placement-anynode.patch
@@ -1,0 +1,26 @@
+diff --git a/pkg/virt-operator/resource/apply/apps.go b/pkg/virt-operator/resource/apply/apps.go
+index 86a7e9cb5d..8554de9a05 100644
+--- a/pkg/virt-operator/resource/apply/apps.go
++++ b/pkg/virt-operator/resource/apply/apps.go
+@@ -51,7 +51,7 @@ func (r *Reconciler) syncDeployment(origDeployment *appsv1.Deployment) (*appsv1.
+ 
+ 	injectOperatorMetadata(kv, &deployment.ObjectMeta, imageTag, imageRegistry, id, true)
+ 	injectOperatorMetadata(kv, &deployment.Spec.Template.ObjectMeta, imageTag, imageRegistry, id, false)
+-	InjectPlacementMetadata(kv.Spec.Infra, &deployment.Spec.Template.Spec, RequireControlPlanePreferNonWorker)
++	InjectPlacementMetadata(kv.Spec.Infra, &deployment.Spec.Template.Spec, AnyNode)
+ 
+ 	if kv.Spec.Infra != nil && kv.Spec.Infra.Replicas != nil {
+ 		replicas := int32(*kv.Spec.Infra.Replicas)
+diff --git a/pkg/virt-operator/strategy_job.go b/pkg/virt-operator/strategy_job.go
+index df94c43bb1..b7ca869207 100644
+--- a/pkg/virt-operator/strategy_job.go
++++ b/pkg/virt-operator/strategy_job.go
+@@ -111,7 +111,7 @@ func (c *KubeVirtController) generateInstallStrategyJob(infraPlacement *v1.Compo
+ 		},
+ 	}
+ 
+-	apply.InjectPlacementMetadata(infraPlacement, &job.Spec.Template.Spec, apply.RequireControlPlanePreferNonWorker)
++	apply.InjectPlacementMetadata(infraPlacement, &job.Spec.Template.Spec, apply.AnyNode)
+ 	env := job.Spec.Template.Spec.Containers[0].Env
+ 	extraEnv := util.NewEnvVarMap(config.GetExtraEnv())
+ 	job.Spec.Template.Spec.Containers[0].Env = append(env, *extraEnv...)

--- a/images/virt-artifact/patches/README.md
+++ b/images/virt-artifact/patches/README.md
@@ -113,5 +113,5 @@ How does it work?
 
 #### `028-inject-placement-anynode.patch`
 
-By default, the virtual operator adds a nodePlacement with the RequireControlPlanePreferNonWorker.
+By default, the virtual-operator adds a nodePlacement with the RequireControlPlanePreferNonWorker.
 But we set up the placement ourselves, so we replace the policy with AnyNode.

--- a/images/virt-artifact/patches/README.md
+++ b/images/virt-artifact/patches/README.md
@@ -110,3 +110,8 @@ How does it work?
 2. When changing the affinity or nodeSelector in vmi, the vmi controller will set the `NodePlacementNotMatched` condition to True in vmi.
 3. The workload-updater controller monitors the vmi and starts migration when there is a `NodePlacementNotMatched` conditions on the vmi.
 4. When the migration is completed, virt-handler will remove the condition `NodePlacementNotMatched` from the vmi 
+
+#### `028-inject-placement-anynode.patch`
+
+By default, the virtual operator adds a nodePlacement with the RequireControlPlanePreferNonWorker.
+But we set up the placement ourselves, so we replace the policy with AnyNode.


### PR DESCRIPTION
## Description
By default, the virtual-operator adds a nodePlacement with the RequireControlPlanePreferNonWorker.
But we set up the placement ourselves, so we replace the policy with AnyNode.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
