### PR TITLE
feat(vi): add snapshot objectRef

### DIFF
--- a/api/core/v1alpha2/cluster_virtual_image.go
+++ b/api/core/v1alpha2/cluster_virtual_image.go
@@ -107,8 +107,8 @@ type ClusterVirtualImageObjectRef struct {
 	Namespace string `json:"namespace,omitempty"`
 }
 
-// Kind of the existing VirtualImage, ClusterVirtualImage, or VirtualDisk resource.
-// +kubebuilder:validation:Enum:={ClusterVirtualImage,VirtualImage,VirtualDisk}
+// Kind of the existing VirtualImage, ClusterVirtualImage, VirtualDisk or VirtualDiskSnapshot resource.
+// +kubebuilder:validation:Enum:={ClusterVirtualImage,VirtualImage,VirtualDisk,VirtualDiskSnapshot}
 type ClusterVirtualImageObjectRefKind string
 
 const (

--- a/api/core/v1alpha2/virtual_image.go
+++ b/api/core/v1alpha2/virtual_image.go
@@ -99,7 +99,7 @@ type VirtualImageStatus struct {
 	UploadCommand   string                   `json:"uploadCommand,omitempty"`
 	ImageUploadURLs *ImageUploadURLs         `json:"imageUploadURLs,omitempty"`
 	Target          VirtualImageStatusTarget `json:"target,omitempty"`
-	// UID of the source (VirtualImage, ClusterVirtualImage, or VirtualDisk) used when creating the virtual image.
+	// UID of the source (VirtualImage, ClusterVirtualImage, VirtualDisk or VirtualDiskSnapshot) used when creating the virtual image.
 	SourceUID *types.UID `json:"sourceUID,omitempty"`
 	// The latest available observations of an object's current state.
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
@@ -139,21 +139,22 @@ type VirtualImageContainerImage struct {
 	CABundle []byte `json:"caBundle,omitempty"`
 }
 
-// Use an existing VirtualImage, ClusterVirtualImage, or VirtualDisk resource to create an image.
+// Use an existing VirtualImage, ClusterVirtualImage, VirtualDisk or VirtualDiskSnapshot resource to create an image.
 type VirtualImageObjectRef struct {
-	// Kind of an existing VirtualImage, ClusterVirtualImage, or VirtualDisk resource.
+	// Kind of an existing VirtualImage, ClusterVirtualImage, VirtualDisk or VirtualDiskSnapshot resource.
 	Kind VirtualImageObjectRefKind `json:"kind"`
-	// Name of an existing VirtualImage, ClusterVirtualImage, or VirtualDisk resource.
+	// Name of an existing VirtualImage, ClusterVirtualImage, VirtualDisk or VirtualDiskSnapshot resource.
 	Name string `json:"name"`
 }
 
-// +kubebuilder:validation:Enum:={ClusterVirtualImage,VirtualImage,VirtualDisk}
+// +kubebuilder:validation:Enum:={ClusterVirtualImage,VirtualImage,VirtualDisk,VirtualDiskSnapshot}
 type VirtualImageObjectRefKind string
 
 const (
 	VirtualImageObjectRefKindVirtualImage        VirtualImageObjectRefKind = "VirtualImage"
 	VirtualImageObjectRefKindClusterVirtualImage VirtualImageObjectRefKind = "ClusterVirtualImage"
 	VirtualImageObjectRefKindVirtualDisk         VirtualImageObjectRefKind = "VirtualDisk"
+	VirtualImageObjectRefKindVirtualDiskSnapshot VirtualImageObjectRefKind = "VirtualDiskSnapshot"
 )
 
 // Storage type to keep the image for the current virtualization setup.

--- a/api/pkg/apiserver/api/generated/openapi/zz_generated.openapi.go
+++ b/api/pkg/apiserver/api/generated/openapi/zz_generated.openapi.go
@@ -2865,12 +2865,12 @@ func schema_virtualization_api_core_v1alpha2_VirtualImageObjectRef(ref common.Re
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "Use an existing VirtualImage, ClusterVirtualImage, or VirtualDisk resource to create an image.",
+				Description: "Use an existing VirtualImage, ClusterVirtualImage, VirtualDisk or VirtualDiskSnapshot resource to create an image.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Kind of an existing VirtualImage, ClusterVirtualImage, or VirtualDisk resource.",
+							Description: "Kind of an existing VirtualImage, ClusterVirtualImage, VirtualDisk or VirtualDiskSnapshot resource.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -2878,7 +2878,7 @@ func schema_virtualization_api_core_v1alpha2_VirtualImageObjectRef(ref common.Re
 					},
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name of an existing VirtualImage, ClusterVirtualImage, or VirtualDisk resource.",
+							Description: "Name of an existing VirtualImage, ClusterVirtualImage, VirtualDisk or VirtualDiskSnapshot resource.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -3012,7 +3012,7 @@ func schema_virtualization_api_core_v1alpha2_VirtualImageStatus(ref common.Refer
 					},
 					"sourceUID": {
 						SchemaProps: spec.SchemaProps{
-							Description: "UID of the source (VirtualImage, ClusterVirtualImage, or VirtualDisk) used when creating the virtual image.",
+							Description: "UID of the source (VirtualImage, ClusterVirtualImage, VirtualDisk or VirtualDiskSnapshot) used when creating the virtual image.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/base-images/deckhouse_image_versions.yml
+++ b/base-images/deckhouse_image_versions.yml
@@ -2,3 +2,4 @@
 REGISTRY_PATH: "registry.deckhouse.io/base_images/"
 
 BASE_SCRATCH: "scratch@sha256:b054705fcc9f2205777d80a558d920c0b4209efdc3163c22b5bfcb5dda1db5fc"
+BASE_ALT_DEV: "dev-alt:p10@sha256:76e6e163fa982f03468166203488b569e6d9fc10855d6a259c662706436cdcad"

--- a/base-images/deckhouse_image_versions.yml
+++ b/base-images/deckhouse_image_versions.yml
@@ -2,4 +2,3 @@
 REGISTRY_PATH: "registry.deckhouse.io/base_images/"
 
 BASE_SCRATCH: "scratch@sha256:b054705fcc9f2205777d80a558d920c0b4209efdc3163c22b5bfcb5dda1db5fc"
-BASE_ALT_DEV: "dev-alt:p10@sha256:76e6e163fa982f03468166203488b569e6d9fc10855d6a259c662706436cdcad"

--- a/crds/clustervirtualimages.yaml
+++ b/crds/clustervirtualimages.yaml
@@ -171,11 +171,12 @@ spec:
                         kind:
                           description:
                             Kind of the existing VirtualImage, ClusterVirtualImage,
-                            or VirtualDisk resource.
+                            VirtualDisk or VirtualDiskSnapshot resource.
                           enum:
                             - ClusterVirtualImage
                             - VirtualImage
                             - VirtualDisk
+                            - VirtualDiskSnapshot
                           type: string
                         name:
                           description:

--- a/crds/doc-ru-virtualimages.yaml
+++ b/crds/doc-ru-virtualimages.yaml
@@ -74,14 +74,14 @@ spec:
                             * xz.
                     objectRef:
                       description: |
-                        Использование существующего ресурса VirtualImage, ClusterVirtualImage или VirtualDisk для создания образа.
+                        Использование существующего ресурса VirtualImage, ClusterVirtualImage, VirtualDisk или VirtualDiskSnapshot для создания образа.
                       properties:
                         kind:
                           description: |
-                            Ссылка на существующий ресурс VirtualImage, ClusterVirtualImage или VirtualDisk.
+                            Ссылка на существующий ресурс VirtualImage, ClusterVirtualImage, VirtualDisk или VirtualDiskSnapshot.
                         name:
                           description: |
-                            Имя существующего ресурса VirtualImage, ClusterVirtualImage или VirtualDisk.
+                            Имя существующего ресурса VirtualImage, ClusterVirtualImage, VirtualDisk или VirtualDiskSnapshot.
                     type:
                       description: |
                         Доступные типы источников для создания образа:
@@ -193,7 +193,7 @@ spec:
                         Команда для загрузки образа с использованием `Service` внутри кластера.
                 sourceUID:
                   description: |
-                    UID источника (VirtualImage, ClusterVirtualImage или VirtualDisk), использованного при создании виртуального образа.
+                    UID источника (VirtualImage, ClusterVirtualImage, VirtualDisk или VirtualDiskSnapshot), использованного при создании виртуального образа.
                 storageClassName:
                   description: |
                     Имя StorageClass, использованного для создания DataVolume, если в поле `storage` был выбран тип `Kubernetes`.

--- a/crds/virtualimages.yaml
+++ b/crds/virtualimages.yaml
@@ -166,21 +166,22 @@ spec:
                     objectRef:
                       description:
                         Use an existing VirtualImage, ClusterVirtualImage,
-                        or VirtualDisk resource to create an image.
+                        VirtualDisk or VirtualDiskSnapshot resource to create an image.
                       properties:
                         kind:
                           description:
                             Kind of an existing VirtualImage, ClusterVirtualImage,
-                            or VirtualDisk resource.
+                            VirtualDisk or VirtualDiskSnapshot resource.
                           enum:
                             - ClusterVirtualImage
                             - VirtualImage
                             - VirtualDisk
+                            - VirtualDiskSnapshot
                           type: string
                         name:
                           description:
                             Name of an existing VirtualImage, ClusterVirtualImage,
-                            or VirtualDisk resource.
+                            VirtualDisk or VirtualDiskSnapshot resource.
                           type: string
                       required:
                         - kind
@@ -399,7 +400,8 @@ spec:
                 sourceUID:
                   description:
                     UID of the source (VirtualImage, ClusterVirtualImage,
-                    or VirtualDisk) used when creating the virtual image.
+                    VirtualDisk or VirtualDiskSnapshot) used when creating the virtual
+                    image.
                   type: string
                 storageClassName:
                   description:

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -412,6 +412,28 @@ spec:
 EOF
 ```
 
+### Creating an image from a disk snapshot
+
+It is possible to create an image from [snapshot](#snapshots). This requires that the disk snapshot is in the ready phase.
+
+Example of creating an image from a disk snapshot:
+
+```yaml
+d8 k apply -f - <<EOF
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: linux-vm-root
+spec:
+  storage: ContainerRegistry
+  dataSource:
+    type: ObjectRef
+    objectRef:
+      kind: VirtualDiskSnapshot
+      name: linux-vm-root-snapshot
+EOF
+```
+
 ## Disks
 
 Disks in virtual machines are necessary for writing and storing data, ensuring that applications and operating systems can fully function. Under the hood of these disks is the storage provided by the platform (PVC).

--- a/docs/USER_GUIDE_RU.md
+++ b/docs/USER_GUIDE_RU.md
@@ -421,6 +421,27 @@ spec:
 EOF
 ```
 
+### Создание образа из снимка диска
+
+Можно создать образ из [снимка](#снимки). Для этого необходимо чтобы снимок диска находился в фазе готовности.
+
+Пример создания образа из моментального снимка диска:
+```yaml
+d8 k apply -f - <<EOF
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: linux-vm-root
+spec:
+  storage: ContainerRegistry
+  dataSource:
+    type: ObjectRef
+    objectRef:
+      kind: VirtualDiskSnapshot
+      name: linux-vm-root-snapshot
+EOF
+```
+
 ## Диски
 
 Диски в виртуальных машинах необходимы для записи и хранения данных, они обеспечивают полноценное функционирование приложений и операционных систем. Хранилище для этих дисков предоставляет платформа.

--- a/images/bounder/werf.inc.yaml
+++ b/images/bounder/werf.inc.yaml
@@ -1,0 +1,3 @@
+---
+image: {{ $.ImageName }}
+from: {{ $.Images.BASE_SCRATCH }}

--- a/images/virtualization-artifact/cmd/virtualization-controller/main.go
+++ b/images/virtualization-artifact/cmd/virtualization-controller/main.go
@@ -241,7 +241,7 @@ func main() {
 	}
 
 	viLogger := logger.NewControllerLogger(vi.ControllerName, logLevel, logOutput, logDebugVerbosity, logDebugControllerList)
-	if _, err = vi.NewController(ctx, mgr, viLogger, importSettings.ImporterImage, importSettings.UploaderImage, importSettings.Requirements, dvcrSettings, viStorageClassSettings); err != nil {
+	if _, err = vi.NewController(ctx, mgr, viLogger, importSettings.ImporterImage, importSettings.UploaderImage, importSettings.BounderImage, importSettings.Requirements, dvcrSettings, viStorageClassSettings); err != nil {
 		log.Error(err.Error())
 		os.Exit(1)
 	}

--- a/images/virtualization-artifact/pkg/common/consts.go
+++ b/images/virtualization-artifact/pkg/common/consts.go
@@ -22,6 +22,8 @@ const (
 	// OwnerUID provides the UID of the owner entity (either PVC or DV)
 	OwnerUID = "OWNER_UID"
 
+	// BounderContainerName provides a constant to use as a name for bounder Container
+	BounderContainerName = "bounder"
 	// ImporterContainerName provides a constant to use as a name for importer Container
 	ImporterContainerName = "importer"
 	// UploaderContainerName provides a constant to use as a name for uploader Container
@@ -34,6 +36,8 @@ const (
 	ImporterPodImageNameVar = "IMPORTER_IMAGE"
 	// UploaderPodImageNameVar is a name of variable with the image name for the uploader Pod
 	UploaderPodImageNameVar = "UPLOADER_IMAGE"
+	// BounderPodImageNameVar is a name of variable with the image name for the bounder Pod
+	BounderPodImageNameVar = "BOUNDER_IMAGE"
 	// ImporterCertDir is where the configmap containing certs will be mounted
 	ImporterCertDir = "/certs"
 	// ImporterProxyCertDir is where the configmap containing proxy certs will be mounted

--- a/images/virtualization-artifact/pkg/config/load_import_settings.go
+++ b/images/virtualization-artifact/pkg/config/load_import_settings.go
@@ -34,6 +34,7 @@ const (
 type ImportSettings struct {
 	ImporterImage string
 	UploaderImage string
+	BounderImage  string
 	Requirements  corev1.ResourceRequirements
 }
 
@@ -46,6 +47,11 @@ func LoadImportSettingsFromEnv() (ImportSettings, error) {
 	}
 
 	settings.UploaderImage, err = GetRequiredEnvVar(common.UploaderPodImageNameVar)
+	if err != nil {
+		return ImportSettings{}, err
+	}
+
+	settings.BounderImage, err = GetRequiredEnvVar(common.BounderPodImageNameVar)
 	if err != nil {
 		return ImportSettings{}, err
 	}

--- a/images/virtualization-artifact/pkg/controller/bounder/bounder.go
+++ b/images/virtualization-artifact/pkg/controller/bounder/bounder.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bounder
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/deckhouse/virtualization-controller/pkg/common"
+	"github.com/deckhouse/virtualization-controller/pkg/common/annotations"
+	"github.com/deckhouse/virtualization-controller/pkg/common/object"
+	podutil "github.com/deckhouse/virtualization-controller/pkg/common/pod"
+	"github.com/deckhouse/virtualization-controller/pkg/common/provisioner"
+)
+
+type Bounder struct {
+	PodSettings *PodSettings
+}
+
+func NewBounder(podSettings *PodSettings) *Bounder {
+	return &Bounder{
+		PodSettings: podSettings,
+	}
+}
+
+type PodSettings struct {
+	Name                 string
+	Image                string
+	PullPolicy           string
+	Namespace            string
+	OwnerReference       metav1.OwnerReference
+	ControllerName       string
+	InstallerLabels      map[string]string
+	ResourceRequirements *corev1.ResourceRequirements
+	ImagePullSecrets     []corev1.LocalObjectReference
+	PriorityClassName    string
+	PVCName              string
+	NodePlacement        *provisioner.NodePlacement
+}
+
+// CreatePod creates and returns a pointer to a pod which is created based on the passed-in endpoint, secret
+// name, etc. A nil secret means the endpoint credentials are not passed to the
+// bounder pod.
+func (imp *Bounder) CreatePod(ctx context.Context, client client.Client) (*corev1.Pod, error) {
+	pod, err := imp.makeBounderPodSpec()
+	if err != nil {
+		return nil, err
+	}
+
+	err = client.Create(ctx, pod)
+	if err != nil {
+		return nil, err
+	}
+
+	return pod, nil
+}
+
+// makeBounderPodSpec creates and return the bounder pod spec based on the passed-in endpoint, secret and pvc.
+func (imp *Bounder) makeBounderPodSpec() (*corev1.Pod, error) {
+	pod := corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      imp.PodSettings.Name,
+			Namespace: imp.PodSettings.Namespace,
+			Annotations: map[string]string{
+				annotations.AnnCreatedBy: "yes",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				imp.PodSettings.OwnerReference,
+			},
+		},
+		Spec: corev1.PodSpec{
+			// Container and volumes will be added later.
+			Containers:        []corev1.Container{},
+			Volumes:           []corev1.Volume{},
+			RestartPolicy:     corev1.RestartPolicyOnFailure,
+			PriorityClassName: imp.PodSettings.PriorityClassName,
+			ImagePullSecrets:  imp.PodSettings.ImagePullSecrets,
+		},
+	}
+
+	if imp.PodSettings.NodePlacement != nil && len(imp.PodSettings.NodePlacement.Tolerations) > 0 {
+		pod.Spec.Tolerations = imp.PodSettings.NodePlacement.Tolerations
+
+		err := provisioner.KeepNodePlacementTolerations(imp.PodSettings.NodePlacement, &pod)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	annotations.SetRecommendedLabels(&pod, imp.PodSettings.InstallerLabels, imp.PodSettings.ControllerName)
+	podutil.SetRestrictedSecurityContext(&pod.Spec)
+
+	container := imp.makeBounderContainerSpec()
+	imp.addVolumes(&pod, container)
+	pod.Spec.Containers = append(pod.Spec.Containers, *container)
+
+	return &pod, nil
+}
+
+func (imp *Bounder) makeBounderContainerSpec() *corev1.Container {
+	container := &corev1.Container{
+		Name:            common.BounderContainerName,
+		Image:           imp.PodSettings.Image,
+		ImagePullPolicy: corev1.PullPolicy(imp.PodSettings.PullPolicy),
+	}
+
+	if imp.PodSettings.ResourceRequirements != nil {
+		container.Resources = *imp.PodSettings.ResourceRequirements
+	}
+
+	return container
+}
+
+// addVolumes fills Volumes in Pod spec and VolumeMounts and envs in container spec.
+func (imp *Bounder) addVolumes(pod *corev1.Pod, container *corev1.Container) {
+	if imp.PodSettings.PVCName != "" {
+		podutil.AddVolumeDevice(
+			pod,
+			container,
+			corev1.Volume{
+				Name: "volume",
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: imp.PodSettings.PVCName,
+					},
+				},
+			},
+			corev1.VolumeDevice{
+				Name:       "volume",
+				DevicePath: "/dev/xvda",
+			},
+		)
+	}
+}
+
+type PodNamer interface {
+	BounderPod() types.NamespacedName
+}
+
+func FindPod(ctx context.Context, client client.Client, name PodNamer) (*corev1.Pod, error) {
+	return object.FetchObject(ctx, name.BounderPod(), client, &corev1.Pod{})
+}

--- a/images/virtualization-artifact/pkg/controller/bounder/bounder_test.go
+++ b/images/virtualization-artifact/pkg/controller/bounder/bounder_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bounder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func Test_MakePodSpec(t *testing.T) {
+	podSettings := &PodSettings{
+		Name:       "bounder-pod",
+		Image:      "localhost:5000/bounder:latest",
+		PullPolicy: string(corev1.PullAlways),
+		Namespace:  "virt-controller",
+		PVCName:    "bounder-pvc",
+		OwnerReference: metav1.OwnerReference{
+			APIVersion:         "v1",
+			Kind:               "Pod",
+			Name:               "other-pod",
+			UID:                "123-123",
+			Controller:         ptr.To(true),
+			BlockOwnerDeletion: ptr.To(true),
+		},
+		ControllerName: "test-controller",
+	}
+
+	imp := NewBounder(podSettings)
+
+	pod, err := imp.makeBounderPodSpec()
+	require.NoError(t, err)
+
+	if pod.Namespace == "" {
+		t.Fatalf("pod.Namespace should not be empty!")
+	}
+}

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref_vdsnapshot.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref_vdsnapshot.go
@@ -258,6 +258,16 @@ func (ds ObjectRefVirtualDiskSnapshot) Sync(ctx context.Context, cvi *virtv2.Clu
 
 			switch {
 			case errors.Is(err, service.ErrNotInitialized), errors.Is(err, service.ErrNotScheduled):
+				if pvc.Status.Phase != corev1.ClaimBound {
+					cvi.Status.Phase = virtv2.ImageProvisioning
+					cb.
+						Status(metav1.ConditionFalse).
+						Reason(vicondition.Provisioning).
+						Message("Waiting for PVC to be bound")
+
+					return reconcile.Result{Requeue: true}, nil
+				}
+
 				cb.
 					Status(metav1.ConditionFalse).
 					Reason(vicondition.ProvisioningNotStarted).

--- a/images/virtualization-artifact/pkg/controller/service/bounder_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/bounder_service.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/deckhouse/virtualization-controller/pkg/common/annotations"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/bounder"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/supplements"
+	"github.com/deckhouse/virtualization-controller/pkg/dvcr"
+)
+
+type BounderPodService struct {
+	dvcrSettings   *dvcr.Settings
+	client         client.Client
+	image          string
+	requirements   corev1.ResourceRequirements
+	pullPolicy     string
+	verbose        string
+	controllerName string
+	protection     *ProtectionService
+}
+
+func NewBounderPodService(
+	dvcrSettings *dvcr.Settings,
+	client client.Client,
+	image string,
+	requirements corev1.ResourceRequirements,
+	pullPolicy string,
+	verbose string,
+	controllerName string,
+	protection *ProtectionService,
+) *BounderPodService {
+	return &BounderPodService{
+		dvcrSettings:   dvcrSettings,
+		client:         client,
+		image:          image,
+		requirements:   requirements,
+		pullPolicy:     pullPolicy,
+		verbose:        verbose,
+		controllerName: controllerName,
+		protection:     protection,
+	}
+}
+
+func (s BounderPodService) Start(ctx context.Context, ownerRef *metav1.OwnerReference, sup *supplements.Generator, pvc *corev1.PersistentVolumeClaim, opts ...Option) error {
+	podSettings := s.GetPodSettings(ownerRef, sup, pvc)
+
+	for _, opt := range opts {
+		switch v := opt.(type) {
+		case *NodePlacementOption:
+			podSettings.NodePlacement = v.nodePlacement
+		default:
+			return fmt.Errorf("unknown Start option")
+		}
+	}
+
+	_, err := bounder.NewBounder(podSettings).CreatePod(ctx, s.client)
+	if err != nil && !k8serrors.IsAlreadyExists(err) {
+		return err
+	}
+
+	return nil
+}
+
+func (s BounderPodService) CleanUp(ctx context.Context, sup *supplements.Generator) (bool, error) {
+	return s.CleanUpSupplements(ctx, sup)
+}
+
+func (s BounderPodService) DeletePod(ctx context.Context, obj ObjectKind, controllerName string) (bool, error) {
+	labelSelector := client.MatchingLabels{annotations.AppKubernetesManagedByLabel: controllerName}
+
+	podList := &corev1.PodList{}
+	if err := s.client.List(ctx, podList, labelSelector); err != nil {
+		return false, err
+	}
+
+	for _, pod := range podList.Items {
+		for _, ownerRef := range pod.OwnerReferences {
+			if ownerRef.Kind == obj.GroupVersionKind().Kind && ownerRef.Name == obj.GetName() && ownerRef.UID == obj.GetUID() {
+				err := s.protection.RemoveProtection(ctx, &pod)
+				if err != nil {
+					return false, err
+				}
+
+				err = s.client.Delete(ctx, &pod)
+				if err != nil {
+					if k8serrors.IsNotFound(err) {
+						return false, nil
+					}
+
+					return false, err
+				}
+
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+func (s BounderPodService) CleanUpSupplements(ctx context.Context, sup *supplements.Generator) (bool, error) {
+	pod, err := s.GetPod(ctx, sup)
+	if err != nil {
+		return false, err
+	}
+
+	err = s.protection.RemoveProtection(ctx, pod)
+	if err != nil {
+		return false, err
+	}
+
+	var hasDeleted bool
+
+	if pod != nil {
+		hasDeleted = true
+		err = s.client.Delete(ctx, pod)
+		if err != nil && !k8serrors.IsNotFound(err) {
+			return false, err
+		}
+	}
+
+	return hasDeleted, nil
+}
+
+func (s BounderPodService) Protect(ctx context.Context, pod *corev1.Pod) error {
+	err := s.protection.AddProtection(ctx, pod)
+	if err != nil {
+		return fmt.Errorf("failed to add protection for bounder's supplements: %w", err)
+	}
+
+	return nil
+}
+
+func (s BounderPodService) Unprotect(ctx context.Context, pod *corev1.Pod) error {
+	err := s.protection.RemoveProtection(ctx, pod)
+	if err != nil {
+		return fmt.Errorf("failed to remove protection for bounder's supplements: %w", err)
+	}
+
+	return nil
+}
+
+func (s BounderPodService) GetPod(ctx context.Context, sup *supplements.Generator) (*corev1.Pod, error) {
+	pod, err := bounder.FindPod(ctx, s.client, sup)
+	if err != nil {
+		return nil, err
+	}
+
+	return pod, nil
+}
+
+func (s BounderPodService) GetPodSettings(ownerRef *metav1.OwnerReference, sup *supplements.Generator, pvc *corev1.PersistentVolumeClaim) *bounder.PodSettings {
+	bounderPod := sup.BounderPod()
+	return &bounder.PodSettings{
+		Name:                 bounderPod.Name,
+		Namespace:            pvc.Namespace,
+		Image:                s.image,
+		PullPolicy:           s.pullPolicy,
+		OwnerReference:       *ownerRef,
+		ControllerName:       s.controllerName,
+		InstallerLabels:      map[string]string{},
+		ResourceRequirements: &s.requirements,
+		PVCName:              pvc.Name,
+	}
+}

--- a/images/virtualization-artifact/pkg/controller/supplements/generator.go
+++ b/images/virtualization-artifact/pkg/controller/supplements/generator.go
@@ -78,6 +78,12 @@ func (g *Generator) ImporterPod() types.NamespacedName {
 	return g.shortenNamespaced(name)
 }
 
+// ImporterPod generates name for importer Pod.
+func (g *Generator) BounderPod() types.NamespacedName {
+	name := fmt.Sprintf("%s-bounder-%s", g.Prefix, g.Name)
+	return g.shortenNamespaced(name)
+}
+
 // UploaderPod generates name for uploader Pod.
 func (g *Generator) UploaderPod() types.NamespacedName {
 	name := fmt.Sprintf("%s-uploader-%s", g.Prefix, g.Name)

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/errors.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/errors.go
@@ -78,3 +78,17 @@ func NewVirtualDiskNotAllowedForUseError(name string) error {
 		name: name,
 	}
 }
+
+type VirtualDiskSnapshotNotReadyError struct {
+	name string
+}
+
+func (e VirtualDiskSnapshotNotReadyError) Error() string {
+	return fmt.Sprintf("VirtualDiskSnapshot %s not ready", e.name)
+}
+
+func NewVirtualDiskSnapshotNotReadyError(name string) error {
+	return VirtualDiskSnapshotNotReadyError{
+		name: name,
+	}
+}

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/interfaces.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/interfaces.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/deckhouse/virtualization-controller/pkg/common/datasource"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/bounder"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/importer"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/supplements"
@@ -43,6 +44,16 @@ type Importer interface {
 	Protect(ctx context.Context, pod *corev1.Pod) error
 	Unprotect(ctx context.Context, pod *corev1.Pod) error
 	GetPodSettingsWithPVC(ownerRef *metav1.OwnerReference, sup *supplements.Generator, pvcName, pvcNamespace string) *importer.PodSettings
+}
+
+type Bounder interface {
+	Start(ctx context.Context, ownerRef *metav1.OwnerReference, sup *supplements.Generator, pvc *corev1.PersistentVolumeClaim, opts ...service.Option) error
+	CleanUp(ctx context.Context, sup *supplements.Generator) (bool, error)
+	CleanUpSupplements(ctx context.Context, sup *supplements.Generator) (bool, error)
+	GetPod(ctx context.Context, sup *supplements.Generator) (*corev1.Pod, error)
+	Protect(ctx context.Context, pod *corev1.Pod) error
+	Unprotect(ctx context.Context, pod *corev1.Pod) error
+	GetPodSettings(ownerRef *metav1.OwnerReference, sup *supplements.Generator, pvc *corev1.PersistentVolumeClaim) *bounder.PodSettings
 }
 
 type Uploader interface {

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vdsnapshot.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vdsnapshot.go
@@ -1,0 +1,583 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	storev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/deckhouse/virtualization-controller/pkg/common"
+	"github.com/deckhouse/virtualization-controller/pkg/common/annotations"
+	"github.com/deckhouse/virtualization-controller/pkg/common/datasource"
+	"github.com/deckhouse/virtualization-controller/pkg/common/object"
+	podutil "github.com/deckhouse/virtualization-controller/pkg/common/pod"
+	"github.com/deckhouse/virtualization-controller/pkg/common/pointer"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/importer"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/supplements"
+	"github.com/deckhouse/virtualization-controller/pkg/dvcr"
+	"github.com/deckhouse/virtualization-controller/pkg/eventrecord"
+	"github.com/deckhouse/virtualization-controller/pkg/logger"
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vicondition"
+)
+
+type ObjectRefVirtualDiskSnapshot struct {
+	importerService     Importer
+	bounderService      Bounder
+	diskService         *service.DiskService
+	statService         Stat
+	dvcrSettings        *dvcr.Settings
+	client              client.Client
+	storageClassService *service.VirtualImageStorageClassService
+	recorder            eventrecord.EventRecorderLogger
+}
+
+func NewObjectRefVirtualDiskSnapshot(
+	recorder eventrecord.EventRecorderLogger,
+	importerService Importer,
+	bounderService Bounder,
+	client client.Client,
+	diskService *service.DiskService,
+	dvcrSettings *dvcr.Settings,
+	statService Stat,
+	storageClassService *service.VirtualImageStorageClassService,
+) *ObjectRefVirtualDiskSnapshot {
+	return &ObjectRefVirtualDiskSnapshot{
+		importerService:     importerService,
+		bounderService:      bounderService,
+		client:              client,
+		recorder:            recorder,
+		diskService:         diskService,
+		statService:         statService,
+		dvcrSettings:        dvcrSettings,
+		storageClassService: storageClassService,
+	}
+}
+
+func (ds ObjectRefVirtualDiskSnapshot) StoreToDVCR(ctx context.Context, vi *virtv2.VirtualImage, vdSnapshotRef *virtv2.VirtualDiskSnapshot, cb *conditions.ConditionBuilder) (reconcile.Result, error) {
+	log, ctx := logger.GetDataSourceContext(ctx, "objectref")
+
+	supgen := supplements.NewGenerator(annotations.VIShortName, vi.Name, vdSnapshotRef.Namespace, vi.UID)
+	pod, err := ds.importerService.GetPod(ctx, supgen)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	pvc, err := ds.diskService.GetPersistentVolumeClaim(ctx, supgen)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	vs, err := ds.diskService.GetVolumeSnapshot(ctx, vdSnapshotRef.Status.VolumeSnapshotName, vdSnapshotRef.Namespace)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	condition, _ := conditions.GetCondition(vicondition.ReadyType, vi.Status.Conditions)
+	switch {
+	case isDiskProvisioningFinished(condition):
+		log.Info("Virtual image provisioning finished: clean up")
+
+		cb.
+			Status(metav1.ConditionTrue).
+			Reason(vicondition.Ready).
+			Message("")
+
+		vi.Status.Phase = virtv2.ImageReady
+
+		err = ds.importerService.Unprotect(ctx, pod)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		return CleanUpSupplements(ctx, vi, ds)
+	case object.AnyTerminating(pod, pvc):
+		vi.Status.Phase = virtv2.ImagePending
+
+		log.Info("Cleaning up...")
+	case pvc == nil:
+		ds.recorder.Event(
+			vi,
+			corev1.EventTypeNormal,
+			virtv2.ReasonDataSourceSyncStarted,
+			"The ObjectRef DataSource import has started",
+		)
+
+		namespacedName := supplements.NewGenerator(annotations.VIShortName, vi.Name, vi.Namespace, vi.UID).PersistentVolumeClaim()
+
+		storageClassName := vs.Annotations["storageClass"]
+		volumeMode := vs.Annotations["volumeMode"]
+		accessModesStr := strings.Split(vs.Annotations["accessModes"], ",")
+		accessModes := make([]corev1.PersistentVolumeAccessMode, 0, len(accessModesStr))
+		for _, accessModeStr := range accessModesStr {
+			accessModes = append(accessModes, corev1.PersistentVolumeAccessMode(accessModeStr))
+		}
+
+		spec := corev1.PersistentVolumeClaimSpec{
+			AccessModes: accessModes,
+			DataSource: &corev1.TypedLocalObjectReference{
+				APIGroup: ptr.To(vs.GroupVersionKind().Group),
+				Kind:     vs.Kind,
+				Name:     vs.Name,
+			},
+		}
+
+		if storageClassName != "" {
+			spec.StorageClassName = &storageClassName
+			vi.Status.StorageClassName = storageClassName
+		}
+
+		if volumeMode != "" {
+			spec.VolumeMode = ptr.To(corev1.PersistentVolumeMode(volumeMode))
+		}
+
+		if vs.Status != nil && vs.Status.RestoreSize != nil {
+			spec.Resources = corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: *vs.Status.RestoreSize,
+				},
+			}
+		}
+
+		pvc = &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      namespacedName.Name,
+				Namespace: namespacedName.Namespace,
+				OwnerReferences: []metav1.OwnerReference{
+					service.MakeOwnerReference(vi),
+				},
+			},
+			Spec: spec,
+		}
+
+		err = ds.diskService.CreatePersistentVolumeClaim(ctx, pvc)
+		if err != nil {
+			setPhaseConditionToFailed(cb, &vi.Status.Phase, err)
+			return reconcile.Result{}, err
+		}
+
+		vi.Status.Phase = virtv2.ImageProvisioning
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(vicondition.Provisioning).
+			Message("PVC has created: waiting to be Bound.")
+
+		vi.Status.Progress = "50%"
+		vi.Status.SourceUID = pointer.GetPointer(vs.UID)
+
+		return reconcile.Result{Requeue: true}, err
+	case pod == nil:
+		vi.Status.Progress = ds.statService.GetProgress(vi.GetUID(), pod, vi.Status.Progress)
+		vi.Status.Target.RegistryURL = ds.statService.GetDVCRImageName(pod)
+
+		envSettings := ds.getEnvSettings(vi, supgen)
+
+		ownerRef := metav1.NewControllerRef(vi, vi.GroupVersionKind())
+		podSettings := ds.importerService.GetPodSettingsWithPVC(ownerRef, supgen, pvc.Name, pvc.Namespace)
+		err = ds.importerService.StartWithPodSetting(ctx, envSettings, supgen, datasource.NewCABundleForVMI(vi.GetNamespace(), vi.Spec.DataSource), podSettings)
+		switch {
+		case err == nil:
+			// OK.
+		case common.ErrQuotaExceeded(err):
+			ds.recorder.Event(vi, corev1.EventTypeWarning, virtv2.ReasonDataSourceQuotaExceeded, "DataSource quota exceed")
+			return setQuotaExceededPhaseCondition(cb, &vi.Status.Phase, err, vi.CreationTimestamp), nil
+		default:
+			setPhaseConditionToFailed(cb, &vi.Status.Phase, fmt.Errorf("unexpected error: %w", err))
+			return reconcile.Result{}, err
+		}
+
+		vi.Status.Phase = virtv2.ImageProvisioning
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(vicondition.Provisioning).
+			Message("DVCR Provisioner not found: create the new one.")
+
+		log.Info("Create importer pod...", "progress", vi.Status.Progress, "pod.phase", "nil")
+
+		return reconcile.Result{Requeue: true}, nil
+	case podutil.IsPodComplete(pod):
+		err = ds.statService.CheckPod(pod)
+		if err != nil {
+			vi.Status.Phase = virtv2.ImageFailed
+
+			switch {
+			case errors.Is(err, service.ErrProvisioningFailed):
+				ds.recorder.Event(vi, corev1.EventTypeWarning, virtv2.ReasonDataSourceDiskProvisioningFailed, "Disk provisioning failed")
+				cb.
+					Status(metav1.ConditionFalse).
+					Reason(vicondition.ProvisioningFailed).
+					Message(service.CapitalizeFirstLetter(err.Error() + "."))
+				return reconcile.Result{}, nil
+			default:
+				return reconcile.Result{}, err
+			}
+		}
+
+		cb.
+			Status(metav1.ConditionTrue).
+			Reason(vicondition.Ready).
+			Message("")
+
+		vi.Status.Phase = virtv2.ImageReady
+		vi.Status.Size = ds.statService.GetSize(pod)
+		vi.Status.CDROM = ds.statService.GetCDROM(pod)
+		vi.Status.Format = ds.statService.GetFormat(pod)
+		vi.Status.Progress = "100%"
+		vi.Status.Target.RegistryURL = ds.statService.GetDVCRImageName(pod)
+
+		log.Info("Ready", "progress", vi.Status.Progress, "pod.phase", pod.Status.Phase)
+	default:
+		err = ds.statService.CheckPod(pod)
+		if err != nil {
+			vi.Status.Phase = virtv2.ImageFailed
+
+			switch {
+			case errors.Is(err, service.ErrNotInitialized), errors.Is(err, service.ErrNotScheduled):
+				cb.
+					Status(metav1.ConditionFalse).
+					Reason(vicondition.ProvisioningNotStarted).
+					Message(service.CapitalizeFirstLetter(err.Error() + "."))
+				return reconcile.Result{}, nil
+			case errors.Is(err, service.ErrProvisioningFailed):
+				ds.recorder.Event(vi, corev1.EventTypeWarning, virtv2.ReasonDataSourceDiskProvisioningFailed, "Disk provisioning failed")
+				cb.
+					Status(metav1.ConditionFalse).
+					Reason(vicondition.ProvisioningFailed).
+					Message(service.CapitalizeFirstLetter(err.Error() + "."))
+				return reconcile.Result{}, nil
+			default:
+				return reconcile.Result{}, err
+			}
+		}
+
+		err = ds.importerService.Protect(ctx, pod)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(vicondition.Provisioning).
+			Message("Import is in the process of provisioning to DVCR.")
+
+		vi.Status.Phase = virtv2.ImageProvisioning
+		vi.Status.Progress = ds.statService.GetProgress(vi.GetUID(), pod, vi.Status.Progress)
+		vi.Status.Target.RegistryURL = ds.statService.GetDVCRImageName(pod)
+
+		log.Info("Provisioning...", "progress", vi.Status.Progress, "pod.phase", pod.Status.Phase)
+	}
+
+	return reconcile.Result{Requeue: true}, nil
+}
+
+func (ds ObjectRefVirtualDiskSnapshot) StoreToPVC(ctx context.Context, vi *virtv2.VirtualImage, vdSnapshotRef *virtv2.VirtualDiskSnapshot, cb *conditions.ConditionBuilder) (reconcile.Result, error) {
+	log, ctx := logger.GetDataSourceContext(ctx, objectRefDataSource)
+
+	supgen := supplements.NewGenerator(annotations.VIShortName, vi.Name, vi.Namespace, vi.UID)
+
+	pod, err := ds.bounderService.GetPod(ctx, supgen)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	pvc, err := ds.diskService.GetPersistentVolumeClaim(ctx, supgen)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	vs, err := ds.diskService.GetVolumeSnapshot(ctx, vdSnapshotRef.Status.VolumeSnapshotName, vdSnapshotRef.Namespace)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	clusterDefaultSC, _ := ds.diskService.GetDefaultStorageClass(ctx)
+	sc, err := ds.storageClassService.GetStorageClass(vi.Spec.PersistentVolumeClaim.StorageClass, clusterDefaultSC)
+	if updated, err := setConditionFromStorageClassError(err, cb); err != nil || updated {
+		return reconcile.Result{}, err
+	}
+
+	storageClass, err := ds.diskService.GetStorageClass(ctx, sc)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	condition, _ := conditions.GetCondition(vicondition.ReadyType, vi.Status.Conditions)
+	switch {
+	case isDiskProvisioningFinished(condition):
+		log.Info("Disk provisioning finished: clean up")
+
+		setPhaseConditionForFinishedImage(pvc, cb, &vi.Status.Phase, supgen)
+
+		// Protect Ready Disk and underlying PVC.
+		err = ds.diskService.Protect(ctx, vi, nil, pvc)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		err = ds.bounderService.Unprotect(ctx, pod)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		return CleanUpSupplements(ctx, vi, ds)
+	case object.AnyTerminating(pvc, pod):
+		log.Info("Waiting for supplements to be terminated")
+	case pvc == nil:
+		ds.recorder.Event(
+			vi,
+			corev1.EventTypeNormal,
+			virtv2.ReasonDataSourceSyncStarted,
+			"The ObjectRef DataSource import has started",
+		)
+
+		namespacedName := supplements.NewGenerator(annotations.VIShortName, vi.Name, vi.Namespace, vi.UID).PersistentVolumeClaim()
+
+		storageClassName := vs.Annotations["storageClass"]
+		volumeMode := vs.Annotations["volumeMode"]
+		accessModesStr := strings.Split(vs.Annotations["accessModes"], ",")
+		accessModes := make([]corev1.PersistentVolumeAccessMode, 0, len(accessModesStr))
+		for _, accessModeStr := range accessModesStr {
+			accessModes = append(accessModes, corev1.PersistentVolumeAccessMode(accessModeStr))
+		}
+
+		spec := corev1.PersistentVolumeClaimSpec{
+			AccessModes: accessModes,
+			DataSource: &corev1.TypedLocalObjectReference{
+				APIGroup: ptr.To(vs.GroupVersionKind().Group),
+				Kind:     vs.Kind,
+				Name:     vs.Name,
+			},
+		}
+
+		if storageClassName != "" {
+			spec.StorageClassName = &storageClassName
+			vi.Status.StorageClassName = storageClassName
+		}
+
+		if volumeMode != "" {
+			spec.VolumeMode = ptr.To(corev1.PersistentVolumeMode(volumeMode))
+		}
+
+		if vs.Status != nil && vs.Status.RestoreSize != nil {
+			spec.Resources = corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: *vs.Status.RestoreSize,
+				},
+			}
+		}
+
+		pvc = &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      namespacedName.Name,
+				Namespace: namespacedName.Namespace,
+				OwnerReferences: []metav1.OwnerReference{
+					service.MakeOwnerReference(vi),
+				},
+			},
+			Spec: spec,
+		}
+
+		err = ds.diskService.CreatePersistentVolumeClaim(ctx, pvc)
+		if err != nil {
+			setPhaseConditionToFailed(cb, &vi.Status.Phase, err)
+			return reconcile.Result{}, err
+		}
+
+		vi.Status.Phase = virtv2.ImageProvisioning
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(vicondition.Provisioning).
+			Message("PVC has created: waiting to be Bound.")
+
+		vi.Status.Progress = "0%"
+		vi.Status.SourceUID = pointer.GetPointer(vs.UID)
+		vi.Status.Target.PersistentVolumeClaim = pvc.Name
+
+		return reconcile.Result{Requeue: true}, err
+	case pvc.Status.Phase == corev1.ClaimPending:
+		isWFFC := storageClass != nil && storageClass.VolumeBindingMode != nil && *storageClass.VolumeBindingMode == storev1.VolumeBindingWaitForFirstConsumer
+
+		if !isWFFC {
+			return reconcile.Result{Requeue: true}, nil
+		}
+
+		ownerRef := metav1.NewControllerRef(vi, vi.GroupVersionKind())
+		err = ds.bounderService.Start(ctx, ownerRef, supgen, pvc)
+		switch {
+		case err == nil:
+			// OK.
+		case common.ErrQuotaExceeded(err):
+			ds.recorder.Event(vi, corev1.EventTypeWarning, virtv2.ReasonDataSourceQuotaExceeded, "DataSource quota exceed")
+			return setQuotaExceededPhaseCondition(cb, &vi.Status.Phase, err, vi.CreationTimestamp), nil
+		default:
+			setPhaseConditionToFailed(cb, &vi.Status.Phase, fmt.Errorf("unexpected error: %w", err))
+			return reconcile.Result{}, err
+		}
+
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(vicondition.Provisioning).
+			Message("Bounder pod has created: waiting to be Bound.")
+
+		return reconcile.Result{Requeue: true}, err
+	case pvc.Status.Phase == corev1.ClaimBound:
+		ds.recorder.Event(
+			vi,
+			corev1.EventTypeNormal,
+			virtv2.ReasonDataSourceSyncCompleted,
+			"The ObjectRef DataSource import has completed",
+		)
+
+		vi.Status.Phase = virtv2.ImageReady
+		cb.
+			Status(metav1.ConditionTrue).
+			Reason(vicondition.Ready).
+			Message("")
+
+		q, err := resource.ParseQuantity(vs.Status.RestoreSize.String())
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		intQ, ok := q.AsInt64()
+		if !ok {
+			return reconcile.Result{}, errors.New("fail to convert quantity to int64")
+		}
+
+		vi.Status.Size = virtv2.ImageStatusSize{
+			Stored:        vs.Status.RestoreSize.String(),
+			StoredBytes:   strconv.FormatInt(intQ, 10),
+			Unpacked:      vs.Status.RestoreSize.String(),
+			UnpackedBytes: strconv.FormatInt(intQ, 10),
+		}
+
+		vi.Status.Progress = "100%"
+	default:
+		vi.Status.Phase = virtv2.ImageProvisioning
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(vicondition.Provisioning).
+			Message("Import is in the process of provisioning to PVC.")
+
+		return reconcile.Result{}, nil
+	}
+
+	return reconcile.Result{Requeue: true}, nil
+}
+
+func (ds ObjectRefVirtualDiskSnapshot) CleanUpSupplements(ctx context.Context, vi *virtv2.VirtualImage) (reconcile.Result, error) {
+	supgen := supplements.NewGenerator(annotations.VIShortName, vi.Name, vi.Namespace, vi.UID)
+
+	importerRequeue, err := ds.importerService.CleanUpSupplements(ctx, supgen)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	diskRequeue, err := ds.diskService.CleanUpSupplements(ctx, supgen)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	bounderRequeue, err := ds.bounderService.CleanUpSupplements(ctx, supgen)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if vi.Spec.Storage == virtv2.StorageContainerRegistry {
+		pvcCleanupRequeue, err := ds.diskService.CleanUp(ctx, supgen)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		return reconcile.Result{Requeue: pvcCleanupRequeue}, nil
+	}
+
+	return reconcile.Result{Requeue: importerRequeue || diskRequeue || bounderRequeue}, nil
+}
+
+func (ds ObjectRefVirtualDiskSnapshot) CleanUp(ctx context.Context, vi *virtv2.VirtualImage) (bool, error) {
+	supgen := supplements.NewGenerator(annotations.VIShortName, vi.Name, vi.Namespace, vi.UID)
+
+	importerRequeue, err := ds.importerService.CleanUp(ctx, supgen)
+	if err != nil {
+		return false, err
+	}
+
+	diskRequeue, err := ds.diskService.CleanUp(ctx, supgen)
+	if err != nil {
+		return false, err
+	}
+
+	bounderRequeue, err := ds.bounderService.CleanUpSupplements(ctx, supgen)
+	if err != nil {
+		return false, err
+	}
+
+	return importerRequeue || diskRequeue || bounderRequeue, nil
+}
+
+func (ds ObjectRefVirtualDiskSnapshot) getEnvSettings(vi *virtv2.VirtualImage, sup *supplements.Generator) *importer.Settings {
+	var settings importer.Settings
+	importer.ApplyBlockDeviceSourceSettings(&settings)
+	importer.ApplyDVCRDestinationSettings(
+		&settings,
+		ds.dvcrSettings,
+		sup,
+		ds.dvcrSettings.RegistryImageForVI(vi),
+	)
+
+	return &settings
+}
+
+func (ds ObjectRefVirtualDiskSnapshot) Validate(ctx context.Context, vi *virtv2.VirtualImage) error {
+	if vi.Spec.DataSource.ObjectRef == nil || vi.Spec.DataSource.ObjectRef.Kind != virtv2.VirtualImageObjectRefKindVirtualDiskSnapshot {
+		return fmt.Errorf("not a %s data source", virtv2.VirtualImageObjectRefKindVirtualDiskSnapshot)
+	}
+
+	vdSnapshot, err := ds.diskService.GetVirtualDiskSnapshot(ctx, vi.Spec.DataSource.ObjectRef.Name, vi.Namespace)
+	if err != nil {
+		return err
+	}
+
+	if vdSnapshot == nil || vdSnapshot.Status.Phase != virtv2.VirtualDiskSnapshotPhaseReady {
+		return NewVirtualDiskSnapshotNotReadyError(vi.Spec.DataSource.ObjectRef.Name)
+	}
+
+	volumeSnapshot, err := ds.diskService.GetVolumeSnapshot(ctx, vdSnapshot.Status.VolumeSnapshotName, vdSnapshot.Namespace)
+	if err != nil {
+		return err
+	}
+
+	if volumeSnapshot == nil || !*volumeSnapshot.Status.ReadyToUse {
+		return NewVirtualDiskSnapshotNotReadyError(vi.Spec.DataSource.ObjectRef.Name)
+	}
+
+	return nil
+}

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vi_on_pvc.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vi_on_pvc.go
@@ -84,8 +84,9 @@ func (ds ObjectRefDataVirtualImageOnPVC) StoreToDVCR(ctx context.Context, vi, vi
 		return reconcile.Result{}, err
 	}
 
