### PR TITLE
feat(api): provide ImagePullError from DataVolume to VirtualDisk and VirtualImage

### DIFF
--- a/api/core/v1alpha2/vdcondition/condition.go
+++ b/api/core/v1alpha2/vdcondition/condition.go
@@ -107,7 +107,7 @@ const (
 	Lost ReadyReason = "PVCLost"
 	// QuotaExceeded indicates that the VirtualDisk is reached project quotas and can not be provisioned.
 	QuotaExceeded ReadyReason = "QuotaExceeded"
-	// ImagePullFailed indicates an issue with importing from DVCR.
+	// ImagePullFailed indicates that there was an issue with importing from DVCR.
 	ImagePullFailed ReadyReason = "ImagePullFailed"
 
 	// ResizingNotRequested indicates that the resize operation has not been requested yet.

--- a/api/core/v1alpha2/vdcondition/condition.go
+++ b/api/core/v1alpha2/vdcondition/condition.go
@@ -107,6 +107,8 @@ const (
 	Lost ReadyReason = "PVCLost"
 	// QuotaExceeded indicates that the VirtualDisk is reached project quotas and can not be provisioned.
 	QuotaExceeded ReadyReason = "QuotaExceeded"
+	// ImagePullFailed indicates an issue with importing from DVCR.
+	ImagePullFailed ReadyReason = "ImagePullFailed"
 
 	// ResizingNotRequested indicates that the resize operation has not been requested yet.
 	ResizingNotRequested ResizedReason = "NotRequested"

--- a/api/core/v1alpha2/vicondition/condition.go
+++ b/api/core/v1alpha2/vicondition/condition.go
@@ -81,6 +81,8 @@ const (
 	Ready ReadyReason = "Ready"
 	// QuotaExceeded indicates that the VirtualImage is reached project quotas and can not be provisioned.
 	QuotaExceeded ReadyReason = "QuotaExceeded"
+	// ImagePullFailed indicates an issue with importing from DVCR.
+	ImagePullFailed ReadyReason = "ImagePullFailed"
 
 	// Lost indicates that the underlying PersistentVolumeClaim has been lost and the `VirtualImage` can no longer be used.
 	Lost ReadyReason = "PVCLost"

--- a/api/core/v1alpha2/vicondition/condition.go
+++ b/api/core/v1alpha2/vicondition/condition.go
@@ -81,7 +81,7 @@ const (
 	Ready ReadyReason = "Ready"
 	// QuotaExceeded indicates that the VirtualImage is reached project quotas and can not be provisioned.
 	QuotaExceeded ReadyReason = "QuotaExceeded"
-	// ImagePullFailed indicates an issue with importing from DVCR.
+	// ImagePullFailed indicates that there was an issue with importing from DVCR.
 	ImagePullFailed ReadyReason = "ImagePullFailed"
 
 	// Lost indicates that the underlying PersistentVolumeClaim has been lost and the `VirtualImage` can no longer be used.

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/blank.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/blank.go
@@ -90,12 +90,9 @@ func (ds BlankDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (rec
 	}
 
 	var dvQuotaNotExceededCondition *cdiv1.DataVolumeCondition
-	if dv != nil {
-		dvQuotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
-	}
-
 	var dvRunningCondition *cdiv1.DataVolumeCondition
 	if dv != nil {
+		dvQuotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
 		dvRunningCondition = service.GetDataVolumeCondition(DVRunningConditionType, dv.Status.Conditions)
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/blank.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/blank.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/deckhouse/virtualization-controller/pkg/eventrecord"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -35,6 +34,7 @@ import (
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/supplements"
+	"github.com/deckhouse/virtualization-controller/pkg/eventrecord"
 	"github.com/deckhouse/virtualization-controller/pkg/logger"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/http.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/http.go
@@ -106,12 +106,9 @@ func (ds HTTPDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (reco
 	}
 
 	var dvQuotaNotExceededCondition *cdiv1.DataVolumeCondition
-	if dv != nil {
-		dvQuotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
-	}
-
 	var dvRunningCondition *cdiv1.DataVolumeCondition
 	if dv != nil {
+		dvQuotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
 		dvRunningCondition = service.GetDataVolumeCondition(DVRunningConditionType, dv.Status.Conditions)
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/http.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/http.go
@@ -105,9 +105,14 @@ func (ds HTTPDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (reco
 		return reconcile.Result{}, err
 	}
 
-	var quotaNotExceededCondition *cdiv1.DataVolumeCondition
+	var dvQuotaNotExceededCondition *cdiv1.DataVolumeCondition
 	if dv != nil {
-		quotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
+		dvQuotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
+	}
+
+	var dvRunningCondition *cdiv1.DataVolumeCondition
+	if dv != nil {
+		dvRunningCondition = service.GetDataVolumeCondition(DVRunningConditionType, dv.Status.Conditions)
 	}
 
 	switch {
@@ -261,12 +266,19 @@ func (ds HTTPDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (reco
 			Message("PVC Provisioner not found: create the new one.")
 
 		return reconcile.Result{Requeue: true}, nil
-	case quotaNotExceededCondition != nil && quotaNotExceededCondition.Status == corev1.ConditionFalse:
+	case dvQuotaNotExceededCondition != nil && dvQuotaNotExceededCondition.Status == corev1.ConditionFalse:
 		vd.Status.Phase = virtv2.DiskPending
 		cb.
 			Status(metav1.ConditionFalse).
 			Reason(vdcondition.QuotaExceeded).
-			Message(quotaNotExceededCondition.Message)
+			Message(dvQuotaNotExceededCondition.Message)
+		return reconcile.Result{}, nil
+	case dvRunningCondition != nil && dvRunningCondition.Status != corev1.ConditionTrue && dvRunningCondition.Reason == DVImagePullFailedReason:
+		vd.Status.Phase = virtv2.DiskPending
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(vdcondition.ImagePullFailed).
+			Message(dvRunningCondition.Message)
 		return reconcile.Result{}, nil
 	case pvc == nil:
 		vd.Status.Phase = virtv2.DiskProvisioning

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/http.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/http.go
@@ -279,6 +279,7 @@ func (ds HTTPDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (reco
 			Status(metav1.ConditionFalse).
 			Reason(vdcondition.ImagePullFailed).
 			Message(dvRunningCondition.Message)
+		ds.recorder.Event(vd, corev1.EventTypeWarning, vdcondition.ImagePullFailed.String(), dvRunningCondition.Message)
 		return reconcile.Result{}, nil
 	case pvc == nil:
 		vd.Status.Phase = virtv2.DiskProvisioning

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_cvi.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_cvi.go
@@ -102,9 +102,14 @@ func (ds ObjectRefClusterVirtualImage) Sync(ctx context.Context, vd *virtv2.Virt
 		return reconcile.Result{}, err
 	}
 
-	var quotaNotExceededCondition *cdiv1.DataVolumeCondition
+	var dvQuotaNotExceededCondition *cdiv1.DataVolumeCondition
 	if dv != nil {
-		quotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
+		dvQuotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
+	}
+
+	var dvRunningCondition *cdiv1.DataVolumeCondition
+	if dv != nil {
+		dvRunningCondition = service.GetDataVolumeCondition(DVRunningConditionType, dv.Status.Conditions)
 	}
 
 	switch {
@@ -176,12 +181,19 @@ func (ds ObjectRefClusterVirtualImage) Sync(ctx context.Context, vd *virtv2.Virt
 			Message("PVC Provisioner not found: create the new one.")
 
 		return reconcile.Result{Requeue: true}, nil
-	case quotaNotExceededCondition != nil && quotaNotExceededCondition.Status == corev1.ConditionFalse:
+	case dvQuotaNotExceededCondition != nil && dvQuotaNotExceededCondition.Status == corev1.ConditionFalse:
 		vd.Status.Phase = virtv2.DiskPending
 		cb.
 			Status(metav1.ConditionFalse).
 			Reason(vdcondition.QuotaExceeded).
-			Message(quotaNotExceededCondition.Message)
+			Message(dvQuotaNotExceededCondition.Message)
+		return reconcile.Result{}, nil
+	case dvRunningCondition != nil && dvRunningCondition.Status != corev1.ConditionTrue && dvRunningCondition.Reason == DVImagePullFailedReason:
+		vd.Status.Phase = virtv2.DiskPending
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(vdcondition.ImagePullFailed).
+			Message(dvRunningCondition.Message)
 		return reconcile.Result{}, nil
 	case pvc == nil:
 		vd.Status.Phase = virtv2.DiskProvisioning

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_cvi.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_cvi.go
@@ -103,12 +103,9 @@ func (ds ObjectRefClusterVirtualImage) Sync(ctx context.Context, vd *virtv2.Virt
 	}
 
 	var dvQuotaNotExceededCondition *cdiv1.DataVolumeCondition
-	if dv != nil {
-		dvQuotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
-	}
-
 	var dvRunningCondition *cdiv1.DataVolumeCondition
 	if dv != nil {
+		dvQuotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
 		dvRunningCondition = service.GetDataVolumeCondition(DVRunningConditionType, dv.Status.Conditions)
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_cvi.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_cvi.go
@@ -194,6 +194,7 @@ func (ds ObjectRefClusterVirtualImage) Sync(ctx context.Context, vd *virtv2.Virt
 			Status(metav1.ConditionFalse).
 			Reason(vdcondition.ImagePullFailed).
 			Message(dvRunningCondition.Message)
+		ds.recorder.Event(vd, corev1.EventTypeWarning, vdcondition.ImagePullFailed.String(), dvRunningCondition.Message)
 		return reconcile.Result{}, nil
 	case pvc == nil:
 		vd.Status.Phase = virtv2.DiskProvisioning

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_vi_dvcr.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_vi_dvcr.go
@@ -193,6 +193,7 @@ func (ds ObjectRefVirtualImageDVCR) Sync(ctx context.Context, vd *virtv2.Virtual
 			Status(metav1.ConditionFalse).
 			Reason(vdcondition.ImagePullFailed).
 			Message(dvRunningCondition.Message)
+		ds.recorder.Event(vd, corev1.EventTypeWarning, vdcondition.ImagePullFailed.String(), dvRunningCondition.Message)
 		return reconcile.Result{}, nil
 	case pvc == nil:
 		vd.Status.Phase = virtv2.DiskProvisioning

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_vi_dvcr.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_vi_dvcr.go
@@ -102,12 +102,9 @@ func (ds ObjectRefVirtualImageDVCR) Sync(ctx context.Context, vd *virtv2.Virtual
 	}
 
 	var dvQuotaNotExceededCondition *cdiv1.DataVolumeCondition
-	if dv != nil {
-		dvQuotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
-	}
-
 	var dvRunningCondition *cdiv1.DataVolumeCondition
 	if dv != nil {
+		dvQuotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
 		dvRunningCondition = service.GetDataVolumeCondition(DVRunningConditionType, dv.Status.Conditions)
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_vi_pvc.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_vi_pvc.go
@@ -98,12 +98,9 @@ func (ds ObjectRefVirtualImagePVC) Sync(ctx context.Context, vd *virtv2.VirtualD
 	}
 
 	var dvQuotaNotExceededCondition *cdiv1.DataVolumeCondition
-	if dv != nil {
-		dvQuotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
-	}
-
 	var dvRunningCondition *cdiv1.DataVolumeCondition
 	if dv != nil {
+		dvQuotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
 		dvRunningCondition = service.GetDataVolumeCondition(DVRunningConditionType, dv.Status.Conditions)
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_vi_pvc.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_vi_pvc.go
@@ -97,9 +97,14 @@ func (ds ObjectRefVirtualImagePVC) Sync(ctx context.Context, vd *virtv2.VirtualD
 		return reconcile.Result{}, err
 	}
 
-	var quotaNotExceededCondition *cdiv1.DataVolumeCondition
+	var dvQuotaNotExceededCondition *cdiv1.DataVolumeCondition
 	if dv != nil {
-		quotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
+		dvQuotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
+	}
+
+	var dvRunningCondition *cdiv1.DataVolumeCondition
+	if dv != nil {
+		dvRunningCondition = service.GetDataVolumeCondition(DVRunningConditionType, dv.Status.Conditions)
 	}
 
 	switch {
@@ -176,12 +181,19 @@ func (ds ObjectRefVirtualImagePVC) Sync(ctx context.Context, vd *virtv2.VirtualD
 			Message("PVC Provisioner not found: create the new one.")
 
 		return reconcile.Result{Requeue: true}, nil
-	case quotaNotExceededCondition != nil && quotaNotExceededCondition.Status == corev1.ConditionFalse:
+	case dvQuotaNotExceededCondition != nil && dvQuotaNotExceededCondition.Status == corev1.ConditionFalse:
 		vd.Status.Phase = virtv2.DiskPending
 		cb.
 			Status(metav1.ConditionFalse).
 			Reason(vdcondition.QuotaExceeded).
-			Message(quotaNotExceededCondition.Message)
+			Message(dvQuotaNotExceededCondition.Message)
+		return reconcile.Result{}, nil
+	case dvRunningCondition != nil && dvRunningCondition.Status != corev1.ConditionTrue && dvRunningCondition.Reason == DVImagePullFailedReason:
+		vd.Status.Phase = virtv2.DiskPending
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(vdcondition.ImagePullFailed).
+			Message(dvRunningCondition.Message)
 		return reconcile.Result{}, nil
 	case pvc == nil:
 		vd.Status.Phase = virtv2.DiskProvisioning

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_vi_pvc.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_vi_pvc.go
@@ -194,6 +194,7 @@ func (ds ObjectRefVirtualImagePVC) Sync(ctx context.Context, vd *virtv2.VirtualD
 			Status(metav1.ConditionFalse).
 			Reason(vdcondition.ImagePullFailed).
 			Message(dvRunningCondition.Message)
+		ds.recorder.Event(vd, corev1.EventTypeWarning, vdcondition.ImagePullFailed.String(), dvRunningCondition.Message)
 		return reconcile.Result{}, nil
 	case pvc == nil:
 		vd.Status.Phase = virtv2.DiskProvisioning

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/registry.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/registry.go
@@ -107,12 +107,9 @@ func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (
 	}
 
 	var dvQuotaNotExceededCondition *cdiv1.DataVolumeCondition
-	if dv != nil {
-		dvQuotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
-	}
-
 	var dvRunningCondition *cdiv1.DataVolumeCondition
 	if dv != nil {
+		dvQuotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
 		dvRunningCondition = service.GetDataVolumeCondition(DVRunningConditionType, dv.Status.Conditions)
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/registry.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/registry.go
@@ -267,7 +267,6 @@ func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (
 			Status(metav1.ConditionFalse).
 			Reason(vdcondition.QuotaExceeded).
 			Message(dvQuotaNotExceededCondition.Message)
-		ds.recorder.Event(vd, corev1.EventTypeWarning, vdcondition.ImagePullFailed.String(), dvRunningCondition.Message)
 		return reconcile.Result{}, nil
 	case dvRunningCondition != nil && dvRunningCondition.Status != corev1.ConditionTrue && dvRunningCondition.Reason == DVImagePullFailedReason:
 		vd.Status.Phase = virtv2.DiskPending
@@ -275,6 +274,7 @@ func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (
 			Status(metav1.ConditionFalse).
 			Reason(vdcondition.ImagePullFailed).
 			Message(dvRunningCondition.Message)
+		ds.recorder.Event(vd, corev1.EventTypeWarning, vdcondition.ImagePullFailed.String(), dvRunningCondition.Message)
 		return reconcile.Result{}, nil
 	case pvc == nil:
 		vd.Status.Phase = virtv2.DiskProvisioning

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/registry.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/registry.go
@@ -270,6 +270,7 @@ func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (
 			Status(metav1.ConditionFalse).
 			Reason(vdcondition.QuotaExceeded).
 			Message(dvQuotaNotExceededCondition.Message)
+		ds.recorder.Event(vd, corev1.EventTypeWarning, vdcondition.ImagePullFailed.String(), dvRunningCondition.Message)
 		return reconcile.Result{}, nil
 	case dvRunningCondition != nil && dvRunningCondition.Status != corev1.ConditionTrue && dvRunningCondition.Reason == DVImagePullFailedReason:
 		vd.Status.Phase = virtv2.DiskPending

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/registry.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/registry.go
@@ -106,9 +106,14 @@ func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (
 		return reconcile.Result{}, err
 	}
 
-	var quotaNotExceededCondition *cdiv1.DataVolumeCondition
+	var dvQuotaNotExceededCondition *cdiv1.DataVolumeCondition
 	if dv != nil {
-		quotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
+		dvQuotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
+	}
+
+	var dvRunningCondition *cdiv1.DataVolumeCondition
+	if dv != nil {
+		dvRunningCondition = service.GetDataVolumeCondition(DVRunningConditionType, dv.Status.Conditions)
 	}
 
 	switch {
@@ -259,12 +264,19 @@ func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (
 			Message("PVC Provisioner not found: create the new one.")
 
 		return reconcile.Result{Requeue: true}, nil
-	case quotaNotExceededCondition != nil && quotaNotExceededCondition.Status == corev1.ConditionFalse:
+	case dvQuotaNotExceededCondition != nil && dvQuotaNotExceededCondition.Status == corev1.ConditionFalse:
 		vd.Status.Phase = virtv2.DiskPending
 		cb.
 			Status(metav1.ConditionFalse).
 			Reason(vdcondition.QuotaExceeded).
-			Message(quotaNotExceededCondition.Message)
+			Message(dvQuotaNotExceededCondition.Message)
+		return reconcile.Result{}, nil
+	case dvRunningCondition != nil && dvRunningCondition.Status != corev1.ConditionTrue && dvRunningCondition.Reason == DVImagePullFailedReason:
+		vd.Status.Phase = virtv2.DiskPending
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(vdcondition.ImagePullFailed).
+			Message(dvRunningCondition.Message)
 		return reconcile.Result{}, nil
 	case pvc == nil:
 		vd.Status.Phase = virtv2.DiskProvisioning

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/sources.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/sources.go
@@ -416,5 +416,8 @@ func setPhaseConditionToFailed(cb *conditions.ConditionBuilder, phase *virtv2.Di
 }
 
 const (
+	DVRunningConditionType          cdiv1.DataVolumeConditionType = "DVRunning"
 	DVQoutaNotExceededConditionType cdiv1.DataVolumeConditionType = "QuotaNotExceeded"
+
+	DVImagePullFailedReason = "ImagePullFailed"
 )

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/sources.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/sources.go
@@ -416,7 +416,7 @@ func setPhaseConditionToFailed(cb *conditions.ConditionBuilder, phase *virtv2.Di
 }
 
 const (
-	DVRunningConditionType          cdiv1.DataVolumeConditionType = "DVRunning"
+	DVRunningConditionType          cdiv1.DataVolumeConditionType = "Running"
 	DVQoutaNotExceededConditionType cdiv1.DataVolumeConditionType = "QuotaNotExceeded"
 
 	DVImagePullFailedReason = "ImagePullFailed"

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/upload.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/upload.go
@@ -113,9 +113,14 @@ func (ds UploadDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (re
 		return reconcile.Result{}, err
 	}
 
-	var quotaNotExceededCondition *cdiv1.DataVolumeCondition
+	var dvQuotaNotExceededCondition *cdiv1.DataVolumeCondition
 	if dv != nil {
-		quotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
+		dvQuotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
+	}
+
+	var dvRunningCondition *cdiv1.DataVolumeCondition
+	if dv != nil {
+		dvRunningCondition = service.GetDataVolumeCondition(DVRunningConditionType, dv.Status.Conditions)
 	}
 
 	switch {
@@ -288,12 +293,19 @@ func (ds UploadDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (re
 			Message("PVC Provisioner not found: create the new one.")
 
 		return reconcile.Result{Requeue: true}, nil
-	case quotaNotExceededCondition != nil && quotaNotExceededCondition.Status == corev1.ConditionFalse:
+	case dvQuotaNotExceededCondition != nil && dvQuotaNotExceededCondition.Status == corev1.ConditionFalse:
 		vd.Status.Phase = virtv2.DiskPending
 		cb.
 			Status(metav1.ConditionFalse).
 			Reason(vdcondition.QuotaExceeded).
-			Message(quotaNotExceededCondition.Message)
+			Message(dvQuotaNotExceededCondition.Message)
+		return reconcile.Result{}, nil
+	case dvRunningCondition != nil && dvRunningCondition.Status != corev1.ConditionTrue && dvRunningCondition.Reason == DVImagePullFailedReason:
+		vd.Status.Phase = virtv2.DiskPending
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(vdcondition.ImagePullFailed).
+			Message(dvRunningCondition.Message)
 		return reconcile.Result{}, nil
 	case pvc == nil:
 		vd.Status.Phase = virtv2.DiskProvisioning

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/upload.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/upload.go
@@ -306,6 +306,7 @@ func (ds UploadDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (re
 			Status(metav1.ConditionFalse).
 			Reason(vdcondition.ImagePullFailed).
 			Message(dvRunningCondition.Message)
+		ds.recorder.Event(vd, corev1.EventTypeWarning, vdcondition.ImagePullFailed.String(), dvRunningCondition.Message)
 		return reconcile.Result{}, nil
 	case pvc == nil:
 		vd.Status.Phase = virtv2.DiskProvisioning

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/upload.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/upload.go
@@ -114,12 +114,9 @@ func (ds UploadDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (re
 	}
 
 	var dvQuotaNotExceededCondition *cdiv1.DataVolumeCondition
-	if dv != nil {
-		dvQuotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
-	}
-
 	var dvRunningCondition *cdiv1.DataVolumeCondition
 	if dv != nil {
+		dvQuotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
 		dvRunningCondition = service.GetDataVolumeCondition(DVRunningConditionType, dv.Status.Conditions)
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vd/vd_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vd/vd_controller.go
@@ -68,7 +68,7 @@ func NewController(
 	scService := service.NewVirtualDiskStorageClassService(storageClassSettings)
 	recorder := eventrecord.NewEventRecorderLogger(mgr, ControllerName)
 
-	blank := source.NewBlankDataSource(stat, disk, scService, mgr.GetClient())
+	blank := source.NewBlankDataSource(recorder, stat, disk, scService, mgr.GetClient())
 
 	sources := source.NewSources()
 	sources.Set(virtv2.DataSourceTypeHTTP, source.NewHTTPDataSource(recorder, stat, importer, disk, dvcr, scService, mgr.GetClient()))

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/http.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/http.go
@@ -216,9 +216,11 @@ func (ds HTTPDataSource) StoreToPVC(ctx context.Context, vi *virtv2.VirtualImage
 		return reconcile.Result{}, err
 	}
 
-	var quotaNotExceededCondition *cdiv1.DataVolumeCondition
+	var dvQuotaNotExceededCondition *cdiv1.DataVolumeCondition
+	var dvRunningCondition *cdiv1.DataVolumeCondition
 	if dv != nil {
-		quotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
+		dvQuotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
+		dvRunningCondition = service.GetDataVolumeCondition(DVRunningConditionType, dv.Status.Conditions)
 	}
 
 	switch {
@@ -347,12 +349,20 @@ func (ds HTTPDataSource) StoreToPVC(ctx context.Context, vi *virtv2.VirtualImage
 			Message("DVCR Provisioner not found: create the new one.")
 
 		return reconcile.Result{Requeue: true}, nil
-	case quotaNotExceededCondition != nil && quotaNotExceededCondition.Status == corev1.ConditionFalse:
+	case dvQuotaNotExceededCondition != nil && dvQuotaNotExceededCondition.Status == corev1.ConditionFalse:
 		vi.Status.Phase = virtv2.ImagePending
 		cb.
 			Status(metav1.ConditionFalse).
 			Reason(vicondition.QuotaExceeded).
-			Message(quotaNotExceededCondition.Message)
+			Message(dvQuotaNotExceededCondition.Message)
+		return reconcile.Result{}, nil
+	case dvRunningCondition != nil && dvRunningCondition.Status != corev1.ConditionTrue && dvRunningCondition.Reason == DVImagePullFailedReason:
+		vi.Status.Phase = virtv2.ImagePending
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(vicondition.ImagePullFailed).
+			Message(dvRunningCondition.Message)
+		ds.recorder.Event(vi, corev1.EventTypeWarning, vicondition.ImagePullFailed.String(), dvRunningCondition.Message)
 		return reconcile.Result{}, nil
 	case pvc == nil:
 		vi.Status.Phase = virtv2.ImageProvisioning

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref.go
@@ -153,9 +153,11 @@ func (ds ObjectRefDataSource) StoreToPVC(ctx context.Context, vi *virtv2.Virtual
 		return reconcile.Result{}, err
 	}
 
-	var quotaNotExceededCondition *cdiv1.DataVolumeCondition
+	var dvQuotaNotExceededCondition *cdiv1.DataVolumeCondition
+	var dvRunningCondition *cdiv1.DataVolumeCondition
 	if dv != nil {
-		quotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
+		dvQuotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
+		dvRunningCondition = service.GetDataVolumeCondition(DVRunningConditionType, dv.Status.Conditions)
 	}
 
 	switch {
@@ -233,12 +235,20 @@ func (ds ObjectRefDataSource) StoreToPVC(ctx context.Context, vi *virtv2.Virtual
 			Message("PVC Provisioner not found: create the new one.")
 
 		return reconcile.Result{Requeue: true}, nil
-	case quotaNotExceededCondition != nil && quotaNotExceededCondition.Status == corev1.ConditionFalse:
+	case dvQuotaNotExceededCondition != nil && dvQuotaNotExceededCondition.Status == corev1.ConditionFalse:
 		vi.Status.Phase = virtv2.ImagePending
 		cb.
 			Status(metav1.ConditionFalse).
 			Reason(vicondition.QuotaExceeded).
-			Message(quotaNotExceededCondition.Message)
+			Message(dvQuotaNotExceededCondition.Message)
+		return reconcile.Result{}, nil
+	case dvRunningCondition != nil && dvRunningCondition.Status != corev1.ConditionTrue && dvRunningCondition.Reason == DVImagePullFailedReason:
+		vi.Status.Phase = virtv2.ImagePending
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(vicondition.ImagePullFailed).
+			Message(dvRunningCondition.Message)
+		ds.recorder.Event(vi, corev1.EventTypeWarning, vicondition.ImagePullFailed.String(), dvRunningCondition.Message)
 		return reconcile.Result{}, nil
 	case pvc == nil:
 		vi.Status.Phase = virtv2.ImageProvisioning

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vd.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vd.go
@@ -234,9 +234,11 @@ func (ds ObjectRefVirtualDisk) StoreToPVC(ctx context.Context, vi *virtv2.Virtua
 		return reconcile.Result{}, err
 	}
 
-	var quotaNotExceededCondition *cdiv1.DataVolumeCondition
+	var dvQuotaNotExceededCondition *cdiv1.DataVolumeCondition
+	var dvRunningCondition *cdiv1.DataVolumeCondition
 	if dv != nil {
-		quotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
+		dvQuotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
+		dvRunningCondition = service.GetDataVolumeCondition(DVRunningConditionType, dv.Status.Conditions)
 	}
 
 	condition, _ := conditions.GetCondition(vicondition.ReadyType, vi.Status.Conditions)
@@ -295,12 +297,20 @@ func (ds ObjectRefVirtualDisk) StoreToPVC(ctx context.Context, vi *virtv2.Virtua
 			Message("PVC Provisioner not found: create the new one.")
 
 		return reconcile.Result{Requeue: true}, nil
-	case quotaNotExceededCondition != nil && quotaNotExceededCondition.Status == corev1.ConditionFalse:
+	case dvQuotaNotExceededCondition != nil && dvQuotaNotExceededCondition.Status == corev1.ConditionFalse:
 		vi.Status.Phase = virtv2.ImagePending
 		cb.
 			Status(metav1.ConditionFalse).
 			Reason(vicondition.QuotaExceeded).
-			Message(quotaNotExceededCondition.Message)
+			Message(dvQuotaNotExceededCondition.Message)
+		return reconcile.Result{}, nil
+	case dvRunningCondition != nil && dvRunningCondition.Status != corev1.ConditionTrue && dvRunningCondition.Reason == DVImagePullFailedReason:
+		vi.Status.Phase = virtv2.ImagePending
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(vicondition.ImagePullFailed).
+			Message(dvRunningCondition.Message)
+		ds.recorder.Event(vi, corev1.EventTypeWarning, vicondition.ImagePullFailed.String(), dvRunningCondition.Message)
 		return reconcile.Result{}, nil
 	case pvc == nil:
 		vi.Status.Phase = virtv2.ImageProvisioning

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vi_on_pvc.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vi_on_pvc.go
@@ -211,9 +211,11 @@ func (ds ObjectRefDataVirtualImageOnPVC) StoreToPVC(ctx context.Context, vi, viR
 		return reconcile.Result{}, err
 	}
 
-	var quotaNotExceededCondition *cdiv1.DataVolumeCondition
+	var dvQuotaNotExceededCondition *cdiv1.DataVolumeCondition
+	var dvRunningCondition *cdiv1.DataVolumeCondition
 	if dv != nil {
-		quotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
+		dvQuotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
+		dvRunningCondition = service.GetDataVolumeCondition(DVRunningConditionType, dv.Status.Conditions)
 	}
 
 	condition, _ := conditions.GetCondition(vicondition.ReadyType, vi.Status.Conditions)
@@ -278,12 +280,20 @@ func (ds ObjectRefDataVirtualImageOnPVC) StoreToPVC(ctx context.Context, vi, viR
 			Message("PVC Provisioner not found: create the new one.")
 
 		return reconcile.Result{Requeue: true}, nil
-	case quotaNotExceededCondition != nil && quotaNotExceededCondition.Status == corev1.ConditionFalse:
+	case dvQuotaNotExceededCondition != nil && dvQuotaNotExceededCondition.Status == corev1.ConditionFalse:
 		vi.Status.Phase = virtv2.ImagePending
 		cb.
 			Status(metav1.ConditionFalse).
 			Reason(vicondition.QuotaExceeded).
-			Message(quotaNotExceededCondition.Message)
+			Message(dvQuotaNotExceededCondition.Message)
+		return reconcile.Result{}, nil
+	case dvRunningCondition != nil && dvRunningCondition.Status != corev1.ConditionTrue && dvRunningCondition.Reason == DVImagePullFailedReason:
+		vi.Status.Phase = virtv2.ImagePending
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(vicondition.ImagePullFailed).
+			Message(dvRunningCondition.Message)
+		ds.recorder.Event(vi, corev1.EventTypeWarning, vicondition.ImagePullFailed.String(), dvRunningCondition.Message)
 		return reconcile.Result{}, nil
 	case pvc == nil:
 		vi.Status.Phase = virtv2.ImageProvisioning

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/sources.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/sources.go
@@ -281,7 +281,7 @@ func setQuotaExceededPhaseCondition(cb *conditions.ConditionBuilder, phase *virt
 }
 
 const (
-	DVRunningConditionType          cdiv1.DataVolumeConditionType = "DVRunning"
+	DVRunningConditionType          cdiv1.DataVolumeConditionType = "Running"
 	DVQoutaNotExceededConditionType cdiv1.DataVolumeConditionType = "QuotaNotExceeded"
 
 	DVImagePullFailedReason = "ImagePullFailed"

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/sources.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/sources.go
@@ -281,5 +281,8 @@ func setQuotaExceededPhaseCondition(cb *conditions.ConditionBuilder, phase *virt
 }
 
 const (
+	DVRunningConditionType          cdiv1.DataVolumeConditionType = "DVRunning"
 	DVQoutaNotExceededConditionType cdiv1.DataVolumeConditionType = "QuotaNotExceeded"
+
+	DVImagePullFailedReason = "ImagePullFailed"
 )

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/upload.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/upload.go
@@ -107,9 +107,11 @@ func (ds UploadDataSource) StoreToPVC(ctx context.Context, vi *virtv2.VirtualIma
 		return reconcile.Result{}, err
 	}
 
-	var quotaNotExceededCondition *cdiv1.DataVolumeCondition
+	var dvQuotaNotExceededCondition *cdiv1.DataVolumeCondition
+	var dvRunningCondition *cdiv1.DataVolumeCondition
 	if dv != nil {
-		quotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
+		dvQuotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
+		dvRunningCondition = service.GetDataVolumeCondition(DVRunningConditionType, dv.Status.Conditions)
 	}
 
 	switch {
@@ -270,12 +272,20 @@ func (ds UploadDataSource) StoreToPVC(ctx context.Context, vi *virtv2.VirtualIma
 			Message("PVC Provisioner not found: create the new one.")
 
 		return reconcile.Result{Requeue: true}, nil
-	case quotaNotExceededCondition != nil && quotaNotExceededCondition.Status == corev1.ConditionFalse:
+	case dvQuotaNotExceededCondition != nil && dvQuotaNotExceededCondition.Status == corev1.ConditionFalse:
 		vi.Status.Phase = virtv2.ImagePending
 		cb.
 			Status(metav1.ConditionFalse).
 			Reason(vicondition.QuotaExceeded).
-			Message(quotaNotExceededCondition.Message)
+			Message(dvQuotaNotExceededCondition.Message)
+		return reconcile.Result{}, nil
+	case dvRunningCondition != nil && dvRunningCondition.Status != corev1.ConditionTrue && dvRunningCondition.Reason == DVImagePullFailedReason:
+		vi.Status.Phase = virtv2.ImagePending
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(vicondition.ImagePullFailed).
+			Message(dvRunningCondition.Message)
+		ds.recorder.Event(vi, corev1.EventTypeWarning, vicondition.ImagePullFailed.String(), dvRunningCondition.Message)
 		return reconcile.Result{}, nil
 	case pvc == nil:
 		vi.Status.Phase = virtv2.ImageProvisioning

--- a/templates/admission-policy.yaml
+++ b/templates/admission-policy.yaml
@@ -52,6 +52,7 @@ spec:
           "system:serviceaccount:d8-virtualization:virtualization-api",
           "system:serviceaccount:d8-virtualization:virtualization-pre-delete-hook",
           "system:serviceaccount:d8-virtualization:vm-route-forge",
+          "system:serviceaccount:kube-system:namespace-controller",
         ]
       message: "Operation forbidden for this user."
 ---

--- a/templates/admission-policy.yaml
+++ b/templates/admission-policy.yaml
@@ -52,7 +52,6 @@ spec:
           "system:serviceaccount:d8-virtualization:virtualization-api",
           "system:serviceaccount:d8-virtualization:virtualization-pre-delete-hook",
           "system:serviceaccount:d8-virtualization:vm-route-forge",
-          "system:serviceaccount:kube-system:namespace-controller",
         ]
       message: "Operation forbidden for this user."
 ---


### PR DESCRIPTION
## Description
Show error if can not connect to `DVCR`.

## Why do we need it, and what problem does it solve?

## What is the expected result?

## Changelog entries

```changes
section: api
type: feature
summary: provide dvcr connection error from DataVolume
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
