### PR TITLE
fix(vd): handle nil importer pod

### DIFF
--- a/images/virtualization-artifact/pkg/controller/service/disk_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/disk_service.go
@@ -176,6 +176,10 @@ func (s DiskService) CheckProvisioning(ctx context.Context, pvc *corev1.Persiste
 		return fmt.Errorf("failed to fetch data volume provisioner %s: %w", podName, err)
 	}
 
+	if pod == nil {
+		return nil
+	}
+
 	scheduled, _ := conditions.GetPodCondition(corev1.PodScheduled, pod.Status.Conditions)
 	if scheduled.Status == corev1.ConditionFalse && scheduled.Reason == corev1.PodReasonUnschedulable {
 		return ErrDataVolumeProvisionerUnschedulable


### PR DESCRIPTION
## Description

The check was lost on nil.
The function thinks that there is already an importer under the cdi, but it is not there yet.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
