### PR TITLE
fix(vm): Improve KVVM Builder. Add method SetMetadata

### DIFF
--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
@@ -584,6 +584,10 @@ func (b *KVVM) GetBootloaderSettings() map[string]interface{} {
 }
 
 func (b *KVVM) SetMetadata(metadata metav1.ObjectMeta) {
+	if b.ResourceExists {
+		// initialize only
+		return
+	}
 	if b.Resource.Spec.Template.ObjectMeta.Labels == nil {
 		b.Resource.Spec.Template.ObjectMeta.Labels = make(map[string]string, len(metadata.Labels))
 	}

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
@@ -582,3 +582,14 @@ func (b *KVVM) GetBootloaderSettings() map[string]interface{} {
 		},
 	}
 }
+
+func (b *KVVM) SetMetadata(metadata metav1.ObjectMeta) {
+	if b.Resource.Spec.Template.ObjectMeta.Labels == nil {
+		b.Resource.Spec.Template.ObjectMeta.Labels = make(map[string]string, len(metadata.Labels))
+	}
+	if b.Resource.Spec.Template.ObjectMeta.Annotations == nil {
+		b.Resource.Spec.Template.ObjectMeta.Annotations = make(map[string]string, len(metadata.Annotations))
+	}
+	maps.Copy(b.Resource.Spec.Template.ObjectMeta.Labels, metadata.Labels)
+	maps.Copy(b.Resource.Spec.Template.ObjectMeta.Annotations, metadata.Annotations)
+}

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
@@ -89,6 +89,7 @@ func ApplyVirtualMachineSpec(
 		return err
 	}
 
+	kvvm.SetMetadata(vm.ObjectMeta)
 	kvvm.SetNetworkInterface(NetworkInterfaceName)
 	kvvm.SetTablet("default-0")
 	kvvm.SetNodeSelector(vm.Spec.NodeSelector, class.Spec.NodeSelector.MatchLabels)

--- a/tests/e2e/Taskfile.yaml
+++ b/tests/e2e/Taskfile.yaml
@@ -55,7 +55,6 @@ tasks:
     cmds:
       - |
         RESULT=$(ginkgo \
-          --skip-file affinity_toleration_test.go \
           --no-color \
           -v | tee /dev/stderr | grep --color=never -E 'FAIL!|SUCCESS!')
         if [ "${PIPESTATUS[0]}" -ne "0" ]; then

--- a/tests/e2e/Taskfile.yaml
+++ b/tests/e2e/Taskfile.yaml
@@ -106,7 +106,6 @@ tasks:
     cmds:
       - |
         ginkgo -v \
-          --skip-file affinity_toleration_test.go \
           {{if .FOCUS -}}
           --focus "{{ .FOCUS }}"
           {{end}}


### PR DESCRIPTION
## Description
This pull request introduces the SetMetadata method to the KVVM Builder. Previously, we did not set metadata in the KVVM template during creation, as it was synchronized later using a dedicated handler. While this approach worked for syncing metadata, it caused an issue with the initial pod scheduling.

Without setting metadata upfront, some required labels were missing during the initial pod scheduling phase. These labels are critical for features like pod affinity and anti-affinity rules. As a result, the initial scheduling could make incorrect decisions, potentially leading to rule violations or suboptimal placement.

By introducing the SetMetadata method, this PR ensures that metadata is properly set in the template during the initial build phase, preventing such scheduling issues.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [X] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
