### PR TITLE
fix(vi, cvi):  Add annotations to disable buffering for ingress used in image uploads

### DIFF
--- a/images/virtualization-artifact/pkg/controller/uploader/uploader_ingress.go
+++ b/images/virtualization-artifact/pkg/controller/uploader/uploader_ingress.go
@@ -76,10 +76,12 @@ func (i *Ingress) makeSpec() *netv1.Ingress {
 			Name:      i.Settings.Name,
 			Namespace: i.Settings.Namespace,
 			Annotations: map[string]string{
-				annotations.AnnUploadURL:                      fmt.Sprintf("https://%s%s", i.Settings.Host, path),
-				"nginx.ingress.kubernetes.io/ssl-redirect":    "true",
-				"nginx.ingress.kubernetes.io/proxy-body-size": "0",
-				"nginx.ingress.kubernetes.io/rewrite-target":  uploadPath,
+				annotations.AnnUploadURL:                              fmt.Sprintf("https://%s%s", i.Settings.Host, path),
+				"nginx.ingress.kubernetes.io/ssl-redirect":            "true",
+				"nginx.ingress.kubernetes.io/proxy-body-size":         "0",
+				"nginx.ingress.kubernetes.io/proxy-request-buffering": "off",
+				"nginx.ingress.kubernetes.io/proxy-buffering":         "off",
+				"nginx.ingress.kubernetes.io/rewrite-target":          uploadPath,
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				i.Settings.OwnerReference,


### PR DESCRIPTION
## Description
Add annotations to disable buffering for ingress used in image uploads

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
