### PR TITLE
fix(vm): fix VM restart behavior with invalid spec

### DIFF
--- a/api/core/v1alpha2/events.go
+++ b/api/core/v1alpha2/events.go
@@ -61,6 +61,9 @@ const (
 	// ReasonVMOPStarted is event reason that the operation is started
 	ReasonVMOPStarted = "VirtualMachineOperationStarted"
 
+	// ReasonVMOPInProgress is event reason that the operation is in progress
+	ReasonVMOPInProgress = "VirtualMachineOperationInProgress"
+
 	// ReasonVDStorageClassWasDeleted is event reason that VDStorageClass was deleted.
 	ReasonVDStorageClassWasDeleted = "VirtualDiskStorageClassWasDeleted"
 	// ReasonVDStorageClassNotFound is event reason that VDStorageClass not found.

--- a/images/virtualization-artifact/pkg/common/annotations/annotations.go
+++ b/images/virtualization-artifact/pkg/common/annotations/annotations.go
@@ -70,6 +70,9 @@ const (
 
 	AnnOsType = AnnAPIGroupV + "/os-type"
 
+	// AnnVmStartRequested is an annotation on KVVM that represents a request to start a virtual machine.
+	AnnVmStartRequested = AnnAPIGroupV + "/vm-start-requested"
+
 	// LabelsPrefix is a prefix for virtualization-controller labels.
 	LabelsPrefix = "virtualization.deckhouse.io"
 

--- a/images/virtualization-artifact/pkg/common/annotations/annotations.go
+++ b/images/virtualization-artifact/pkg/common/annotations/annotations.go
@@ -73,6 +73,9 @@ const (
 	// AnnVmStartRequested is an annotation on KVVM that represents a request to start a virtual machine.
 	AnnVmStartRequested = AnnAPIGroupV + "/vm-start-requested"
 
+	// AnnVmRestartRequested is an annotation on KVVM that represents a request to restart a virtual machine.
+	AnnVmRestartRequested = AnnAPIGroupV + "/vm-restart-requested"
+
 	// LabelsPrefix is a prefix for virtualization-controller labels.
 	LabelsPrefix = "virtualization.deckhouse.io"
 

--- a/images/virtualization-artifact/pkg/common/kvvm/kvvm.go
+++ b/images/virtualization-artifact/pkg/common/kvvm/kvvm.go
@@ -19,6 +19,7 @@ package kvvm
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -26,7 +27,9 @@ import (
 	virtv1 "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/deckhouse/virtualization-controller/pkg/common/annotations"
 	"github.com/deckhouse/virtualization-controller/pkg/common/object"
+	"github.com/deckhouse/virtualization-controller/pkg/common/patch"
 )
 
 // PatchRunStrategy returns JSON merge patch to set 'runStrategy' field to the desired value
@@ -97,4 +100,78 @@ func DeletePodByKVVMI(ctx context.Context, cli client.Client, kvvmi *virtv1.Virt
 		return nil
 	}
 	return object.DeleteObject(ctx, cli, pod, opts)
+}
+
+func AddRestartAnnotation(ctx context.Context, cl client.Client, kvvm *virtv1.VirtualMachine) error {
+	if kvvm.Annotations[annotations.AnnVmStartRequested] == "" {
+		jp := patch.NewJsonPatch(
+			patch.NewJsonPatchOperation(patch.PatchReplaceOp, fmt.Sprintf("/metadata/annotations/%s", escapeJSONPointer(annotations.AnnVmRestartRequested)), "true"),
+		)
+		bytes, err := jp.Bytes()
+		if err != nil {
+			return err
+		}
+		err = cl.Patch(ctx, kvvm, client.RawPatch(types.JSONPatchType, bytes))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func AddStartAnnotation(ctx context.Context, cl client.Client, kvvm *virtv1.VirtualMachine) error {
+	if kvvm.Annotations[annotations.AnnVmStartRequested] == "" {
+		jp := patch.NewJsonPatch(
+			patch.NewJsonPatchOperation(patch.PatchReplaceOp, fmt.Sprintf("/metadata/annotations/%s", escapeJSONPointer(annotations.AnnVmStartRequested)), "true"),
+		)
+		bytes, err := jp.Bytes()
+		if err != nil {
+			return err
+		}
+		err = cl.Patch(ctx, kvvm, client.RawPatch(types.JSONPatchType, bytes))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func escapeJSONPointer(path string) string {
+	return strings.ReplaceAll(path, "/", "~1")
+}
+
+func RemoveStartAnnotation(ctx context.Context, cl client.Client, kvvm *virtv1.VirtualMachine) error {
+	if kvvm.Annotations[annotations.AnnVmStartRequested] != "" {
+		jp := patch.NewJsonPatch(
+			patch.NewJsonPatchOperation(patch.PatchReplaceOp, fmt.Sprintf("/metadata/annotations/%s", escapeJSONPointer(annotations.AnnVmStartRequested)), ""),
+		)
+		bytes, err := jp.Bytes()
+		if err != nil {
+			return err
+		}
+		err = cl.Patch(ctx, kvvm, client.RawPatch(types.JSONPatchType, bytes))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func RemoveRestartAnnotation(ctx context.Context, cl client.Client, kvvm *virtv1.VirtualMachine) error {
+	if kvvm.Annotations[annotations.AnnVmRestartRequested] != "" {
+		jp := patch.NewJsonPatch(
+			patch.NewJsonPatchOperation(patch.PatchReplaceOp, fmt.Sprintf("/metadata/annotations/%s", escapeJSONPointer(annotations.AnnVmRestartRequested)), ""),
+		)
+		bytes, err := jp.Bytes()
+		if err != nil {
+			return err
+		}
+		err = cl.Patch(ctx, kvvm, client.RawPatch(types.JSONPatchType, bytes))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/images/virtualization-artifact/pkg/controller/service/vm_operation.go
+++ b/images/virtualization-artifact/pkg/controller/service/vm_operation.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/deckhouse/virtualization-controller/pkg/common"
+	kvvmutil "github.com/deckhouse/virtualization-controller/pkg/common/kvvm"
 	"github.com/deckhouse/virtualization-controller/pkg/common/object"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/powerstate"
@@ -76,7 +77,7 @@ func (s VMOperationService) DoStart(ctx context.Context, vmNamespace, vmName str
 	if err != nil {
 		return fmt.Errorf("get kvvm %q: %w", vmName, err)
 	}
-	return powerstate.StartVM(ctx, s.client, kvvm)
+	return kvvmutil.AddStartAnnotation(ctx, s.client, kvvm)
 }
 
 func (s VMOperationService) DoStop(ctx context.Context, vmNamespace, vmName string, force bool) error {
@@ -92,11 +93,7 @@ func (s VMOperationService) DoRestart(ctx context.Context, vmNamespace, vmName s
 	if err != nil {
 		return fmt.Errorf("get kvvm %q: %w", vmName, err)
 	}
-	kvvmi, err := s.getKVVMI(ctx, vmNamespace, vmName)
-	if err != nil {
-		return fmt.Errorf("get kvvmi %q: %w", vmName, err)
-	}
-	return powerstate.RestartVM(ctx, s.client, kvvm, kvvmi, force)
+	return kvvmutil.AddRestartAnnotation(ctx, s.client, kvvm)
 }
 
 func (s VMOperationService) DoEvict(ctx context.Context, vmNamespace, vmName string) error {

--- a/images/virtualization-artifact/pkg/controller/vm/internal/lifecycle.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/lifecycle.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/deckhouse/virtualization-controller/pkg/common/annotations"
 	podutil "github.com/deckhouse/virtualization-controller/pkg/common/pod"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
@@ -96,7 +97,20 @@ func (h *LifeCycleHandler) Handle(ctx context.Context, s state.VirtualMachineSta
 	if phase == "" {
 		phase = virtv2.MachinePending
 	}
+
+	confAppliedCondtion, _ := conditions.GetCondition(vmcondition.TypeConfigurationApplied, s.VirtualMachine().Changed().Status.Conditions)
+	if confAppliedCondtion.Status == metav1.ConditionFalse && kvvm != nil && kvvm.Annotations[annotations.AnnVmStartRequested] == "true" && phase == virtv2.MachineStopped {
+		phase = virtv2.MachinePending
+	}
+
 	changed.Status.Phase = phase
+
+	if phase == virtv2.MachineStarting && kvvm.Annotations[annotations.AnnVmStartRequested] == "true" {
+		err = removeStartAnnotationToKVVM(ctx, h.client, kvvm)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+	}
 
 	kvvmi, err := s.KVVMI(ctx)
 	if err != nil {

--- a/images/virtualization-artifact/pkg/controller/vm/internal/util.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/util.go
@@ -18,18 +18,15 @@ package internal
 
 import (
 	"context"
-	"fmt"
 	"slices"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	virtv1 "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/deckhouse/virtualization-controller/pkg/common/annotations"
-	"github.com/deckhouse/virtualization-controller/pkg/common/patch"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
@@ -243,43 +240,4 @@ func isInternalVirtualMachineError(phase virtv1.VirtualMachinePrintableStatus) b
 
 func podFinal(pod corev1.Pod) bool {
 	return pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed
-}
-
-func addStartAnnotationToKVVM(ctx context.Context, cl client.Client, kvvm *virtv1.VirtualMachine) error {
-	if kvvm.Annotations[annotations.AnnVmStartRequested] == "" {
-		jp := patch.NewJsonPatch(
-			patch.NewJsonPatchOperation(patch.PatchReplaceOp, fmt.Sprintf("/metadata/annotations/%s", escapeJSONPointer(annotations.AnnVmStartRequested)), "true"),
-		)
-		bytes, err := jp.Bytes()
-		if err != nil {
-			return err
-		}
-		err = cl.Patch(ctx, kvvm, client.RawPatch(types.JSONPatchType, bytes))
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func removeStartAnnotationToKVVM(ctx context.Context, cl client.Client, kvvm *virtv1.VirtualMachine) error {
-	if kvvm.Annotations[annotations.AnnVmStartRequested] == "" {
-		jp := patch.NewJsonPatch(
-			patch.NewJsonPatchOperation(patch.PatchReplaceOp, fmt.Sprintf("/metadata/annotations/%s", escapeJSONPointer(annotations.AnnVmStartRequested)), ""),
-		)
-		bytes, err := jp.Bytes()
-		if err != nil {
-			return err
-		}
-		err = cl.Patch(ctx, kvvm, client.RawPatch(types.JSONPatchType, bytes))
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func escapeJSONPointer(path string) string {
-	return strings.ReplaceAll(path, "/", "~1")
 }

--- a/images/virtualization-artifact/pkg/controller/vm/internal/util.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/util.go
@@ -70,69 +70,120 @@ func conditionStatus(status string) metav1.ConditionStatus {
 }
 
 func vmIsPending(kvvm *virtv1.VirtualMachine) bool {
-	return getPhase(kvvm) == virtv2.MachinePending
+	return getPhase(nil, kvvm) == virtv2.MachinePending
 }
 
 func vmIsStopped(kvvm *virtv1.VirtualMachine) bool {
-	return getPhase(kvvm) == virtv2.MachineStopped
+	return getPhase(nil, kvvm) == virtv2.MachineStopped
 }
 
 func vmIsCreated(kvvm *virtv1.VirtualMachine) bool {
 	return kvvm != nil && kvvm.Status.Created
 }
 
-func getPhase(kvvm *virtv1.VirtualMachine) virtv2.MachinePhase {
+func getPhase(vm *virtv2.VirtualMachine, kvvm *virtv1.VirtualMachine) virtv2.MachinePhase {
 	if kvvm == nil {
 		return virtv2.MachinePending
 	}
 
-	return mapPhases[kvvm.Status.PrintableStatus]
+	if handler, exists := mapPhases[kvvm.Status.PrintableStatus]; exists {
+		return handler(vm, kvvm)
+	}
+
+	return virtv2.MachinePending
 }
 
-var mapPhases = map[virtv1.VirtualMachinePrintableStatus]virtv2.MachinePhase{
+type PhaseHandler func(...interface{}) virtv2.MachinePhase
+
+var mapPhases = map[virtv1.VirtualMachinePrintableStatus]PhaseHandler{
 	// VirtualMachineStatusStopped indicates that the virtual machine is currently stopped and isn't expected to start.
-	virtv1.VirtualMachineStatusStopped: virtv2.MachineStopped,
+	virtv1.VirtualMachineStatusStopped: func(args ...interface{}) virtv2.MachinePhase {
+		vm := args[0].(*virtv2.VirtualMachine)
+		kvvm := args[1].(*virtv1.VirtualMachine)
+
+		if vm != nil && kvvm != nil {
+			confAppliedCondition, _ := conditions.GetCondition(vmcondition.TypeConfigurationApplied, vm.Status.Conditions)
+			if confAppliedCondition.Status == metav1.ConditionFalse &&
+				kvvm != nil && kvvm.Annotations[annotations.AnnVmStartRequested] == "true" {
+				return virtv2.MachinePending
+			}
+		}
+
+		return virtv2.MachineStopped
+	},
 	// VirtualMachineStatusProvisioning indicates that cluster resources associated with the virtual machine
 	// (e.g., DataVolumes) are being provisioned and prepared.
-	virtv1.VirtualMachineStatusProvisioning: virtv2.MachineStarting,
+	virtv1.VirtualMachineStatusProvisioning: func(args ...interface{}) virtv2.MachinePhase {
+		return virtv2.MachineStarting
+	},
 	// VirtualMachineStatusStarting indicates that the virtual machine is being prepared for running.
-	virtv1.VirtualMachineStatusStarting: virtv2.MachineStarting,
+	virtv1.VirtualMachineStatusStarting: func(args ...interface{}) virtv2.MachinePhase {
+		return virtv2.MachineStarting
+	},
 	// VirtualMachineStatusRunning indicates that the virtual machine is running.
-	virtv1.VirtualMachineStatusRunning: virtv2.MachineRunning,
+	virtv1.VirtualMachineStatusRunning: func(args ...interface{}) virtv2.MachinePhase {
+		return virtv2.MachineRunning
+	},
 	// VirtualMachineStatusPaused indicates that the virtual machine is paused.
-	virtv1.VirtualMachineStatusPaused: virtv2.MachinePause,
+	virtv1.VirtualMachineStatusPaused: func(args ...interface{}) virtv2.MachinePhase {
+		return virtv2.MachinePause
+	},
 	// VirtualMachineStatusStopping indicates that the virtual machine is in the process of being stopped.
-	virtv1.VirtualMachineStatusStopping: virtv2.MachineStopping,
+	virtv1.VirtualMachineStatusStopping: func(args ...interface{}) virtv2.MachinePhase {
+		return virtv2.MachineStopping
+	},
 	// VirtualMachineStatusTerminating indicates that the virtual machine is in the process of deletion,
 	// as well as its associated resources (VirtualMachineInstance, DataVolumes, …).
-	virtv1.VirtualMachineStatusTerminating: virtv2.MachineTerminating,
+	virtv1.VirtualMachineStatusTerminating: func(args ...interface{}) virtv2.MachinePhase {
+		return virtv2.MachineTerminating
+	},
 	// VirtualMachineStatusCrashLoopBackOff indicates that the virtual machine is currently in a crash loop waiting to be retried.
-	virtv1.VirtualMachineStatusCrashLoopBackOff: virtv2.MachinePending,
+	virtv1.VirtualMachineStatusCrashLoopBackOff: func(args ...interface{}) virtv2.MachinePhase {
+		return virtv2.MachinePending
+	},
 	// VirtualMachineStatusMigrating indicates that the virtual machine is in the process of being migrated
 	// to another host.
-	virtv1.VirtualMachineStatusMigrating: virtv2.MachineMigrating,
+	virtv1.VirtualMachineStatusMigrating: func(args ...interface{}) virtv2.MachinePhase {
+		return virtv2.MachineMigrating
+	},
 	// VirtualMachineStatusUnknown indicates that the state of the virtual machine could not be obtained,
 	// typically due to an error in communicating with the host on which it's running.
-	virtv1.VirtualMachineStatusUnknown: virtv2.MachinePending,
+	virtv1.VirtualMachineStatusUnknown: func(args ...interface{}) virtv2.MachinePhase {
+		return virtv2.MachinePending
+	},
 	// VirtualMachineStatusUnschedulable indicates that an error has occurred while scheduling the virtual machine,
 	// e.g. due to unsatisfiable resource requests or unsatisfiable scheduling constraints.
-	virtv1.VirtualMachineStatusUnschedulable: virtv2.MachinePending,
+	virtv1.VirtualMachineStatusUnschedulable: func(args ...interface{}) virtv2.MachinePhase {
+		return virtv2.MachinePending
+	},
 	// VirtualMachineStatusErrImagePull indicates that an error has occurred while pulling an image for
 	// a containerDisk VM volume.
-	virtv1.VirtualMachineStatusErrImagePull: virtv2.MachinePending,
+	virtv1.VirtualMachineStatusErrImagePull: func(args ...interface{}) virtv2.MachinePhase {
+		return virtv2.MachinePending
+	},
 	// VirtualMachineStatusImagePullBackOff indicates that an error has occurred while pulling an image for
 	// a containerDisk VM volume, and that kubelet is backing off before retrying.
-	virtv1.VirtualMachineStatusImagePullBackOff: virtv2.MachinePending,
+	virtv1.VirtualMachineStatusImagePullBackOff: func(args ...interface{}) virtv2.MachinePhase {
+		return virtv2.MachinePending
+	},
 	// VirtualMachineStatusPvcNotFound indicates that the virtual machine references a PVC volume which doesn't exist.
-	virtv1.VirtualMachineStatusPvcNotFound: virtv2.MachinePending,
+	virtv1.VirtualMachineStatusPvcNotFound: func(args ...interface{}) virtv2.MachinePhase {
+		return virtv2.MachinePending
+	},
 	// VirtualMachineStatusDataVolumeError indicates that an error has been reported by one of the DataVolumes
 	// referenced by the virtual machines.
-	virtv1.VirtualMachineStatusDataVolumeError: virtv2.MachinePending,
+	virtv1.VirtualMachineStatusDataVolumeError: func(args ...interface{}) virtv2.MachinePhase {
+		return virtv2.MachinePending
+	},
 	// VirtualMachineStatusWaitingForVolumeBinding indicates that some PersistentVolumeClaims backing
 	// the virtual machine volume are still not bound.
-	virtv1.VirtualMachineStatusWaitingForVolumeBinding: virtv2.MachinePending,
+	virtv1.VirtualMachineStatusWaitingForVolumeBinding: func(args ...interface{}) virtv2.MachinePhase {
+		return virtv2.MachinePending
+	},
 
-	kvvmEmptyPhase: virtv2.MachinePending,
+	kvvmEmptyPhase: func(args ...interface{}) virtv2.MachinePhase {
+		return virtv2.MachinePending
+	},
 }
 
 const (
@@ -216,18 +267,19 @@ func addStartAnnotationToKVVM(ctx context.Context, cl client.Client, kvvm *virtv
 }
 
 func removeStartAnnotationToKVVM(ctx context.Context, cl client.Client, kvvm *virtv1.VirtualMachine) error {
-	jp := patch.NewJsonPatch(
-		patch.NewJsonPatchOperation(patch.PatchReplaceOp, fmt.Sprintf("/metadata/annotations/%s", escapeJSONPointer(annotations.AnnVmStartRequested)), ""),
-	)
-	bytes, err := jp.Bytes()
-	if err != nil {
-		return err
+	if kvvm.Annotations[annotations.AnnVmStartRequested] == "" {
+		jp := patch.NewJsonPatch(
+			patch.NewJsonPatchOperation(patch.PatchReplaceOp, fmt.Sprintf("/metadata/annotations/%s", escapeJSONPointer(annotations.AnnVmStartRequested)), ""),
+		)
+		bytes, err := jp.Bytes()
+		if err != nil {
+			return err
+		}
+		err = cl.Patch(ctx, kvvm, client.RawPatch(types.JSONPatchType, bytes))
+		if err != nil {
+			return err
+		}
 	}
-	err = cl.Patch(ctx, kvvm, client.RawPatch(types.JSONPatchType, bytes))
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/images/virtualization-artifact/pkg/controller/vm/internal/util.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/util.go
@@ -18,14 +18,18 @@ package internal
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	virtv1 "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/deckhouse/virtualization-controller/pkg/common/annotations"
+	"github.com/deckhouse/virtualization-controller/pkg/common/patch"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
@@ -191,4 +195,42 @@ func isInternalVirtualMachineError(phase virtv1.VirtualMachinePrintableStatus) b
 
 func podFinal(pod corev1.Pod) bool {
 	return pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed
+}
+
+func addStartAnnotationToKVVM(ctx context.Context, cl client.Client, kvvm *virtv1.VirtualMachine) error {
+	if kvvm.Annotations[annotations.AnnVmStartRequested] == "" {
+		jp := patch.NewJsonPatch(
+			patch.NewJsonPatchOperation(patch.PatchReplaceOp, fmt.Sprintf("/metadata/annotations/%s", escapeJSONPointer(annotations.AnnVmStartRequested)), "true"),
+		)
+		bytes, err := jp.Bytes()
+		if err != nil {
+			return err
+		}
+		err = cl.Patch(ctx, kvvm, client.RawPatch(types.JSONPatchType, bytes))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func removeStartAnnotationToKVVM(ctx context.Context, cl client.Client, kvvm *virtv1.VirtualMachine) error {
+	jp := patch.NewJsonPatch(
+		patch.NewJsonPatchOperation(patch.PatchReplaceOp, fmt.Sprintf("/metadata/annotations/%s", escapeJSONPointer(annotations.AnnVmStartRequested)), ""),
+	)
+	bytes, err := jp.Bytes()
+	if err != nil {
+		return err
+	}
+	err = cl.Patch(ctx, kvvm, client.RawPatch(types.JSONPatchType, bytes))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func escapeJSONPointer(path string) string {
+	return strings.ReplaceAll(path, "/", "~1")
 }

--- a/images/virtualization-artifact/pkg/controller/vm/vm_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/vm/vm_reconciler.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/deckhouse/virtualization-controller/pkg/common/annotations"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/indexer"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
@@ -85,7 +86,9 @@ func (r *Reconciler) SetupController(_ context.Context, mgr manager.Manager, ctr
 				oldVM := e.ObjectOld.(*virtv1.VirtualMachine)
 				newVM := e.ObjectNew.(*virtv1.VirtualMachine)
 				return oldVM.Status.PrintableStatus != newVM.Status.PrintableStatus ||
-					oldVM.Status.Ready != newVM.Status.Ready
+					oldVM.Status.Ready != newVM.Status.Ready ||
+					oldVM.Annotations[annotations.AnnVmStartRequested] != newVM.Annotations[annotations.AnnVmStartRequested] ||
+					oldVM.Annotations[annotations.AnnVmRestartRequested] != newVM.Annotations[annotations.AnnVmRestartRequested]
 			},
 		},
 	); err != nil {

--- a/images/virtualization-artifact/pkg/controller/vmop/internal/operation.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/internal/operation.go
@@ -114,7 +114,7 @@ func (h OperationHandler) Handle(ctx context.Context, s state.VMOperationState) 
 
 	msg := fmt.Sprintf("Sent signal %q to VM without errors.", changed.Spec.Type)
 	log.Debug(msg)
-	h.recorder.Event(changed, corev1.EventTypeNormal, virtv2.ReasonVMOPSucceeded, msg)
+	h.recorder.Event(changed, corev1.EventTypeNormal, virtv2.ReasonVMOPInProgress, msg)
 
 	changed.Status.Phase = virtv2.VMOPPhaseInProgress
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This change introduces a "Pending" phase for virtual machines (VMs) that have an invalid specification and are in the restart process. Previously, if a VM was rebooted while having an invalid spec, it would start with the old spec.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
This update is necessary to ensure that VMs do not continue to operate with outdated or invalid configurations after a restart.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
With this change, when a VM with an invalid spec is restarted, it will enter a "Pending" phase, allowing for corrective actions before proceeding with the boot process. 

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: vm
type: fix
summary: move the vm to a pending phase instead of starting it if it has invalid specs during start/restart to prevent the use of outdated specifications
```
