### PR TITLE
fix(kubevirt): improve unmount for hotplug container disks

### DIFF
--- a/images/virt-artifact/patches/031-hotplug-container-disk.patch
+++ b/images/virt-artifact/patches/031-hotplug-container-disk.patch
@@ -869,10 +869,10 @@ index fa4e86ee17..c40f1fad89 100644
  			pvcName := storagetypes.PVCNameFromVirtVolume(&volume)
 diff --git a/pkg/virt-handler/container-disk/hotplug.go b/pkg/virt-handler/container-disk/hotplug.go
 new file mode 100644
-index 0000000000..3960b6bcb2
+index 0000000000..fa3a7c39af
 --- /dev/null
 +++ b/pkg/virt-handler/container-disk/hotplug.go
-@@ -0,0 +1,644 @@
+@@ -0,0 +1,667 @@
 +package container_disk
 +
 +import (
@@ -1185,7 +1185,7 @@ index 0000000000..3960b6bcb2
 +	virtLauncherUID, sourceUID types.UID,
 +	volumeName string,
 +) (vmiMountTargetEntry, error) {
-+	target, err := m.hotplugManager.GetFileSystemDiskTargetPathFromHostView(virtLauncherUID, volumeName, true)
++	targetFile, err := m.getTarget(virtLauncherUID, volumeName)
 +	if err != nil {
 +		return vmiMountTargetEntry{}, err
 +	}
@@ -1195,9 +1195,17 @@ index 0000000000..3960b6bcb2
 +		return vmiMountTargetEntry{}, err
 +	}
 +	return vmiMountTargetEntry{
-+		TargetFile: unsafepath.UnsafeAbsolute(target.Raw()),
++		TargetFile: targetFile,
 +		SocketFile: sock,
 +	}, nil
++}
++
++func (m *hotplugMounter) getTarget(virtLauncherUID types.UID, volumeName string) (string, error) {
++	target, err := m.hotplugManager.GetFileSystemDiskTargetPathFromHostView(virtLauncherUID, volumeName, true)
++	if err != nil {
++		return "", err
++	}
++	return unsafepath.UnsafeAbsolute(target.Raw()), nil
 +}
 +
 +func (m *hotplugMounter) getMountedVolumesInWorld(vmi *v1.VirtualMachineInstance, virtLauncherUID types.UID) ([]vmiMountTargetEntry, error) {
@@ -1220,7 +1228,7 @@ index 0000000000..3960b6bcb2
 +			continue
 +		}
 +		if strings.HasSuffix(entry.Name(), ".img") {
-+			name := strings.TrimPrefix(entry.Name(), ".img")
++			name := strings.TrimSuffix(entry.Name(), ".img")
 +			volumes = append(volumes, name)
 +		}
 +	}
