### PR TITLE
fix(vmbda): allow vmbda to be deleted when VirtualMachine is not running

### DIFF
--- a/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/console.go
+++ b/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/console.go
@@ -96,5 +96,14 @@ func ConsoleLocation(
 	kubevirt KubevirtApiServerConfig,
 	proxyCertManager certmanager.CertificateManager,
 ) (*url.URL, *http.Transport, error) {
-	return streamLocation(ctx, getter, name, opts, newKVVMIPather("console"), kubevirt, proxyCertManager)
+	return streamLocation(
+		ctx,
+		getter,
+		name,
+		opts,
+		newKVVMIPather("console"),
+		kubevirt,
+		proxyCertManager,
+		virtualMachineNeedRunning,
+	)
 }

--- a/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/freeze.go
+++ b/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/freeze.go
@@ -87,5 +87,14 @@ func FreezeLocation(
 	kubevirt KubevirtApiServerConfig,
 	proxyCertManager certmanager.CertificateManager,
 ) (*url.URL, *http.Transport, error) {
-	return streamLocation(ctx, getter, name, opts, newKVVMIPather("freeze"), kubevirt, proxyCertManager)
+	return streamLocation(
+		ctx,
+		getter,
+		name,
+		opts,
+		newKVVMIPather("freeze"),
+		kubevirt,
+		proxyCertManager,
+		virtualMachineNeedRunning,
+	)
 }

--- a/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/migrate.go
+++ b/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/migrate.go
@@ -87,5 +87,14 @@ func MigrateLocation(
 	kubevirt KubevirtApiServerConfig,
 	proxyCertManager certmanager.CertificateManager,
 ) (*url.URL, *http.Transport, error) {
-	return streamLocation(ctx, getter, name, opts, newKVVMPather("migrate"), kubevirt, proxyCertManager)
+	return streamLocation(
+		ctx,
+		getter,
+		name,
+		opts,
+		newKVVMPather("migrate"),
+		kubevirt,
+		proxyCertManager,
+		virtualMachineNeedRunning,
+	)
 }

--- a/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/portforward.go
+++ b/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/portforward.go
@@ -92,7 +92,16 @@ func PortForwardLocation(
 	proxyCertManager certmanager.CertificateManager,
 ) (*url.URL, *http.Transport, error) {
 	streamPath := buildPortForwardResourcePath(opts)
-	return streamLocation(ctx, getter, name, opts, newKVVMIPather(streamPath), kubevirt, proxyCertManager)
+	return streamLocation(
+		ctx,
+		getter,
+		name,
+		opts,
+		newKVVMIPather(streamPath),
+		kubevirt,
+		proxyCertManager,
+		virtualMachineNeedRunning,
+	)
 }
 
 func buildPortForwardResourcePath(opts *subresources.VirtualMachinePortForward) string {

--- a/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/unfreeze.go
+++ b/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/unfreeze.go
@@ -87,5 +87,14 @@ func UnfreezeLocation(
 	kubevirt KubevirtApiServerConfig,
 	proxyCertManager certmanager.CertificateManager,
 ) (*url.URL, *http.Transport, error) {
-	return streamLocation(ctx, getter, name, opts, newKVVMIPather("unfreeze"), kubevirt, proxyCertManager)
+	return streamLocation(
+		ctx,
+		getter,
+		name,
+		opts,
+		newKVVMIPather("unfreeze"),
+		kubevirt,
+		proxyCertManager,
+		virtualMachineNeedRunning,
+	)
 }

--- a/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/vnc.go
+++ b/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/vnc.go
@@ -89,5 +89,14 @@ func VNCLocation(
 	kubevirt KubevirtApiServerConfig,
 	proxyCertManager certmanager.CertificateManager,
 ) (*url.URL, *http.Transport, error) {
-	return streamLocation(ctx, getter, name, opts, newKVVMIPather("vnc"), kubevirt, proxyCertManager)
+	return streamLocation(
+		ctx,
+		getter,
+		name,
+		opts,
+		newKVVMIPather("vnc"),
+		kubevirt,
+		proxyCertManager,
+		virtualMachineNeedRunning,
+	)
 }


### PR DESCRIPTION
## Description
Allow vmbda to be deleted when VirtualMachine is not running

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
