### PR TITLE
test(api): replace intvirtvmim with vmop

### DIFF
--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -208,11 +208,12 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
 				})
-				By(fmt.Sprintf("VMs should be in %s phase", PhaseRunning))
-				WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, kc.WaitOptions{
+				By("Virtual machines should be migrated")
+				WaitByLabel(kc.ResourceVM, kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
+					For:       "'jsonpath={.status.migrationState.result}=Succeeded'",
 				})
 			})
 

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -230,6 +230,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 			})
 		})
 	})
+
 	Context("When test is completed", func() {
 		It("deletes test case resources", func() {
 			DeleteTestCaseResources(ResourcesToDelete{

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -201,9 +201,9 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 		})
 
 		Context("When VMs migrations are applied", func() {
-			It("checks VMs and KubevirtVMIMs phases", func() {
-				By(fmt.Sprintf("KubevirtVMIMs should be in %s phases", PhaseSucceeded))
-				WaitPhaseByLabel(kc.ResourceKubevirtVMIM, PhaseSucceeded, kc.WaitOptions{
+			It("checks VMs and VMOPs phases", func() {
+				By(fmt.Sprintf("VMOPs should be in %s phases", virtv2.VMOPPhaseCompleted))
+				WaitPhaseByLabel(kc.ResourceVMOP, string(virtv2.VMOPPhaseCompleted), kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
@@ -228,18 +228,17 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 				CheckExternalConnection(externalHost, httpStatusOk, vms...)
 			})
 		})
-
-		Context("When test is completed", func() {
-			It("deletes test case resources", func() {
-				DeleteTestCaseResources(ResourcesToDelete{
-					KustomizationDir: conf.TestData.ComplexTest,
-					AdditionalResources: []AdditionalResource{
-						{
-							kc.ResourceKubevirtVMIM,
-							testCaseLabel,
-						},
+	})
+	Context("When test is completed", func() {
+		It("deletes test case resources", func() {
+			DeleteTestCaseResources(ResourcesToDelete{
+				KustomizationDir: conf.TestData.ComplexTest,
+				AdditionalResources: []AdditionalResource{
+					{
+						kc.ResourceVMOP,
+						testCaseLabel,
 					},
-				})
+				},
 			})
 		})
 	})

--- a/tests/e2e/kubectl/resource.go
+++ b/tests/e2e/kubectl/resource.go
@@ -38,4 +38,5 @@ const (
 	ResourceCVI                    Resource = "clustervirtualimages.virtualization.deckhouse.io"
 	ResourceVI                     Resource = "virtualimages.virtualization.deckhouse.io"
 	ResourceVMBDA                  Resource = "virtualmachineblockdeviceattachments.virtualization.deckhouse.io"
+	ResourceVMOP                   Resource = "virtualmachineoperations.virtualization.deckhouse.io"
 )

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -257,6 +257,12 @@ func ChmodFile(pathFile string, permission os.FileMode) {
 //	Static condition `wait --for`: `jsonpath={.status.phase}=phase`.
 func WaitPhaseByLabel(resource kc.Resource, phase string, opts kc.WaitOptions) {
 	GinkgoHelper()
+	opts.For = fmt.Sprintf("'jsonpath={.status.phase}=%s'", phase)
+	WaitByLabel(resource, opts)
+}
+
+func WaitByLabel(resource kc.Resource, opts kc.WaitOptions) {
+	GinkgoHelper()
 	wg := sync.WaitGroup{}
 	mu := sync.Mutex{}
 
@@ -271,7 +277,7 @@ func WaitPhaseByLabel(resource kc.Resource, phase string, opts kc.WaitOptions) {
 	resources := strings.Split(res.StdOut(), " ")
 	waitErr := make([]string, 0, len(resources))
 	waitOpts := kc.WaitOptions{
-		For:       fmt.Sprintf("'jsonpath={.status.phase}=%s'", phase),
+		For:       opts.For,
 		Namespace: opts.Namespace,
 		Timeout:   opts.Timeout,
 	}

--- a/tests/e2e/vm_migration_test.go
+++ b/tests/e2e/vm_migration_test.go
@@ -142,11 +142,12 @@ var _ = Describe("Virtual machine migration", ginkgoutil.CommonE2ETestDecorators
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,
 			})
-			By(fmt.Sprintf("Virtual machines should be in %s phase", PhaseRunning))
-			WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, kc.WaitOptions{
+			By("Virtual machines should be migrated")
+			WaitByLabel(kc.ResourceVM, kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,
+				For:       "'jsonpath={.status.migrationState.result}=Succeeded'",
 			})
 		})
 

--- a/tests/e2e/vm_migration_test.go
+++ b/tests/e2e/vm_migration_test.go
@@ -30,11 +30,6 @@ import (
 	kc "github.com/deckhouse/virtualization/tests/e2e/kubectl"
 )
 
-const (
-	InternalApiVersion = "internal.virtualization.deckhouse.io/v1"
-	KubevirtVMIMKind   = "InternalVirtualizationVirtualMachineInstanceMigration"
-)
-
 func MigrateVirtualMachines(label map[string]string, templatePath string, virtualMachines ...string) {
 	GinkgoHelper()
 	migrationFilesPath := fmt.Sprintf("%s/migrations", templatePath)


### PR DESCRIPTION
## Description
Replace intvirtvmim with vmop.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
We should not use internal virtualization resources in the E2E tests and now there is the `ValidatingAdmissionPolicy` virtualization-restricted-access-policy on it.
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [X] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
