### PR TITLE
fix(vd): fix condition status updates in VirtualDisk

### DIFF
--- a/api/core/v1alpha2/vdcondition/condition.go
+++ b/api/core/v1alpha2/vdcondition/condition.go
@@ -127,8 +127,10 @@ const (
 	// StorageClassNotFound indicates that the storage class is not ready
 	StorageClassNotFound StorageClassReadyReason = "StorageClassNotFound"
 
-	// AllowedForImageUsage indicates that the VirtualDisk is permitted for use in a process of an image creation.
-	AllowedForImageUsage InUseReason = "AllowedForImageUsage"
-	// AllowedForVirtualMachineUsage indicates that the VirtualDisk is permitted for use by a running VirtualMachine.
-	AllowedForVirtualMachineUsage InUseReason = "AllowedForVirtualMachineUsage"
+	// UsedForImageCreation indicates that the VirtualDisk is used for create image.
+	UsedForImageCreation InUseReason = "UsedForImageCreation"
+	// AttachedToVirtualMachine indicates that the VirtualDisk is attached to VirtualMachine.
+	AttachedToVirtualMachine InUseReason = "AttachedToVirtualMachine"
+	// NotInUse indicates that VirtualDisk free for use.
+	NotInUse InUseReason = "NotInUse"
 )

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/errors.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/errors.go
@@ -70,7 +70,7 @@ type VirtualDiskNotAllowedForUseError struct {
 }
 
 func (e VirtualDiskNotAllowedForUseError) Error() string {
-	return fmt.Sprintf("use of VirtualDisk %s is not allowed, it may be connected to a running VirtualMachine", e.name)
+	return fmt.Sprintf("the VirtualDisk %s attached to VirtualMachine", e.name)
 }
 
 func NewVirtualDiskNotAllowedForUseError(name string) error {

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref_vd.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref_vd.go
@@ -243,7 +243,7 @@ func (ds ObjectRefVirtualDisk) Validate(ctx context.Context, cvi *virtv2.Cluster
 	inUseCondition, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
 	if inUseCondition.Status == metav1.ConditionTrue &&
 		inUseCondition.Reason == vdcondition.UsedForImageCreation.String() &&
-		inUseCondition.ObservedGeneration == vd.Status.ObservedGeneration {
+		inUseCondition.ObservedGeneration == vd.Generation {
 		return nil
 	}
 

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref_vd.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref_vd.go
@@ -242,7 +242,7 @@ func (ds ObjectRefVirtualDisk) Validate(ctx context.Context, cvi *virtv2.Cluster
 
 	inUseCondition, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
 	if inUseCondition.Status == metav1.ConditionTrue &&
-		inUseCondition.Reason == vdcondition.AllowedForImageUsage.String() &&
+		inUseCondition.Reason == vdcondition.UsedForImageCreation.String() &&
 		inUseCondition.ObservedGeneration == vd.Status.ObservedGeneration {
 		return nil
 	}

--- a/images/virtualization-artifact/pkg/controller/vd/internal/inuse_test.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/inuse_test.go
@@ -152,7 +152,7 @@ var _ = Describe("InUseHandler", func() {
 			cond, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
 			Expect(cond).ToNot(BeNil())
 			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
-			Expect(cond.Reason).To(Equal(vdcondition.AllowedForVirtualMachineUsage.String()))
+			Expect(cond.Reason).To(Equal(vdcondition.AttachedToVirtualMachine.String()))
 		})
 	})
 
@@ -248,7 +248,7 @@ var _ = Describe("InUseHandler", func() {
 			cond, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
 			Expect(cond).ToNot(BeNil())
 			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
-			Expect(cond.Reason).To(Equal(vdcondition.AllowedForImageUsage.String()))
+			Expect(cond.Reason).To(Equal(vdcondition.UsedForImageCreation.String()))
 		})
 	})
 
@@ -295,7 +295,7 @@ var _ = Describe("InUseHandler", func() {
 			cond, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
 			Expect(cond).ToNot(BeNil())
 			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
-			Expect(cond.Reason).To(Equal(vdcondition.AllowedForImageUsage.String()))
+			Expect(cond.Reason).To(Equal(vdcondition.UsedForImageCreation.String()))
 		})
 	})
 
@@ -356,7 +356,7 @@ var _ = Describe("InUseHandler", func() {
 			cond, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
 			Expect(cond).ToNot(BeNil())
 			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
-			Expect(cond.Reason).To(Equal(vdcondition.AllowedForVirtualMachineUsage.String()))
+			Expect(cond.Reason).To(Equal(vdcondition.AttachedToVirtualMachine.String()))
 		})
 	})
 
