### PR TITLE
fix(ci): fix grep in nightly e2e tests

### DIFF
--- a/tests/e2e/Taskfile.yaml
+++ b/tests/e2e/Taskfile.yaml
@@ -59,7 +59,7 @@ tasks:
           --skip-file ipam_test.go \
           --skip-file disks_test.go \
           --no-color \
-          -v | tee /dev/stderr | grep --color=never !)
+          -v | tee /dev/stderr | grep --color=never -E 'FAIL!|SUCCESS!')
         if [[ $RESULT == SUCCESS!* ]]; then
           RESULT_STATUS=":white_check_mark: SUCCESS!"
         elif [[ $RESULT == FAIL!* ]]; then


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Change grep for RESULT variable to get the test results correctly.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Fix #593 

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Correct message in LOOP

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
