### PR TITLE
feat(vm): add hotplug images to `VirtualMachine` status

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm/internal/state/state.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/state/state.go
@@ -44,6 +44,8 @@ type VirtualMachineState interface {
 	Pod(ctx context.Context) (*corev1.Pod, error)
 	VMBDAList(ctx context.Context) ([]virtv2.VirtualMachineBlockDeviceAttachment, error)
 	VirtualDisk(ctx context.Context, name string) (*virtv2.VirtualDisk, error)
+	VirtualImage(ctx context.Context, name string) (*virtv2.VirtualImage, error)
+	ClusterVirtualImage(ctx context.Context, name string) (*virtv2.ClusterVirtualImage, error)
 	VirtualDisksByName(ctx context.Context) (map[string]*virtv2.VirtualDisk, error)
 	VirtualImagesByName(ctx context.Context) (map[string]*virtv2.VirtualImage, error)
 	ClusterVirtualImagesByName(ctx context.Context) (map[string]*virtv2.ClusterVirtualImage, error)
@@ -191,6 +193,19 @@ func (s *state) VirtualDisk(ctx context.Context, name string) (*virtv2.VirtualDi
 		Name:      name,
 		Namespace: s.vm.Current().GetNamespace(),
 	}, s.client, &virtv2.VirtualDisk{})
+}
+
+func (s *state) VirtualImage(ctx context.Context, name string) (*virtv2.VirtualImage, error) {
+	return object.FetchObject(ctx, types.NamespacedName{
+		Name:      name,
+		Namespace: s.vm.Current().GetNamespace(),
+	}, s.client, &virtv2.VirtualImage{})
+}
+
+func (s *state) ClusterVirtualImage(ctx context.Context, name string) (*virtv2.ClusterVirtualImage, error) {
+	return object.FetchObject(ctx, types.NamespacedName{
+		Name: name,
+	}, s.client, &virtv2.ClusterVirtualImage{})
 }
 
 func (s *state) VirtualDisksByName(ctx context.Context) (map[string]*virtv2.VirtualDisk, error) {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
It adds hotplugged images to the VirtualMachine status.
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
VirtualMachine status will be contains all type of hotplugged VirtualImages. 
## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: vm
type: feature
summary: VirtualMachine.Status.BlockDeviceRefs contains hotplugged images
```
