### PR TITLE
fix(vi): add warning for create virtual image with storage type 'Kube…

### DIFF
--- a/templates/virtualization-controller/validation-webhook.yaml
+++ b/templates/virtualization-controller/validation-webhook.yaml
@@ -37,11 +37,28 @@ webhooks:
         {{ .Values.virtualization.internal.controller.cert.ca }}
     admissionReviewVersions: ["v1"]
     sideEffects: None
+  - name: "vi.virtualization-controller.validate.d8-virtualization"
+    rules:
+      - apiGroups: [ "virtualization.deckhouse.io" ]
+        apiVersions: [ "v1alpha2" ]
+        operations: [ "CREATE", "UPDATE" ]
+        resources: [ "virtualimages" ]
+        scope: "Namespaced"
+    clientConfig:
+      service:
+        namespace: d8-{{ .Chart.Name }}
+        name: virtualization-controller
+        path: /validate-virtualization-deckhouse-io-v1alpha2-virtualimage
+        port: 443
+      caBundle: |
+        {{ .Values.virtualization.internal.controller.cert.ca }}
+    admissionReviewVersions: [ "v1" ]
+    sideEffects: None
   - name: "cvi.virtualization-controller.validate.d8-virtualization"
     rules:
       - apiGroups: [ "virtualization.deckhouse.io" ]
         apiVersions: [ "v1alpha2" ]
-        operations: [ "UPDATE" ]
+        operations: [ "CREATE", "UPDATE" ]
         resources: [ "clustervirtualimages" ]
         scope: "Cluster"
     clientConfig:


### PR DESCRIPTION
…rnetes'

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add a warning for creating a virtual image with the deprecated storage type 'Kubernetes'.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

This change solves the problem where a user creates a virtual image with the deprecated storage type 'Kubernetes'.
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

After this change is implemented, when a user attempts to create a virtual image with 'Kubernetes' as the selected storage type, they will receive a clear warning message.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
