### PR TITLE
feat(vmip): add new events

### DIFF
--- a/api/core/v1alpha2/events.go
+++ b/api/core/v1alpha2/events.go
@@ -117,13 +117,13 @@ const (
 	// ReasonVMSnapshottingFailed is event reason that VirtualMachine snapshotting is failed.
 	ReasonVMSnapshottingFailed = "VirtualMachineSnapshottingFailed"
 
-	// ReasonVMIPAttached is event reason that VMIP is attached to VM
-	ReasonVMIPAttached = "Attached"
-	// ReasonVMIPNotAttached is event reason that VirtualMachineIPAddress is not attached to VirtualMachine.
-	ReasonVMIPNotAttached = "NotAttached"
+	// ReasonAttached is event reason that VirtualMachineIPAddress is attached to VM.
+	ReasonAttached = "Attached"
+	// ReasonNotAttached is event reason that VirtualMachineIPAddress is not attached to VirtualMachine.
+	ReasonNotAttached = "NotAttached"
 
-	// ReasonVMIPLeaseBound is the event reason indicating that a VirtualMachineIPLease is bound to a VirtualMachineIPAddress.
-	ReasonVMIPLeaseBound = "Bound"
-	// ReasonVMIPLeaseBoundFailed is the event reason indicating that the binding of a VirtualMachineIPLease to a VirtualMachineIPAddress has failed.
-	ReasonVMIPLeaseBoundFailed = "Failed"
+	// ReasonBound is the event reason indicating that a VirtualMachineIPLease is bound to a VirtualMachineIPAddress.
+	ReasonBound = "Bound"
+	// ReasonFailed is the event reason indicating that the binding of a VirtualMachineIPLease to a VirtualMachineIPAddress has failed.
+	ReasonFailed = "Failed"
 )

--- a/api/core/v1alpha2/events.go
+++ b/api/core/v1alpha2/events.go
@@ -117,13 +117,13 @@ const (
 	// ReasonVMSnapshottingFailed is event reason that VirtualMachine snapshotting is failed.
 	ReasonVMSnapshottingFailed = "VirtualMachineSnapshottingFailed"
 
-	// ReasonVMIPAttached is event reason that VMIP attached to VM
-	ReasonVMIPAttached = "VMIPtoVMAttached"
+	// ReasonVMIPAttached is event reason that VMIP is attached to VM
+	ReasonVMIPAttached = "Attached"
 	// ReasonVMIPNotAttached is event reason that VirtualMachineIPAddress is not attached to VirtualMachine.
-	ReasonVMIPNotAttached = "VMIPtoVMNotAttached"
+	ReasonVMIPNotAttached = "NotAttached"
 
 	// ReasonVMIPLeaseBound is the event reason indicating that a VirtualMachineIPLease is bound to a VirtualMachineIPAddress.
-	ReasonVMIPLeaseBound = "VMIPLeaseBound"
+	ReasonVMIPLeaseBound = "Bound"
 	// ReasonVMIPLeaseBoundFailed is the event reason indicating that the binding of a VirtualMachineIPLease to a VirtualMachineIPAddress has failed.
-	ReasonVMIPLeaseBoundFailed = "VMIPLeaseBoundFailed"
+	ReasonVMIPLeaseBoundFailed = "Failed"
 )