+	condition, _ := conditions.GetCondition(vicondition.ReadyType, vi.Status.Conditions)
 	switch {
-	case isDiskProvisioningFinished(cb.Condition()):
+	case isDiskProvisioningFinished(condition):
 		log.Info("Virtual image provisioning finished: clean up")
 
 		cb.
@@ -215,8 +216,9 @@ func (ds ObjectRefDataVirtualImageOnPVC) StoreToPVC(ctx context.Context, vi, viR
 		quotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
 	}
 
+	condition, _ := conditions.GetCondition(vicondition.ReadyType, vi.Status.Conditions)
 	switch {
-	case isDiskProvisioningFinished(cb.Condition()):
+	case isDiskProvisioningFinished(condition):
 		log.Info("Disk provisioning finished: clean up")
 
 		setPhaseConditionForFinishedImage(pvc, cb, &vi.Status.Phase, supgen)

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/registry.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/registry.go
@@ -253,6 +253,7 @@ func (ds RegistryDataSource) StoreToPVC(ctx context.Context, vi *virtv2.VirtualI
 
 		vi.Status.Progress = "100%"
 		vi.Status.Size = ds.statService.GetSize(pod)
+		vi.Status.CDROM = ds.statService.GetCDROM(pod)
 		vi.Status.DownloadSpeed = ds.statService.GetDownloadSpeed(vi.GetUID(), pod)
 		vi.Status.Target.PersistentVolumeClaim = dv.Status.ClaimName
 	default:

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/upload.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/upload.go
@@ -301,6 +301,7 @@ func (ds UploadDataSource) StoreToPVC(ctx context.Context, vi *virtv2.VirtualIma
 
 		vi.Status.Progress = "100%"
 		vi.Status.Size = ds.statService.GetSize(pod)
+		vi.Status.CDROM = ds.statService.GetCDROM(pod)
 		vi.Status.DownloadSpeed = ds.statService.GetDownloadSpeed(vi.GetUID(), pod)
 		vi.Status.Target.PersistentVolumeClaim = dv.Status.ClaimName
 

--- a/templates/virtualization-controller/_helpers.tpl
+++ b/templates/virtualization-controller/_helpers.tpl
@@ -20,6 +20,8 @@
   value: {{ include "helm_lib_module_image" (list . "dvcrImporter") }}
 - name: UPLOADER_IMAGE
   value: {{ include "helm_lib_module_image" (list . "dvcrUploader") }}
+- name: BOUNDER_IMAGE
+  value: {{ include "helm_lib_module_image" (list . "bounder") }}
 - name: DVCR_AUTH_SECRET
   value: dvcr-dockercfg-rw
 - name: DVCR_CERTS_SECRET


### PR DESCRIPTION
## Changelog entries

```changes
section: vi
type: feature
summary: add the ability to create a VirtualImage from a VirtualDiskSnapshot.
```

## Description
Add the ability to create a VirtualImage from a VirtualDiskSnapshot.

## Why do we need it, and what problem does it solve?
User should be able to create a new VI from VDSnapshot.

## What is the expected result?
New ObjectRef type

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
