### PR TITLE
test(vm): add reusable mode to use previously created virtual machines for e2e tests

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -74,6 +74,23 @@ For example, run only "Complex text" without cleanup on failure:
 FOCUS="Complex test" STOP_ON_FAILURE=yes task run
 ```
 
+### Reusable mode option
+
+The environment variable REUSABLE used to retain all resources created during e2e test after its completion (no cleanup).
+When a test starts, it will reuse existing virtual machines created earlier, if they exist.
+If no virtual machines were found, they will be created.
+
+For example, run test in reusable mode:
+```bash
+REUSABLE=yes task run
+```
+
+! Only the following e2e tests are supported in REUSABLE mode. All other tests will be skipped.
+- "Virtual machine configuration"
+- "Virtual machine migration"
+- "VM connectivity"
+- "Complex test"
+
 ## Run tests in CI
 ```bash
 task run:ci

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -76,7 +76,9 @@ FOCUS="Complex test" STOP_ON_FAILURE=yes task run
 
 ### Reusable mode option
 
-The environment variable REUSABLE used to retain all resources created during e2e test after its completion (no cleanup).
+The environment variable REUSABLE used to reuse resources created previously.
+By default, it retains all resources created during the e2e test after its completion (no cleanup by default in this mode).
+Use the `WITH_POST_CLEANUP=yes` environment variable to clean up resources created or used during the test.
 When a test starts, it will reuse existing virtual machines created earlier, if they exist.
 If no virtual machines were found, they will be created.
 
@@ -90,6 +92,17 @@ REUSABLE=yes task run
 - "Virtual machine migration"
 - "VM connectivity"
 - "Complex test"