--- a/api/core/v1alpha2/events.go
+++ b/api/core/v1alpha2/events.go
@@ -119,10 +119,11 @@ const (
 
 	// ReasonVMIPVMAttached is event reason that VMIP attached to VM
 	ReasonVMIPVMAttached = "VMIPVMAttached"
-	// ReasonVMIPVMDetached is event reason that VMIP not attached to VM
-	ReasonVMIPVMDetached = "VMIPVMDetached"
+	// ReasonVMIPVMNotAttached is event reason that VirtualMachineIPAddress not attached to VirtualMachine.
+	ReasonVMIPVMNotAttached = "VMIPVMNotAttached"
 
-	ReasonVMIPLeaseBound       = "VMIPLeaseBound"
-	ReasonVMIPLeaseNotBound    = "VMIPLeaseNotBound"
+	// ReasonVMIPLeaseBound is the event reason indicating that a VirtualMachineIPLease is bound to a VirtualMachineIPAddress.
+	ReasonVMIPLeaseBound = "VMIPLeaseBound"
+	// ReasonVMIPLeaseBoundFailed is the event reason indicating that the binding of a VirtualMachineIPLease to a VirtualMachineIPAddress has failed.
 	ReasonVMIPLeaseBoundFailed = "VMIPLeaseBoundFailed"
 )

--- a/api/core/v1alpha2/events.go
+++ b/api/core/v1alpha2/events.go
@@ -116,4 +116,13 @@ const (
 
 	// ReasonVMSnapshottingFailed is event reason that VirtualMachine snapshotting is failed.
 	ReasonVMSnapshottingFailed = "VirtualMachineSnapshottingFailed"
+
+	// ReasonVMIPVMAttached is event reason that VMIP attached to VM
+	ReasonVMIPVMAttached = "VMIPVMAttached"
+	// ReasonVMIPVMDetached is event reason that VMIP not attached to VM
+	ReasonVMIPVMDetached = "VMIPVMDetached"
+
+	ReasonVMIPLeaseBound       = "VMIPLeaseBound"
+	ReasonVMIPLeaseNotBound    = "VMIPLeaseNotBound"
+	ReasonVMIPLeaseBoundFailed = "VMIPLeaseBoundFailed"
 )

