### PR TITLE
test(images): images creation e2e

### DIFF
--- a/tests/e2e/config/config.go
+++ b/tests/e2e/config/config.go
@@ -137,6 +137,7 @@ type TestData struct {
 	Connectivity       string `yaml:"connectivity"`
 	DiskResizing       string `yaml:"diskResizing"`
 	SizingPolicy       string `yaml:"sizingPolicy"`
+	ImagesCreation     string `yaml:"imagesCreation"`
 	VmConfiguration    string `yaml:"vmConfiguration"`
 	VmLabelAnnotation  string `yaml:"vmLabelAnnotation"`
 	VmMigration        string `yaml:"vmMigration"`

--- a/tests/e2e/d8/d8.go
+++ b/tests/e2e/d8/d8.go
@@ -57,6 +57,9 @@ type D8VirtualizationConf struct {
 
 type D8Virtualization interface {
 	SshCommand(vmName, command string, opts SshOptions) *executor.CMDResult
+	StopVM(vmName string, opts SshOptions) *executor.CMDResult
+	StartVM(vmName string, opts SshOptions) *executor.CMDResult
+	RestartVM(vmName string, opts SshOptions) *executor.CMDResult
 }
 
 func NewD8Virtualization(conf D8VirtualizationConf) (*d8VirtualizationCMD, error) {
@@ -102,6 +105,51 @@ func (v d8VirtualizationCMD) SshCommand(vmName, command string, opts SshOptions)
 	if opts.Port != 0 {
 		cmd = fmt.Sprintf("%s --port=%d", cmd, opts.Port)
 	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	return v.ExecContext(ctx, cmd)
+}
+
+func (v d8VirtualizationCMD) StartVM(vmName string, opts SshOptions) *executor.CMDResult {
+	timeout := ShortTimeout
+	if opts.Timeout != 0 {
+		timeout = opts.Timeout
+	}
+
+	cmd := fmt.Sprintf("%s start %s", v.cmd, vmName)
+	cmd = v.addNamespace(cmd, opts.Namespace)
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	return v.ExecContext(ctx, cmd)
+}
+
+func (v d8VirtualizationCMD) StopVM(vmName string, opts SshOptions) *executor.CMDResult {
+	timeout := ShortTimeout
+	if opts.Timeout != 0 {
+		timeout = opts.Timeout
+	}
+
+	cmd := fmt.Sprintf("%s stop %s", v.cmd, vmName)
+	cmd = v.addNamespace(cmd, opts.Namespace)
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	return v.ExecContext(ctx, cmd)
+}
+
+func (v d8VirtualizationCMD) RestartVM(vmName string, opts SshOptions) *executor.CMDResult {
+	timeout := ShortTimeout
+	if opts.Timeout != 0 {
+		timeout = opts.Timeout
+	}
+
+	cmd := fmt.Sprintf("%s restart %s", v.cmd, vmName)
+	cmd = v.addNamespace(cmd, opts.Namespace)
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()

--- a/tests/e2e/default_config.yaml
+++ b/tests/e2e/default_config.yaml
@@ -24,6 +24,7 @@ testData:
   connectivity: "/tmp/testdata/connectivity"
   diskResizing: "/tmp/testdata/disk-resizing"
   sizingPolicy: "/tmp/testdata/sizing-policy"
+  imagesCreation: "/tmp/testdata/images-creation"
   vmConfiguration: "/tmp/testdata/vm-configuration"
   vmLabelAnnotation: "/tmp/testdata/vm-label-annotation"
   vmMigration: "/tmp/testdata/vm-migration"

--- a/tests/e2e/images_creation_test.go
+++ b/tests/e2e/images_creation_test.go
@@ -133,6 +133,15 @@ var _ = Describe("Virtual images creation", ginkgoutil.CommonE2ETestDecorators()
 				Timeout:   MaxWaitTimeout,
 			})
 		})
+
+		It("checks CVIs phases", func() {
+			By(fmt.Sprintf("CVIs should be in %s phases", virtv2.ImageReady))
+			WaitPhaseByLabel(kc.ResourceCVI, string(virtv2.ImageReady), kc.WaitOptions{
+				Labels:    testCaseLabel,
+				Namespace: conf.Namespace,
+				Timeout:   MaxWaitTimeout,
+			})
+		})
 	})
 
 	Context("When test is completed", func() {

--- a/tests/e2e/images_creation_test.go
+++ b/tests/e2e/images_creation_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	storagev1 "k8s.io/api/storage/v1"
+
+	sdsrepvolv1 "github.com/deckhouse/sds-replicated-volume/api/v1alpha1"
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/tests/e2e/config"
+	"github.com/deckhouse/virtualization/tests/e2e/ginkgoutil"
+	. "github.com/deckhouse/virtualization/tests/e2e/helper"
+	. "github.com/onsi/gomega"
+
+	kc "github.com/deckhouse/virtualization/tests/e2e/kubectl"
+)
+
+var _ = Describe("Virtual images creation", ginkgoutil.CommonE2ETestDecorators(), func() {
+	var (
+		immediateStorageClassName string // require for unattached virtual disk snapshots
+		testCaseLabel             = map[string]string{"testcase": "images-creation"}
+	)
+
+	BeforeEach(func() {
+		if config.IsReusable() {
+			Skip("Test not available in REUSABLE mode: not supported yet.")
+		}
+	})
+
+	Context("Preparing the environment", func() {
+		It("sets the namespace", func() {
+			kustomization := fmt.Sprintf("%s/%s", conf.TestData.ImagesCreation, "kustomization.yaml")
+			ns, err := kustomize.GetNamespace(kustomization)
+			Expect(err).NotTo(HaveOccurred(), "%w", err)
+			conf.SetNamespace(ns)
+		})
+
+		It("prepares `Immediate` storage class and virtual disk that use it", func() {
+			sc, err := GetDefaultStorageClass()
+			Expect(err).NotTo(HaveOccurred(), "cannot get default storage class\nstderr: %s", err)
+
+			defaultVolumeSnapshotClassName, err := GetVolumeSnapshotClassName(sc)
+			Expect(err).NotTo(HaveOccurred(), "cannot define default `VolumeSnapshotClass`\nstderr: %s", err)
+
+			if sc.Provisioner == LinstorProviderName {
+				storagePoolName := sc.Parameters["replicated.csi.storage.deckhouse.io/storagePool"]
+				storagePoolObj := sdsrepvolv1.ReplicatedStoragePool{}
+				err := GetObject(kc.ResourceReplicatedStoragePool, storagePoolName, &storagePoolObj, kc.GetOptions{})
+				Expect(err).NotTo(HaveOccurred(), "cannot get `storagePoolObj`: %s\nstderr: %s", storagePoolName, err)
+				Expect(storagePoolObj.Spec.Type).To(Equal(LVMThinName), "type of replicated storage pool should be `LVMThin`")
+			}
+
+			if *sc.VolumeBindingMode != storagev1.VolumeBindingImmediate {
+				immediateStorageClassName, err = CreateImmediateStorageClass(sc.Provisioner, testCaseLabel)
+				Expect(err).NotTo(HaveOccurred(), "%s", err)
+
+				virtualDisk := virtv2.VirtualDisk{}
+				vdFilePath := fmt.Sprintf("%s/vd/vd-alpine-http.yaml", conf.TestData.ImagesCreation)
+				err = UnmarshalResource(vdFilePath, &virtualDisk)
+				Expect(err).NotTo(HaveOccurred(), "cannot get object from file: %s\nstderr: %s", vdFilePath, err)
+
+				virtualDisk.Spec.PersistentVolumeClaim.StorageClass = &immediateStorageClassName
+				err = WriteYamlObject(vdFilePath, &virtualDisk)
+				Expect(err).NotTo(HaveOccurred(), "cannot update virtual disk with custom storage class: %s\nstderr: %s", vdFilePath, err)
+			} else {
+				immediateStorageClassName = sc.Name
+			}
+
+			virtualDiskSnapshot := virtv2.VirtualDiskSnapshot{}
+			vdSnapshotFilePath := fmt.Sprintf("%s/vdsnapshot/vdsnapshot.yaml", conf.TestData.ImagesCreation)
+			err = UnmarshalResource(vdSnapshotFilePath, &virtualDiskSnapshot)
+			Expect(err).NotTo(HaveOccurred(), "cannot get object from file: %s\nstderr: %s", vdSnapshotFilePath, err)
+
+			virtualDiskSnapshot.Spec.VolumeSnapshotClassName = defaultVolumeSnapshotClassName
+			err = WriteYamlObject(vdSnapshotFilePath, &virtualDiskSnapshot)
+			Expect(err).NotTo(HaveOccurred(), "cannot update virtual disk with custom storage class: %s\nstderr: %s", vdSnapshotFilePath, err)
+		})
+	})
+
+	Context("When resources are applied", func() {
+		It("result should be succeeded", func() {
+			res := kubectl.Apply(kc.ApplyOptions{
+				Filename:       []string{conf.TestData.ImagesCreation},
+				FilenameOption: kc.Kustomize,
+			})
+			Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
+		})
+	})
+
+	Context("When base virtual resources are ready", func() {
+		It("checks VD phase", func() {
+			By(fmt.Sprintf("VD should be in %s phase", virtv2.DiskReady))
+			WaitPhaseByLabel(kc.ResourceVD, string(virtv2.DiskReady), kc.WaitOptions{
+				Labels:    testCaseLabel,
+				Namespace: conf.Namespace,
+				Timeout:   MaxWaitTimeout,
+			})
+		})
+
+		It("checks VDSnapshot phase", func() {
+			By(fmt.Sprintf("VDSnapshot should be in %s phase", virtv2.VirtualDiskSnapshotPhaseReady))
+			WaitPhaseByLabel(kc.ResourceVDSnapshot, string(virtv2.VirtualDiskSnapshotPhaseReady), kc.WaitOptions{
+				Labels:    testCaseLabel,
+				Namespace: conf.Namespace,
+				Timeout:   MaxWaitTimeout,
+			})
+		})
+	})
+
+	Context("When virtual images are applied", func() {
+		It("checks VIs phases", func() {
+			By(fmt.Sprintf("VIs should be in %s phases", virtv2.ImageReady))
+			WaitPhaseByLabel(kc.ResourceVI, string(virtv2.ImageReady), kc.WaitOptions{
+				Labels:    testCaseLabel,
+				Namespace: conf.Namespace,
+				Timeout:   MaxWaitTimeout,
+			})
+		})
+	})
+
+	Context("When test is completed", func() {
+		It("deletes test case resources", func() {
+			DeleteTestCaseResources(ResourcesToDelete{
+				KustomizationDir: conf.TestData.ImagesCreation,
+				AdditionalResources: []AdditionalResource{
+					{
+						Resource: kc.ResourceReplicatedStorageClass,
+						Labels:   testCaseLabel,
+					},
+					{
+						Resource: kc.ResourceStorageClass,
+						Labels:   testCaseLabel,
+					},
+				},
+			})
+		})
+	})
+})

--- a/tests/e2e/testdata/images-creation/cvi/cvi_containerimage.yaml
+++ b/tests/e2e/testdata/images-creation/cvi/cvi_containerimage.yaml
@@ -1,0 +1,9 @@
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: ClusterVirtualImage
+metadata:
+  name: cvi-containerimage
+spec:
+  dataSource:
+    type: ContainerImage
+    containerImage:
+      image: "registry.hub.docker.com/yaroslavborbat/alpine-image:latest"

--- a/tests/e2e/testdata/images-creation/cvi/cvi_http.yaml
+++ b/tests/e2e/testdata/images-creation/cvi/cvi_http.yaml
@@ -6,4 +6,4 @@ spec:
   dataSource:
     type: "HTTP"
     http:
-      url: "http://download.cirros-cloud.net/0.5.1/cirros-0.5.1-x86_64-disk.img"
+      url: https://0e773854-6b4e-4e76-a65b-d9d81675451a.selstorage.ru/alpine/alpine-virt-3.21.0-x86.iso

--- a/tests/e2e/testdata/images-creation/cvi/cvi_http.yaml
+++ b/tests/e2e/testdata/images-creation/cvi/cvi_http.yaml
@@ -1,0 +1,9 @@
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: ClusterVirtualImage
+metadata:
+  name: cvi-http
+spec:
+  dataSource:
+    type: "HTTP"
+    http:
+      url: "http://download.cirros-cloud.net/0.5.1/cirros-0.5.1-x86_64-disk.img"

--- a/tests/e2e/testdata/images-creation/cvi/cvi_objectref_cvi.yaml
+++ b/tests/e2e/testdata/images-creation/cvi/cvi_objectref_cvi.yaml
@@ -1,0 +1,10 @@
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: ClusterVirtualImage
+metadata:
+  name: cvi-objectref-cvi
+spec:
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "ClusterVirtualImage"
+      name: cvi-http

--- a/tests/e2e/testdata/images-creation/cvi/cvi_objectref_vd.yaml
+++ b/tests/e2e/testdata/images-creation/cvi/cvi_objectref_vd.yaml
@@ -1,0 +1,11 @@
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: ClusterVirtualImage
+metadata:
+  name: cvi-objectref-vd
+spec:
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualDisk"
+      name: vd-base
+      namespace: test-d8-virtualization

--- a/tests/e2e/testdata/images-creation/cvi/cvi_objectref_vd.yaml
+++ b/tests/e2e/testdata/images-creation/cvi/cvi_objectref_vd.yaml
@@ -7,5 +7,5 @@ spec:
     type: "ObjectRef"
     objectRef:
       kind: "VirtualDisk"
-      name: vd-base
+      name: vd-alpine-http
       namespace: test-d8-virtualization

--- a/tests/e2e/testdata/images-creation/cvi/cvi_objectref_vdsnapshot.yaml
+++ b/tests/e2e/testdata/images-creation/cvi/cvi_objectref_vdsnapshot.yaml
@@ -7,5 +7,5 @@ spec:
     type: "ObjectRef"
     objectRef:
       kind: "VirtualDiskSnapshot"
-      name: vdsnapshot-base
+      name: vdsnapshot
       namespace: test-d8-virtualization

--- a/tests/e2e/testdata/images-creation/cvi/cvi_objectref_vdsnapshot.yaml
+++ b/tests/e2e/testdata/images-creation/cvi/cvi_objectref_vdsnapshot.yaml
@@ -1,0 +1,11 @@
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: ClusterVirtualImage
+metadata:
+  name: cvi-objectref-vdsnapshot
+spec:
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualDiskSnapshot"
+      name: vdsnapshot-base
+      namespace: test-d8-virtualization

--- a/tests/e2e/testdata/images-creation/cvi/cvi_objectref_vi.yaml
+++ b/tests/e2e/testdata/images-creation/cvi/cvi_objectref_vi.yaml
@@ -1,0 +1,122 @@
+# DVCR
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: ClusterVirtualImage
+metadata:
+  name: cvi-objectref-vi-http
+spec:
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualImage"
+      name: vi-http
+      namespace: test-d8-virtualization
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: ClusterVirtualImage
+metadata:
+  name: cvi-objectref-vi-containerimage
+spec:
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualImage"
+      name: vi-containerimage
+      namespace: test-d8-virtualization
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: ClusterVirtualImage
+metadata:
+  name: cvi-objectref-vi-objectref-cvi
+spec:
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualImage"
+      name: vi-objectref-cvi
+      namespace: test-d8-virtualization
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: ClusterVirtualImage
+metadata:
+  name: cvi-objectref-vi-objectref-vd
+spec:
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualImage"
+      name: vi-objectref-vd
+      namespace: test-d8-virtualization
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: ClusterVirtualImage
+metadata:
+  name: cvi-objectref-vi-objectref-vdsnapshot
+spec:
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualImage"
+      name: vi-objectref-vdsnapshot
+      namespace: test-d8-virtualization
+
+# PVC SOURCE
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: ClusterVirtualImage
+metadata:
+  name: cvi-objectref-vi-http-pvc
+spec:
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualImage"
+      name: vi-pvc-http
+      namespace: test-d8-virtualization
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: ClusterVirtualImage
+metadata:
+  name: cvi-objectref-vi-containerimage-pvc
+spec:
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualImage"
+      name: vi-pvc-containerimage
+      namespace: test-d8-virtualization
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: ClusterVirtualImage
+metadata:
+  name: cvi-objectref-vi-objectref-cvi-pvc
+spec:
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualImage"
+      name: vi-pvc-objectref-cvi
+      namespace: test-d8-virtualization
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: ClusterVirtualImage
+metadata:
+  name: cvi-objectref-vi-objectref-vd-pvc
+spec:
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualImage"
+      name: vi-pvc-objectref-vd
+      namespace: test-d8-virtualization
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: ClusterVirtualImage
+metadata:
+  name: cvi-objectref-vi-objectref-vdsnapshot-pvc
+spec:
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualImage"
+      name: vi-pvc-objectref-vdsnapshot
+      namespace: test-d8-virtualization

--- a/tests/e2e/testdata/images-creation/cvi/kustomization.yaml
+++ b/tests/e2e/testdata/images-creation/cvi/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cvi_http.yaml
+  - ./cvi_containerimage.yaml
+  - ./cvi_objectref_cvi.yaml
+  - ./cvi_objectref_vi.yaml
+  - ./cvi_objectref_vd.yaml
+  - ./cvi_objectref_vdsnapshot.yaml

--- a/tests/e2e/testdata/images-creation/kustomization.yaml
+++ b/tests/e2e/testdata/images-creation/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: testcases
+namePrefix: pr-number-or-commit-hash-
+resources:
+  - ns.yaml
+  - vd
+  - vdsnapshot
+  - vi
+  - cvi
+configurations:
+  - transformer.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      id: pr-number-or-commit-hash
+      testcase: images-creation

--- a/tests/e2e/testdata/images-creation/ns.yaml
+++ b/tests/e2e/testdata/images-creation/ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default

--- a/tests/e2e/testdata/images-creation/transformer.yaml
+++ b/tests/e2e/testdata/images-creation/transformer.yaml
@@ -1,0 +1,51 @@
+namespace:
+  - kind: ClusterVirtualImage
+    path: spec/dataSource/objectRef/namespace
+nameReference:
+  - kind: VirtualImage
+    version: v1alpha2 # optional
+    fieldSpecs:
+      - path: spec/dataSource/objectRef/name
+        kind: ClusterVirtualImage
+      - path: spec/dataSource/objectRef/name
+        kind: VirtualImage
+      - path: spec/dataSource/objectRef/name
+        kind: VirtualDisk
+      - path: spec/blockDeviceRefs/name
+        kind: VirtualMachine
+  - kind: ClusterVirtualImage
+    version: v1alpha2 # optional
+    fieldSpecs:
+      - path: spec/dataSource/objectRef/name
+        kind: ClusterVirtualImage
+      - path: spec/dataSource/objectRef/name
+        kind: VirtualImage
+      - path: spec/dataSource/objectRef/name
+        kind: VirtualDisk
+      - path: spec/blockDeviceRefs/name
+        kind: VirtualMachine
+  - kind: VirtualDisk
+    version: v1alpha2 # optional
+    fieldSpecs:
+      - path: spec/blockDeviceRefs/name
+        kind: VirtualMachine
+      - path: spec/blockDeviceRef/name
+        kind: VirtualMachineBlockDeviceAttachment
+      - path: spec/virtualDiskName
+        kind: VirtualDiskSnapshot
+      - path: spec/dataSource/objectRef/name
+        kind: VirtualImage
+      - path: spec/dataSource/objectRef/name
+        kind: ClusterVirtualImage
+  - kind: VirtualMachine
+    version: v1alpha2
+    fieldSpecs:
+      - path: spec/virtualMachineName
+        kind: VirtualMachineBlockDeviceAttachment
+  - kind: VirtualDiskSnapshot
+    version: v1alpha2
+    fieldSpecs:
+      - path: spec/dataSource/objectRef/name
+        kind: VirtualImage
+      - path: spec/dataSource/objectRef/name
+        kind: ClusterVirtualImage

--- a/tests/e2e/testdata/images-creation/vd/kustomization.yaml
+++ b/tests/e2e/testdata/images-creation/vd/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - vd-alpine-http.yaml

--- a/tests/e2e/testdata/images-creation/vd/vd-alpine-http.yaml
+++ b/tests/e2e/testdata/images-creation/vd/vd-alpine-http.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualDisk
+metadata:
+  name: vd-alpine-http
+spec:
+  dataSource:
+    type: HTTP
+    http:
+      url: https://0e773854-6b4e-4e76-a65b-d9d81675451a.selstorage.ru/alpine/alpine-v3-20.qcow2
+  persistentVolumeClaim:
+    size: 260Mi

--- a/tests/e2e/testdata/images-creation/vdsnapshot/kustomization.yaml
+++ b/tests/e2e/testdata/images-creation/vdsnapshot/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - vdsnapshot.yaml

--- a/tests/e2e/testdata/images-creation/vdsnapshot/vdsnapshot.yaml
+++ b/tests/e2e/testdata/images-creation/vdsnapshot/vdsnapshot.yaml
@@ -1,0 +1,8 @@
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualDiskSnapshot
+metadata:
+  name: vdsnapshot
+spec:
+  requiredConsistency: true
+  virtualDiskName: vd-alpine-http
+  volumeSnapshotClassName: sds-replicated-volume

--- a/tests/e2e/testdata/images-creation/vdsnapshot/vdsnapshot.yaml
+++ b/tests/e2e/testdata/images-creation/vdsnapshot/vdsnapshot.yaml
@@ -5,4 +5,3 @@ metadata:
 spec:
   requiredConsistency: true
   virtualDiskName: vd-alpine-http
-  volumeSnapshotClassName: sds-replicated-volume

--- a/tests/e2e/testdata/images-creation/vi/kustomization.yaml
+++ b/tests/e2e/testdata/images-creation/vi/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./vi_http.yaml
+  - ./vi_containerimage.yaml
+  - ./vi_objectref_cvi.yaml
+  - ./vi_objectref_vi.yaml
+  - ./vi_pvc_objectref_vi.yaml
+  - ./vi_objectref_vd.yaml
+  - ./vi_objectref_vdsnapshot.yaml

--- a/tests/e2e/testdata/images-creation/vi/vi_containerimage.yaml
+++ b/tests/e2e/testdata/images-creation/vi/vi_containerimage.yaml
@@ -1,0 +1,27 @@
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-containerimage
+  namespace: test-d8-virtualization
+  annotations:
+    virt.deckhouse.io/storage.pod.retainAfterCompletion: "true"
+spec:
+  storage: ContainerRegistry
+  dataSource:
+    type: ContainerImage
+    containerImage:
+      image: "registry.hub.docker.com/yaroslavborbat/alpine-image:latest"
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-pvc-containerimage
+  namespace: test-d8-virtualization
+  annotations:
+    virt.deckhouse.io/storage.pod.retainAfterCompletion: "true"
+spec:
+  storage: PersistentVolumeClaim
+  dataSource:
+    type: ContainerImage
+    containerImage:
+      image: "registry.hub.docker.com/yaroslavborbat/alpine-image:latest"

--- a/tests/e2e/testdata/images-creation/vi/vi_http.yaml
+++ b/tests/e2e/testdata/images-creation/vi/vi_http.yaml
@@ -1,0 +1,23 @@
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-http
+  namespace: test-d8-virtualization
+spec:
+  storage: ContainerRegistry
+  dataSource:
+    type: "HTTP"
+    http:
+      url: "http://download.cirros-cloud.net/0.5.1/cirros-0.5.1-x86_64-disk.img"
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-pvc-http
+  namespace: test-d8-virtualization
+spec:
+  storage: PersistentVolumeClaim
+  dataSource:
+    type: "HTTP"
+    http:
+      url: "http://download.cirros-cloud.net/0.5.1/cirros-0.5.1-x86_64-disk.img"

--- a/tests/e2e/testdata/images-creation/vi/vi_http.yaml
+++ b/tests/e2e/testdata/images-creation/vi/vi_http.yaml
@@ -8,7 +8,7 @@ spec:
   dataSource:
     type: "HTTP"
     http:
-      url: "http://download.cirros-cloud.net/0.5.1/cirros-0.5.1-x86_64-disk.img"
+      url: https://0e773854-6b4e-4e76-a65b-d9d81675451a.selstorage.ru/alpine/alpine-virt-3.21.0-x86.iso
 ---
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
@@ -20,4 +20,4 @@ spec:
   dataSource:
     type: "HTTP"
     http:
-      url: "http://download.cirros-cloud.net/0.5.1/cirros-0.5.1-x86_64-disk.img"
+      url: https://0e773854-6b4e-4e76-a65b-d9d81675451a.selstorage.ru/alpine/alpine-virt-3.21.0-x86.iso

--- a/tests/e2e/testdata/images-creation/vi/vi_objectref_cvi.yaml
+++ b/tests/e2e/testdata/images-creation/vi/vi_objectref_cvi.yaml
@@ -1,0 +1,25 @@
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-objectref-cvi
+  namespace: test-d8-virtualization
+spec:
+  storage: ContainerRegistry
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "ClusterVirtualImage"
+      name: cvi-http
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-pvc-objectref-cvi
+  namespace: test-d8-virtualization
+spec:
+  storage: PersistentVolumeClaim
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "ClusterVirtualImage"
+      name: cvi-http

--- a/tests/e2e/testdata/images-creation/vi/vi_objectref_vd.yaml
+++ b/tests/e2e/testdata/images-creation/vi/vi_objectref_vd.yaml
@@ -1,0 +1,25 @@
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-objectref-vd
+  namespace: test-d8-virtualization
+spec:
+  storage: ContainerRegistry
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualDisk"
+      name: vd-base
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-pvc-objectref-vd
+  namespace: test-d8-virtualization
+spec:
+  storage: PersistentVolumeClaim
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualDisk"
+      name: vd-base

--- a/tests/e2e/testdata/images-creation/vi/vi_objectref_vd.yaml
+++ b/tests/e2e/testdata/images-creation/vi/vi_objectref_vd.yaml
@@ -9,7 +9,7 @@ spec:
     type: "ObjectRef"
     objectRef:
       kind: "VirtualDisk"
-      name: vd-base
+      name: vd-alpine-http
 ---
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
@@ -22,4 +22,4 @@ spec:
     type: "ObjectRef"
     objectRef:
       kind: "VirtualDisk"
-      name: vd-base
+      name: vd-alpine-http

--- a/tests/e2e/testdata/images-creation/vi/vi_objectref_vdsnapshot.yaml
+++ b/tests/e2e/testdata/images-creation/vi/vi_objectref_vdsnapshot.yaml
@@ -1,0 +1,25 @@
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-objectref-vdsnapshot
+  namespace: test-d8-virtualization
+spec:
+  storage: ContainerRegistry
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualDiskSnapshot"
+      name: vdsnapshot-base
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-pvc-objectref-vdsnapshot
+  namespace: test-d8-virtualization
+spec:
+  storage: PersistentVolumeClaim
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualDiskSnapshot"
+      name: vdsnapshot-base

--- a/tests/e2e/testdata/images-creation/vi/vi_objectref_vdsnapshot.yaml
+++ b/tests/e2e/testdata/images-creation/vi/vi_objectref_vdsnapshot.yaml
@@ -9,7 +9,7 @@ spec:
     type: "ObjectRef"
     objectRef:
       kind: "VirtualDiskSnapshot"
-      name: vdsnapshot-base
+      name: vdsnapshot
 ---
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
@@ -22,4 +22,4 @@ spec:
     type: "ObjectRef"
     objectRef:
       kind: "VirtualDiskSnapshot"
-      name: vdsnapshot-base
+      name: vdsnapshot

--- a/tests/e2e/testdata/images-creation/vi/vi_objectref_vi.yaml
+++ b/tests/e2e/testdata/images-creation/vi/vi_objectref_vi.yaml
@@ -1,0 +1,132 @@
+# DVCR
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-objectref-vi-http
+  namespace: test-d8-virtualization
+spec:
+  storage: ContainerRegistry
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualImage"
+      name: vi-http
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-objectref-vi-containerimage
+  namespace: test-d8-virtualization
+spec:
+  storage: ContainerRegistry
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualImage"
+      name: vi-containerimage
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-objectref-vi-objectref-cvi
+  namespace: test-d8-virtualization
+spec:
+  storage: ContainerRegistry
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualImage"
+      name: vi-objectref-cvi
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-objectref-vi-objectref-vd
+  namespace: test-d8-virtualization
+spec:
+  storage: ContainerRegistry
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualImage"
+      name: vi-objectref-vd
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-objectref-vi-objectref-vdsnapshot
+  namespace: test-d8-virtualization
+spec:
+  storage: ContainerRegistry
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualImage"
+      name: vi-objectref-vdsnapshot
+
+# PVC SOURCE
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-objectref-vi-http-pvc
+  namespace: test-d8-virtualization
+spec:
+  storage: ContainerRegistry
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualImage"
+      name: vi-pvc-http
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-objectref-vi-containerimage-pvc
+  namespace: test-d8-virtualization
+spec:
+  storage: ContainerRegistry
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualImage"
+      name: vi-pvc-containerimage
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-objectref-vi-objectref-cvi-pvc
+  namespace: test-d8-virtualization
+spec:
+  storage: ContainerRegistry
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualImage"
+      name: vi-pvc-objectref-cvi
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-objectref-vi-objectref-vd-pvc
+  namespace: test-d8-virtualization
+spec:
+  storage: ContainerRegistry
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualImage"
+      name: vi-pvc-objectref-vd
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-objectref-vi-objectref-vdsnapshot-pvc
+  namespace: test-d8-virtualization
+spec:
+  storage: ContainerRegistry
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualImage"
+      name: vi-pvc-objectref-vdsnapshot

--- a/tests/e2e/testdata/images-creation/vi/vi_pvc_objectref_vi.yaml
+++ b/tests/e2e/testdata/images-creation/vi/vi_pvc_objectref_vi.yaml
@@ -1,0 +1,119 @@
+### DVCR
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-pvc-objectref-vi-http
+  namespace: test-d8-virtualization
+spec:
+  storage: PersistentVolumeClaim
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualImage"
+      name: vi-http
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-pvc-objectref-vi-containerimage
+  namespace: test-d8-virtualization
+spec:
+  storage: PersistentVolumeClaim
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualImage"
+      name: vi-containerimage
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-pvc-objectref-vi-objectref-cvi
+  namespace: test-d8-virtualization
+spec:
+  storage: PersistentVolumeClaim
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualImage"
+      name: vi-objectref-cvi
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-pvc-objectref-vi-objectref-vd
+  namespace: test-d8-virtualization
+spec:
+  storage: PersistentVolumeClaim
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualImage"
+      name: vi-objectref-vd
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-pvc-objectref-vi-objectref-vdsnapshot
+  namespace: test-d8-virtualization
+spec:
+  storage: PersistentVolumeClaim
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualImage"
+      name: vi-objectref-vdsnapshot
+
+### PVC
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-pvc-objectref-vi-http-pvc
+  namespace: test-d8-virtualization
+spec:
+  storage: PersistentVolumeClaim
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualImage"
+      name: vi-pvc-http
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-pvc-objectref-vi-containerimage-pvc
+  namespace: test-d8-virtualization
+spec:
+  storage: PersistentVolumeClaim
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualImage"
+      name: vi-pvc-containerimage
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-pvc-objectref-vi-objectref-vd-pvc
+  namespace: test-d8-virtualization
+spec:
+  storage: PersistentVolumeClaim
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualImage"
+      name: vi-pvc-objectref-vd
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-pvc-objectref-vi-objectref-vdsnapshot-pvc
+  namespace: test-d8-virtualization
+spec:
+  storage: PersistentVolumeClaim
+  dataSource:
+    type: "ObjectRef"
+    objectRef:
+      kind: "VirtualImage"
+      name: vi-pvc-objectref-vdsnapshot

--- a/tests/e2e/tests_suite_test.go
+++ b/tests/e2e/tests_suite_test.go
@@ -105,6 +105,7 @@ func init() {
 		fmt.Sprintf("%s/%s", conf.TestData.DiskResizing, "kustomization.yaml"),
 		fmt.Sprintf("%s/%s", conf.TestData.SizingPolicy, "kustomization.yaml"),
 		fmt.Sprintf("%s/%s", conf.TestData.VdSnapshots, "kustomization.yaml"),
+		fmt.Sprintf("%s/%s", conf.TestData.ImagesCreation, "kustomization.yaml"),
 		fmt.Sprintf("%s/%s", conf.TestData.VmConfiguration, "kustomization.yaml"),
 		fmt.Sprintf("%s/%s", conf.TestData.VmLabelAnnotation, "kustomization.yaml"),
 		fmt.Sprintf("%s/%s", conf.TestData.VmMigration, "kustomization.yaml"),

--- a/tests/e2e/vd_snapshots_test.go
+++ b/tests/e2e/vd_snapshots_test.go
@@ -84,7 +84,7 @@ func CreateVirtualDiskSnapshot(vdName, snapshotName, volumeSnapshotClassName str
 	return nil
 }
 
-func createImmediateStorageClass(provisioner string, labels map[string]string) (string, error) {
+func CreateImmediateStorageClass(provisioner string, labels map[string]string) (string, error) {
 	GinkgoHelper()
 	filePath := fmt.Sprintf("%s/immediate-storage-class.yaml", conf.TestData.VdSnapshots)
 	switch provisioner {
@@ -265,7 +265,7 @@ var _ = Describe("Virtual disk snapshots", ginkgoutil.CommonE2ETestDecorators(),
 			}
 
 			if *sc.VolumeBindingMode != storagev1.VolumeBindingImmediate {
-				immediateStorageClassName, err = createImmediateStorageClass(sc.Provisioner, testCaseLabel)
+				immediateStorageClassName, err = CreateImmediateStorageClass(sc.Provisioner, testCaseLabel)
 				Expect(err).NotTo(HaveOccurred(), "%s", err)
 
 				virtualDiskWithoutConsumer := virtv2.VirtualDisk{}

--- a/tests/e2e/vm_configuration_test.go
+++ b/tests/e2e/vm_configuration_test.go
@@ -53,6 +53,39 @@ func ExecSshCommand(vmName, cmd string) {
 	}).WithTimeout(Timeout).WithPolling(Interval).ShouldNot(HaveOccurred())
 }
 
+func ExecStartCommand(vmName string) {
+	GinkgoHelper()
+	Eventually(func() error {
+		res := d8Virtualization.StartVM(vmName, d8.SshOptions{Namespace: conf.Namespace})
+		if res.Error() != nil {
+			return fmt.Errorf("cmd: %s\nstderr: %s", res.GetCmd(), res.StdErr())
+		}
+		return nil
+	}).WithTimeout(Timeout).WithPolling(Interval).ShouldNot(HaveOccurred())
+}
+
+func ExecStopCommand(vmName string) {
+	GinkgoHelper()
+	Eventually(func() error {
+		res := d8Virtualization.StopVM(vmName, d8.SshOptions{Namespace: conf.Namespace})
+		if res.Error() != nil {
+			return fmt.Errorf("cmd: %s\nstderr: %s", res.GetCmd(), res.StdErr())
+		}
+		return nil
+	}).WithTimeout(Timeout).WithPolling(Interval).ShouldNot(HaveOccurred())
+}
+
+func ExecRestartCommand(vmName string) {
+	GinkgoHelper()
+	Eventually(func() error {
+		res := d8Virtualization.RestartVM(vmName, d8.SshOptions{Namespace: conf.Namespace})
+		if res.Error() != nil {
+			return fmt.Errorf("cmd: %s\nstderr: %s", res.GetCmd(), res.StdErr())
+		}
+		return nil
+	}).WithTimeout(Timeout).WithPolling(Interval).ShouldNot(HaveOccurred())
+}
+
 func ChangeCPUCoresNumber(cpuNumber int, virtualMachines ...string) {
 	vms := strings.Join(virtualMachines, " ")
 	cmd := fmt.Sprintf("patch %s --namespace %s %s --type merge --patch '{\"spec\":{\"cpu\":{\"cores\":%d}}}'", kc.ResourceVM, conf.Namespace, vms, cpuNumber)


### PR DESCRIPTION
## Description
Add images creation e2e tests.

## Why do we need it, and what problem does it solve?
Test to create VI and CVI's from various sources.

## What is the expected result?
New e2e tests, with all available data sources.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
