### PR TITLE
feat(vd) add InUse condition to brief output

### DIFF
--- a/api/core/v1alpha2/virtual_disk.go
+++ b/api/core/v1alpha2/virtual_disk.go
@@ -36,6 +36,7 @@ const (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="Capacity",type=string,JSONPath=`.status.capacity`
+// +kubebuilder:printcolumn:name="InUse",type=string,JSONPath=`.status.conditions[?(@.type=='InUse')].status`,priority=1
 // +kubebuilder:printcolumn:name="Progress",type=string,JSONPath=`.status.progress`,priority=1
 // +kubebuilder:printcolumn:name="StorageClass",type=string,JSONPath=`.spec.persistentVolumeClaim.storageClassName`,priority=1
 // +kubebuilder:printcolumn:name="TargetPVC",type=string,JSONPath=`.status.target.persistentVolumeClaimName`,priority=1

--- a/crds/virtualdisks.yaml
+++ b/crds/virtualdisks.yaml
@@ -30,6 +30,10 @@ spec:
         - jsonPath: .status.capacity
           name: Capacity
           type: string
+        - jsonPath: .status.conditions[?(@.type=='InUse')].status
+          name: InUse
+          priority: 1
+          type: string
         - jsonPath: .status.progress
           name: Progress
           priority: 1


### PR DESCRIPTION
## Description
Add InUse condition to brief output

## Why do we need it, and what problem does it solve?
Make vd info more useful

## What is the expected result?
`kubectl get vd -o wide`
![image](https://github.com/user-attachments/assets/18c4698a-f1c2-4b57-93fb-7be9c31612fa)

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