--- a/api/core/v1alpha2/events.go
+++ b/api/core/v1alpha2/events.go
@@ -117,10 +117,10 @@ const (
 	// ReasonVMSnapshottingFailed is event reason that VirtualMachine snapshotting is failed.
 	ReasonVMSnapshottingFailed = "VirtualMachineSnapshottingFailed"
 
-	// ReasonVMIPtoVMAttached is event reason that VMIP attached to VM
-	ReasonVMIPtoVMAttached = "VMIPtoVMAttached"
-	// ReasonVMIPtoVMNotAttached is event reason that VirtualMachineIPAddress is not attached to VirtualMachine.
-	ReasonVMIPtoVMNotAttached = "VMIPtoVMNotAttached"
+	// ReasonVMIPAttached is event reason that VMIP attached to VM
+	ReasonVMIPAttached = "VMIPtoVMAttached"
+	// ReasonVMIPNotAttached is event reason that VirtualMachineIPAddress is not attached to VirtualMachine.
+	ReasonVMIPNotAttached = "VMIPtoVMNotAttached"
 
 	// ReasonVMIPLeaseBound is the event reason indicating that a VirtualMachineIPLease is bound to a VirtualMachineIPAddress.
 	ReasonVMIPLeaseBound = "VMIPLeaseBound"

--- a/api/core/v1alpha2/events.go
+++ b/api/core/v1alpha2/events.go
@@ -117,10 +117,10 @@ const (
 	// ReasonVMSnapshottingFailed is event reason that VirtualMachine snapshotting is failed.
 	ReasonVMSnapshottingFailed = "VirtualMachineSnapshottingFailed"
 
-	// ReasonVMIPVMAttached is event reason that VMIP attached to VM
-	ReasonVMIPVMAttached = "VMIPVMAttached"
-	// ReasonVMIPVMNotAttached is event reason that VirtualMachineIPAddress not attached to VirtualMachine.
-	ReasonVMIPVMNotAttached = "VMIPVMNotAttached"
+	// ReasonVMIPtoVMAttached is event reason that VMIP attached to VM
+	ReasonVMIPtoVMAttached = "VMIPtoVMAttached"
+	// ReasonVMIPtoVMNotAttached is event reason that VirtualMachineIPAddress is not attached to VirtualMachine.
+	ReasonVMIPtoVMNotAttached = "VMIPtoVMNotAttached"
 
 	// ReasonVMIPLeaseBound is the event reason indicating that a VirtualMachineIPLease is bound to a VirtualMachineIPAddress.
 	ReasonVMIPLeaseBound = "VMIPLeaseBound"

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/iplease_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/iplease_handler.go
@@ -23,7 +23,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -32,6 +31,7 @@ import (
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vmip/internal/state"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vmip/internal/util"
+	"github.com/deckhouse/virtualization-controller/pkg/eventrecord"
 	"github.com/deckhouse/virtualization-controller/pkg/logger"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmipcondition"
@@ -42,10 +42,10 @@ const IpLeaseHandlerName = "IPLeaseHandler"
 type IPLeaseHandler struct {
 	client    client.Client
 	ipService *service.IpAddressService
-	recorder  record.EventRecorder
+	recorder  eventrecord.EventRecorderLogger
 }
 
-func NewIPLeaseHandler(client client.Client, ipAddressService *service.IpAddressService, recorder record.EventRecorder) *IPLeaseHandler {
+func NewIPLeaseHandler(client client.Client, ipAddressService *service.IpAddressService, recorder eventrecord.EventRecorderLogger) *IPLeaseHandler {
 	return &IPLeaseHandler{
 		client:    client,
 		ipService: ipAddressService,
@@ -144,14 +144,18 @@ func (h IPLeaseHandler) createNewLease(ctx context.Context, state state.VMIPStat
 				Reason(vmipcondition.VirtualMachineIPAddressIsOutOfTheValidRange).
 				Message(fmt.Sprintf("The requested address %s is out of the valid range",
 					vmip.Spec.StaticIP))
-			h.recorder.Event(vmip, corev1.EventTypeWarning, vmipcondition.VirtualMachineIPAddressIsOutOfTheValidRange.String(), msg)
+			h.recorder.Eventf(vmip, corev1.EventTypeWarning, virtv2.ReasonVMIPLeaseBoundFailed, "The requested address %s is out of the valid range", vmip.Spec.StaticIP)
 		case errors.Is(err, service.ErrIPAddressAlreadyExist):
 			vmipStatus.Phase = virtv2.VirtualMachineIPAddressPhasePending
 			conditionBound.Status(metav1.ConditionFalse).
 				Reason(vmipcondition.VirtualMachineIPAddressLeaseAlreadyExists).
 				Message(fmt.Sprintf("VirtualMachineIPAddressLease %s is bound to another VirtualMachineIPAddress",
 					ip.IpToLeaseName(vmipStatus.Address)))
-			h.recorder.Event(vmip, corev1.EventTypeWarning, vmipcondition.VirtualMachineIPAddressLeaseAlreadyExists.String(), msg)
+			h.recorder.Eventf(
+				vmip, corev1.EventTypeWarning, virtv2.ReasonVMIPLeaseBoundFailed,
+				"VirtualMachineIPAddressLease %s is bound to another VirtualMachineIPAddress",
+				vmip.Status.Address,
+			)
 		}
 		conditions.SetCondition(conditionBound, &vmipStatus.Conditions)
 		return reconcile.Result{}, nil
@@ -179,6 +183,8 @@ func (h IPLeaseHandler) createNewLease(ctx context.Context, state state.VMIPStat
 	if err != nil {
 		return reconcile.Result{}, err
 	}
+
+	h.recorder.Event(vmip, corev1.EventTypeNormal, virtv2.ReasonVMIPLeaseBound, "VMIP is bound to a new lease")
 
 	return reconcile.Result{}, nil
 }

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/iplease_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/iplease_handler.go
@@ -181,7 +181,7 @@ func (h IPLeaseHandler) createNewLease(ctx context.Context, state state.VMIPStat
 		return reconcile.Result{}, err
 	}
 
-	h.recorder.Event(vmip, corev1.EventTypeNormal, virtv2.ReasonBound, "VirtualMachineIPAddress is bound to a new lease.")
+	h.recorder.Event(vmip, corev1.EventTypeNormal, virtv2.ReasonBound, "VirtualMachineIPAddress is bound to a new VirtualMachineIPAddressLease.")
 
 	return reconcile.Result{}, nil
 }

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/iplease_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/iplease_handler.go
@@ -144,7 +144,7 @@ func (h IPLeaseHandler) createNewLease(ctx context.Context, state state.VMIPStat
 			conditionBound.Status(metav1.ConditionFalse).
 				Reason(vmipcondition.VirtualMachineIPAddressIsOutOfTheValidRange).
 				Message(msg)
-			h.recorder.Eventf(vmip, corev1.EventTypeWarning, virtv2.ReasonVMIPLeaseBoundFailed, msg, vmip.Spec.StaticIP)
+			h.recorder.Event(vmip, corev1.EventTypeWarning, virtv2.ReasonVMIPLeaseBoundFailed, msg)
 		case errors.Is(err, service.ErrIPAddressAlreadyExist):
 			vmipStatus.Phase = virtv2.VirtualMachineIPAddressPhasePending
 			msg := fmt.Sprintf("VirtualMachineIPAddressLease %s is bound to another VirtualMachineIPAddress",
@@ -152,7 +152,7 @@ func (h IPLeaseHandler) createNewLease(ctx context.Context, state state.VMIPStat
 			conditionBound.Status(metav1.ConditionFalse).
 				Reason(vmipcondition.VirtualMachineIPAddressLeaseAlreadyExists).
 				Message(msg)
-			h.recorder.Eventf(vmip, corev1.EventTypeWarning, virtv2.ReasonVMIPLeaseBoundFailed, msg, vmip.Status.Address)
+			h.recorder.Event(vmip, corev1.EventTypeWarning, virtv2.ReasonVMIPLeaseBoundFailed, msg)
 		}
 		conditions.SetCondition(conditionBound, &vmipStatus.Conditions)
 		return reconcile.Result{}, nil

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/iplease_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/iplease_handler.go
@@ -140,7 +140,7 @@ func (h IPLeaseHandler) createNewLease(ctx context.Context, state state.VMIPStat
 		switch {
 		case errors.Is(err, service.ErrIPAddressOutOfRange):
 			vmipStatus.Phase = virtv2.VirtualMachineIPAddressPhasePending
-			msg := fmt.Sprintf("The requested address %s is out of the valid range", vmip.Spec.StaticIP)
+			msg := fmt.Sprintf("The requested address %s is out of the valid range.", vmip.Spec.StaticIP)
 			conditionBound.Status(metav1.ConditionFalse).
 				Reason(vmipcondition.VirtualMachineIPAddressIsOutOfTheValidRange).
 				Message(msg)
@@ -181,7 +181,7 @@ func (h IPLeaseHandler) createNewLease(ctx context.Context, state state.VMIPStat
 		return reconcile.Result{}, err
 	}
 
-	h.recorder.Event(vmip, corev1.EventTypeNormal, virtv2.ReasonVMIPLeaseBound, "VMIP is bound to a new lease")
+	h.recorder.Event(vmip, corev1.EventTypeNormal, virtv2.ReasonVMIPLeaseBound, "VirtualMachineIPAddress is bound to a new lease")
 
 	return reconcile.Result{}, nil
 }

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/iplease_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/iplease_handler.go
@@ -144,15 +144,15 @@ func (h IPLeaseHandler) createNewLease(ctx context.Context, state state.VMIPStat
 			conditionBound.Status(metav1.ConditionFalse).
 				Reason(vmipcondition.VirtualMachineIPAddressIsOutOfTheValidRange).
 				Message(msg)
-			h.recorder.Event(vmip, corev1.EventTypeWarning, virtv2.ReasonVMIPLeaseBoundFailed, msg)
+			h.recorder.Event(vmip, corev1.EventTypeWarning, virtv2.ReasonFailed, msg)
 		case errors.Is(err, service.ErrIPAddressAlreadyExist):
 			vmipStatus.Phase = virtv2.VirtualMachineIPAddressPhasePending
-			msg := fmt.Sprintf("VirtualMachineIPAddressLease %s is bound to another VirtualMachineIPAddress",
+			msg := fmt.Sprintf("VirtualMachineIPAddressLease %s is bound to another VirtualMachineIPAddress.",
 				ip.IpToLeaseName(vmipStatus.Address))
 			conditionBound.Status(metav1.ConditionFalse).
 				Reason(vmipcondition.VirtualMachineIPAddressLeaseAlreadyExists).
 				Message(msg)
-			h.recorder.Event(vmip, corev1.EventTypeWarning, virtv2.ReasonVMIPLeaseBoundFailed, msg)
+			h.recorder.Event(vmip, corev1.EventTypeWarning, virtv2.ReasonBound, msg)
 		}
 		conditions.SetCondition(conditionBound, &vmipStatus.Conditions)
 		return reconcile.Result{}, nil
@@ -181,7 +181,7 @@ func (h IPLeaseHandler) createNewLease(ctx context.Context, state state.VMIPStat
 		return reconcile.Result{}, err
 	}
 
-	h.recorder.Event(vmip, corev1.EventTypeNormal, virtv2.ReasonVMIPLeaseBound, "VirtualMachineIPAddress is bound to a new lease")
+	h.recorder.Event(vmip, corev1.EventTypeNormal, virtv2.ReasonBound, "VirtualMachineIPAddress is bound to a new lease.")
 
 	return reconcile.Result{}, nil
 }

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/lifecycle_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/lifecycle_handler.go
@@ -78,7 +78,7 @@ func (h *LifecycleHandler) Handle(ctx context.Context, state state.VMIPState) (r
 		conditionAttach.Status(metav1.ConditionFalse).
 			Reason(vmipcondition.VirtualMachineNotFound).
 			Message("Virtual machine not found")
-		h.recorder.Event(vmip, corev1.EventTypeWarning, virtv2.ReasonVMIPVMNotAttached, "Virtual machine not found")
+		h.recorder.Event(vmip, corev1.EventTypeWarning, virtv2.ReasonVMIPtoVMNotAttached, "Virtual machine not found")
 	}
 
 	lease, err := state.VirtualMachineIPLease(ctx)
@@ -111,7 +111,7 @@ func (h *LifecycleHandler) Handle(ctx context.Context, state state.VMIPState) (r
 			vmipStatus.VirtualMachine = vm.Name
 			conditionAttach.Status(metav1.ConditionTrue).
 				Reason(vmipcondition.Attached)
-			h.recorder.Eventf(vmip, corev1.EventTypeNormal, virtv2.ReasonVMIPVMAttached, "VirtualMachineIPAddress is attached to %q/%q", vm.Namespace, vm.Name)
+			h.recorder.Eventf(vmip, corev1.EventTypeNormal, virtv2.ReasonVMIPtoVMAttached, "VirtualMachineIPAddress is attached to %q/%q", vm.Namespace, vm.Name)
 		}
 
 	case util.IsBoundLease(lease, vmip):

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/lifecycle_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/lifecycle_handler.go
@@ -78,7 +78,7 @@ func (h *LifecycleHandler) Handle(ctx context.Context, state state.VMIPState) (r
 		conditionAttach.Status(metav1.ConditionFalse).
 			Reason(vmipcondition.VirtualMachineNotFound).
 			Message("Virtual machine not found")
-		h.recorder.Event(vmip, corev1.EventTypeWarning, virtv2.ReasonVMIPtoVMNotAttached, "Virtual machine not found")
+		h.recorder.Event(vmip, corev1.EventTypeWarning, virtv2.ReasonVMIPNotAttached, "Virtual machine not found")
 	}
 
 	lease, err := state.VirtualMachineIPLease(ctx)
@@ -111,7 +111,7 @@ func (h *LifecycleHandler) Handle(ctx context.Context, state state.VMIPState) (r
 			vmipStatus.VirtualMachine = vm.Name
 			conditionAttach.Status(metav1.ConditionTrue).
 				Reason(vmipcondition.Attached)
-			h.recorder.Eventf(vmip, corev1.EventTypeNormal, virtv2.ReasonVMIPtoVMAttached, "VirtualMachineIPAddress is attached to %q/%q", vm.Namespace, vm.Name)
+			h.recorder.Eventf(vmip, corev1.EventTypeNormal, virtv2.ReasonVMIPAttached, "VirtualMachineIPAddress is attached to %q/%q", vm.Namespace, vm.Name)
 		}
 
 	case util.IsBoundLease(lease, vmip):

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/lifecycle_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/lifecycle_handler.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -28,6 +29,7 @@ import (
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vmip/internal/state"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vmip/internal/util"
+	"github.com/deckhouse/virtualization-controller/pkg/eventrecord"
 	"github.com/deckhouse/virtualization-controller/pkg/logger"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmipcondition"
@@ -35,10 +37,14 @@ import (
 
 const LifecycleHandlerName = "LifecycleHandler"
 
-type LifecycleHandler struct{}
+type LifecycleHandler struct {
+	recorder eventrecord.EventRecorderLogger
+}
 
-func NewLifecycleHandler() *LifecycleHandler {
-	return &LifecycleHandler{}
+func NewLifecycleHandler(recorder eventrecord.EventRecorderLogger) *LifecycleHandler {
+	return &LifecycleHandler{
+		recorder: recorder,
+	}
 }
 
 func (h *LifecycleHandler) Handle(ctx context.Context, state state.VMIPState) (reconcile.Result, error) {
@@ -72,6 +78,7 @@ func (h *LifecycleHandler) Handle(ctx context.Context, state state.VMIPState) (r
 		conditionAttach.Status(metav1.ConditionFalse).
 			Reason(vmipcondition.VirtualMachineNotFound).
 			Message("Virtual machine not found")
+		h.recorder.Event(vmip, corev1.EventTypeWarning, virtv2.ReasonVMIPVMDetached, "Virtual machine not found")
 	}
 
 	lease, err := state.VirtualMachineIPLease(ctx)
@@ -104,6 +111,7 @@ func (h *LifecycleHandler) Handle(ctx context.Context, state state.VMIPState) (r
 			vmipStatus.VirtualMachine = vm.Name
 			conditionAttach.Status(metav1.ConditionTrue).
 				Reason(vmipcondition.Attached)
+			h.recorder.Eventf(vmip, corev1.EventTypeNormal, virtv2.ReasonVMIPVMAttached, "VMIP is attached to %q/%q", vm.Namespace, vm.Name)
 		}
 
 	case util.IsBoundLease(lease, vmip):

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/lifecycle_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/lifecycle_handler.go
@@ -78,7 +78,7 @@ func (h *LifecycleHandler) Handle(ctx context.Context, state state.VMIPState) (r
 		conditionAttach.Status(metav1.ConditionFalse).
 			Reason(vmipcondition.VirtualMachineNotFound).
 			Message("Virtual machine not found")
-		h.recorder.Event(vmip, corev1.EventTypeWarning, virtv2.ReasonVMIPNotAttached, "Virtual machine not found")
+		h.recorder.Event(vmip, corev1.EventTypeWarning, virtv2.ReasonNotAttached, "Virtual machine not found.")
 	}
 
 	lease, err := state.VirtualMachineIPLease(ctx)
@@ -111,7 +111,7 @@ func (h *LifecycleHandler) Handle(ctx context.Context, state state.VMIPState) (r
 			vmipStatus.VirtualMachine = vm.Name
 			conditionAttach.Status(metav1.ConditionTrue).
 				Reason(vmipcondition.Attached)
-			h.recorder.Eventf(vmip, corev1.EventTypeNormal, virtv2.ReasonVMIPAttached, "VirtualMachineIPAddress is attached to %q/%q", vm.Namespace, vm.Name)
+			h.recorder.Eventf(vmip, corev1.EventTypeNormal, virtv2.ReasonAttached, "VirtualMachineIPAddress is attached to %q/%q.", vm.Namespace, vm.Name)
 		}
 
 	case util.IsBoundLease(lease, vmip):

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/lifecycle_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/lifecycle_handler.go
@@ -78,7 +78,7 @@ func (h *LifecycleHandler) Handle(ctx context.Context, state state.VMIPState) (r
 		conditionAttach.Status(metav1.ConditionFalse).
 			Reason(vmipcondition.VirtualMachineNotFound).
 			Message("Virtual machine not found")
-		h.recorder.Event(vmip, corev1.EventTypeWarning, virtv2.ReasonVMIPVMDetached, "Virtual machine not found")
+		h.recorder.Event(vmip, corev1.EventTypeWarning, virtv2.ReasonVMIPVMNotAttached, "Virtual machine not found")
 	}
 
 	lease, err := state.VirtualMachineIPLease(ctx)
@@ -111,7 +111,7 @@ func (h *LifecycleHandler) Handle(ctx context.Context, state state.VMIPState) (r
 			vmipStatus.VirtualMachine = vm.Name
 			conditionAttach.Status(metav1.ConditionTrue).
 				Reason(vmipcondition.Attached)
-			h.recorder.Eventf(vmip, corev1.EventTypeNormal, virtv2.ReasonVMIPVMAttached, "VMIP is attached to %q/%q", vm.Namespace, vm.Name)
+			h.recorder.Eventf(vmip, corev1.EventTypeNormal, virtv2.ReasonVMIPVMAttached, "VirtualMachineIPAddress is attached to %q/%q", vm.Namespace, vm.Name)
 		}
 
 	case util.IsBoundLease(lease, vmip):

--- a/images/virtualization-artifact/pkg/controller/vmip/vmip_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/vmip_controller.go
@@ -28,6 +28,7 @@ import (
 	"github.com/deckhouse/deckhouse/pkg/log"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vmip/internal"
+	"github.com/deckhouse/virtualization-controller/pkg/eventrecord"
 	"github.com/deckhouse/virtualization-controller/pkg/logger"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
@@ -42,13 +43,13 @@ func NewController(
 	log *log.Logger,
 	virtualMachineCIDRs []string,
 ) (controller.Controller, error) {
-	recorder := mgr.GetEventRecorderFor(ControllerName)
+	recorder := eventrecord.NewEventRecorderLogger(mgr, ControllerName)
 	ipService := service.NewIpAddressService(log, virtualMachineCIDRs)
 
 	handlers := []Handler{
 		internal.NewProtectionHandler(mgr.GetClient()),
 		internal.NewIPLeaseHandler(mgr.GetClient(), ipService, recorder),
-		internal.NewLifecycleHandler(),
+		internal.NewLifecycleHandler(recorder),
 	}
 
 	r, err := NewReconciler(mgr.GetClient(), handlers...)


### PR DESCRIPTION
## Description

The `VirtualMachineIPAddress` controller has been updated to use the new event registration API.

Events for connecting and disconnecting `VirtualMachineIPAddress` to a `VirtualMachine` have been introduced.
Events related to `VirtualMachineIPLease` have been added.

## Why do we need it, and what problem does it solve?

## What is the expected result?

## Changelog entries

```changes
section: vmip
type: feature
summary: add new events
```

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
