### PR TITLE
fix(core, kubevirt): virt-launcher with efi and cpu >= 12 not starting

### DIFF
--- a/images/virt-artifact/patches/029-use-OFVM_CODE-for-linux.patch
+++ b/images/virt-artifact/patches/029-use-OFVM_CODE-for-linux.patch
@@ -1,0 +1,29 @@
+diff --git a/pkg/virt-launcher/virtwrap/manager.go b/pkg/virt-launcher/virtwrap/manager.go
+index 2513ad62a8..19f8aa7e83 100644
+--- a/pkg/virt-launcher/virtwrap/manager.go
++++ b/pkg/virt-launcher/virtwrap/manager.go
+@@ -966,9 +966,24 @@ func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineIn
+ 
+ 	var efiConf *converter.EFIConfiguration
+ 	if vmi.IsBootloaderEFI() {
++		const ann = "virtualization.deckhouse.io/os-type"
++		const windows = "Windows"
++
+ 		secureBoot := vmi.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot == nil || *vmi.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot
+ 		sev := kutil.IsSEVVMI(vmi)
+ 
++		if !sev {
++			if a := vmi.GetAnnotations()[ann]; a != windows {
++				/*
++				 Kubevirt always uses OVFM_CODE.secboot.fd.
++				 Even if the security boot is turned off.
++				 It is believed that this firmware works correctly with OVFM_VERS, but on altlinux we see problems, the virtual machine with efi and cpu >=12 does not start.
++				 OVFM_CODE.fd is not exist, but the OVFM_CODE.cc.fd is always symlink to OVFM_CODE.fd
++				 That's why we set the sev to true for always virtual machines with linux.
++				*/
++				sev = true
++			}
++		}
+ 		if !l.efiEnvironment.Bootable(secureBoot, sev) {
+ 			log.Log.Errorf("EFI OVMF roms missing for booting in EFI mode with SecureBoot=%v, SEV=%v", secureBoot, sev)
+ 			return nil, fmt.Errorf("EFI OVMF roms missing for booting in EFI mode with SecureBoot=%v, SEV=%v", secureBoot, sev)

--- a/images/virt-artifact/patches/029-use-OFVM_CODE-for-linux.patch
+++ b/images/virt-artifact/patches/029-use-OFVM_CODE-for-linux.patch
@@ -1,8 +1,8 @@
 diff --git a/pkg/virt-launcher/virtwrap/manager.go b/pkg/virt-launcher/virtwrap/manager.go
-index 2513ad62a8..19f8aa7e83 100644
+index 2513ad62a8..4a1d22de46 100644
 --- a/pkg/virt-launcher/virtwrap/manager.go
 +++ b/pkg/virt-launcher/virtwrap/manager.go
-@@ -966,9 +966,24 @@ func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineIn
+@@ -966,17 +966,36 @@ func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineIn
  
  	var efiConf *converter.EFIConfiguration
  	if vmi.IsBootloaderEFI() {
@@ -12,18 +12,32 @@ index 2513ad62a8..19f8aa7e83 100644
  		secureBoot := vmi.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot == nil || *vmi.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot
  		sev := kutil.IsSEVVMI(vmi)
  
++		forceCCEFI := false
 +		if !sev {
 +			if a := vmi.GetAnnotations()[ann]; a != windows {
 +				/*
-+				 Kubevirt always uses OVFM_CODE.secboot.fd.
-+				 Even if the security boot is turned off.
-+				 It is believed that this firmware works correctly with OVFM_VERS, but on altlinux we see problems, the virtual machine with efi and cpu >=12 does not start.
-+				 OVFM_CODE.fd is not exist, but the OVFM_CODE.cc.fd is always symlink to OVFM_CODE.fd
-+				 That's why we set the sev to true for always virtual machines with linux.
++					Kubevirt uses OVFM_CODE.secboot.fd in 2 combinations: OVFM_CODE.secboot.fd + OVFM_VARS.secboot.fd when secboot is enabled and OVFM_CODE.secboot.fd + OVFM_VARS.fd when secboot is disabled.
++					It works fine with original CentOS based virt-launcher in both secboot modes.
++					We use ALTLinux based virt-launcher, and it fails to start Linux VM with more than 12 CPUs in secboot disabled mode.
++
++					Kubevirt uses flags to detect firmware combinations in converter.
++					EFIConfiguration, so we can't set needed files directly.
++					But there is combination for SEV: OVFM_CODE.cc.fd + OVMF_VARS.fd that works for Linux, because OVFM_CODE.cc.fd is actually a symlink to OVFM_CODE.fd.
++					So, we set true for the second flag to force OVFM_CODE.cc.fd + OVMF_VARS.fd for non-Windows virtual machines.
 +				*/
-+				sev = true
++				forceCCEFI = true
 +			}
 +		}
  		if !l.efiEnvironment.Bootable(secureBoot, sev) {
  			log.Log.Errorf("EFI OVMF roms missing for booting in EFI mode with SecureBoot=%v, SEV=%v", secureBoot, sev)
  			return nil, fmt.Errorf("EFI OVMF roms missing for booting in EFI mode with SecureBoot=%v, SEV=%v", secureBoot, sev)
+ 		}
+ 
+ 		efiConf = &converter.EFIConfiguration{
+-			EFICode:      l.efiEnvironment.EFICode(secureBoot, sev),
+-			EFIVars:      l.efiEnvironment.EFIVars(secureBoot, sev),
++			EFICode:      l.efiEnvironment.EFICode(secureBoot, sev || forceCCEFI),
++			EFIVars:      l.efiEnvironment.EFIVars(secureBoot, sev || forceCCEFI),
+ 			SecureLoader: secureBoot,
+ 		}
+ 	}

--- a/images/virt-artifact/patches/README.md
+++ b/images/virt-artifact/patches/README.md
@@ -115,3 +115,11 @@ How does it work?
 
 By default, the virtual-operator adds a nodePlacement with the RequireControlPlanePreferNonWorker.
 But we set up the placement ourselves, so we replace the policy with AnyNode.
+
+#### `029-use-OFVM_CODE-for-linux.patch`
+
+Kubevirt always uses OVFM_CODE.secboot.fd.
+Even if the security boot is turned off.
+It is believed that this firmware works correctly with OVFM_VERS, but on altlinux we see problems, the virtual machine with efi and cpu >=12 does not start.
+OVFM_CODE.fd is not exist, but the OVFM_CODE.cc.fd is always symlink to OVFM_CODE.fd
+That's why we set the sev to true for always virtual machines with linux.

--- a/images/virt-artifact/patches/README.md
+++ b/images/virt-artifact/patches/README.md
@@ -118,8 +118,11 @@ But we set up the placement ourselves, so we replace the policy with AnyNode.
 
 #### `029-use-OFVM_CODE-for-linux.patch`
 
-Kubevirt always uses OVFM_CODE.secboot.fd.
-Even if the security boot is turned off.
-It is believed that this firmware works correctly with OVFM_VERS, but on altlinux we see problems, the virtual machine with efi and cpu >=12 does not start.
-OVFM_CODE.fd is not exist, but the OVFM_CODE.cc.fd is always symlink to OVFM_CODE.fd
-That's why we set the sev to true for always virtual machines with linux.
+Kubevirt uses OVFM_CODE.secboot.fd in 2 combinations: OVFM_CODE.secboot.fd + OVFM_VARS.secboot.fd when secboot is enabled and OVFM_CODE.secboot.fd + OVFM_VARS.fd when secboot is disabled.
+It works fine with original CentOS based virt-launcher in both secboot modes.
+We use ALTLinux based virt-launcher, and it fails to start Linux VM with more than 12 CPUs in secboot disabled mode.
+
+Kubevirt uses flags to detect firmware combinations in converter.
+EFIConfiguration, so we can't set needed files directly. 
+But there is combination for SEV: OVFM_CODE.cc.fd + OVMF_VARS.fd that works for Linux, because OVFM_CODE.cc.fd is actually a symlink to OVFM_CODE.fd. 
+So, we set true for the second flag to force OVFM_CODE.cc.fd + OVMF_VARS.fd for non-Windows virtual machines._

--- a/images/virtualization-artifact/pkg/common/annotations/annotations.go
+++ b/images/virtualization-artifact/pkg/common/annotations/annotations.go
@@ -68,6 +68,8 @@ const (
 	// LastPropagatedVMLabelsAnnotation is a marshalled map of previously applied virtual machine labels.
 	LastPropagatedVMLabelsAnnotation = AnnAPIGroup + "/last-propagated-vm-labels"
 
+	AnnOsType = AnnAPIGroupV + "/os-type"
+
 	// LabelsPrefix is a prefix for virtualization-controller labels.
 	LabelsPrefix = "virtualization.deckhouse.io"
 

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
@@ -434,7 +434,7 @@ func (b *KVVM) SetOsType(osType virtv2.OsType) error {
 	switch osType {
 	case virtv2.Windows:
 		// Need for `029-use-OFVM_CODE-for-linux.patch`
-		b.AddAnnotation(annotations.AnnOsType, string(virtv2.Windows))
+		b.SetKVVMIAnnotation(annotations.AnnOsType, string(virtv2.Windows))
 
 		b.Resource.Spec.Template.Spec.Domain.Machine = &virtv1.Machine{
 			Type: "q35",

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
@@ -28,6 +28,7 @@ import (
 	virtv1 "kubevirt.io/api/core/v1"
 
 	"github.com/deckhouse/virtualization-controller/pkg/common"
+	"github.com/deckhouse/virtualization-controller/pkg/common/annotations"
 	"github.com/deckhouse/virtualization-controller/pkg/common/array"
 	"github.com/deckhouse/virtualization-controller/pkg/common/pointer"
 	"github.com/deckhouse/virtualization-controller/pkg/common/resource_builder"
@@ -432,6 +433,9 @@ func (b *KVVM) SetProvisioning(p *virtv2.Provisioning) error {
 func (b *KVVM) SetOsType(osType virtv2.OsType) error {
 	switch osType {
 	case virtv2.Windows:
+		// Need for `029-use-OFVM_CODE-for-linux.patch`
+		b.AddAnnotation(annotations.AnnOsType, string(virtv2.Windows))
+
 		b.Resource.Spec.Template.Spec.Domain.Machine = &virtv1.Machine{
 			Type: "q35",
 		}


### PR DESCRIPTION
## Description

Add `029-use-OFVM_CODE-for-linux.patch` to allow non-Windows configurations with more than 12 CPUs.

## Why do we need it, and what problem does it solve?

Kubevirt uses OVFM_CODE.secboot.fd in 2 combinations: OVFM_CODE.secboot.fd + OVFM_VARS.secboot.fd when secboot is enabled and OVFM_CODE.secboot.fd + OVFM_VARS.fd when secboot is disabled.
It works fine with original CentOS based virt-launcher in both secboot modes.
We use ALTLinux based virt-launcher and it fails to start Linux VM with more than 12 CPUs in secboot disabled mode.

Kubevirt uses flags to detect firmware combinations in converter.EFIConfiguration, so we can't set needed files directly. But there is combination for SEV: OVFM_CODE.cc.fd + OVMF_VARS.fd that works for Linux, because OVFM_CODE.cc.fd is actually a symlink to OVFM_CODE.fd. So, we set true for the second flag to force OVFM_CODE.cc.fd + OVMF_VARS.fd for non-Windows virtual machines.

## What is the expected result?

- Windows VMs works with secboot
- Linux VMs works with more than 12 CPUs.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
