### PR TITLE
fix(vi): create from vd

### DIFF
--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref_vd.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref_vd.go
@@ -73,8 +73,9 @@ func (ds ObjectRefVirtualDisk) Sync(ctx context.Context, cvi *virtv2.ClusterVirt
 		return reconcile.Result{}, err
 	}
 
+	condition, _ := conditions.GetCondition(cvicondition.ReadyType, cvi.Status.Conditions)
 	switch {
-	case isDiskProvisioningFinished(cb.Condition()):
+	case isDiskProvisioningFinished(condition):
 		log.Info("Cluster virtual image provisioning finished: clean up")
 
 		cb.


### PR DESCRIPTION
## Description
VI on DVCR from VD datasource not creating, cycle provisioning. VI on PVC from VD provisioning not starting.

## What is the expected result?
VI from VD datasource creating

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