@@ -1231,30 +1239,41 @@ index 0000000000..3960b6bcb2
 +			return nil, err
 +		}
 +		if mounted {
-+			entry, err := m.newMountTargetEntry(vmi, virtLauncherUID, "", v)
++			target, err := m.getTarget(virtLauncherUID, v)
 +			if err != nil {
 +				return nil, err
 +			}
-+			mountedVolumes = append(mountedVolumes, entry)
++			mountedVolumes = append(mountedVolumes, vmiMountTargetEntry{
++				TargetFile: target,
++			})
 +		}
 +	}
 +	return mountedVolumes, nil
 +}
 +
 +func (m *hotplugMounter) mergeMountEntries(r1, r2 []vmiMountTargetEntry) []vmiMountTargetEntry {
-+	newRecords := make([]vmiMountTargetEntry, 0)
-+	added := make(map[vmiMountTargetEntry]struct{})
++	targetSocket := make(map[string]string)
 +
-+	fn := func(r []vmiMountTargetEntry) {
++	sortTargetSocket := func(r []vmiMountTargetEntry) {
 +		for _, entry := range r {
-+			if _, ok := added[entry]; ok {
-+				continue
++			socket := targetSocket[entry.TargetFile]
++			if socket == "" {
++				targetSocket[entry.TargetFile] = entry.SocketFile
 +			}
-+			newRecords = append(newRecords, entry)
 +		}
 +	}
-+	fn(r1)
-+	fn(r2)
++	sortTargetSocket(r1)
++	sortTargetSocket(r2)
++
++	newRecords := make([]vmiMountTargetEntry, len(targetSocket))
++	count := 0
++	for t, s := range targetSocket {
++		newRecords[count] = vmiMountTargetEntry{
++			TargetFile: t,
++			SocketFile: s,
++		}
++		count++
++	}
 +
 +	return newRecords
 +}
@@ -1281,13 +1300,11 @@ index 0000000000..3960b6bcb2
 +		return nil
 +	}
 +
-+	entriesForDelete := make(map[vmiMountTargetEntry]struct{})
++	entriesTargetForDelete := make(map[string]struct{})
 +
 +	for _, r := range mountEntries {
-+		name, err := extractNameFromSocket(r.SocketFile)
-+		if err != nil {
-+			return err
-+		}
++		name := extractNameFromTarget(r.TargetFile)
++
 +		needUmount := true
 +		for _, v := range vmi.Status.VolumeStatus {
 +			if v.Name == name {
@@ -1298,7 +1315,7 @@ index 0000000000..3960b6bcb2
 +			file, err := safepath.NewFileNoFollow(r.TargetFile)
 +			if err != nil {
 +				if errors.Is(err, os.ErrNotExist) {
-+					entriesForDelete[r] = struct{}{}
++					entriesTargetForDelete[r.TargetFile] = struct{}{}
 +					continue
 +				}
 +				return fmt.Errorf(failedCheckMountPointFmt, r.TargetFile, err)
@@ -1312,7 +1329,7 @@ index 0000000000..3960b6bcb2
 +				if err = safepath.UnlinkAtNoFollow(file.Path()); err != nil {
 +					return fmt.Errorf("failed to delete file %s: %w", file.Path(), err)
 +				}
-+				entriesForDelete[r] = struct{}{}
++				entriesTargetForDelete[r.TargetFile] = struct{}{}
 +				continue
 +			}
 +			// #nosec No risk for attacket injection. Parameters are predefined strings
@@ -1323,12 +1340,12 @@ index 0000000000..3960b6bcb2
 +			if err = safepath.UnlinkAtNoFollow(file.Path()); err != nil {
 +				return fmt.Errorf("failed to delete file %s: %w", file.Path(), err)
 +			}
-+			entriesForDelete[r] = struct{}{}
++			entriesTargetForDelete[r.TargetFile] = struct{}{}
 +		}
 +	}
-+	newEntries := make([]vmiMountTargetEntry, 0, len(record.MountTargetEntries)-len(entriesForDelete))
-+	for _, entry := range record.MountTargetEntries {
-+		if _, found := entriesForDelete[entry]; found {
++	newEntries := make([]vmiMountTargetEntry, 0, len(recordMountTargetEntries)-len(entriesTargetForDelete))
++	for _, entry := range recordMountTargetEntries {
++		if _, found := entriesTargetForDelete[entry.TargetFile]; found {
 +			continue
 +		}
 +		newEntries = append(newEntries, entry)
@@ -1345,6 +1362,12 @@ index 0000000000..3960b6bcb2
 +		return name, nil
 +	}
 +	return "", fmt.Errorf("name not found in path")
++}
++
++func extractNameFromTarget(targetFile string) string {
++	filename := filepath.Base(targetFile)
++	name := strings.TrimSuffix(filename, filepath.Ext(filename))
++	return name
 +}
 +
 +func (m *hotplugMounter) UmountAll(vmi *v1.VirtualMachineInstance) error {

--- a/images/virt-artifact/patches/031-hotplug-container-disk.patch
+++ b/images/virt-artifact/patches/031-hotplug-container-disk.patch
@@ -869,10 +869,10 @@ index fa4e86ee17..c40f1fad89 100644
  			pvcName := storagetypes.PVCNameFromVirtVolume(&volume)
 diff --git a/pkg/virt-handler/container-disk/hotplug.go b/pkg/virt-handler/container-disk/hotplug.go
 new file mode 100644
-index 0000000000..553f76cb0a
+index 0000000000..3960b6bcb2
 --- /dev/null
 +++ b/pkg/virt-handler/container-disk/hotplug.go
-@@ -0,0 +1,538 @@
+@@ -0,0 +1,644 @@
 +package container_disk
 +
 +import (
@@ -1119,20 +1119,11 @@ index 0000000000..553f76cb0a
 +
 +	for _, volume := range vmi.Spec.Volumes {
 +		if volume.ContainerDisk != nil && volume.ContainerDisk.Hotpluggable {
-+			target, err := m.hotplugManager.GetFileSystemDiskTargetPathFromHostView(virtLauncherUID, volume.Name, true)
++			entry, err := m.newMountTargetEntry(vmi, virtLauncherUID, sourceUID, volume.Name)
 +			if err != nil {
 +				return nil, err
 +			}
-+
-+			sock, err := m.hotplugPathGetter(vmi, volume.Name, sourceUID)
-+			if err != nil {
-+				return nil, err
-+			}
-+
-+			record.MountTargetEntries = append(record.MountTargetEntries, vmiMountTargetEntry{
-+				TargetFile: unsafepath.UnsafeAbsolute(target.Raw()),
-+				SocketFile: sock,
-+			})
++			record.MountTargetEntries = append(record.MountTargetEntries, entry)
 +		}
 +	}
 +
@@ -1189,20 +1180,110 @@ index 0000000000..553f76cb0a
 +	return disksInfo, nil
 +}
 +
++func (m *hotplugMounter) newMountTargetEntry(
++	vmi *v1.VirtualMachineInstance,
++	virtLauncherUID, sourceUID types.UID,
++	volumeName string,
++) (vmiMountTargetEntry, error) {
++	target, err := m.hotplugManager.GetFileSystemDiskTargetPathFromHostView(virtLauncherUID, volumeName, true)
++	if err != nil {
++		return vmiMountTargetEntry{}, err
++	}
++
++	sock, err := m.hotplugPathGetter(vmi, volumeName, sourceUID)
++	if err != nil {
++		return vmiMountTargetEntry{}, err
++	}
++	return vmiMountTargetEntry{
++		TargetFile: unsafepath.UnsafeAbsolute(target.Raw()),
++		SocketFile: sock,
++	}, nil
++}
++
++func (m *hotplugMounter) getMountedVolumesInWorld(vmi *v1.VirtualMachineInstance, virtLauncherUID types.UID) ([]vmiMountTargetEntry, error) {
++	path, err := m.hotplugManager.GetHotplugTargetPodPathOnHost(virtLauncherUID)
++	if err != nil {
++		return nil, err
++	}
++	rawPath := unsafepath.UnsafeAbsolute(path.Raw())
++	entries, err := os.ReadDir(rawPath)
++	if err != nil {
++		return nil, err
++	}
++	var volumes []string
++	for _, entry := range entries {
++		info, err := entry.Info()
++		if err != nil {
++			return nil, err
++		}
++		if info.IsDir() {
++			continue
++		}
++		if strings.HasSuffix(entry.Name(), ".img") {
++			name := strings.TrimPrefix(entry.Name(), ".img")
++			volumes = append(volumes, name)
++		}
++	}
++	var mountedVolumes []vmiMountTargetEntry
++	for _, v := range volumes {
++		mounted, err := m.IsMounted(vmi, v)
++		if err != nil {
++			return nil, err
++		}
++		if mounted {
++			entry, err := m.newMountTargetEntry(vmi, virtLauncherUID, "", v)
++			if err != nil {
++				return nil, err
++			}
++			mountedVolumes = append(mountedVolumes, entry)
++		}
++	}
++	return mountedVolumes, nil
++}
++
++func (m *hotplugMounter) mergeMountEntries(r1, r2 []vmiMountTargetEntry) []vmiMountTargetEntry {
++	newRecords := make([]vmiMountTargetEntry, 0)
++	added := make(map[vmiMountTargetEntry]struct{})
++
++	fn := func(r []vmiMountTargetEntry) {
++		for _, entry := range r {
++			if _, ok := added[entry]; ok {
++				continue
++			}
++			newRecords = append(newRecords, entry)
++		}
++	}
++	fn(r1)
++	fn(r2)
++
++	return newRecords
++}
++
 +func (m *hotplugMounter) Umount(vmi *v1.VirtualMachineInstance) error {
 +	record, err := m.getMountTargetRecord(vmi)
 +	if err != nil {
 +		return err
-+	} else if record == nil {
-+		// no entries to unmount
++	}
 +
++	worldEntries, err := m.getMountedVolumesInWorld(vmi, m.findVirtlauncherUID(vmi))
++	if err != nil {
++		return fmt.Errorf("failed to get world entries: %w", err)
++	}
++	var recordMountTargetEntries []vmiMountTargetEntry
++	if record != nil {
++		recordMountTargetEntries = record.MountTargetEntries
++	}
++
++	mountEntries := m.mergeMountEntries(recordMountTargetEntries, worldEntries)
++
++	if len(mountEntries) == 0 {
 +		log.DefaultLogger().Object(vmi).Infof("No container disk mount entries found to unmount")
 +		return nil
 +	}
 +
 +	entriesForDelete := make(map[vmiMountTargetEntry]struct{})
 +
-+	for _, r := range record.MountTargetEntries {
++	for _, r := range mountEntries {
 +		name, err := extractNameFromSocket(r.SocketFile)
 +		if err != nil {
 +			return err
@@ -1228,6 +1309,9 @@ index 0000000000..553f76cb0a
 +				return fmt.Errorf(failedCheckMountPointFmt, r.TargetFile, err)
 +			}
 +			if !mounted {
++				if err = safepath.UnlinkAtNoFollow(file.Path()); err != nil {
++					return fmt.Errorf("failed to delete file %s: %w", file.Path(), err)
++				}
 +				entriesForDelete[r] = struct{}{}
 +				continue
 +			}
@@ -1235,6 +1319,9 @@ index 0000000000..553f76cb0a
 +			out, err := virt_chroot.UmountChroot(file.Path()).CombinedOutput()
 +			if err != nil {
 +				return fmt.Errorf(failedUnmountFmt, file, string(out), err)
++			}
++			if err = safepath.UnlinkAtNoFollow(file.Path()); err != nil {
++				return fmt.Errorf("failed to delete file %s: %w", file.Path(), err)
 +			}
 +			entriesForDelete[r] = struct{}{}
 +		}
@@ -1268,15 +1355,27 @@ index 0000000000..553f76cb0a
 +	record, err := m.getMountTargetRecord(vmi)
 +	if err != nil {
 +		return err
-+	} else if record == nil {
-+		// no entries to unmount
++	}
 +
++	worldEntries, err := m.getMountedVolumesInWorld(vmi, m.findVirtlauncherUID(vmi))
++	if err != nil {
++		return fmt.Errorf("failed to get world entries: %w", err)
++	}
++	var recordMountTargetEntries []vmiMountTargetEntry
++	if record != nil {
++		recordMountTargetEntries = record.MountTargetEntries
++	}
++
++	mountEntries := m.mergeMountEntries(recordMountTargetEntries, worldEntries)
++
++	if len(mountEntries) == 0 {
 +		log.DefaultLogger().Object(vmi).Infof("No container disk mount entries found to unmount")
 +		return nil
 +	}
 +
 +	log.DefaultLogger().Object(vmi).Infof("Found container disk mount entries")
-+	for _, entry := range record.MountTargetEntries {
++
++	for _, entry := range mountEntries {
 +		log.DefaultLogger().Object(vmi).Infof("Looking to see if containerdisk is mounted at path %s", entry.TargetFile)
 +		file, err := safepath.NewFileNoFollow(entry.TargetFile)
 +		if err != nil {
@@ -1294,6 +1393,13 @@ index 0000000000..553f76cb0a
 +			out, err := virt_chroot.UmountChroot(file.Path()).CombinedOutput()
 +			if err != nil {
 +				return fmt.Errorf(failedUnmountFmt, file, string(out), err)
++			}
++			if err = safepath.UnlinkAtNoFollow(file.Path()); err != nil {
++				return fmt.Errorf("failed to delete file %s: %w", file.Path(), err)
++			}
++		} else {
++			if err = safepath.UnlinkAtNoFollow(file.Path()); err != nil {
++				return fmt.Errorf("failed to delete file %s: %w", file.Path(), err)
 +			}
 +		}
 +	}


### PR DESCRIPTION
## Description
This PR enhances the unmounting process for hotplugged container disks by introducing improvements that ensure a more reliable and thorough cleanup.

## Changes
1. Added the removal of mount point files after unmounting to clean up leftover artifacts.
2. Updated the unmounting logic to rely not only on our managed mount records (stored in files) but also on the actual state of mount points.  
   - The implementation now actively checks the real mount points on the system to verify their state and ensures they are properly unmounted.

## Why do we need it, and what problem does it solve?
These changes make the unmounting process more robust and help prevent stale mount points from causing issues.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: kubevirt
type: fix
summary: Improve unmounting process by cleaning up mount point files and verifying actual mount states
```