+
+### PostCleanUp option
+
+WithPostCleanUpEnv defines an environment variable used to explicitly request the deletion of created/used resources.
+For example, this option is useful when combined with the `REUSABLE=yes` option,
+as the reusable mode does not delete created/used resources by default.
+
+For example, run test in reusable mode with the removal of all used resources after test completion:
+```bash
+REUSABLE=yes WITH_POST_CLEANUP=yes task run
+```
 
 ## Run tests in CI
 ```bash

--- a/tests/e2e/affinity_toleration_test.go
+++ b/tests/e2e/affinity_toleration_test.go
@@ -44,6 +44,15 @@ var _ = Describe("Virtual machine affinity and toleration", ginkgoutil.CommonE2E
 		vmD           = map[string]string{"vm": "vm-d"}
 	)
 
+	Context("Preparing the environment", func() {
+		It("sets the namespace", func() {
+			kustomization := fmt.Sprintf("%s/%s", conf.TestData.AffinityToleration, "kustomization.yaml")
+			ns, err := kustomize.GetNamespace(kustomization)
+			Expect(err).NotTo(HaveOccurred(), "%w", err)
+			conf.SetNamespace(ns)
+		})
+	})
+
 	Context("When virtualization resources are applied:", func() {
 		It("result should be succeeded", func() {
 			res := kubectl.Apply(kc.ApplyOptions{

--- a/tests/e2e/affinity_toleration_test.go
+++ b/tests/e2e/affinity_toleration_test.go
@@ -24,11 +24,18 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/tests/e2e/config"
 	"github.com/deckhouse/virtualization/tests/e2e/ginkgoutil"
 	kc "github.com/deckhouse/virtualization/tests/e2e/kubectl"
 )
 
 var _ = Describe("Virtual machine affinity and toleration", ginkgoutil.CommonE2ETestDecorators(), func() {
+	BeforeEach(func() {
+		if config.IsReusable() {
+			Skip("Test not available in REUSABLE mode: not supported yet.")
+		}
+	})
+
 	var (
 		testCaseLabel = map[string]string{"testcase": "affinity-toleration"}
 		vmA           = map[string]string{"vm": "vm-a"}

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -265,7 +265,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 				},
 			}
 
-			if !config.IsReusable() {
+			if !config.IsCleanUpNeeded() {
 				resourcesToDelete.KustomizationDir = conf.TestData.ComplexTest
 			}
 

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -66,6 +66,15 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 		hasNoConsumerLabel = map[string]string{"hasNoConsumer": "complex-test"}
 	)
 
+	Context("Preparing the environment", func() {
+		It("sets the namespace", func() {
+			kustomization := fmt.Sprintf("%s/%s", conf.TestData.ComplexTest, "kustomization.yaml")
+			ns, err := kustomize.GetNamespace(kustomization)
+			Expect(err).NotTo(HaveOccurred(), "%w", err)
+			conf.SetNamespace(ns)
+		})
+	})
+
 	Context("When virtualization resources are applied", func() {
 		It("result should be succeeded", func() {
 			if config.IsReusable() {

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -29,11 +29,7 @@ import (
 	kc "github.com/deckhouse/virtualization/tests/e2e/kubectl"
 )
 
-func GetComplexNamespace() string {
-	return conf.Namespace + "-complex"
-}
-
-func AssignIPToVMIP(name, namespace string) error {
+func AssignIPToVMIP(name string) error {
 	assignErr := fmt.Sprintf("cannot patch VMIP %q with unnassigned IP address", name)
 	unassignedIP, err := FindUnassignedIP(mc.Spec.Settings.VirtualMachineCIDRs)
 	if err != nil {
@@ -46,14 +42,14 @@ func AssignIPToVMIP(name, namespace string) error {
 	}
 	vmip := virtv2.VirtualMachineIPAddress{}
 	err = GetObject(kc.ResourceVMIP, name, &vmip, kc.GetOptions{
-		Namespace: namespace,
+		Namespace: conf.Namespace,
 	})
 	if err != nil {
 		return fmt.Errorf("%s\n%s", assignErr, err)
 	}
 	jsonPath := fmt.Sprintf("'jsonpath={.status.phase}=%s'", PhaseAttached)
 	waitOpts := kc.WaitOptions{
-		Namespace: namespace,
+		Namespace: conf.Namespace,
 		For:       jsonPath,
 		Timeout:   ShortWaitDuration,
 	}
@@ -68,19 +64,14 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 	var (
 		testCaseLabel      = map[string]string{"testcase": "complex-test"}
 		hasNoConsumerLabel = map[string]string{"hasNoConsumer": "complex-test"}
-		namespace          = conf.Namespace
 	)
-
-	if config.IsReusable() {
-		namespace = GetComplexNamespace()
-	}
 
 	Context("When virtualization resources are applied", func() {
 		It("result should be succeeded", func() {
 			if config.IsReusable() {
 				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 					Labels:    testCaseLabel,
-					Namespace: namespace,
+					Namespace: conf.Namespace,
 					Output:    "jsonpath='{.items[*].metadata.name}'",
 				})
 				Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
@@ -103,7 +94,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 			By(fmt.Sprintf("VIs should be in %s phases", PhaseReady))
 			WaitPhaseByLabel(kc.ResourceVI, PhaseReady, kc.WaitOptions{
 				Labels:    testCaseLabel,
-				Namespace: namespace,
+				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,
 			})
 		})
@@ -114,7 +105,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 			By(fmt.Sprintf("CVIs should be in %s phases", PhaseReady))
 			WaitPhaseByLabel(kc.ResourceCVI, PhaseReady, kc.WaitOptions{
 				Labels:    testCaseLabel,
-				Namespace: namespace,
+				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,
 			})
 		})
@@ -125,7 +116,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 			By(fmt.Sprintf("VMClasses should be in %s phases", PhaseReady))
 			WaitPhaseByLabel(kc.ResourceVMClass, PhaseReady, kc.WaitOptions{
 				Labels:    testCaseLabel,
-				Namespace: namespace,
+				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,
 			})
 		})
@@ -135,7 +126,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 		It("patches custom VMIP with unassigned address", func() {
 			vmipName := fmt.Sprintf("%s-%s", namePrefix, "vm-custom-ip")
 			Eventually(func() error {
-				return AssignIPToVMIP(vmipName, namespace)
+				return AssignIPToVMIP(vmipName)
 			}).Should(Succeed())
 		})
 
@@ -143,7 +134,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 			By(fmt.Sprintf("VMIPs should be in %s phases", PhaseAttached))
 			WaitPhaseByLabel(kc.ResourceVMIP, PhaseAttached, kc.WaitOptions{
 				Labels:    testCaseLabel,
-				Namespace: namespace,
+				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,
 			})
 		})
@@ -155,7 +146,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 			WaitPhaseByLabel(kc.ResourceVD, PhaseReady, kc.WaitOptions{
 				ExcludedLabels: []string{"hasNoConsumer"},
 				Labels:         testCaseLabel,
-				Namespace:      namespace,
+				Namespace:      conf.Namespace,
 				Timeout:        MaxWaitTimeout,
 			})
 		})
@@ -164,7 +155,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 			By(fmt.Sprintf("VDs should be in %s phases", phaseByVolumeBindingMode))
 			WaitPhaseByLabel(kc.ResourceVD, phaseByVolumeBindingMode, kc.WaitOptions{
 				Labels:    hasNoConsumerLabel,
-				Namespace: namespace,
+				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,
 			})
 		})
@@ -175,7 +166,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 			By(fmt.Sprintf("VMs should be in %s phases", PhaseRunning))
 			WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, kc.WaitOptions{
 				Labels:    testCaseLabel,
-				Namespace: namespace,
+				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,
 			})
 		})
@@ -186,7 +177,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 			By(fmt.Sprintf("VMBDAs should be in %s phases", PhaseAttached))
 			WaitPhaseByLabel(kc.ResourceVMBDA, PhaseAttached, kc.WaitOptions{
 				Labels:    testCaseLabel,
-				Namespace: namespace,
+				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,
 			})
 		})
@@ -197,13 +188,13 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 			It("checks VMs external connectivity", func() {
 				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 					Labels:    testCaseLabel,
-					Namespace: namespace,
+					Namespace: conf.Namespace,
 					Output:    "jsonpath='{.items[*].metadata.name}'",
 				})
 				Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
 
 				vms := strings.Split(res.StdOut(), " ")
-				CheckExternalConnection(externalHost, httpStatusOk, namespace, vms...)
+				CheckExternalConnection(externalHost, httpStatusOk, vms...)
 			})
 		})
 	})
@@ -213,13 +204,13 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 			It("starts migrations", func() {
 				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 					Labels:    testCaseLabel,
-					Namespace: namespace,
+					Namespace: conf.Namespace,
 					Output:    "jsonpath='{.items[*].metadata.name}'",
 				})
 				Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
 
 				vms := strings.Split(res.StdOut(), " ")
-				MigrateVirtualMachines(testCaseLabel, conf.TestData.ComplexTest, namespace, vms...)
+				MigrateVirtualMachines(testCaseLabel, conf.TestData.ComplexTest, vms...)
 			})
 		})
 
@@ -228,13 +219,13 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 				By(fmt.Sprintf("VMOPs should be in %s phases", virtv2.VMOPPhaseCompleted))
 				WaitPhaseByLabel(kc.ResourceVMOP, string(virtv2.VMOPPhaseCompleted), kc.WaitOptions{
 					Labels:    testCaseLabel,
-					Namespace: namespace,
+					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
 				})
 				By("Virtual machines should be migrated")
 				WaitByLabel(kc.ResourceVM, kc.WaitOptions{
 					Labels:    testCaseLabel,
-					Namespace: namespace,
+					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
 					For:       "'jsonpath={.status.migrationState.result}=Succeeded'",
 				})
@@ -243,13 +234,13 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 			It("checks VMs external connection after migrations", func() {
 				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 					Labels:    testCaseLabel,
-					Namespace: namespace,
+					Namespace: conf.Namespace,
 					Output:    "jsonpath='{.items[*].metadata.name}'",
 				})
 				Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
 
 				vms := strings.Split(res.StdOut(), " ")
-				CheckExternalConnection(externalHost, httpStatusOk, namespace, vms...)
+				CheckExternalConnection(externalHost, httpStatusOk, vms...)
 			})
 		})
 	})

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -265,7 +265,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 				},
 			}
 
-			if !config.IsCleanUpNeeded() {
+			if config.IsCleanUpNeeded() {
 				resourcesToDelete.KustomizationDir = conf.TestData.ComplexTest
 			}
 

--- a/tests/e2e/config/cleanup.go
+++ b/tests/e2e/config/cleanup.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+	"log"
+	"os"
+)
+
+// WithPostCleanUpEnv defines an environment variable used to explicitly request the deletion of created/used resources.
+// For example, this option is useful when combined with the `REUSABLE=yes` option,
+// as the reusable mode does not delete created/used resources by default.
+const WithPostCleanUpEnv = "WITH_POST_CLEANUP"
+
+func CheckWithPostCleanUpOption() error {
+	env := os.Getenv(WithPostCleanUpEnv)
+	switch env {
+	case "yes", "":
+		return nil
+	default:
+		log.Printf("To run tests in %s mode, set %s=yes. If you don't intend to use this mode, leave the variable unset.\n", WithPostCleanUpEnv, WithPostCleanUpEnv)
+		return fmt.Errorf("invalid value for the %s env: %q", WithPostCleanUpEnv, env)
+	}
+}
+
+func WithPostCleanUp() bool {
+	return os.Getenv(WithPostCleanUpEnv) == "yes"
+}
+
+func IsCleanUpNeeded() bool {
+	if IsReusable() {
+		return WithPostCleanUp()
+	}
+
+	return true
+}

--- a/tests/e2e/config/config.go
+++ b/tests/e2e/config/config.go
@@ -31,12 +31,12 @@ import (
 
 var (
 	conf    *Config
-	err     error
 	git     gt.Git
 	kubectl kc.Kubectl
 )
 
 func init() {
+	var err error
 	if conf, err = GetConfig(); err != nil {
 		log.Fatal(err)
 	}

--- a/tests/e2e/config/reusable.go
+++ b/tests/e2e/config/reusable.go
@@ -18,10 +18,14 @@ package config
 
 import (
 	"fmt"
+	"log"
 	"os"
 )
 
-// ReusableEnv defines an environment variable used to retain all resources created during e2e test after its completion (no cleanup).
+// ReusableEnv defines an environment variable used to reuse resources created previously.
+// By default, it retains all resources created during the e2e test after its completion (no cleanup by default in this mode).
+// Use the `WITH_POST_CLEANUP=yes` environment variable to clean up resources created or used during the test.
+//
 // When a test starts, it will reuse existing virtual machines created earlier, if they exist.
 // If no virtual machines were found, they will be created.
 // Only the following e2e tests are supported in REUSABLE mode. All other tests will be skipped.
@@ -31,18 +35,17 @@ import (
 // - "Complex test"
 const ReusableEnv = "REUSABLE"
 
-const reusableValue = "yes"
-
 func CheckReusableOption() error {
 	env := os.Getenv(ReusableEnv)
 	switch env {
-	case reusableValue, "":
+	case "yes", "":
 		return nil
 	default:
-		return fmt.Errorf("invalid value for the REUSABLE env: %q", env)
+		log.Printf("To run tests in %s mode, set %s=yes. If you don't intend to use this mode, leave the variable unset.\n", ReusableEnv, ReusableEnv)
+		return fmt.Errorf("invalid value for the %s env: %q", ReusableEnv, env)
 	}
 }
 
 func IsReusable() bool {
-	return os.Getenv(ReusableEnv) == reusableValue
+	return os.Getenv(ReusableEnv) == "yes"
 }

--- a/tests/e2e/config/reusable.go
+++ b/tests/e2e/config/reusable.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+	"os"
+)
+
+// ReusableEnv defines an environment variable used to retain all resources created during e2e test after its completion (no cleanup).
+// When a test starts, it will reuse existing virtual machines created earlier, if they exist.
+// If no virtual machines were found, they will be created.
+// Only the following e2e tests are supported in REUSABLE mode. All other tests will be skipped.
+// - "Virtual machine configuration"
+// - "Virtual machine migration"
+// - "VM connectivity"
+// - "Complex test"
+const ReusableEnv = "REUSABLE"
+
+const reusableValue = "yes"
+
+func CheckReusableOption() error {
+	env := os.Getenv(ReusableEnv)
+	switch env {
+	case reusableValue, "":
+		return nil
+	default:
+		return fmt.Errorf("invalid value for the REUSABLE env: %q", env)
+	}
+}
+
+func IsReusable() bool {
+	return os.Getenv(ReusableEnv) == reusableValue
+}

--- a/tests/e2e/sizing_policy_test.go
+++ b/tests/e2e/sizing_policy_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/tests/e2e/config"
 	"github.com/deckhouse/virtualization/tests/e2e/ginkgoutil"
 	. "github.com/deckhouse/virtualization/tests/e2e/helper"
 	kc "github.com/deckhouse/virtualization/tests/e2e/kubectl"
@@ -67,6 +68,12 @@ func CompareVirtualMachineClassReadyStatus(vmName, expectedStatus string) {
 }
 
 var _ = Describe("Sizing policy", ginkgoutil.CommonE2ETestDecorators(), func() {
+	BeforeEach(func() {
+		if config.IsReusable() {
+			Skip("Test not available in REUSABLE mode: not supported yet.")
+		}
+	})
+
 	var (
 		vmNotValidSizingPolicyChanging string
 		vmNotValidSizingPolicyCreating string

--- a/tests/e2e/sizing_policy_test.go
+++ b/tests/e2e/sizing_policy_test.go
@@ -92,6 +92,13 @@ var _ = Describe("Sizing policy", ginkgoutil.CommonE2ETestDecorators(), func() {
 		vmClassDiscovery = fmt.Sprintf("%s-discovery", namePrefix)
 		vmClassDiscoveryCopy = fmt.Sprintf("%s-discovery-copy", namePrefix)
 		newVmClassFilePath = fmt.Sprintf("%s/vmc-copy.yaml", conf.TestData.SizingPolicy)
+
+		It("sets the namespace", func() {
+			kustomization := fmt.Sprintf("%s/%s", conf.TestData.SizingPolicy, "kustomization.yaml")
+			ns, err := kustomize.GetNamespace(kustomization)
+			Expect(err).NotTo(HaveOccurred(), "%w", err)
+			conf.SetNamespace(ns)
+		})
 	})
 
 	Context("When resources are applied", func() {

--- a/tests/e2e/tests_suite_test.go
+++ b/tests/e2e/tests_suite_test.go
@@ -120,7 +120,7 @@ func init() {
 			log.Fatal(err)
 		}
 	} else {
-		log.Println("Run test in REUSABLE mode")
+		log.Printf("Run test in REUSABLE mode\n")
 	}
 
 	res := kubectl.CreateResource(kc.ResourceNamespace, conf.Namespace, kc.CreateOptions{})
@@ -147,13 +147,7 @@ func TestTests(t *testing.T) {
 
 func Cleanup() error {
 	res := kubectl.Delete(kc.DeleteOptions{
-		Filename: []string{
-			conf.Namespace,
-			GetVirtualMachineConfigurationNamespace(),
-			GetVirtualMachineConnectivityNamespace(),
-			GetVirtualMachineMigrationNamespace(),
-			GetComplexNamespace(),
-		},
+		Filename:       []string{conf.Namespace},
 		IgnoreNotFound: true,
 		Resource:       kc.ResourceNamespace,
 	})

--- a/tests/e2e/tests_suite_test.go
+++ b/tests/e2e/tests_suite_test.go
@@ -66,7 +66,10 @@ var (
 func init() {
 	err := config.CheckReusableOption()
 	if err != nil {
-		log.Println("To run tests in REUSABLE mode, set REUSABLE=yes. If you don't intend to use this mode, leave the variable unset.")
+		log.Fatal(err)
+	}
+	err = config.CheckWithPostCleanUpOption()
+	if err != nil {
 		log.Fatal(err)
 	}
 	if conf, err = config.GetConfig(); err != nil {
@@ -114,9 +117,9 @@ func init() {
 	}
 
 	if !config.IsReusable() {
-		err := Cleanup()
-		if len(err) != 0 {
-			log.Fatal(err)
+		errs := Cleanup()
+		if len(errs) != 0 {
+			log.Fatal(errs)
 		}
 	} else {
 		log.Println("Run test in REUSABLE mode")
@@ -128,7 +131,7 @@ func TestTests(t *testing.T) {
 	fmt.Fprintf(GinkgoWriter, "Starting test suite\n")
 	RunSpecs(t, "Tests")
 
-	if (ginkgoutil.FailureBehaviourEnvSwitcher{}).IsStopOnFailure() || config.IsReusable() {
+	if (ginkgoutil.FailureBehaviourEnvSwitcher{}).IsStopOnFailure() || !config.IsCleanUpNeeded() {
 		return
 	}
 

--- a/tests/e2e/tests_suite_test.go
+++ b/tests/e2e/tests_suite_test.go
@@ -120,7 +120,7 @@ func init() {
 			log.Fatal(err)
 		}
 	} else {
-		log.Printf("Run test in REUSABLE mode\n")
+		log.Println("Run test in REUSABLE mode")
 	}
 
 	res := kubectl.CreateResource(kc.ResourceNamespace, conf.Namespace, kc.CreateOptions{})
@@ -147,7 +147,13 @@ func TestTests(t *testing.T) {
 
 func Cleanup() error {
 	res := kubectl.Delete(kc.DeleteOptions{
-		Filename:       []string{conf.Namespace},
+		Filename: []string{
+			conf.Namespace,
+			GetVirtualMachineConfigurationNamespace(),
+			GetVirtualMachineConnectivityNamespace(),
+			GetVirtualMachineMigrationNamespace(),
+			GetComplexNamespace(),
+		},
 		IgnoreNotFound: true,
 		Resource:       kc.ResourceNamespace,
 	})

--- a/tests/e2e/tests_suite_test.go
+++ b/tests/e2e/tests_suite_test.go
@@ -172,8 +172,9 @@ func Cleanup() []error {
 	}
 
 	res := kubectl.Delete(kc.DeleteOptions{
-		Labels:   map[string]string{"id": namePrefix},
-		Resource: kc.ResourceCVI,
+		IgnoreNotFound: true,
+		Labels:         map[string]string{"id": namePrefix},
+		Resource:       kc.ResourceCVI,
 	})
 	if res.Error() != nil {
 		cleanupErrs = append(
@@ -181,8 +182,9 @@ func Cleanup() []error {
 		)
 	}
 	res = kubectl.Delete(kc.DeleteOptions{
-		Labels:   map[string]string{"id": namePrefix},
-		Resource: kc.ResourceVMClass,
+		IgnoreNotFound: true,
+		Labels:         map[string]string{"id": namePrefix},
+		Resource:       kc.ResourceVMClass,
 	})
 	if res.Error() != nil {
 		cleanupErrs = append(

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -463,10 +463,6 @@ func DeleteTestCaseResources(resources ResourcesToDelete) {
 	const errMessage = "cannot delete test case resources"
 
 	if resources.KustomizationDir != "" {
-		kustimizationFile := fmt.Sprintf("%s/%s", resources.KustomizationDir, "kustomization.yaml")
-		err := kustomize.ExcludeResource(kustimizationFile, "ns.yaml")
-		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("%s\nkustomizationDir: %s\nstderr: %s", errMessage, resources.KustomizationDir, err))
-
 		res := kubectl.Delete(kc.DeleteOptions{
 			Filename:       []string{resources.KustomizationDir},
 			FilenameOption: kc.Kustomize,

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -460,12 +460,13 @@ type ResourcesToDelete struct {
 // This function checks that all resources in test case can be deleted correctly.
 func DeleteTestCaseResources(resources ResourcesToDelete) {
 	By("Response on deletion request should be successful")
-	errMessage := "cannot delete test case resources"
-	kustimizationFile := fmt.Sprintf("%s/%s", resources.KustomizationDir, "kustomization.yaml")
-	err := kustomize.ExcludeResource(kustimizationFile, "ns.yaml")
-	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("%s\nkustomizationDir: %s\nstderr: %s", errMessage, resources.KustomizationDir, err))
+	const errMessage = "cannot delete test case resources"
 
 	if resources.KustomizationDir != "" {
+		kustimizationFile := fmt.Sprintf("%s/%s", resources.KustomizationDir, "kustomization.yaml")
+		err := kustomize.ExcludeResource(kustimizationFile, "ns.yaml")
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("%s\nkustomizationDir: %s\nstderr: %s", errMessage, resources.KustomizationDir, err))
+
 		res := kubectl.Delete(kc.DeleteOptions{
 			Filename:       []string{resources.KustomizationDir},
 			FilenameOption: kc.Kustomize,

--- a/tests/e2e/vd_snapshots_test.go
+++ b/tests/e2e/vd_snapshots_test.go
@@ -30,6 +30,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	sdsrepvolv1 "github.com/deckhouse/sds-replicated-volume/api/v1alpha1"
+
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 	"github.com/deckhouse/virtualization/tests/e2e/config"
 	"github.com/deckhouse/virtualization/tests/e2e/ginkgoutil"

--- a/tests/e2e/vd_snapshots_test.go
+++ b/tests/e2e/vd_snapshots_test.go
@@ -243,7 +243,14 @@ var _ = Describe("Virtual disk snapshots", ginkgoutil.CommonE2ETestDecorators(),
 		vmAutomaticWithHotplug         = map[string]string{"vm": "automatic-with-hotplug"}
 	)
 
-	Context("Environment preparing", func() {
+	Context("Preparing the environment", func() {
+		It("sets the namespace", func() {
+			kustomization := fmt.Sprintf("%s/%s", conf.TestData.VdSnapshots, "kustomization.yaml")
+			ns, err := kustomize.GetNamespace(kustomization)
+			Expect(err).NotTo(HaveOccurred(), "%w", err)
+			conf.SetNamespace(ns)
+		})
+
 		It("prepares `Immediate` storage class and virtual disk that use it", func() {
 			sc, err := GetDefaultStorageClass()
 			Expect(err).NotTo(HaveOccurred(), "cannot get default storage class\nstderr: %s", err)

--- a/tests/e2e/vd_snapshots_test.go
+++ b/tests/e2e/vd_snapshots_test.go
@@ -30,7 +30,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	sdsrepvolv1 "github.com/deckhouse/sds-replicated-volume/api/v1alpha1"
-
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 	"github.com/deckhouse/virtualization/tests/e2e/config"
 	"github.com/deckhouse/virtualization/tests/e2e/ginkgoutil"

--- a/tests/e2e/vd_snapshots_test.go
+++ b/tests/e2e/vd_snapshots_test.go
@@ -23,14 +23,16 @@ import (
 	"sync"
 	"time"
 
-	sdsrepvolv1 "github.com/deckhouse/sds-replicated-volume/api/v1alpha1"
 	snapshotvolv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	storagev1 "k8s.io/api/storage/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	sdsrepvolv1 "github.com/deckhouse/sds-replicated-volume/api/v1alpha1"
+
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/tests/e2e/config"
 	"github.com/deckhouse/virtualization/tests/e2e/ginkgoutil"
 	. "github.com/deckhouse/virtualization/tests/e2e/helper"
 	kc "github.com/deckhouse/virtualization/tests/e2e/kubectl"
@@ -226,6 +228,12 @@ func CheckFilesystemReadyStatus(vmName string, status v1.ConditionStatus) (strin
 }
 
 var _ = Describe("Virtual disk snapshots", ginkgoutil.CommonE2ETestDecorators(), func() {
+	BeforeEach(func() {
+		if config.IsReusable() {
+			Skip("Test not available in REUSABLE mode: not supported yet.")
+		}
+	})
+
 	var (
 		immediateStorageClassName      string // require for unattached virtual disk snapshots
 		defaultVolumeSnapshotClassName string

--- a/tests/e2e/vm_configuration_test.go
+++ b/tests/e2e/vm_configuration_test.go
@@ -305,7 +305,7 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 		It("deletes test case resources", func() {
 			var resourcesToDelete ResourcesToDelete
 
-			if !config.IsCleanUpNeeded() {
+			if config.IsCleanUpNeeded() {
 				resourcesToDelete.KustomizationDir = conf.TestData.VmConfiguration
 			}
 

--- a/tests/e2e/vm_configuration_test.go
+++ b/tests/e2e/vm_configuration_test.go
@@ -18,12 +18,14 @@ package e2e
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/tests/e2e/config"
 	d8 "github.com/deckhouse/virtualization/tests/e2e/d8"
 	"github.com/deckhouse/virtualization/tests/e2e/ginkgoutil"
 	kc "github.com/deckhouse/virtualization/tests/e2e/kubectl"
@@ -51,7 +53,7 @@ func ExecSshCommand(vmName, cmd string) {
 	}).WithTimeout(Timeout).WithPolling(Interval).ShouldNot(HaveOccurred())
 }
 
-func ChangeCPUCoresNumber(namespace string, cpuNumber int, virtualMachines ...string) {
+func ChangeCPUCoresNumber(cpuNumber int, virtualMachines ...string) {
 	vms := strings.Join(virtualMachines, " ")
 	cmd := fmt.Sprintf("patch %s --namespace %s %s --type merge --patch '{\"spec\":{\"cpu\":{\"cores\":%d}}}'", kc.ResourceVM, conf.Namespace, vms, cpuNumber)
 	By("Patching virtual machine specification")
@@ -92,6 +94,19 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 
 	Context("When resources are applied", func() {
 		It("result should be succeeded", func() {
+			if config.IsReusable() {
+				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
+					Labels:    testCaseLabel,
+					Namespace: conf.Namespace,
+					Output:    "jsonpath='{.items[*].metadata.name}'",
+				})
+				Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
+
+				if res.StdOut() != "" {
+					return
+				}
+			}
+
 			res := kubectl.Apply(kc.ApplyOptions{
 				Filename:       []string{conf.TestData.VmConfiguration},
 				FilenameOption: kc.Kustomize,
@@ -132,6 +147,9 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 	})
 
 	Describe("Manual restart approval mode", func() {
+		var oldCpuCores int
+		var newCPUCores int
+
 		Context(fmt.Sprintf("When virtual machine is in %s phase", PhaseRunning), func() {
 			It("changes the number of processor cores", func() {
 				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
@@ -142,8 +160,17 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 				Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
 
 				vms := strings.Split(res.StdOut(), " ")
-				CheckCPUCoresNumber(ManualMode, StageBefore, 1, vms...)
-				ChangeCPUCoresNumber(conf.Namespace, 2, vms...)
+				Expect(vms).NotTo(BeEmpty())
+
+				vmResource := virtv2.VirtualMachine{}
+				err := GetObject(kc.ResourceVM, vms[0], &vmResource, kc.GetOptions{Namespace: conf.Namespace})
+				Expect(err).NotTo(HaveOccurred(), err)
+
+				oldCpuCores = vmResource.Spec.CPU.Cores
+				newCPUCores = 1 + (vmResource.Spec.CPU.Cores & 1)
+
+				CheckCPUCoresNumber(ManualMode, StageBefore, oldCpuCores, vms...)
+				ChangeCPUCoresNumber(newCPUCores, vms...)
 			})
 		})
 
@@ -157,7 +184,7 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 				Expect(res.WasSuccess()).To(Equal(true), res.StdErr())
 
 				vms := strings.Split(res.StdOut(), " ")
-				CheckCPUCoresNumber(ManualMode, StageAfter, 2, vms...)
+				CheckCPUCoresNumber(ManualMode, StageAfter, newCPUCores, vms...)
 			})
 		})
 
@@ -193,12 +220,15 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 				Expect(res.WasSuccess()).To(Equal(true), res.StdErr())
 
 				vms := strings.Split(res.StdOut(), " ")
-				CheckCPUCoresNumberFromVirtualMachine("2", vms...)
+				CheckCPUCoresNumberFromVirtualMachine(strconv.FormatInt(int64(newCPUCores), 10), vms...)
 			})
 		})
 	})
 
 	Describe("Automatic restart approval mode", func() {
+		var oldCpuCores int
+		var newCPUCores int
+
 		Context(fmt.Sprintf("When virtual machine is in %s phase", PhaseRunning), func() {
 			It("changes the number of processor cores", func() {
 				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
@@ -209,8 +239,17 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 				Expect(res.WasSuccess()).To(Equal(true), res.StdErr())
 
 				vms := strings.Split(res.StdOut(), " ")
-				CheckCPUCoresNumber(AutomaticMode, StageBefore, 1, vms...)
-				ChangeCPUCoresNumber(conf.Namespace, 2, vms...)
+				Expect(vms).NotTo(BeEmpty())
+
+				vmResource := virtv2.VirtualMachine{}
+				err := GetObject(kc.ResourceVM, vms[0], &vmResource, kc.GetOptions{Namespace: conf.Namespace})
+				Expect(err).NotTo(HaveOccurred(), err)
+
+				oldCpuCores = vmResource.Spec.CPU.Cores
+				newCPUCores = 1 + (vmResource.Spec.CPU.Cores & 1)
+
+				CheckCPUCoresNumber(AutomaticMode, StageBefore, oldCpuCores, vms...)
+				ChangeCPUCoresNumber(newCPUCores, vms...)
 			})
 		})
 
@@ -224,7 +263,7 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 				Expect(res.WasSuccess()).To(Equal(true), res.StdErr())
 
 				vms := strings.Split(res.StdOut(), " ")
-				CheckCPUCoresNumber(AutomaticMode, StageAfter, 2, vms...)
+				CheckCPUCoresNumber(AutomaticMode, StageAfter, newCPUCores, vms...)
 			})
 		})
 
@@ -248,16 +287,20 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 				Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
 
 				vms := strings.Split(res.StdOut(), " ")
-				CheckCPUCoresNumberFromVirtualMachine("2", vms...)
+				CheckCPUCoresNumberFromVirtualMachine(strconv.FormatInt(int64(newCPUCores), 10), vms...)
 			})
 		})
 	})
 
 	Context("When test is completed", func() {
 		It("deletes test case resources", func() {
-			DeleteTestCaseResources(ResourcesToDelete{
-				KustomizationDir: conf.TestData.VmConfiguration,
-			})
+			var resourcesToDelete ResourcesToDelete
+
+			if !config.IsReusable() {
+				resourcesToDelete.KustomizationDir = conf.TestData.VmConfiguration
+			}
+
+			DeleteTestCaseResources(resourcesToDelete)
 		})
 	})
 })

--- a/tests/e2e/vm_configuration_test.go
+++ b/tests/e2e/vm_configuration_test.go
@@ -38,11 +38,15 @@ const (
 	StageAfter    = "after"
 )
 
-func ExecSshCommand(vmName, cmd string) {
+func GetVirtualMachineConfigurationNamespace() string {
+	return conf.Namespace + "-vm-configuration"
+}
+
+func ExecSshCommand(vmName, namespace, cmd string) {
 	GinkgoHelper()
 	Eventually(func() error {
 		res := d8Virtualization.SshCommand(vmName, cmd, d8.SshOptions{
-			Namespace:   conf.Namespace,
+			Namespace:   namespace,
 			Username:    conf.TestData.SshUser,
 			IdenityFile: conf.TestData.Sshkey,
 		})
@@ -53,9 +57,9 @@ func ExecSshCommand(vmName, cmd string) {
 	}).WithTimeout(Timeout).WithPolling(Interval).ShouldNot(HaveOccurred())
 }
 
-func ChangeCPUCoresNumber(cpuNumber int, virtualMachines ...string) {
+func ChangeCPUCoresNumber(cpuNumber int, namespace string, virtualMachines ...string) {
 	vms := strings.Join(virtualMachines, " ")
-	cmd := fmt.Sprintf("patch %s --namespace %s %s --type merge --patch '{\"spec\":{\"cpu\":{\"cores\":%d}}}'", kc.ResourceVM, conf.Namespace, vms, cpuNumber)
+	cmd := fmt.Sprintf("patch %s --namespace %s %s --type merge --patch '{\"spec\":{\"cpu\":{\"cores\":%d}}}'", kc.ResourceVM, namespace, vms, cpuNumber)
 	By("Patching virtual machine specification")
 	patchRes := kubectl.RawCommand(cmd, ShortWaitDuration)
 	Expect(patchRes.Error()).NotTo(HaveOccurred(), patchRes.StdErr())
@@ -77,11 +81,11 @@ func CheckCPUCoresNumber(approvalMode, stage string, requiredValue int, virtualM
 	}
 }
 
-func CheckCPUCoresNumberFromVirtualMachine(requiredValue string, virtualMachines ...string) {
+func CheckCPUCoresNumberFromVirtualMachine(requiredValue, namespace string, virtualMachines ...string) {
 	By("Checking the number of processor cores after changing from virtual machine")
 	for _, vm := range virtualMachines {
 		cmd := "nproc --all"
-		CheckResultSshCommand(vm, cmd, requiredValue)
+		CheckResultSshCommand(vm, namespace, cmd, requiredValue)
 	}
 }
 
@@ -90,14 +94,19 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 		testCaseLabel  = map[string]string{"testcase": "vm-configuration"}
 		automaticLabel = map[string]string{"vm": "automatic-conf"}
 		manualLabel    = map[string]string{"vm": "manual-conf"}
+		namespace      = conf.Namespace
 	)
+
+	if config.IsReusable() {
+		namespace = GetVirtualMachineConfigurationNamespace()
+	}
 
 	Context("When resources are applied", func() {
 		It("result should be succeeded", func() {
 			if config.IsReusable() {
 				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 					Labels:    testCaseLabel,
-					Namespace: conf.Namespace,
+					Namespace: namespace,
 					Output:    "jsonpath='{.items[*].metadata.name}'",
 				})
 				Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
@@ -120,7 +129,7 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 			By(fmt.Sprintf("VIs should be in %s phases", PhaseReady))
 			WaitPhaseByLabel(kc.ResourceVI, PhaseReady, kc.WaitOptions{
 				Labels:    testCaseLabel,
-				Namespace: conf.Namespace,
+				Namespace: namespace,
 				Timeout:   MaxWaitTimeout,
 			})
 		})
@@ -130,7 +139,7 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 		It(fmt.Sprintf("should be in %s phase", PhaseReady), func() {
 			WaitPhaseByLabel(kc.ResourceVD, PhaseReady, kc.WaitOptions{
 				Labels:    testCaseLabel,
-				Namespace: conf.Namespace,
+				Namespace: namespace,
 				Timeout:   MaxWaitTimeout,
 			})
 		})
@@ -140,7 +149,7 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 		It(fmt.Sprintf("should be in %s phase", PhaseRunning), func() {
 			WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, kc.WaitOptions{
 				Labels:    testCaseLabel,
-				Namespace: conf.Namespace,
+				Namespace: namespace,
 				Timeout:   MaxWaitTimeout,
 			})
 		})
@@ -154,7 +163,7 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 			It("changes the number of processor cores", func() {
 				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 					Labels:    manualLabel,
-					Namespace: conf.Namespace,
+					Namespace: namespace,
 					Output:    "jsonpath='{.items[*].metadata.name}'",
 				})
 				Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
@@ -170,7 +179,7 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 				newCPUCores = 1 + (vmResource.Spec.CPU.Cores & 1)
 
 				CheckCPUCoresNumber(ManualMode, StageBefore, oldCpuCores, vms...)
-				ChangeCPUCoresNumber(newCPUCores, vms...)
+				ChangeCPUCoresNumber(newCPUCores, namespace, vms...)
 			})
 		})
 
@@ -178,7 +187,7 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 			It("checks the number of processor cores in specification", func() {
 				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 					Labels:    manualLabel,
-					Namespace: conf.Namespace,
+					Namespace: namespace,
 					Output:    "jsonpath='{.items[*].metadata.name}'",
 				})
 				Expect(res.WasSuccess()).To(Equal(true), res.StdErr())
@@ -192,7 +201,7 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 			It(fmt.Sprintf("should be in %s phase", PhaseRunning), func() {
 				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 					Labels:    manualLabel,
-					Namespace: conf.Namespace,
+					Namespace: namespace,
 					Output:    "jsonpath='{.items[*].metadata.name}'",
 				})
 				Expect(res.WasSuccess()).To(Equal(true), res.StdErr())
@@ -200,11 +209,11 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 				vms := strings.Split(res.StdOut(), " ")
 				for _, vm := range vms {
 					cmd := "sudo reboot"
-					ExecSshCommand(vm, cmd)
+					ExecSshCommand(vm, namespace, cmd)
 				}
 				WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, kc.WaitOptions{
 					Labels:    manualLabel,
-					Namespace: conf.Namespace,
+					Namespace: namespace,
 					Timeout:   MaxWaitTimeout,
 				})
 			})
@@ -214,13 +223,13 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 			It("checks that the number of processor cores was changed", func() {
 				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 					Labels:    manualLabel,
-					Namespace: conf.Namespace,
+					Namespace: namespace,
 					Output:    "jsonpath='{.items[*].metadata.name}'",
 				})
 				Expect(res.WasSuccess()).To(Equal(true), res.StdErr())
 
 				vms := strings.Split(res.StdOut(), " ")
-				CheckCPUCoresNumberFromVirtualMachine(strconv.FormatInt(int64(newCPUCores), 10), vms...)
+				CheckCPUCoresNumberFromVirtualMachine(strconv.FormatInt(int64(newCPUCores), 10), namespace, vms...)
 			})
 		})
 	})
@@ -233,7 +242,7 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 			It("changes the number of processor cores", func() {
 				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 					Labels:    automaticLabel,
-					Namespace: conf.Namespace,
+					Namespace: namespace,
 					Output:    "jsonpath='{.items[*].metadata.name}'",
 				})
 				Expect(res.WasSuccess()).To(Equal(true), res.StdErr())
@@ -249,7 +258,7 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 				newCPUCores = 1 + (vmResource.Spec.CPU.Cores & 1)
 
 				CheckCPUCoresNumber(AutomaticMode, StageBefore, oldCpuCores, vms...)
-				ChangeCPUCoresNumber(newCPUCores, vms...)
+				ChangeCPUCoresNumber(newCPUCores, namespace, vms...)
 			})
 		})
 
@@ -257,7 +266,7 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 			It("checks the number of processor cores in specification", func() {
 				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 					Labels:    automaticLabel,
-					Namespace: conf.Namespace,
+					Namespace: namespace,
 					Output:    "jsonpath='{.items[*].metadata.name}'",
 				})
 				Expect(res.WasSuccess()).To(Equal(true), res.StdErr())
@@ -271,7 +280,7 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 			It(fmt.Sprintf("should be in %s phase", PhaseRunning), func() {
 				WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, kc.WaitOptions{
 					Labels:    automaticLabel,
-					Namespace: conf.Namespace,
+					Namespace: namespace,
 					Timeout:   MaxWaitTimeout,
 				})
 			})
@@ -281,13 +290,13 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 			It("checks that the number of processor cores was changed", func() {
 				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 					Labels:    automaticLabel,
-					Namespace: conf.Namespace,
+					Namespace: namespace,
 					Output:    "jsonpath='{.items[*].metadata.name}'",
 				})
 				Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
 
 				vms := strings.Split(res.StdOut(), " ")
-				CheckCPUCoresNumberFromVirtualMachine(strconv.FormatInt(int64(newCPUCores), 10), vms...)
+				CheckCPUCoresNumberFromVirtualMachine(strconv.FormatInt(int64(newCPUCores), 10), namespace, vms...)
 			})
 		})
 	})

--- a/tests/e2e/vm_configuration_test.go
+++ b/tests/e2e/vm_configuration_test.go
@@ -92,6 +92,15 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 		manualLabel    = map[string]string{"vm": "manual-conf"}
 	)
 
+	Context("Preparing the environment", func() {
+		It("sets the namespace", func() {
+			kustomization := fmt.Sprintf("%s/%s", conf.TestData.VmConfiguration, "kustomization.yaml")
+			ns, err := kustomize.GetNamespace(kustomization)
+			Expect(err).NotTo(HaveOccurred(), "%w", err)
+			conf.SetNamespace(ns)
+		})
+	})
+
 	Context("When resources are applied", func() {
 		It("result should be succeeded", func() {
 			if config.IsReusable() {

--- a/tests/e2e/vm_configuration_test.go
+++ b/tests/e2e/vm_configuration_test.go
@@ -305,7 +305,7 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 		It("deletes test case resources", func() {
 			var resourcesToDelete ResourcesToDelete
 
-			if !config.IsReusable() {
+			if !config.IsCleanUpNeeded() {
 				resourcesToDelete.KustomizationDir = conf.TestData.VmConfiguration
 			}
 

--- a/tests/e2e/vm_connectivity_test.go
+++ b/tests/e2e/vm_connectivity_test.go
@@ -306,7 +306,7 @@ var _ = Describe("VM connectivity", ginkgoutil.CommonE2ETestDecorators(), func()
 				},
 			}
 
-			if !config.IsReusable() {
+			if !config.IsCleanUpNeeded() {
 				resourcesToDelete.KustomizationDir = conf.TestData.Connectivity
 			}
 

--- a/tests/e2e/vm_connectivity_test.go
+++ b/tests/e2e/vm_connectivity_test.go
@@ -106,6 +106,15 @@ var _ = Describe("VM connectivity", ginkgoutil.CommonE2ETestDecorators(), func()
 		selectorB string
 	)
 
+	Context("Preparing the environment", func() {
+		It("sets the namespace", func() {
+			kustomization := fmt.Sprintf("%s/%s", conf.TestData.Connectivity, "kustomization.yaml")
+			ns, err := kustomize.GetNamespace(kustomization)
+			Expect(err).NotTo(HaveOccurred(), "%w", err)
+			conf.SetNamespace(ns)
+		})
+	})
+
 	Context("When resources are applied", func() {
 		It("result should be succeeded", func() {
 			if config.IsReusable() {

--- a/tests/e2e/vm_connectivity_test.go
+++ b/tests/e2e/vm_connectivity_test.go
@@ -306,7 +306,7 @@ var _ = Describe("VM connectivity", ginkgoutil.CommonE2ETestDecorators(), func()
 				},
 			}
 
-			if !config.IsCleanUpNeeded() {
+			if config.IsCleanUpNeeded() {
 				resourcesToDelete.KustomizationDir = conf.TestData.Connectivity
 			}
 

--- a/tests/e2e/vm_connectivity_test.go
+++ b/tests/e2e/vm_connectivity_test.go
@@ -46,6 +46,10 @@ type PodEntrypoint struct {
 	Args    []string
 }
 
+func GetVirtualMachineConnectivityNamespace() string {
+	return conf.Namespace + "-vm-connectivity"
+}
+
 func RunPod(podName, namespace, image string, entrypoint PodEntrypoint) *executor.CMDResult {
 	GinkgoHelper()
 	cmd := fmt.Sprintf("run %s --namespace %s --image=%s --labels='name=%s'", podName, namespace, image, podName)
@@ -69,20 +73,20 @@ func GetResponseViaPodWithCurl(podName, namespace, host string) *executor.CMDRes
 	return kubectl.RawCommand(cmd, ShortWaitDuration)
 }
 
-func CheckExternalConnection(host, httpCode string, vms ...string) {
+func CheckExternalConnection(host, httpCode, namespace string, vms ...string) {
 	GinkgoHelper()
 	for _, vm := range vms {
 		By(fmt.Sprintf("Response code from %q should be %q for %q", host, httpCode, vm))
 		cmd := fmt.Sprintf("curl -o /dev/null -s -w \"%%{http_code}\\n\" %s", host)
-		CheckResultSshCommand(vm, cmd, httpCode)
+		CheckResultSshCommand(vm, namespace, cmd, httpCode)
 	}
 }
 
-func CheckResultSshCommand(vmName, cmd, equal string) {
+func CheckResultSshCommand(vmName, namespace, cmd, equal string) {
 	GinkgoHelper()
 	Eventually(func() (string, error) {
 		res := d8Virtualization.SshCommand(vmName, cmd, d8.SshOptions{
-			Namespace:   conf.Namespace,
+			Namespace:   namespace,
 			Username:    conf.TestData.SshUser,
 			IdenityFile: conf.TestData.Sshkey,
 		})
@@ -104,14 +108,20 @@ var _ = Describe("VM connectivity", ginkgoutil.CommonE2ETestDecorators(), func()
 
 		selectorA string
 		selectorB string
+
+		namespace = conf.Namespace
 	)
+
+	if config.IsReusable() {
+		namespace = GetVirtualMachineConnectivityNamespace()
+	}
 
 	Context("When resources are applied", func() {
 		It("result should be succeeded", func() {
 			if config.IsReusable() {
 				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 					Labels:    testCaseLabel,
-					Namespace: conf.Namespace,
+					Namespace: namespace,
 					Output:    "jsonpath='{.items[*].metadata.name}'",
 				})
 				Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
@@ -134,7 +144,7 @@ var _ = Describe("VM connectivity", ginkgoutil.CommonE2ETestDecorators(), func()
 			By(fmt.Sprintf("VIs should be in %s phases", PhaseReady))
 			WaitPhaseByLabel(kc.ResourceVI, PhaseReady, kc.WaitOptions{
 				Labels:    testCaseLabel,
-				Namespace: conf.Namespace,
+				Namespace: namespace,
 				Timeout:   MaxWaitTimeout,
 			})
 		})
@@ -145,7 +155,7 @@ var _ = Describe("VM connectivity", ginkgoutil.CommonE2ETestDecorators(), func()
 			By(fmt.Sprintf("VDs should be in %s phase", PhaseReady))
 			WaitPhaseByLabel(kc.ResourceVD, PhaseReady, kc.WaitOptions{
 				Labels:    testCaseLabel,
-				Namespace: conf.Namespace,
+				Namespace: namespace,
 				Timeout:   MaxWaitTimeout,
 			})
 		})
@@ -156,7 +166,7 @@ var _ = Describe("VM connectivity", ginkgoutil.CommonE2ETestDecorators(), func()
 			By(fmt.Sprintf("VMs should be in %s phase", PhaseRunning))
 			WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, kc.WaitOptions{
 				Labels:    testCaseLabel,
-				Namespace: conf.Namespace,
+				Namespace: namespace,
 				Timeout:   MaxWaitTimeout,
 			})
 		})
@@ -166,7 +176,7 @@ var _ = Describe("VM connectivity", ginkgoutil.CommonE2ETestDecorators(), func()
 		It(fmt.Sprintf("status should be in %s phase", PhaseRunning), func() {
 			jsonPath := "jsonpath={.status.phase}"
 			waitFor := fmt.Sprintf("%s=%s", jsonPath, PhaseRunning)
-			res := RunPod(CurlPod, conf.Namespace, conf.HelperImages.CurlImage, PodEntrypoint{
+			res := RunPod(CurlPod, namespace, conf.HelperImages.CurlImage, PodEntrypoint{
 				Command: "sleep",
 				Args:    []string{"10000"},
 			})
@@ -179,23 +189,23 @@ var _ = Describe("VM connectivity", ginkgoutil.CommonE2ETestDecorators(), func()
 		It("gets VMs and SVCs objects", func() {
 			vmA = virtv2.VirtualMachine{}
 			err = GetObject(kc.ResourceVM, aObjName, &vmA, kc.GetOptions{
-				Namespace: conf.Namespace,
+				Namespace: namespace,
 			})
 			Expect(err).NotTo(HaveOccurred(), err)
 			vmB = virtv2.VirtualMachine{}
 			err = GetObject(kc.ResourceVM, bObjName, &vmB, kc.GetOptions{
-				Namespace: conf.Namespace,
+				Namespace: namespace,
 			})
 			Expect(err).NotTo(HaveOccurred(), err)
 
 			svcA = corev1.Service{}
 			err = GetObject(kc.ResourceService, aObjName, &svcA, kc.GetOptions{
-				Namespace: conf.Namespace,
+				Namespace: namespace,
 			})
 			Expect(err).NotTo(HaveOccurred(), err)
 			svcB = corev1.Service{}
 			err = GetObject(kc.ResourceService, bObjName, &svcB, kc.GetOptions{
-				Namespace: conf.Namespace,
+				Namespace: namespace,
 			})
 			Expect(err).NotTo(HaveOccurred(), err)
 		})
@@ -204,7 +214,7 @@ var _ = Describe("VM connectivity", ginkgoutil.CommonE2ETestDecorators(), func()
 			cmd := "hostname"
 			for _, vmName := range []string{vmA.Name, vmB.Name} {
 				By(fmt.Sprintf("VirtualMachine %q", vmName))
-				CheckResultSshCommand(vmName, cmd, vmName)
+				CheckResultSshCommand(vmName, namespace, cmd, vmName)
 			}
 		})
 
@@ -216,14 +226,14 @@ var _ = Describe("VM connectivity", ginkgoutil.CommonE2ETestDecorators(), func()
 			cmd := "systemctl is-active nginx.service"
 			for _, vmName := range []string{vmA.Name, vmB.Name} {
 				By(fmt.Sprintf("VirtualMachine %q", vmName))
-				CheckResultSshCommand(vmName, cmd, nginxActiveStatus)
+				CheckResultSshCommand(vmName, namespace, cmd, nginxActiveStatus)
 			}
 		})
 
 		It(fmt.Sprintf("gets page from service %s", aObjName), func() {
 			service := GenerateServiceUrl(&svcA, conf.Namespace)
 			Eventually(func() (string, error) {
-				res := GetResponseViaPodWithCurl(CurlPod, conf.Namespace, service)
+				res := GetResponseViaPodWithCurl(CurlPod, namespace, service)
 				if res.Error() != nil {
 					return "", fmt.Errorf("cmd: %s\nstderr: %s", res.GetCmd(), res.StdErr())
 				}
@@ -234,7 +244,7 @@ var _ = Describe("VM connectivity", ginkgoutil.CommonE2ETestDecorators(), func()
 		It(fmt.Sprintf("gets page from service %s", bObjName), func() {
 			service := GenerateServiceUrl(&svcB, conf.Namespace)
 			Eventually(func() (string, error) {
-				res := GetResponseViaPodWithCurl(CurlPod, conf.Namespace, service)
+				res := GetResponseViaPodWithCurl(CurlPod, namespace, service)
 				if res.Error() != nil {
 					return "", fmt.Errorf("cmd: %s\nstderr: %s", res.GetCmd(), res.StdErr())
 				}
@@ -263,7 +273,7 @@ var _ = Describe("VM connectivity", ginkgoutil.CommonE2ETestDecorators(), func()
 			By(fmt.Sprintf("Response should be from virtual machine %q", vmB.Name))
 			service := GenerateServiceUrl(&svcA, conf.Namespace)
 			Eventually(func() (string, error) {
-				res := GetResponseViaPodWithCurl(CurlPod, conf.Namespace, service)
+				res := GetResponseViaPodWithCurl(CurlPod, namespace, service)
 				if res.Error() != nil {
 					return "", fmt.Errorf("cmd: %s\nstderr: %s", res.GetCmd(), res.StdErr())
 				}

--- a/tests/e2e/vm_connectivity_test.go
+++ b/tests/e2e/vm_connectivity_test.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/tests/e2e/config"
 	d8 "github.com/deckhouse/virtualization/tests/e2e/d8"
 	"github.com/deckhouse/virtualization/tests/e2e/executor"
 	"github.com/deckhouse/virtualization/tests/e2e/ginkgoutil"
@@ -100,10 +101,26 @@ var _ = Describe("VM connectivity", ginkgoutil.CommonE2ETestDecorators(), func()
 		vmA, vmB      virtv2.VirtualMachine
 		svcA, svcB    corev1.Service
 		err           error
+
+		selectorA string
+		selectorB string
 	)
 
 	Context("When resources are applied", func() {
 		It("result should be succeeded", func() {
+			if config.IsReusable() {
+				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
+					Labels:    testCaseLabel,
+					Namespace: conf.Namespace,
+					Output:    "jsonpath='{.items[*].metadata.name}'",
+				})
+				Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
+
+				if res.StdOut() != "" {
+					return
+				}
+			}
+
 			res := kubectl.Apply(kc.ApplyOptions{
 				Filename:       []string{conf.TestData.Connectivity},
 				FilenameOption: kc.Kustomize,
@@ -226,18 +243,20 @@ var _ = Describe("VM connectivity", ginkgoutil.CommonE2ETestDecorators(), func()
 		})
 
 		It(fmt.Sprintf("changes selector in service %s with selector from service %s", aObjName, bObjName), func() {
+			selectorA = svcA.Spec.Selector["service"]
+			selectorB = svcB.Spec.Selector["service"]
+
 			PatchResource(kc.ResourceService, svcA.Name, &kc.JsonPatch{
 				Op:    "replace",
 				Path:  "/spec/selector/service",
-				Value: svcB.Spec.Selector["service"],
+				Value: selectorB,
 			})
 		})
 
 		It(fmt.Sprintf("checks selector in service %s", aObjName), func() {
-			By(fmt.Sprintf("Selector should be %q", svcB.Spec.Selector["service"]))
-			label := svcB.Spec.Selector["service"]
+			By(fmt.Sprintf("Selector should be %q", selectorB))
 			output := "jsonpath={.spec.selector.service}"
-			CheckField(kc.ResourceService, svcA.Name, output, label)
+			CheckField(kc.ResourceService, svcA.Name, output, selectorB)
 		})
 
 		It(fmt.Sprintf("gets page from service %s", aObjName), func() {
@@ -251,19 +270,38 @@ var _ = Describe("VM connectivity", ginkgoutil.CommonE2ETestDecorators(), func()
 				return strings.TrimSpace(res.StdOut()), nil
 			}).WithTimeout(Timeout).WithPolling(Interval).Should(ContainSubstring(vmB.Name))
 		})
+
+		It(fmt.Sprintf("changes back selector in service %s", aObjName), func() {
+			PatchResource(kc.ResourceService, svcA.Name, &kc.JsonPatch{
+				Op:    "replace",
+				Path:  "/spec/selector/service",
+				Value: selectorA,
+			})
+		})
+
+		It(fmt.Sprintf("checks selector in service %s", aObjName), func() {
+			By(fmt.Sprintf("Selector should be %q", selectorA))
+			output := "jsonpath={.spec.selector.service}"
+			CheckField(kc.ResourceService, svcA.Name, output, selectorA)
+		})
 	})
 
 	Context("When test is completed", func() {
 		It("deletes test case resources", func() {
-			DeleteTestCaseResources(ResourcesToDelete{
-				KustomizationDir: conf.TestData.Connectivity,
+			resourcesToDelete := ResourcesToDelete{
 				AdditionalResources: []AdditionalResource{
 					{
 						Resource: kc.ResourcePod,
 						Labels:   map[string]string{"name": CurlPod},
 					},
 				},
-			})
+			}
+
+			if !config.IsReusable() {
+				resourcesToDelete.KustomizationDir = conf.TestData.Connectivity
+			}
+
+			DeleteTestCaseResources(resourcesToDelete)
 		})
 	})
 })

--- a/tests/e2e/vm_disk_attachment_test.go
+++ b/tests/e2e/vm_disk_attachment_test.go
@@ -25,6 +25,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/tests/e2e/config"
 	d8 "github.com/deckhouse/virtualization/tests/e2e/d8"
 	"github.com/deckhouse/virtualization/tests/e2e/ginkgoutil"
 	. "github.com/deckhouse/virtualization/tests/e2e/helper"
@@ -105,6 +106,12 @@ func GetDisksMetadata(vmName string, disks *Disks) error {
 }
 
 var _ = Describe("Virtual disk attachment", ginkgoutil.CommonE2ETestDecorators(), func() {
+	BeforeEach(func() {
+		if config.IsReusable() {
+			Skip("Test not available in REUSABLE mode: not supported yet.")
+		}
+	})
+
 	var (
 		testCaseLabel      = map[string]string{"testcase": "vm-disk-attachment"}
 		hasNoConsumerLabel = map[string]string{"hasNoConsumer": "vm-disk-attachment"}

--- a/tests/e2e/vm_disk_attachment_test.go
+++ b/tests/e2e/vm_disk_attachment_test.go
@@ -127,6 +127,13 @@ var _ = Describe("Virtual disk attachment", ginkgoutil.CommonE2ETestDecorators()
 		vdAttach = fmt.Sprintf("%s-vd-attach-%s", namePrefix, nameSuffix)
 		vmName = fmt.Sprintf("%s-vm-%s", namePrefix, nameSuffix)
 		vmbdaName = fmt.Sprintf("%s-vm-%s", namePrefix, nameSuffix)
+
+		It("sets the namespace", func() {
+			kustomization := fmt.Sprintf("%s/%s", conf.TestData.VmDiskAttachment, "kustomization.yaml")
+			ns, err := kustomize.GetNamespace(kustomization)
+			Expect(err).NotTo(HaveOccurred(), "%w", err)
+			conf.SetNamespace(ns)
+		})
 	})
 
 	Context("When resources are applied", func() {

--- a/tests/e2e/vm_disk_resizing_test.go
+++ b/tests/e2e/vm_disk_resizing_test.go
@@ -159,6 +159,12 @@ func GetVirtualMachineDisks(vmName string, config *cfg.Config) (VirtualMachineDi
 }
 
 var _ = Describe("Virtual disk resizing", ginkgoutil.CommonE2ETestDecorators(), func() {
+	BeforeEach(func() {
+		if cfg.IsReusable() {
+			Skip("Test not available in REUSABLE mode: not supported yet.")
+		}
+	})
+
 	testCaseLabel := map[string]string{"testcase": "disk-resizing"}
 
 	Context("When resources are applied", func() {

--- a/tests/e2e/vm_label_annotation_test.go
+++ b/tests/e2e/vm_label_annotation_test.go
@@ -25,6 +25,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/tests/e2e/config"
 	"github.com/deckhouse/virtualization/tests/e2e/ginkgoutil"
 	kc "github.com/deckhouse/virtualization/tests/e2e/kubectl"
 )
@@ -99,6 +100,12 @@ func GetActiveVirtualMachinePod(vmObj *virtv2.VirtualMachine) string {
 }
 
 var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETestDecorators(), func() {
+	BeforeEach(func() {
+		if config.IsReusable() {
+			Skip("Test not available in REUSABLE mode: not supported yet.")
+		}
+	})
+
 	testCaseLabel := map[string]string{"testcase": "vm-label-annotation"}
 	specialKeyValue := map[string]string{"specialKey": "specialValue"}
 

--- a/tests/e2e/vm_label_annotation_test.go
+++ b/tests/e2e/vm_label_annotation_test.go
@@ -109,6 +109,15 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 	testCaseLabel := map[string]string{"testcase": "vm-label-annotation"}
 	specialKeyValue := map[string]string{"specialKey": "specialValue"}
 
+	Context("Preparing the environment", func() {
+		It("sets the namespace", func() {
+			kustomization := fmt.Sprintf("%s/%s", conf.TestData.VmLabelAnnotation, "kustomization.yaml")
+			ns, err := kustomize.GetNamespace(kustomization)
+			Expect(err).NotTo(HaveOccurred(), "%w", err)
+			conf.SetNamespace(ns)
+		})
+	})
+
 	Context("When resources are applied", func() {
 		It("result should be succeeded", func() {
 			res := kubectl.Apply(kc.ApplyOptions{

--- a/tests/e2e/vm_migration_test.go
+++ b/tests/e2e/vm_migration_test.go
@@ -198,7 +198,7 @@ var _ = Describe("Virtual machine migration", ginkgoutil.CommonE2ETestDecorators
 				},
 			}
 
-			if !config.IsReusable() {
+			if !config.IsCleanUpNeeded() {
 				resourcesToDelete.KustomizationDir = conf.TestData.VmMigration
 			}
 

--- a/tests/e2e/vm_migration_test.go
+++ b/tests/e2e/vm_migration_test.go
@@ -198,7 +198,7 @@ var _ = Describe("Virtual machine migration", ginkgoutil.CommonE2ETestDecorators
 				},
 			}
 
-			if !config.IsCleanUpNeeded() {
+			if config.IsCleanUpNeeded() {
 				resourcesToDelete.KustomizationDir = conf.TestData.VmMigration
 			}
 

--- a/tests/e2e/vm_migration_test.go
+++ b/tests/e2e/vm_migration_test.go
@@ -78,6 +78,15 @@ func CreateMigrationManifest(vmName, filePath string, labels map[string]string) 
 var _ = Describe("Virtual machine migration", ginkgoutil.CommonE2ETestDecorators(), func() {
 	testCaseLabel := map[string]string{"testcase": "vm-migration"}
 
+	Context("Preparing the environment", func() {
+		It("sets the namespace", func() {
+			kustomization := fmt.Sprintf("%s/%s", conf.TestData.VmMigration, "kustomization.yaml")
+			ns, err := kustomize.GetNamespace(kustomization)
+			Expect(err).NotTo(HaveOccurred(), "%w", err)
+			conf.SetNamespace(ns)
+		})
+	})
+
 	Context("When resources are applied", func() {
 		It("result should be succeeded", func() {
 			if config.IsReusable() {


### PR DESCRIPTION
## Reusable mode option

The environment variable REUSABLE used to reuse resources created previously.
By default, it retains all resources created during the e2e test after its completion (no cleanup by default in this mode).
Use the `WITH_POST_CLEANUP=yes` environment variable to clean up resources created or used during the test.
When a test starts, it will reuse existing virtual machines created earlier, if they exist.
If no virtual machines were found, they will be created.

For example, run test in reusable mode:
```bash
REUSABLE=yes task run
```

! Only the following e2e tests are supported in REUSABLE mode. All other tests will be skipped.
- "Virtual machine configuration"
- "Virtual machine migration"
- "VM connectivity"
- "Complex test"

## PostCleanUp option

WithPostCleanUpEnv defines an environment variable used to explicitly request the deletion of created/used resources.
For example, this option is useful when combined with the `REUSABLE=yes` option,
as the reusable mode does not delete created/used resources by default.

For example, run test in reusable mode with the removal of all used resources after test completion:
```bash
REUSABLE=yes WITH_POST_CLEANUP=yes task run
```
