### PR TITLE
test(api): increase `kubectl apply` timeout

### DIFF
--- a/tests/e2e/kubectl/kubectl.go
+++ b/tests/e2e/kubectl/kubectl.go
@@ -166,7 +166,7 @@ type KubectlCMD struct {
 func (k KubectlCMD) Apply(opts ApplyOptions) *executor.CMDResult {
 	cmd := fmt.Sprintf("%s apply", k.cmd)
 	cmd = k.applyOptions(cmd, opts)
-	ctx, cancel := context.WithTimeout(context.Background(), MediumTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), LongTimeout)
 	defer cancel()
 	return k.ExecContext(ctx, cmd)
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
When tests run on Github runner some requests are failed because of timeout on the `apply` operation.  
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
