### PR TITLE
fix(vdsnapshot,vmsnapshot): unfreeze virtual machines

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/interfaces.go
+++ b/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/interfaces.go
@@ -35,7 +35,7 @@ type LifeCycleSnapshotter interface {
 	Freeze(ctx context.Context, name, namespace string) error
 	IsFrozen(vm *virtv2.VirtualMachine) bool
 	CanFreeze(vm *virtv2.VirtualMachine) bool
-	CanUnfreeze(ctx context.Context, vdSnapshotName string, vm *virtv2.VirtualMachine) (bool, error)
+	CanUnfreezeWithVirtualDiskSnapshot(ctx context.Context, vdSnapshotName string, vm *virtv2.VirtualMachine) (bool, error)
 	Unfreeze(ctx context.Context, name, namespace string) error
 	CreateVolumeSnapshot(ctx context.Context, vs *vsv1.VolumeSnapshot) (*vsv1.VolumeSnapshot, error)
 	GetPersistentVolumeClaim(ctx context.Context, name, namespace string) (*corev1.PersistentVolumeClaim, error)

--- a/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/life_cycle_test.go
+++ b/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/life_cycle_test.go
@@ -165,6 +165,8 @@ var _ = Describe("LifeCycle handler", func() {
 		var vm *virtv2.VirtualMachine
 
 		BeforeEach(func() {
+			vdSnapshot.Status.Phase = virtv2.VirtualDiskSnapshotPhaseInProgress
+
 			vm = &virtv2.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{Name: "vm"},
 				Status: virtv2.VirtualMachineStatus{
@@ -185,7 +187,7 @@ var _ = Describe("LifeCycle handler", func() {
 			snapshotter.FreezeFunc = func(_ context.Context, _, _ string) error {
 				return nil
 			}
-			snapshotter.CanUnfreezeFunc = func(_ context.Context, _ string, _ *virtv2.VirtualMachine) (bool, error) {
+			snapshotter.CanUnfreezeWithVirtualDiskSnapshotFunc = func(_ context.Context, _ string, _ *virtv2.VirtualMachine) (bool, error) {
 				return true, nil
 			}
 			snapshotter.UnfreezeFunc = func(_ context.Context, _, _ string) error {

--- a/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/mock.go
+++ b/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/mock.go
@@ -102,8 +102,8 @@ var _ LifeCycleSnapshotter = &LifeCycleSnapshotterMock{}
 //			CanFreezeFunc: func(vm *virtv2.VirtualMachine) bool {
 //				panic("mock out the CanFreeze method")
 //			},
-//			CanUnfreezeFunc: func(ctx context.Context, vdSnapshotName string, vm *virtv2.VirtualMachine) (bool, error) {
-//				panic("mock out the CanUnfreeze method")
+//			CanUnfreezeWithVirtualDiskSnapshotFunc: func(ctx context.Context, vdSnapshotName string, vm *virtv2.VirtualMachine) (bool, error) {
+//				panic("mock out the CanUnfreezeWithVirtualDiskSnapshot method")
 //			},
 //			CreateVolumeSnapshotFunc: func(ctx context.Context, vs *vsv1.VolumeSnapshot) (*vsv1.VolumeSnapshot, error) {
 //				panic("mock out the CreateVolumeSnapshot method")
@@ -139,8 +139,8 @@ type LifeCycleSnapshotterMock struct {
 	// CanFreezeFunc mocks the CanFreeze method.
 	CanFreezeFunc func(vm *virtv2.VirtualMachine) bool
 
-	// CanUnfreezeFunc mocks the CanUnfreeze method.
-	CanUnfreezeFunc func(ctx context.Context, vdSnapshotName string, vm *virtv2.VirtualMachine) (bool, error)
+	// CanUnfreezeWithVirtualDiskSnapshotFunc mocks the CanUnfreezeWithVirtualDiskSnapshot method.
+	CanUnfreezeWithVirtualDiskSnapshotFunc func(ctx context.Context, vdSnapshotName string, vm *virtv2.VirtualMachine) (bool, error)
 
 	// CreateVolumeSnapshotFunc mocks the CreateVolumeSnapshot method.
 	CreateVolumeSnapshotFunc func(ctx context.Context, vs *vsv1.VolumeSnapshot) (*vsv1.VolumeSnapshot, error)
@@ -173,8 +173,8 @@ type LifeCycleSnapshotterMock struct {
 			// VM is the vm argument value.
 			VM *virtv2.VirtualMachine
 		}
-		// CanUnfreeze holds details about calls to the CanUnfreeze method.
-		CanUnfreeze []struct {
+		// CanUnfreezeWithVirtualDiskSnapshot holds details about calls to the CanUnfreezeWithVirtualDiskSnapshot method.
+		CanUnfreezeWithVirtualDiskSnapshot []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// VdSnapshotName is the vdSnapshotName argument value.
@@ -249,16 +249,16 @@ type LifeCycleSnapshotterMock struct {
 			Namespace string
 		}
 	}
-	lockCanFreeze                sync.RWMutex
-	lockCanUnfreeze              sync.RWMutex
-	lockCreateVolumeSnapshot     sync.RWMutex
-	lockFreeze                   sync.RWMutex
-	lockGetPersistentVolumeClaim sync.RWMutex
-	lockGetVirtualDisk           sync.RWMutex
-	lockGetVirtualMachine        sync.RWMutex
-	lockGetVolumeSnapshot        sync.RWMutex
-	lockIsFrozen                 sync.RWMutex
-	lockUnfreeze                 sync.RWMutex
+	lockCanFreeze                          sync.RWMutex
+	lockCanUnfreezeWithVirtualDiskSnapshot sync.RWMutex
+	lockCreateVolumeSnapshot               sync.RWMutex
+	lockFreeze                             sync.RWMutex
+	lockGetPersistentVolumeClaim           sync.RWMutex
+	lockGetVirtualDisk                     sync.RWMutex
+	lockGetVirtualMachine                  sync.RWMutex
+	lockGetVolumeSnapshot                  sync.RWMutex
+	lockIsFrozen                           sync.RWMutex
+	lockUnfreeze                           sync.RWMutex
 }
 
 // CanFreeze calls CanFreezeFunc.
@@ -293,10 +293,10 @@ func (mock *LifeCycleSnapshotterMock) CanFreezeCalls() []struct {
 	return calls
 }
 
-// CanUnfreeze calls CanUnfreezeFunc.
-func (mock *LifeCycleSnapshotterMock) CanUnfreeze(ctx context.Context, vdSnapshotName string, vm *virtv2.VirtualMachine) (bool, error) {
-	if mock.CanUnfreezeFunc == nil {
-		panic("LifeCycleSnapshotterMock.CanUnfreezeFunc: method is nil but LifeCycleSnapshotter.CanUnfreeze was just called")
+// CanUnfreezeWithVirtualDiskSnapshot calls CanUnfreezeWithVirtualDiskSnapshotFunc.
+func (mock *LifeCycleSnapshotterMock) CanUnfreezeWithVirtualDiskSnapshot(ctx context.Context, vdSnapshotName string, vm *virtv2.VirtualMachine) (bool, error) {
+	if mock.CanUnfreezeWithVirtualDiskSnapshotFunc == nil {
+		panic("LifeCycleSnapshotterMock.CanUnfreezeWithVirtualDiskSnapshotFunc: method is nil but LifeCycleSnapshotter.CanUnfreezeWithVirtualDiskSnapshot was just called")
 	}
 	callInfo := struct {
 		Ctx            context.Context
@@ -307,17 +307,17 @@ func (mock *LifeCycleSnapshotterMock) CanUnfreeze(ctx context.Context, vdSnapsho
 		VdSnapshotName: vdSnapshotName,
 		VM:             vm,
 	}
-	mock.lockCanUnfreeze.Lock()
-	mock.calls.CanUnfreeze = append(mock.calls.CanUnfreeze, callInfo)
-	mock.lockCanUnfreeze.Unlock()
-	return mock.CanUnfreezeFunc(ctx, vdSnapshotName, vm)
+	mock.lockCanUnfreezeWithVirtualDiskSnapshot.Lock()
+	mock.calls.CanUnfreezeWithVirtualDiskSnapshot = append(mock.calls.CanUnfreezeWithVirtualDiskSnapshot, callInfo)
+	mock.lockCanUnfreezeWithVirtualDiskSnapshot.Unlock()
+	return mock.CanUnfreezeWithVirtualDiskSnapshotFunc(ctx, vdSnapshotName, vm)
 }
 
-// CanUnfreezeCalls gets all the calls that were made to CanUnfreeze.
+// CanUnfreezeWithVirtualDiskSnapshotCalls gets all the calls that were made to CanUnfreezeWithVirtualDiskSnapshot.
 // Check the length with:
 //
-//	len(mockedLifeCycleSnapshotter.CanUnfreezeCalls())
-func (mock *LifeCycleSnapshotterMock) CanUnfreezeCalls() []struct {
+//	len(mockedLifeCycleSnapshotter.CanUnfreezeWithVirtualDiskSnapshotCalls())
+func (mock *LifeCycleSnapshotterMock) CanUnfreezeWithVirtualDiskSnapshotCalls() []struct {
 	Ctx            context.Context
 	VdSnapshotName string
 	VM             *virtv2.VirtualMachine
@@ -327,9 +327,9 @@ func (mock *LifeCycleSnapshotterMock) CanUnfreezeCalls() []struct {
 		VdSnapshotName string
 		VM             *virtv2.VirtualMachine
 	}
-	mock.lockCanUnfreeze.RLock()
-	calls = mock.calls.CanUnfreeze
-	mock.lockCanUnfreeze.RUnlock()
+	mock.lockCanUnfreezeWithVirtualDiskSnapshot.RLock()
+	calls = mock.calls.CanUnfreezeWithVirtualDiskSnapshot
+	mock.lockCanUnfreezeWithVirtualDiskSnapshot.RUnlock()
 	return calls
 }
 

--- a/images/virtualization-artifact/pkg/controller/vm/internal/filesystem.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/filesystem.go
@@ -18,7 +18,6 @@ package internal
 
 import (
 	"context"
-	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -65,7 +64,7 @@ func (h *FilesystemHandler) Handle(ctx context.Context, s state.VirtualMachineSt
 	if kvvmi == nil {
 		cb.Status(metav1.ConditionFalse).
 			Reason(vmcondition.ReasonFilesystemNotReady).
-			Message(fmt.Sprintf("The internal virtual machine %q is not running.", changed.Name))
+			Message("The virtual machine is not running.")
 		return reconcile.Result{}, nil
 	}
 
@@ -78,7 +77,7 @@ func (h *FilesystemHandler) Handle(ctx context.Context, s state.VirtualMachineSt
 	if kvvmi.Status.FSFreezeStatus == "frozen" {
 		cb.Status(metav1.ConditionFalse).
 			Reason(vmcondition.ReasonFilesystemFrozen).
-			Message(fmt.Sprintf("The internal virtual machine %q is frozen.", changed.Name))
+			Message("The virtual machine is frozen.")
 		return reconcile.Result{}, nil
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_power_state.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_power_state.go
@@ -79,7 +79,7 @@ func (h *SyncPowerStateHandler) syncPowerState(ctx context.Context, s state.Virt
 
 	kvvmi, err := s.KVVMI(ctx)
 	if err != nil {
-		return fmt.Errorf("find the internal virtual machine instance: %w", err)
+		return fmt.Errorf("find the virtual machine instance: %w", err)
 	}
 
 	if runPolicy == virtv2.AlwaysOnUnlessStoppedManually {

--- a/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/interfaces.go
+++ b/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/interfaces.go
@@ -41,5 +41,5 @@ type Snapshotter interface {
 	Unfreeze(ctx context.Context, name, namespace string) error
 	IsFrozen(vm *virtv2.VirtualMachine) bool
 	CanFreeze(vm *virtv2.VirtualMachine) bool
-	CanUnfreeze(ctx context.Context, vdSnapshotName string, vm *virtv2.VirtualMachine) (bool, error)
+	CanUnfreezeWithVirtualMachineSnapshot(ctx context.Context, vmSnapshotName string, vm *virtv2.VirtualMachine) (bool, error)
 }

--- a/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/life_cycle_test.go
+++ b/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/life_cycle_test.go
@@ -112,7 +112,8 @@ var _ = Describe("LifeCycle handler", func() {
 		vdSnapshot = &virtv2.VirtualDiskSnapshot{
 			ObjectMeta: metav1.ObjectMeta{Name: getVDSnapshotName(vd.Name, vmSnapshot)},
 			Status: virtv2.VirtualDiskSnapshotStatus{
-				Phase: virtv2.VirtualDiskSnapshotPhaseReady,
+				Phase:      virtv2.VirtualDiskSnapshotPhaseReady,
+				Consistent: ptr.To(true),
 			},
 		}
 
@@ -126,8 +127,11 @@ var _ = Describe("LifeCycle handler", func() {
 			IsFrozenFunc: func(_ *virtv2.VirtualMachine) bool {
 				return true
 			},
-			CanUnfreezeFunc: func(_ context.Context, _ string, _ *virtv2.VirtualMachine) (bool, error) {
+			CanUnfreezeWithVirtualMachineSnapshotFunc: func(_ context.Context, _ string, _ *virtv2.VirtualMachine) (bool, error) {
 				return true, nil
+			},
+			CanFreezeFunc: func(_ *virtv2.VirtualMachine) bool {
+				return false
 			},
 			UnfreezeFunc: func(ctx context.Context, _, _ string) error {
 				return nil
@@ -278,6 +282,10 @@ var _ = Describe("LifeCycle handler", func() {
 	})
 
 	Context("The virtual machine snapshot is Ready", func() {
+		BeforeEach(func() {
+			vmSnapshot.Status.Phase = virtv2.VirtualMachineSnapshotPhaseInProgress
+		})
+
 		It("The snapshot of virtual machine is Ready", func() {
 			h := NewLifeCycleHandler(snapshotter, storer)
 
@@ -314,11 +322,9 @@ var _ = Describe("LifeCycle handler", func() {
 
 		It("The virtual machine snapshot is potentially inconsistent", func() {
 			vmSnapshot.Spec.RequiredConsistency = false
-			snapshotter.IsFrozenFunc = func(_ *virtv2.VirtualMachine) bool {
-				return false
-			}
-			snapshotter.CanFreezeFunc = func(_ *virtv2.VirtualMachine) bool {
-				return false
+			snapshotter.GetVirtualDiskSnapshotFunc = func(_ context.Context, _, _ string) (*virtv2.VirtualDiskSnapshot, error) {
+				vdSnapshot.Status.Consistent = nil
+				return vdSnapshot, nil
 			}
 			h := NewLifeCycleHandler(snapshotter, storer)
 

--- a/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/mock.go
+++ b/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/mock.go
@@ -101,8 +101,8 @@ var _ Snapshotter = &SnapshotterMock{}
 //			CanFreezeFunc: func(vm *virtv2.VirtualMachine) bool {
 //				panic("mock out the CanFreeze method")
 //			},
-//			CanUnfreezeFunc: func(ctx context.Context, vdSnapshotName string, vm *virtv2.VirtualMachine) (bool, error) {
-//				panic("mock out the CanUnfreeze method")
+//			CanUnfreezeWithVirtualMachineSnapshotFunc: func(ctx context.Context, vmSnapshotName string, vm *virtv2.VirtualMachine) (bool, error) {
+//				panic("mock out the CanUnfreezeWithVirtualMachineSnapshot method")
 //			},
 //			CreateVirtualDiskSnapshotFunc: func(ctx context.Context, vdSnapshot *virtv2.VirtualDiskSnapshot) (*virtv2.VirtualDiskSnapshot, error) {
 //				panic("mock out the CreateVirtualDiskSnapshot method")
@@ -141,8 +141,8 @@ type SnapshotterMock struct {
 	// CanFreezeFunc mocks the CanFreeze method.
 	CanFreezeFunc func(vm *virtv2.VirtualMachine) bool
 
-	// CanUnfreezeFunc mocks the CanUnfreeze method.
-	CanUnfreezeFunc func(ctx context.Context, vdSnapshotName string, vm *virtv2.VirtualMachine) (bool, error)
+	// CanUnfreezeWithVirtualMachineSnapshotFunc mocks the CanUnfreezeWithVirtualMachineSnapshot method.
+	CanUnfreezeWithVirtualMachineSnapshotFunc func(ctx context.Context, vmSnapshotName string, vm *virtv2.VirtualMachine) (bool, error)
 
 	// CreateVirtualDiskSnapshotFunc mocks the CreateVirtualDiskSnapshot method.
 	CreateVirtualDiskSnapshotFunc func(ctx context.Context, vdSnapshot *virtv2.VirtualDiskSnapshot) (*virtv2.VirtualDiskSnapshot, error)
@@ -178,12 +178,12 @@ type SnapshotterMock struct {
 			// VM is the vm argument value.
 			VM *virtv2.VirtualMachine
 		}
-		// CanUnfreeze holds details about calls to the CanUnfreeze method.
-		CanUnfreeze []struct {
+		// CanUnfreezeWithVirtualMachineSnapshot holds details about calls to the CanUnfreezeWithVirtualMachineSnapshot method.
+		CanUnfreezeWithVirtualMachineSnapshot []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// VdSnapshotName is the vdSnapshotName argument value.
-			VdSnapshotName string
+			// VmSnapshotName is the vmSnapshotName argument value.
+			VmSnapshotName string
 			// VM is the vm argument value.
 			VM *virtv2.VirtualMachine
 		}
@@ -263,17 +263,17 @@ type SnapshotterMock struct {
 			Namespace string
 		}
 	}
-	lockCanFreeze                 sync.RWMutex
-	lockCanUnfreeze               sync.RWMutex
-	lockCreateVirtualDiskSnapshot sync.RWMutex
-	lockFreeze                    sync.RWMutex
-	lockGetPersistentVolumeClaim  sync.RWMutex
-	lockGetSecret                 sync.RWMutex
-	lockGetVirtualDisk            sync.RWMutex
-	lockGetVirtualDiskSnapshot    sync.RWMutex
-	lockGetVirtualMachine         sync.RWMutex
-	lockIsFrozen                  sync.RWMutex
-	lockUnfreeze                  sync.RWMutex
+	lockCanFreeze                             sync.RWMutex
+	lockCanUnfreezeWithVirtualMachineSnapshot sync.RWMutex
+	lockCreateVirtualDiskSnapshot             sync.RWMutex
+	lockFreeze                                sync.RWMutex
+	lockGetPersistentVolumeClaim              sync.RWMutex
+	lockGetSecret                             sync.RWMutex
+	lockGetVirtualDisk                        sync.RWMutex
+	lockGetVirtualDiskSnapshot                sync.RWMutex
+	lockGetVirtualMachine                     sync.RWMutex
+	lockIsFrozen                              sync.RWMutex
+	lockUnfreeze                              sync.RWMutex
 }
 
 // CanFreeze calls CanFreezeFunc.
@@ -308,43 +308,43 @@ func (mock *SnapshotterMock) CanFreezeCalls() []struct {
 	return calls
 }
 
-// CanUnfreeze calls CanUnfreezeFunc.
-func (mock *SnapshotterMock) CanUnfreeze(ctx context.Context, vdSnapshotName string, vm *virtv2.VirtualMachine) (bool, error) {
-	if mock.CanUnfreezeFunc == nil {
-		panic("SnapshotterMock.CanUnfreezeFunc: method is nil but Snapshotter.CanUnfreeze was just called")
+// CanUnfreezeWithVirtualMachineSnapshot calls CanUnfreezeWithVirtualMachineSnapshotFunc.
+func (mock *SnapshotterMock) CanUnfreezeWithVirtualMachineSnapshot(ctx context.Context, vmSnapshotName string, vm *virtv2.VirtualMachine) (bool, error) {
+	if mock.CanUnfreezeWithVirtualMachineSnapshotFunc == nil {
+		panic("SnapshotterMock.CanUnfreezeWithVirtualMachineSnapshotFunc: method is nil but Snapshotter.CanUnfreezeWithVirtualMachineSnapshot was just called")
 	}
 	callInfo := struct {
 		Ctx            context.Context
-		VdSnapshotName string
+		VmSnapshotName string
 		VM             *virtv2.VirtualMachine
 	}{
 		Ctx:            ctx,
-		VdSnapshotName: vdSnapshotName,
+		VmSnapshotName: vmSnapshotName,
 		VM:             vm,
 	}
-	mock.lockCanUnfreeze.Lock()
-	mock.calls.CanUnfreeze = append(mock.calls.CanUnfreeze, callInfo)
-	mock.lockCanUnfreeze.Unlock()
-	return mock.CanUnfreezeFunc(ctx, vdSnapshotName, vm)
+	mock.lockCanUnfreezeWithVirtualMachineSnapshot.Lock()
+	mock.calls.CanUnfreezeWithVirtualMachineSnapshot = append(mock.calls.CanUnfreezeWithVirtualMachineSnapshot, callInfo)
+	mock.lockCanUnfreezeWithVirtualMachineSnapshot.Unlock()
+	return mock.CanUnfreezeWithVirtualMachineSnapshotFunc(ctx, vmSnapshotName, vm)
 }
 
-// CanUnfreezeCalls gets all the calls that were made to CanUnfreeze.
+// CanUnfreezeWithVirtualMachineSnapshotCalls gets all the calls that were made to CanUnfreezeWithVirtualMachineSnapshot.
 // Check the length with:
 //
-//	len(mockedSnapshotter.CanUnfreezeCalls())
-func (mock *SnapshotterMock) CanUnfreezeCalls() []struct {
+//	len(mockedSnapshotter.CanUnfreezeWithVirtualMachineSnapshotCalls())
+func (mock *SnapshotterMock) CanUnfreezeWithVirtualMachineSnapshotCalls() []struct {
 	Ctx            context.Context
-	VdSnapshotName string
+	VmSnapshotName string
 	VM             *virtv2.VirtualMachine
 } {
 	var calls []struct {
 		Ctx            context.Context
-		VdSnapshotName string
+		VmSnapshotName string
 		VM             *virtv2.VirtualMachine
 	}
-	mock.lockCanUnfreeze.RLock()
-	calls = mock.calls.CanUnfreeze
-	mock.lockCanUnfreeze.RUnlock()
+	mock.lockCanUnfreezeWithVirtualMachineSnapshot.RLock()
+	calls = mock.calls.CanUnfreezeWithVirtualMachineSnapshot
+	mock.lockCanUnfreezeWithVirtualMachineSnapshot.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
## Description

Fix unfreeze of virtual machines
Fix VolumeSnapshot deletion
Improve processing of concurrent snapshots

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
