### PR TITLE
fix(ci): add color output to nightly e2e tests & fix exit code

### DIFF
--- a/tests/e2e/Taskfile.yaml
+++ b/tests/e2e/Taskfile.yaml
@@ -54,18 +54,16 @@ tasks:
       - d8
     cmds:
       - |
-        RESULT=$(ginkgo \
-          --no-color \
-          -v | tee /dev/stderr | grep --color=never -E 'FAIL!|SUCCESS!')
-        if [ "${PIPESTATUS[0]}" -ne "0" ]; then
+        GINKGO_RESULT=$(mktemp)
+        ginkgo \
+          --skip-file affinity_toleration_test.go \
+          -v | tee $GINKGO_RESULT
+        EXIT_CODE=${PIPESTATUS[0]}
+        RESULT=$(sed -e 's/\x1b\[[0-9;]*m//g' $GINKGO_RESULT | grep --color=never -E 'FAIL!|SUCCESS!')
+        if [[ $RESULT == FAIL!* || $EXIT_CODE -ne "0" ]]; then
           RESULT_STATUS=":x: FAIL!"
-          EXIT_CODE=${PIPESTATUS[0]}
         elif [[ $RESULT == SUCCESS!* ]]; then
           RESULT_STATUS=":white_check_mark: SUCCESS!"
-          EXIT_CODE=0
-        elif [[ $RESULT == FAIL!* ]]; then
-          RESULT_STATUS=":x: FAIL!"
-          EXIT_CODE=1
         else
           RESULT_STATUS=":question: UNKNOWN"
           EXIT_CODE=1

--- a/tests/e2e/Taskfile.yaml
+++ b/tests/e2e/Taskfile.yaml
@@ -55,9 +55,7 @@ tasks:
     cmds:
       - |
         bash -c 'GINKGO_RESULT=$(mktemp)
-        ginkgo \
-          --skip-file affinity_toleration_test.go \
-          -v | tee $GINKGO_RESULT
+        ginkgo -v | tee $GINKGO_RESULT
         EXIT_CODE="${PIPESTATUS[0]}"
         RESULT=$(sed -e "s/\x1b\[[0-9;]*m//g" $GINKGO_RESULT | grep --color=never -E "FAIL!|SUCCESS!")
         if [[ $RESULT == FAIL!* || $EXIT_CODE -ne "0" ]]; then

--- a/tests/e2e/Taskfile.yaml
+++ b/tests/e2e/Taskfile.yaml
@@ -54,12 +54,12 @@ tasks:
       - d8
     cmds:
       - |
-        GINKGO_RESULT=$(mktemp)
+        bash -c 'GINKGO_RESULT=$(mktemp)
         ginkgo \
           --skip-file affinity_toleration_test.go \
           -v | tee $GINKGO_RESULT
-        EXIT_CODE=${PIPESTATUS[0]}
-        RESULT=$(sed -e 's/\x1b\[[0-9;]*m//g' $GINKGO_RESULT | grep --color=never -E 'FAIL!|SUCCESS!')
+        EXIT_CODE="${PIPESTATUS[0]}"
+        RESULT=$(sed -e "s/\x1b\[[0-9;]*m//g" $GINKGO_RESULT | grep --color=never -E "FAIL!|SUCCESS!")
         if [[ $RESULT == FAIL!* || $EXIT_CODE -ne "0" ]]; then
           RESULT_STATUS=":x: FAIL!"
         elif [[ $RESULT == SUCCESS!* ]]; then
@@ -70,10 +70,10 @@ tasks:
         fi
         DATE=$(date +"%Y-%m-%d")
 
-        PASSED=$(echo "$RESULT" | grep -oP '\d+(?= Passed)')
-        FAILED=$(echo "$RESULT" | grep -oP '\d+(?= Failed)')
-        PENDING=$(echo "$RESULT" | grep -oP '\d+(?= Pending)')
-        SKIPPED=$(echo "$RESULT" | grep -oP '\d+(?= Skipped)')
+        PASSED=$(echo "$RESULT" | grep -oP "\d+(?= Passed)")
+        FAILED=$(echo "$RESULT" | grep -oP "\d+(?= Failed)")
+        PENDING=$(echo "$RESULT" | grep -oP "\d+(?= Pending)")
+        SKIPPED=$(echo "$RESULT" | grep -oP "\d+(?= Skipped)")
 
         SUMMARY="
         ### :dvp: **DVP $DATE Nightly e2e Tests**
@@ -91,7 +91,7 @@ tasks:
         echo "SUMMARY<<EOF" >> $GITHUB_ENV
         echo "$SUMMARY" >> $GITHUB_ENV
         echo "EOF" >> $GITHUB_ENV
-        exit $EXIT_CODE
+        exit $EXIT_CODE'
 
   run:
     desc: "Run e2e tests"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add color output to nightly e2e tests and fix exit code problem. As of now, PIPESTATUS can't capture exit codes from command substitution `$()`, and this PR addresses that.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Color output improves readability.
The exit code part fixes #667.
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Color output in nightly e2e tests.
Proper failure on non-zero exit codes from ginkgo.
## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
