### PR TITLE
fix(vd): add owner ref for tmp pvc created in cdi

### DIFF
--- a/images/cdi-artifact/patches/020-manage-provisioner-tolerations.patch
+++ b/images/cdi-artifact/patches/020-manage-provisioner-tolerations.patch
@@ -14,6 +14,46 @@ index 59ee5fd3f..046d1f916 100644
  	sourcePvc, err := r.getCloneRequestSourcePVC(pvc)
  	if err != nil {
  		return nil, err
+diff --git a/pkg/controller/clone/planner.go b/pkg/controller/clone/planner.go
+index ae5cfeaae..106f3f7f4 100644
+--- a/pkg/controller/clone/planner.go
++++ b/pkg/controller/clone/planner.go
+@@ -9,6 +9,7 @@ import (
+ 
+ 	"github.com/go-logr/logr"
+ 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
++	"k8s.io/apimachinery/pkg/runtime/schema"
+ 
+ 	corev1 "k8s.io/api/core/v1"
+ 	storagev1 "k8s.io/api/storage/v1"
+@@ -769,6 +770,13 @@ func createDesiredClaim(namespace string, targetClaim *corev1.PersistentVolumeCl
+ 			Name:        fmt.Sprintf("tmp-pvc-%s", string(targetClaim.UID)),
+ 			Labels:      targetCpy.Labels,
+ 			Annotations: targetCpy.Annotations,
++			OwnerReferences: []metav1.OwnerReference{
++				*metav1.NewControllerRef(targetClaim, schema.GroupVersionKind{
++					Group:   "",
++					Version: "v1",
++					Kind:    "PersistentVolumeClaim",
++				}),
++			},
+ 		},
+ 		Spec: targetCpy.Spec,
+ 	}
+@@ -812,6 +820,13 @@ func createTempSourceClaim(ctx context.Context, log logr.Logger, namespace strin
+ 			Name:        fmt.Sprintf("tmp-source-pvc-%s", string(targetClaim.UID)),
+ 			Labels:      targetCpy.Labels,
+ 			Annotations: targetCpy.Annotations,
++			OwnerReferences: []metav1.OwnerReference{
++				*metav1.NewControllerRef(targetClaim, schema.GroupVersionKind{
++					Group:   "",
++					Version: "v1",
++					Kind:    "PersistentVolumeClaim",
++				}),
++			},
+ 		},
+ 		Spec: corev1.PersistentVolumeClaimSpec{
+ 			StorageClassName: &scName,
 diff --git a/pkg/controller/clone/prep-claim.go b/pkg/controller/clone/prep-claim.go
 index 9317b7429..68a249b77 100644
 --- a/pkg/controller/clone/prep-claim.go
@@ -176,10 +216,10 @@ index 6c6fd8f8a..a69ce4f2a 100644
  func (r *ReconcilerBase) updatePVCWithPVCPrimeAnnotations(pvc, pvcPrime *corev1.PersistentVolumeClaim, updateFunc updatePVCAnnotationsFunc) (*corev1.PersistentVolumeClaim, error) {
  	pvcCopy := pvc.DeepCopy()
 diff --git a/pkg/controller/upload-controller.go b/pkg/controller/upload-controller.go
-index f251cae5d..ed4420fb9 100644
+index 99f5494dc..424ebe834 100644
 --- a/pkg/controller/upload-controller.go
 +++ b/pkg/controller/upload-controller.go
-@@ -623,6 +623,11 @@ func (r *UploadReconciler) createUploadPod(args UploadPodArgs) (*corev1.Pod, err
+@@ -624,6 +624,11 @@ func (r *UploadReconciler) createUploadPod(args UploadPodArgs) (*corev1.Pod, err
  		return nil, err
  	}
  
@@ -192,10 +232,10 @@ index f251cae5d..ed4420fb9 100644
  	util.SetRecommendedLabels(pod, r.installerLabels, "cdi-controller")
  
 diff --git a/pkg/controller/util.go b/pkg/controller/util.go
-index 81e050464..367b5453b 100644
+index 4d25ae36b..2fea57d3c 100644
 --- a/pkg/controller/util.go
 +++ b/pkg/controller/util.go
-@@ -298,7 +298,21 @@ func podSucceededFromPVC(pvc *corev1.PersistentVolumeClaim) bool {
+@@ -341,7 +341,21 @@ func podSucceededFromPVC(pvc *corev1.PersistentVolumeClaim) bool {
  }
  
  func setAnnotationsFromPodWithPrefix(anno map[string]string, pod *corev1.Pod, termMsg *common.TerminationMessage, prefix string) {


### PR DESCRIPTION
## Description

For the tmp pvc, the owner reference was missing, which could be used to find the target pvc. 
However, the AdjustWorkloadNodePlacement fn relies on this.
Added the owner reference for tmp pvc.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
