### PR TITLE
fix(vm):  do not detect vmclass specification changes if vmclass is not found

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
@@ -116,10 +116,12 @@ func (h *SyncKvvmHandler) Handle(ctx context.Context, s state.VirtualMachineStat
 		if !changes.IsEmpty() {
 			allChanges.Add(changes.GetAll()...)
 		}
-		classChanges := h.detectClassSpecChanges(ctx, &class.Spec, lastClassAppliedSpec)
-		if !classChanges.IsEmpty() {
-			allChanges.Add(classChanges.GetAll()...)
-			classChanged = true
+		if class != nil {
+			classChanges := h.detectClassSpecChanges(ctx, &class.Spec, lastClassAppliedSpec)
+			if !classChanges.IsEmpty() {
+				allChanges.Add(classChanges.GetAll()...)
+				classChanged = true
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description

do not detect vmclass specification changes if vmclass is not found

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
