### PR TITLE
fix(kube-api-rewriter): respond with correct error

### DIFF
--- a/images/kube-api-rewriter/pkg/proxy/handler.go
+++ b/images/kube-api-rewriter/pkg/proxy/handler.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"github.com/tidwall/gjson"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/deckhouse/kube-api-rewriter/pkg/labels"
 	logutil "github.com/deckhouse/kube-api-rewriter/pkg/log"
@@ -186,10 +187,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	resp, err := h.TargetClient.Do(req)
 	if err != nil {
 		logger.Error("Error passing request to the target", logutil.SlogErr(err))
-		http.Error(w, "Error passing request to the target", http.StatusInternalServerError)
+		http.Error(w, k8serrors.NewInternalError(err).Error(), http.StatusInternalServerError)
 		metrics.TargetResponseError()
-		// TODO return apimachinery NewInternalError
-		// https://github.com/kubernetes/apimachinery/blob/master/pkg/api/errors/errors.go
 		return
 	}
 


### PR DESCRIPTION
## Description
wrap api error with NewInternalError

## Why do we need it, and what problem does it solve?
Passthrough api error


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
