### PR TITLE
test(ci): fix e2e namespace cleanup operation

### DIFF
--- a/tests/e2e/tests_suite_test.go
+++ b/tests/e2e/tests_suite_test.go
@@ -159,7 +159,7 @@ func Cleanup() []error {
 			continue
 		}
 		res := kubectl.Delete(kc.DeleteOptions{
-			Filename:       []string{conf.Namespace},
+			Filename:       []string{namespace},
 			IgnoreNotFound: true,
 			Resource:       kc.ResourceNamespace,
 		})


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Empty namespaces remain after E2E tests.
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Namespaces will be deleted correctly after each E2E tests.
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: fix
summary: cleanup namespaces after e2e tests
```
