### PR TITLE
test(ci): fix e2e false positive on failure of resource deletion

### DIFF
--- a/tests/e2e/Taskfile.yaml
+++ b/tests/e2e/Taskfile.yaml
@@ -58,7 +58,10 @@ tasks:
           --skip-file affinity_toleration_test.go \
           --no-color \
           -v | tee /dev/stderr | grep --color=never -E 'FAIL!|SUCCESS!')
-        if [[ $RESULT == SUCCESS!* ]]; then
+        if [ "${PIPESTATUS[0]}" -ne "0" ]; then
+          RESULT_STATUS=":x: FAIL!"
+          EXIT_CODE=${PIPESTATUS[0]}
+        elif [[ $RESULT == SUCCESS!* ]]; then
           RESULT_STATUS=":white_check_mark: SUCCESS!"
           EXIT_CODE=0
         elif [[ $RESULT == FAIL!* ]]; then


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix e2e message and status in pipeline on non-zero exit codes.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Fix #593 
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