@@ -403,7 +403,7 @@ var _ = Describe("InUseHandler", func() {
 			cond, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
 			Expect(cond).ToNot(BeNil())
 			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
-			Expect(cond.Reason).To(Equal(vdcondition.AllowedForVirtualMachineUsage.String()))
+			Expect(cond.Reason).To(Equal(vdcondition.AttachedToVirtualMachine.String()))
 		})
 	})
 
@@ -455,12 +455,12 @@ var _ = Describe("InUseHandler", func() {
 			cond, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
 			Expect(cond).ToNot(BeNil())
 			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
-			Expect(cond.Reason).To(Equal(vdcondition.AllowedForImageUsage.String()))
+			Expect(cond.Reason).To(Equal(vdcondition.UsedForImageCreation.String()))
 		})
 	})
 
 	Context("when VirtualDisk is not in use after image creation", func() {
-		It("must set status Unknown and reason Unknown", func() {
+		It("must set status False and reason NotInUse", func() {
 			vd := &virtv2.VirtualDisk{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-vd",
@@ -470,7 +470,7 @@ var _ = Describe("InUseHandler", func() {
 					Conditions: []metav1.Condition{
 						{
 							Type:   vdcondition.InUseType.String(),
-							Reason: vdcondition.AllowedForImageUsage.String(),
+							Reason: vdcondition.UsedForImageCreation.String(),
 							Status: metav1.ConditionTrue,
 						},
 					},
@@ -486,12 +486,13 @@ var _ = Describe("InUseHandler", func() {
 
 			cond, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
 			Expect(cond).ToNot(BeNil())
-			Expect(cond.Status).To(Equal(metav1.ConditionUnknown))
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal(vdcondition.NotInUse.String()))
 		})
 	})
 
 	Context("when VirtualDisk is not in use after VM deletion", func() {
-		It("must set status Unknown and reason Unknown", func() {
+		It("must set status False and reason NotInUse", func() {
 			vd := &virtv2.VirtualDisk{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-vd",
@@ -501,7 +502,7 @@ var _ = Describe("InUseHandler", func() {
 					Conditions: []metav1.Condition{
 						{
 							Type:   vdcondition.InUseType.String(),
-							Reason: vdcondition.AllowedForVirtualMachineUsage.String(),
+							Reason: vdcondition.AttachedToVirtualMachine.String(),
 							Status: metav1.ConditionTrue,
 						},
 					},
@@ -517,7 +518,8 @@ var _ = Describe("InUseHandler", func() {
 
 			cond, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
 			Expect(cond).ToNot(BeNil())
-			Expect(cond.Status).To(Equal(metav1.ConditionUnknown))
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal(vdcondition.NotInUse.String()))
 		})
 	})
 })

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/errors.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/errors.go
@@ -70,7 +70,7 @@ type VirtualDiskNotAllowedForUseError struct {
 }
 
 func (e VirtualDiskNotAllowedForUseError) Error() string {
-	return fmt.Sprintf("use of VirtualDisk %s is not allowed, it may be connected to a running VirtualMachine", e.name)
+	return fmt.Sprintf("the VirtualDisk %s attached to VirtualMachine", e.name)
 }
 
 func NewVirtualDiskNotAllowedForUseError(name string) error {

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vd.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vd.go
@@ -395,7 +395,7 @@ func (ds ObjectRefVirtualDisk) Validate(ctx context.Context, vi *virtv2.VirtualI
 
 	inUseCondition, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
 	if inUseCondition.Status == metav1.ConditionTrue &&
-		inUseCondition.Reason == vdcondition.AllowedForImageUsage.String() &&
+		inUseCondition.Reason == vdcondition.UsedForImageCreation.String() &&
 		inUseCondition.ObservedGeneration == vd.Status.ObservedGeneration {
 		return nil
 	}

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vd.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vd.go
@@ -396,7 +396,7 @@ func (ds ObjectRefVirtualDisk) Validate(ctx context.Context, vi *virtv2.VirtualI
 	inUseCondition, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
 	if inUseCondition.Status == metav1.ConditionTrue &&
 		inUseCondition.Reason == vdcondition.UsedForImageCreation.String() &&
-		inUseCondition.ObservedGeneration == vd.Status.ObservedGeneration {
+		inUseCondition.ObservedGeneration == vd.Generation {
 		return nil
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vm/internal/block_device.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/block_device.go
@@ -189,7 +189,7 @@ func (h *BlockDeviceHandler) areVirtualDisksAllowedToUse(vds map[string]*virtv2.
 		inUseCondition, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
 		if inUseCondition.Status != metav1.ConditionTrue ||
 			inUseCondition.Reason != vdcondition.AllowedForVirtualMachineUsage.String() ||
-			inUseCondition.ObservedGeneration != vd.Status.ObservedGeneration {
+			inUseCondition.ObservedGeneration != vd.Generation {
 			return false
 		}
 	}

--- a/images/virtualization-artifact/pkg/controller/vm/internal/block_device.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/block_device.go
@@ -172,7 +172,7 @@ func (h *BlockDeviceHandler) Handle(ctx context.Context, s state.VirtualMachineS
 	if !h.areVirtualDisksAllowedToUse(vds) {
 		mgr.Update(cb.Status(metav1.ConditionFalse).
 			Reason(vmcondition.ReasonBlockDevicesNotReady).
-			Message("Virtual disks are not allowed to be used in the virtual machine, check where else they are used.").Condition())
+			Message("Virtual disks cannot be used because they are being used for creating an image.").Condition())
 		changed.Status.Conditions = mgr.Generate()
 		return reconcile.Result{}, nil
 	}

--- a/images/virtualization-artifact/pkg/controller/vm/internal/block_device.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/block_device.go
@@ -188,7 +188,7 @@ func (h *BlockDeviceHandler) areVirtualDisksAllowedToUse(vds map[string]*virtv2.
 	for _, vd := range vds {
 		inUseCondition, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
 		if inUseCondition.Status != metav1.ConditionTrue ||
-			inUseCondition.Reason != vdcondition.AllowedForVirtualMachineUsage.String() ||
+			inUseCondition.Reason != vdcondition.AttachedToVirtualMachine.String() ||
 			inUseCondition.ObservedGeneration != vd.Generation {
 			return false
 		}

--- a/images/virtualization-artifact/pkg/controller/vm/internal/block_devices_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/block_devices_test.go
@@ -51,7 +51,7 @@ var _ = Describe("func areVirtualDisksAllowedToUse", func() {
 				Conditions: []metav1.Condition{
 					{
 						Type:   vdcondition.InUseType.String(),
-						Reason: vdcondition.AllowedForVirtualMachineUsage.String(),
+						Reason: vdcondition.AttachedToVirtualMachine.String(),
 						Status: metav1.ConditionTrue,
 					},
 				},
@@ -63,7 +63,7 @@ var _ = Describe("func areVirtualDisksAllowedToUse", func() {
 				Conditions: []metav1.Condition{
 					{
 						Type:   vdcondition.InUseType.String(),
-						Reason: vdcondition.AllowedForVirtualMachineUsage.String(),
+						Reason: vdcondition.AttachedToVirtualMachine.String(),
 						Status: metav1.ConditionTrue,
 					},
 				},
@@ -112,7 +112,7 @@ var _ = Describe("func areVirtualDisksAllowedToUse", func() {
 						},
 						{
 							Type:   vdcondition.InUseType.String(),
-							Reason: vdcondition.AllowedForImageUsage.String(),
+							Reason: vdcondition.UsedForImageCreation.String(),
 							Status: metav1.ConditionTrue,
 						},
 					},
@@ -186,7 +186,7 @@ var _ = Describe("BlockDeviceHandler", func() {
 					},
 					{
 						Type:   vdcondition.InUseType.String(),
-						Reason: vdcondition.AllowedForVirtualMachineUsage.String(),
+						Reason: vdcondition.AttachedToVirtualMachine.String(),
 						Status: metav1.ConditionTrue,
 					},
 				},
@@ -205,7 +205,7 @@ var _ = Describe("BlockDeviceHandler", func() {
 					},
 					{
 						Type:   vdcondition.InUseType.String(),
-						Reason: vdcondition.AllowedForVirtualMachineUsage.String(),
+						Reason: vdcondition.AttachedToVirtualMachine.String(),
 						Status: metav1.ConditionTrue,
 					},
 				},
@@ -308,7 +308,7 @@ var _ = Describe("BlockDeviceHandler", func() {
 				},
 				{
 					Type:   vdcondition.InUseType.String(),
-					Reason: vdcondition.AllowedForVirtualMachineUsage.String(),
+					Reason: vdcondition.AttachedToVirtualMachine.String(),
 					Status: metav1.ConditionTrue,
 				},
 			}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This PR addresses two issues related to the update generation in conditions for the VirtualDisk module. It fixes the update generation process and changes the status of in-use conditions from "Unknown" to "False".

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
By fixing the update generation and clarifying the status of in-use conditions, this PR ensures that the system behaves predictably and accurately reflects the actual state of conditions.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
After these changes, condition statuses will be updated correctly, and in-use conditions will no longer show as "Unknown".
## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
