### PR TITLE
feat(vmclass): add events about available nodes and sizing policies changed

### DIFF
--- a/api/core/v1alpha2/events.go
+++ b/api/core/v1alpha2/events.go
@@ -124,9 +124,12 @@ const (
 	// ReasonFailed is the event reason indicating that the binding of a VirtualMachineIPLease to a VirtualMachineIPAddress has failed.
 	ReasonFailed = "Failed"
 
-	// ReasonVMClassSizingPoliciesWereChanged is event reason that VMClass sizing policies were changed.
+	// ReasonVMClassSizingPoliciesWereChanged is event reason indicating that VMClass sizing policies were changed.
 	ReasonVMClassSizingPoliciesWereChanged = "SizingPoliciesWereChanged"
 
-	// ReasonVMClassAvailableNodesListEmpty is event reason that VMClass has no available nodes.
+	// ReasonVMClassAvailableNodesListEmpty is event reason indicating that VMClass has no available nodes.
 	ReasonVMClassAvailableNodesListEmpty = "AvailableNodesListEmpty"
+
+	// ReasonVMClassNodesWereUpdated is event reason indicating that VMClass available nodes list was updated.
+	ReasonVMClassNodesWereUpdated = "NodesWereUpdated"
 )

--- a/api/core/v1alpha2/events.go
+++ b/api/core/v1alpha2/events.go
@@ -61,9 +61,6 @@ const (
 	// ReasonVMOPStarted is event reason that the operation is started
 	ReasonVMOPStarted = "VirtualMachineOperationStarted"
 
-	// ReasonVMClassInUse is event reason that VMClass is used by virtual machine.
-	ReasonVMClassInUse = "VirtualMachineClassInUse"
-
 	// ReasonVDStorageClassWasDeleted is event reason that VDStorageClass was deleted.
 	ReasonVDStorageClassWasDeleted = "VirtualDiskStorageClassWasDeleted"
 	// ReasonVDStorageClassNotFound is event reason that VDStorageClass not found.

--- a/api/core/v1alpha2/events.go
+++ b/api/core/v1alpha2/events.go
@@ -119,14 +119,14 @@ const (
 	// ReasonNotAttached is event reason that VirtualMachineIPAddress is not attached to VirtualMachine.
 	ReasonNotAttached = "NotAttached"
 
+	// ReasonBound is the event reason indicating that a VirtualMachineIPLease is bound to a VirtualMachineIPAddress.
+	ReasonBound = "Bound"
+	// ReasonFailed is the event reason indicating that the binding of a VirtualMachineIPLease to a VirtualMachineIPAddress has failed.
+	ReasonFailed = "Failed"
+
 	// ReasonVMClassSizingPoliciesWereChanged is event reason that VMClass sizing policies were changed.
 	ReasonVMClassSizingPoliciesWereChanged = "SizingPoliciesWereChanged"
 
 	// ReasonVMClassAvailableNodesListEmpty is event reason that VMClass has no available nodes.
 	ReasonVMClassAvailableNodesListEmpty = "AvailableNodesListEmpty"
-
-	// ReasonBound is the event reason indicating that a VirtualMachineIPLease is bound to a VirtualMachineIPAddress.
-	ReasonBound = "Bound"
-	// ReasonFailed is the event reason indicating that the binding of a VirtualMachineIPLease to a VirtualMachineIPAddress has failed.
-	ReasonFailed = "Failed"
 )

--- a/api/core/v1alpha2/events.go
+++ b/api/core/v1alpha2/events.go
@@ -119,6 +119,12 @@ const (
 	// ReasonNotAttached is event reason that VirtualMachineIPAddress is not attached to VirtualMachine.
 	ReasonNotAttached = "NotAttached"
 
+	// ReasonVMClassSizingPoliciesWereChanged is event reason that VMClass sizing policies were changed.
+	ReasonVMClassSizingPoliciesWereChanged = "SizingPoliciesWereChanged"
+
+	// ReasonVMClassAvailableNodesListEmpty is event reason that VMClass has no available nodes.
+	ReasonVMClassAvailableNodesListEmpty = "AvailableNodesListEmpty"
+
 	// ReasonBound is the event reason indicating that a VirtualMachineIPLease is bound to a VirtualMachineIPAddress.
 	ReasonBound = "Bound"
 	// ReasonFailed is the event reason indicating that the binding of a VirtualMachineIPLease to a VirtualMachineIPAddress has failed.

--- a/api/core/v1alpha2/vmclasscondition/condition.go
+++ b/api/core/v1alpha2/vmclasscondition/condition.go
@@ -46,6 +46,6 @@ const (
 	ReasonDiscoverySkip      Reason = "DiscoverySkip"
 	ReasonDiscoveryFailed    Reason = "DiscoveryFailed"
 
-	// ReasonVMClassInUse is event reason that VMClass is used by virtual machine.
+	// ReasonVMClassInUse is the event reason indicating that the VMClass is being used by a virtual machine.
 	ReasonVMClassInUse Reason = "VirtualMachineClassInUse"
 )

--- a/api/core/v1alpha2/vmclasscondition/condition.go
+++ b/api/core/v1alpha2/vmclasscondition/condition.go
@@ -48,6 +48,4 @@ const (
 
 	// ReasonVMClassInUse is event reason that VMClass is used by virtual machine.
 	ReasonVMClassInUse Reason = "VirtualMachineClassInUse"
-	// ReasonVMClassFree is event reason that VMClass not used by virtual machine.
-	ReasonVMClassFree Reason = "VirtualMachineClassFree"
 )

--- a/api/core/v1alpha2/vmclasscondition/condition.go
+++ b/api/core/v1alpha2/vmclasscondition/condition.go
@@ -25,6 +25,7 @@ func (t Type) String() string {
 const (
 	TypeReady      Type = "Ready"
 	TypeDiscovered Type = "Discovered"
+	TypeInUse      Type = "InUse"
 )
 
 type Reason string
@@ -44,4 +45,9 @@ const (
 	ReasonDiscoverySucceeded Reason = "DiscoverySucceeded"
 	ReasonDiscoverySkip      Reason = "DiscoverySkip"
 	ReasonDiscoveryFailed    Reason = "DiscoveryFailed"
+
+	// ReasonVMClassInUse is event reason that VMClass is used by virtual machine.
+	ReasonVMClassInUse Reason = "VirtualMachineClassInUse"
+	// ReasonVMClassFree is event reason that VMClass not used by virtual machine.
+	ReasonVMClassFree Reason = "VirtualMachineClassFree"
 )

--- a/images/virtualization-artifact/pkg/controller/vm/internal/watcher/vmclass_watcher.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/watcher/vmclass_watcher.go
@@ -43,7 +43,7 @@ func NewVirtualMachineClassWatcher() *VirtualMachineClassWatcher {
 
 func (w VirtualMachineClassWatcher) Watch(mgr manager.Manager, ctr controller.Controller) error {
 	return ctr.Watch(
-		source.Kind(mgr.GetCache(), &virtv2.VirtualMachineClass{}),
+		source.Kind(mgr.GetCache(), &virtv2.VirtualMachine{}),
 		handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
 			c := mgr.GetClient()
 			vms := &virtv2.VirtualMachineList{}

--- a/images/virtualization-artifact/pkg/controller/vm/vm_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/vm/vm_reconciler.go
@@ -259,7 +259,7 @@ func (r *Reconciler) SetupController(_ context.Context, mgr manager.Manager, ctr
 	} {
 		err := w.Watch(mgr, ctr)
 		if err != nil {
-			return fmt.Errorf("faield to run watcher %s: %w", reflect.TypeOf(w).Elem().Name(), err)
+			return fmt.Errorf("failed to run watcher %s: %w", reflect.TypeOf(w).Elem().Name(), err)
 		}
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vmclass/internal/deletion.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/internal/deletion.go
@@ -19,11 +19,12 @@ package internal
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"strings"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
 	"github.com/deckhouse/virtualization-controller/pkg/common/object"

--- a/images/virtualization-artifact/pkg/controller/vmclass/internal/deletion.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/internal/deletion.go
@@ -78,10 +78,6 @@ func (h *DeletionHandler) Handle(ctx context.Context, s state.VirtualMachineClas
 			Message(msg)
 		return reconcile.Result{RequeueAfter: 60 * time.Second}, nil
 	}
-	cb.
-		Status(metav1.ConditionFalse).
-		Reason(vmclasscondition.ReasonVMClassFree).
-		Message("")
 	h.logger.Info("Deletion observed: remove cleanup finalizer from VirtualMachineClass")
 	controllerutil.RemoveFinalizer(changed, virtv2.FinalizerVMCleanup)
 	return reconcile.Result{}, nil

--- a/images/virtualization-artifact/pkg/controller/vmclass/internal/deletion.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/internal/deletion.go
@@ -70,7 +70,13 @@ func (h *DeletionHandler) Handle(ctx context.Context, s state.VirtualMachineClas
 		for i := range vms {
 			vmNamespacedNames = append(vmNamespacedNames, object.NamespacedName(&vms[i]).String())
 		}
-		msg := fmt.Sprintf("VirtualMachineClass cannot be deleted, there are VMs that use it %s.", strings.Join(vmNamespacedNames, ", "))
+		var msg string
+		switch len(vms) {
+		case 1:
+			msg = fmt.Sprintf("VirtualMachineClass cannot be deleted, there is VM that use it: %s.", vmNamespacedNames[0])
+		default:
+			msg = fmt.Sprintf("VirtualMachineClass cannot be deleted, there are VMs that use it %s.", strings.Join(vmNamespacedNames, ", "))
+		}
 		cb := conditions.NewConditionBuilder(vmclasscondition.TypeInUse).
 			Generation(changed.Generation).
 			Status(metav1.ConditionTrue).

--- a/images/virtualization-artifact/pkg/controller/vmclass/internal/deletion.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/internal/deletion.go
@@ -21,16 +21,18 @@ import (
 	"fmt"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
 	"github.com/deckhouse/virtualization-controller/pkg/common/object"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vmclass/internal/state"
 	"github.com/deckhouse/virtualization-controller/pkg/eventrecord"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmclasscondition"
 )
 
 const nameDeletionHandler = "DeletionHandler"
@@ -58,15 +60,28 @@ func (h *DeletionHandler) Handle(ctx context.Context, s state.VirtualMachineClas
 		controllerutil.AddFinalizer(changed, virtv2.FinalizerVMCleanup)
 		return reconcile.Result{}, nil
 	}
+	cb := conditions.NewConditionBuilder(vmclasscondition.TypeInUse).Generation(changed.Generation)
+	defer func() { conditions.SetCondition(cb, &changed.Status.Conditions) }()
 	vms, err := s.VirtualMachines(ctx)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 	if len(vms) > 0 {
-		msg := fmt.Sprintf("VirtualMachineClass cannot be deleted, there are VMs that use it. %s...", object.NamespacedName(&vms[0]))
-		h.recorder.Event(changed, corev1.EventTypeWarning, virtv2.ReasonVMClassInUse, msg)
+		var vmNamespacedNames []string
+		for i := range vms {
+			vmNamespacedNames = append(vmNamespacedNames, object.NamespacedName(&vms[i]).String())
+		}
+		msg := fmt.Sprintf("VirtualMachineClass cannot be deleted, there are VMs that use it. %q", vmNamespacedNames)
+		cb.
+			Status(metav1.ConditionTrue).
+			Reason(vmclasscondition.ReasonVMClassInUse).
+			Message(msg)
 		return reconcile.Result{RequeueAfter: 60 * time.Second}, nil
 	}
+	cb.
+		Status(metav1.ConditionFalse).
+		Reason(vmclasscondition.ReasonVMClassFree).
+		Message("")
 	h.logger.Info("Deletion observed: remove cleanup finalizer from VirtualMachineClass")
 	controllerutil.RemoveFinalizer(changed, virtv2.FinalizerVMCleanup)
 	return reconcile.Result{}, nil

--- a/images/virtualization-artifact/pkg/controller/vmclass/internal/deletion.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/internal/deletion.go
@@ -19,6 +19,7 @@ package internal
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,7 +72,7 @@ func (h *DeletionHandler) Handle(ctx context.Context, s state.VirtualMachineClas
 		for i := range vms {
 			vmNamespacedNames = append(vmNamespacedNames, object.NamespacedName(&vms[i]).String())
 		}
-		msg := fmt.Sprintf("VirtualMachineClass cannot be deleted, there are VMs that use it. %q", vmNamespacedNames)
+		msg := fmt.Sprintf("VirtualMachineClass cannot be deleted, there are VMs that use it %s.", strings.Join(vmNamespacedNames, ", "))
 		cb.
 			Status(metav1.ConditionTrue).
 			Reason(vmclasscondition.ReasonVMClassInUse).

--- a/images/virtualization-artifact/pkg/controller/vmclass/internal/deletion.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/internal/deletion.go
@@ -19,13 +19,11 @@ package internal
 import (
 	"context"
 	"fmt"
-	"strings"
-	"time"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"strings"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
 	"github.com/deckhouse/virtualization-controller/pkg/common/object"
@@ -78,7 +76,7 @@ func (h *DeletionHandler) Handle(ctx context.Context, s state.VirtualMachineClas
 			Reason(vmclasscondition.ReasonVMClassInUse).
 			Message(msg)
 		conditions.SetCondition(cb, &changed.Status.Conditions)
-		return reconcile.Result{RequeueAfter: 60 * time.Second}, nil
+		return reconcile.Result{}, nil
 	} else {
 		conditions.RemoveCondition(vmclasscondition.ReasonVMClassInUse, &changed.Status.Conditions)
 	}

--- a/images/virtualization-artifact/pkg/controller/vmclass/internal/discovery.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/internal/discovery.go
@@ -125,7 +125,7 @@ func (h *DiscoveryHandler) Handle(ctx context.Context, s state.VirtualMachineCla
 	sort.Strings(featuresEnabled)
 	sort.Strings(featuresNotEnabled)
 
-	addedNodes, removedNodes := nodeNamesDiff(current.Status.AvailableNodes, availableNodeNames)
+	addedNodes, removedNodes := NodeNamesDiff(current.Status.AvailableNodes, availableNodeNames)
 	if len(addedNodes) > 0 || len(removedNodes) > 0 {
 		if len(availableNodes) > 0 {
 			h.recorder.Eventf(
@@ -203,7 +203,9 @@ func (h *DiscoveryHandler) maxAllocatableResources(nodes []corev1.Node) corev1.R
 	return resourceList
 }
 
-func nodeNamesDiff(prev, current []string) (added, removed []string) {
+func NodeNamesDiff(prev, current []string) (added, removed []string) {
+	added = make([]string, 0)
+	removed = make([]string, 0)
 	prevMap := make(map[string]struct{})
 	currentMap := make(map[string]struct{})
 

--- a/images/virtualization-artifact/pkg/controller/vmclass/internal/discovery.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/internal/discovery.go
@@ -131,7 +131,7 @@ func (h *DiscoveryHandler) Handle(ctx context.Context, s state.VirtualMachineCla
 			h.recorder.Eventf(
 				changed,
 				corev1.EventTypeNormal,
-				virtv2.ReasonVMClassNodesWasUpdated,
+				virtv2.ReasonVMClassNodesWereUpdated,
 				"List of available nodes was updated, added nodes: %q, removed nodes: %q",
 				addedNodes,
 				removedNodes,

--- a/images/virtualization-artifact/pkg/controller/vmclass/internal/discovery.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/internal/discovery.go
@@ -161,6 +161,35 @@ func (h *DiscoveryHandler) Name() string {
 	return nameDiscoveryHandler
 }
 
+func NodeNamesDiff(prev, current []string) (added, removed []string) {
+	added = make([]string, 0)
+	removed = make([]string, 0)
+	prevMap := make(map[string]struct{})
+	currentMap := make(map[string]struct{})
+
+	for _, nodeName := range prev {
+		prevMap[nodeName] = struct{}{}
+	}
+
+	for _, nodeName := range current {
+		currentMap[nodeName] = struct{}{}
+	}
+
+	for _, nodeName := range prev {
+		if _, ok := currentMap[nodeName]; !ok {
+			removed = append(removed, nodeName)
+		}
+	}
+
+	for _, nodeName := range current {
+		if _, ok := prevMap[nodeName]; !ok {
+			added = append(added, nodeName)
+		}
+	}
+
+	return added, removed
+}
+
 func (h *DiscoveryHandler) discoveryCommonFeatures(nodes []corev1.Node) []string {
 	if len(nodes) == 0 {
 		return nil
@@ -201,33 +230,4 @@ func (h *DiscoveryHandler) maxAllocatableResources(nodes []corev1.Node) corev1.R
 		}
 	}
 	return resourceList
-}
-
-func NodeNamesDiff(prev, current []string) (added, removed []string) {
-	added = make([]string, 0)
-	removed = make([]string, 0)
-	prevMap := make(map[string]struct{})
-	currentMap := make(map[string]struct{})
-
-	for _, n := range prev {
-		prevMap[n] = struct{}{}
-	}
-
-	for _, n := range current {
-		currentMap[n] = struct{}{}
-	}
-
-	for _, n := range prev {
-		if _, ok := currentMap[n]; !ok {
-			removed = append(removed, n)
-		}
-	}
-
-	for _, n := range current {
-		if _, ok := prevMap[n]; !ok {
-			added = append(added, n)
-		}
-	}
-
-	return added, removed
 }

--- a/images/virtualization-artifact/pkg/controller/vmclass/internal/discovery.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/internal/discovery.go
@@ -131,7 +131,7 @@ func (h *DiscoveryHandler) Handle(ctx context.Context, s state.VirtualMachineCla
 			h.recorder.Eventf(
 				changed,
 				corev1.EventTypeNormal,
-				virtv2.ReasonVMClassAvailableNodesWasUpdated,
+				virtv2.ReasonVMClassNodesWasUpdated,
 				"List of available nodes was updated, added nodes: %q, removed nodes: %q",
 				addedNodes,
 				removedNodes,

--- a/images/virtualization-artifact/pkg/controller/vmclass/internal/discovery_test.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/internal/discovery_test.go
@@ -28,106 +28,104 @@ type nodeNamesDiffTestParams struct {
 	removed []string
 }
 
-var _ = Describe("DiscoveryHandler Run", func() {
-	DescribeTable(
-		"NodeNamesDiffTest",
-		func(params nodeNamesDiffTestParams) {
-			calculatedAdded, calculatedRemoved := NodeNamesDiff(params.prev, params.current)
-			Expect(calculatedAdded).Should(Equal(params.added))
-			Expect(calculatedRemoved).Should(Equal(params.removed))
+var _ = DescribeTable(
+	"DiscoveryHandler NodeNamesDiff Test",
+	func(params nodeNamesDiffTestParams) {
+		calculatedAdded, calculatedRemoved := NodeNamesDiff(params.prev, params.current)
+		Expect(calculatedAdded).Should(Equal(params.added))
+		Expect(calculatedRemoved).Should(Equal(params.removed))
+	},
+	Entry(
+		"Should be no diff",
+		nodeNamesDiffTestParams{
+			prev: []string{
+				"node1",
+				"node2",
+			},
+			current: []string{
+				"node1",
+				"node2",
+			},
+			added:   []string{},
+			removed: []string{},
 		},
-		Entry(
-			"Should be no diff",
-			nodeNamesDiffTestParams{
-				prev: []string{
-					"node1",
-					"node2",
-				},
-				current: []string{
-					"node1",
-					"node2",
-				},
-				added:   []string{},
-				removed: []string{},
+	),
+	Entry(
+		"Should be added node",
+		nodeNamesDiffTestParams{
+			prev: []string{
+				"node1",
+				"node2",
 			},
-		),
-		Entry(
-			"Should be added node",
-			nodeNamesDiffTestParams{
-				prev: []string{
-					"node1",
-					"node2",
-				},
-				current: []string{
-					"node1",
-					"node2",
-					"node3",
-				},
-				added: []string{
-					"node3",
-				},
-				removed: []string{},
+			current: []string{
+				"node1",
+				"node2",
+				"node3",
 			},
-		),
-		Entry(
-			"Should be removed node",
-			nodeNamesDiffTestParams{
-				prev: []string{
-					"node1",
-					"node2",
-					"node3",
-				},
-				current: []string{
-					"node1",
-					"node2",
-				},
-				added: []string{},
-				removed: []string{
-					"node3",
-				},
+			added: []string{
+				"node3",
 			},
-		),
-		Entry(
-			"Should be added and removed node",
-			nodeNamesDiffTestParams{
-				prev: []string{
-					"node1",
-					"node2",
-				},
-				current: []string{
-					"node2",
-					"node3",
-				},
-				added: []string{
-					"node3",
-				},
-				removed: []string{
-					"node1",
-				},
+			removed: []string{},
+		},
+	),
+	Entry(
+		"Should be removed node",
+		nodeNamesDiffTestParams{
+			prev: []string{
+				"node1",
+				"node2",
+				"node3",
 			},
-		),
-		Entry(
-			"Should be multiple added and removed node",
-			nodeNamesDiffTestParams{
-				prev: []string{
-					"node3",
-					"node4",
-					"node5",
-				},
-				current: []string{
-					"node1",
-					"node2",
-					"node3",
-				},
-				added: []string{
-					"node1",
-					"node2",
-				},
-				removed: []string{
-					"node4",
-					"node5",
-				},
+			current: []string{
+				"node1",
+				"node2",
 			},
-		),
-	)
-})
+			added: []string{},
+			removed: []string{
+				"node3",
+			},
+		},
+	),
+	Entry(
+		"Should be added and removed node",
+		nodeNamesDiffTestParams{
+			prev: []string{
+				"node1",
+				"node2",
+			},
+			current: []string{
+				"node2",
+				"node3",
+			},
+			added: []string{
+				"node3",
+			},
+			removed: []string{
+				"node1",
+			},
+		},
+	),
+	Entry(
+		"Should be multiple added and removed node",
+		nodeNamesDiffTestParams{
+			prev: []string{
+				"node3",
+				"node4",
+				"node5",
+			},
+			current: []string{
+				"node1",
+				"node2",
+				"node3",
+			},
+			added: []string{
+				"node1",
+				"node2",
+			},
+			removed: []string{
+				"node4",
+				"node5",
+			},
+		},
+	),
+)

--- a/images/virtualization-artifact/pkg/controller/vmclass/internal/discovery_test.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/internal/discovery_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type nodeNamesDiffTestParams struct {
+	prev    []string
+	current []string
+	added   []string
+	removed []string
+}
+
+var _ = Describe("DiscoveryHandler Run", func() {
+	DescribeTable(
+		"NodeNamesDiffTest",
+		func(params nodeNamesDiffTestParams) {
+			calculatedAdded, calculatedRemoved := NodeNamesDiff(params.prev, params.current)
+			Expect(calculatedAdded).Should(Equal(params.added))
+			Expect(calculatedRemoved).Should(Equal(params.removed))
+		},
+		Entry(
+			"Should be no diff",
+			nodeNamesDiffTestParams{
+				prev: []string{
+					"node1",
+					"node2",
+				},
+				current: []string{
+					"node1",
+					"node2",
+				},
+				added:   []string{},
+				removed: []string{},
+			},
+		),
+		Entry(
+			"Should be added node",
+			nodeNamesDiffTestParams{
+				prev: []string{
+					"node1",
+					"node2",
+				},
+				current: []string{
+					"node1",
+					"node2",
+					"node3",
+				},
+				added: []string{
+					"node3",
+				},
+				removed: []string{},
+			},
+		),
+		Entry(
+			"Should be removed node",
+			nodeNamesDiffTestParams{
+				prev: []string{
+					"node1",
+					"node2",
+					"node3",
+				},
+				current: []string{
+					"node1",
+					"node2",
+				},
+				added: []string{},
+				removed: []string{
+					"node3",
+				},
+			},
+		),
+		Entry(
+			"Should be added and removed node",
+			nodeNamesDiffTestParams{
+				prev: []string{
+					"node1",
+					"node2",
+				},
+				current: []string{
+					"node2",
+					"node3",
+				},
+				added: []string{
+					"node3",
+				},
+				removed: []string{
+					"node1",
+				},
+			},
+		),
+		Entry(
+			"Should be multiple added and removed node",
+			nodeNamesDiffTestParams{
+				prev: []string{
+					"node3",
+					"node4",
+					"node5",
+				},
+				current: []string{
+					"node1",
+					"node2",
+					"node3",
+				},
+				added: []string{
+					"node1",
+					"node2",
+				},
+				removed: []string{
+					"node4",
+					"node5",
+				},
+			},
+		),
+	)
+})

--- a/images/virtualization-artifact/pkg/controller/vmclass/internal/internal_test.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/internal/internal_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestInternal(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Internal")
+}

--- a/images/virtualization-artifact/pkg/controller/vmclass/internal/validators/policy_changes_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/internal/validators/policy_changes_validator.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validators
+
+import (
+	"context"
+	"reflect"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/deckhouse/virtualization-controller/pkg/eventrecord"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+)
+
+type PolicyChangesValidator struct {
+	recorder eventrecord.EventRecorderLogger
+}
+
+func NewPolicyChangesValidator(recorder eventrecord.EventRecorderLogger) *PolicyChangesValidator {
+	return &PolicyChangesValidator{recorder: recorder}
+}
+
+func (v *PolicyChangesValidator) ValidateCreate(_ context.Context, _ *v1alpha2.VirtualMachineClass) (admission.Warnings, error) {
+	return nil, nil
+}
+
+func (v *PolicyChangesValidator) ValidateUpdate(_ context.Context, oldVMClass, newVMClass *v1alpha2.VirtualMachineClass) (admission.Warnings, error) {
+	if !reflect.DeepEqual(oldVMClass.Spec.SizingPolicies, newVMClass.Spec.SizingPolicies) {
+		v.recorder.Event(newVMClass, corev1.EventTypeNormal, v1alpha2.ReasonVMClassSizingPoliciesWasChanged, "Sizing policies was changed")
+	}
+
+	return nil, nil
+}

--- a/images/virtualization-artifact/pkg/controller/vmclass/internal/validators/policy_changes_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/internal/validators/policy_changes_validator.go
@@ -41,7 +41,7 @@ func (v *PolicyChangesValidator) ValidateCreate(_ context.Context, _ *v1alpha2.V
 
 func (v *PolicyChangesValidator) ValidateUpdate(_ context.Context, oldVMClass, newVMClass *v1alpha2.VirtualMachineClass) (admission.Warnings, error) {
 	if !reflect.DeepEqual(oldVMClass.Spec.SizingPolicies, newVMClass.Spec.SizingPolicies) {
-		v.recorder.Event(newVMClass, corev1.EventTypeNormal, v1alpha2.ReasonVMClassSizingPoliciesWasChanged, "Sizing policies was changed")
+		v.recorder.Event(newVMClass, corev1.EventTypeNormal, v1alpha2.ReasonVMClassSizingPoliciesWasChanged, "Sizing policies were changed")
 	}
 
 	return nil, nil

--- a/images/virtualization-artifact/pkg/controller/vmclass/internal/validators/policy_changes_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/internal/validators/policy_changes_validator.go
@@ -41,7 +41,7 @@ func (v *PolicyChangesValidator) ValidateCreate(_ context.Context, _ *v1alpha2.V
 
 func (v *PolicyChangesValidator) ValidateUpdate(_ context.Context, oldVMClass, newVMClass *v1alpha2.VirtualMachineClass) (admission.Warnings, error) {
 	if !reflect.DeepEqual(oldVMClass.Spec.SizingPolicies, newVMClass.Spec.SizingPolicies) {
-		v.recorder.Event(newVMClass, corev1.EventTypeNormal, v1alpha2.ReasonVMClassSizingPoliciesWasChanged, "Sizing policies were changed")
+		v.recorder.Event(newVMClass, corev1.EventTypeNormal, v1alpha2.ReasonVMClassSizingPoliciesWereChanged, "Sizing policies were changed")
 	}
 
 	return nil, nil

--- a/images/virtualization-artifact/pkg/controller/vmclass/internal/watcher/vm_watcher.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/internal/watcher/vm_watcher.go
@@ -18,9 +18,6 @@ package watcher
 
 import (
 	"context"
-	"fmt"
-	"log/slog"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -32,18 +29,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	"github.com/deckhouse/virtualization-controller/pkg/logger"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
-type VirtualMachinesWatcher struct {
-	log *slog.Logger
-}
+type VirtualMachinesWatcher struct{}
 
 func NewVirtualMachinesWatcher() *VirtualMachinesWatcher {
-	return &VirtualMachinesWatcher{
-		log: slog.Default().With("watcher", strings.ToLower(virtv2.VirtualMachineClassKind)),
-	}
+	return &VirtualMachinesWatcher{}
 }
 
 func (w *VirtualMachinesWatcher) Watch(mgr manager.Manager, ctr controller.Controller) error {
@@ -52,7 +44,6 @@ func (w *VirtualMachinesWatcher) Watch(mgr manager.Manager, ctr controller.Contr
 		handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
 			vm, ok := obj.(*virtv2.VirtualMachine)
 			if !ok {
-				w.log.Error(fmt.Sprintf("expected a new VirtualMachine but got a %T", obj))
 				return nil
 			}
 
@@ -62,10 +53,6 @@ func (w *VirtualMachinesWatcher) Watch(mgr manager.Manager, ctr controller.Contr
 				Name: vm.Spec.VirtualMachineClassName,
 			}, vmc)
 			if err != nil {
-				w.log.Error(
-					"error retrieving virtual machines during the search for virtual machine class belonging changed virtual machine",
-					logger.SlogErr(err),
-				)
 				return nil
 			}
 

--- a/images/virtualization-artifact/pkg/controller/vmclass/internal/watcher/vm_watcher.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/internal/watcher/vm_watcher.go
@@ -18,6 +18,7 @@ package watcher
 
 import (
 	"context"
+	"fmt"
 
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/deckhouse/virtualization-controller/pkg/common/object"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
@@ -48,11 +50,16 @@ func (w *VirtualMachinesWatcher) Watch(mgr manager.Manager, ctr controller.Contr
 			}
 
 			c := mgr.GetClient()
-			vmc := &virtv2.VirtualMachineClass{}
-			err := c.Get(ctx, types.NamespacedName{
+
+			vmc, err := object.FetchObject(ctx, types.NamespacedName{
 				Name: vm.Spec.VirtualMachineClassName,
-			}, vmc)
+			}, c, &virtv2.VirtualMachineClass{})
 			if err != nil {
+				log := mgr.GetLogger()
+				fmt.Println(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>")
+				log.Error(err, "failed to fetch virtual machine class")
+				fmt.Println("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<")
+
 				return nil
 			}
 

--- a/images/virtualization-artifact/pkg/controller/vmclass/internal/watcher/vm_watcher.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/internal/watcher/vm_watcher.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watcher
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/deckhouse/virtualization-controller/pkg/logger"
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+)
+
+type VirtualMachinesWatcher struct{}
+
+func NewVirtualMachinesWatcher() *VirtualMachinesWatcher {
+	return &VirtualMachinesWatcher{}
+}
+
+func (vmw *VirtualMachinesWatcher) Watch(mgr manager.Manager, ctr controller.Controller) error {
+	return ctr.Watch(
+		source.Kind(mgr.GetCache(), &virtv2.VirtualMachine{}),
+		handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
+			vm, ok := obj.(*virtv2.VirtualMachine)
+			log := logger.FromContext(ctx)
+			if !ok {
+				log.Error(fmt.Sprintf("expected a new VirtualMachine but got a %T", obj))
+				return nil
+			}
+
+			c := mgr.GetClient()
+			vmc := &virtv2.VirtualMachineClass{}
+			err := c.Get(ctx, types.NamespacedName{
+				Name: vm.Spec.VirtualMachineClassName,
+			}, vmc)
+			if err != nil {
+				log.Error(
+					"error retrieving virtual machines during the search for virtual machine class belonging changed virtual machine",
+					logger.SlogErr(err),
+				)
+				return nil
+			}
+
+			return []reconcile.Request{
+				{
+					NamespacedName: types.NamespacedName{
+						Name: vmc.Name,
+					},
+				},
+			}
+		}),
+		predicate.Funcs{
+			CreateFunc: func(createEvent event.CreateEvent) bool {
+				return false
+			},
+			UpdateFunc: func(updateEvent event.UpdateEvent) bool {
+				return false
+			},
+			DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
+				return true
+			},
+		},
+	)
+}

--- a/images/virtualization-artifact/pkg/controller/vmclass/internal/watcher/vm_watcher.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/internal/watcher/vm_watcher.go
@@ -18,7 +18,7 @@ package watcher
 
 import (
 	"context"
-	"fmt"
+	"log/slog"
 
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -51,15 +51,17 @@ func (w *VirtualMachinesWatcher) Watch(mgr manager.Manager, ctr controller.Contr
 
 			c := mgr.GetClient()
 
+			vmClassName := vm.Spec.VirtualMachineClassName
 			vmc, err := object.FetchObject(ctx, types.NamespacedName{
-				Name: vm.Spec.VirtualMachineClassName,
+				Name: vmClassName,
 			}, c, &virtv2.VirtualMachineClass{})
-			if err != nil {
-				log := mgr.GetLogger()
-				fmt.Println(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>")
-				log.Error(err, "failed to fetch virtual machine class")
-				fmt.Println("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<")
 
+			if vmc == nil {
+				return nil
+			}
+
+			if err != nil {
+				slog.Default().Error("failed to fetch virtual machine class %s: %q", vmClassName, err)
 				return nil
 			}
 

--- a/images/virtualization-artifact/pkg/controller/vmclass/vmclass_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/vmclass_reconciler.go
@@ -66,7 +66,7 @@ type Reconciler struct {
 	handlers            []Handler
 }
 
-func (r *Reconciler) SetupController(_ context.Context, mgr manager.Manager, ctr controller.Controller) error {
+func (r *Reconciler) SetupController(ctx context.Context, mgr manager.Manager, ctr controller.Controller) error {
 	if err := ctr.Watch(source.Kind(mgr.GetCache(),
 		&virtv2.VirtualMachineClass{}),
 		&handler.EnqueueRequestForObject{}); err != nil {

--- a/images/virtualization-artifact/pkg/controller/vmclass/vmclass_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/vmclass_reconciler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"slices"
 
 	corev1 "k8s.io/api/core/v1"
@@ -37,6 +38,7 @@ import (
 	"github.com/deckhouse/virtualization-controller/pkg/common/object"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vmclass/internal/state"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/vmclass/internal/watcher"
 	"github.com/deckhouse/virtualization-controller/pkg/logger"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
@@ -44,6 +46,10 @@ import (
 type Handler interface {
 	Handle(ctx context.Context, s state.VirtualMachineClassState) (reconcile.Result, error)
 	Name() string
+}
+
+type Watcher interface {
+	Watch(mgr manager.Manager, ctr controller.Controller) error
 }
 
 func NewReconciler(controllerNamespace string, client client.Client, handlers ...Handler) *Reconciler {
@@ -124,6 +130,16 @@ func (r *Reconciler) SetupController(_ context.Context, mgr manager.Manager, ctr
 	); err != nil {
 		return fmt.Errorf("error setting watch on Node: %w", err)
 	}
+
+	for _, w := range []Watcher{
+		watcher.NewVirtualMachinesWatcher(),
+	} {
+		err := w.Watch(mgr, ctr)
+		if err != nil {
+			return fmt.Errorf("failed to run watcher %s: %w", reflect.TypeOf(w).Elem().Name(), err)
+		}
+	}
+
 	return nil
 }
 

--- a/images/virtualization-artifact/pkg/controller/vmclass/vmclass_webhook.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/vmclass_webhook.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/deckhouse/deckhouse/pkg/log"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vmclass/internal/validators"
+	"github.com/deckhouse/virtualization-controller/pkg/eventrecord"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
@@ -36,10 +37,11 @@ type Validator struct {
 	log        *log.Logger
 }
 
-func NewValidator(client client.Client, log *log.Logger) *Validator {
+func NewValidator(client client.Client, log *log.Logger, recorder eventrecord.EventRecorderLogger) *Validator {
 	return &Validator{
 		validators: []VirtualMachineClassValidator{
 			validators.NewSizingPoliciesValidator(client),
+			validators.NewPolicyChangesValidator(recorder),
 		},
 		log: log.With("webhook", "validation"),
 	}

--- a/images/virtualization-artifact/pkg/logger/logger.go
+++ b/images/virtualization-artifact/pkg/logger/logger.go
@@ -103,6 +103,7 @@ func detectLogOutput(output string) io.Writer {
 }
 
 func SetDefaultLogger(l *log.Logger) {
+	slog.SetDefault(slog.New(l.Handler()))
 	log.SetDefault(l)
 	fromSlog := logr.FromSlogHandler(l.Handler())
 	logf.SetLogger(fromSlog)


### PR DESCRIPTION
## Description
Using new events api.
Add event when list of available nodes changed.
Add event when sizing policies changed.

## Why do we need it, and what problem does it solve?

## What is the expected result?

## Changelog entries

```changes
section: vmclass
type: feature
summary: add events about available nodes and sizing policies changed
```

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
