### PR TITLE
fix(kubevirt): migration disk serial

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -216,3 +216,36 @@ tasks:
       }'
       kubectl -n d8-virtualization port-forward pod/<virt-handler-pod> 2345:2345
       EOF
+
+  dlv:virt-api:build:
+    desc: "Build image virt-api with dlv"
+    cmd: docker build -f ./images/virt-api/debug/dlv.Dockerfile -t "{{ .DLV_IMAGE }}" --platform linux/amd64 .
+
+  dlv:virt-api:build-push:
+    desc: "Build and Push image virt-api with dlv"
+    cmds:
+      - task: dlv:virt-api:build
+      - docker push "{{ .DLV_IMAGE }}"
+      - task: dlv:virt-api:print
+
+  dlv:virt-api:print:
+    desc: "Print commands for debug"
+    env:
+      IMAGE: "{{ .DLV_IMAGE }}"
+    cmd: |
+      cat <<EOF
+      kubectl -n d8-virtualization patch deploy virt-api --type='strategic' -p '{
+        "spec": {
+          "template": {
+            "spec": {
+              "containers": [ {
+                "name": "virt-api",
+                "image": "${IMAGE}",
+                "ports": [ { "containerPort": 2345, "name": "dlv" } ]
+              }]
+            }
+          }
+        }
+      }'
+      kubectl -n d8-virtualization port-forward deploy/vit-api 2345:2345
+      EOF

--- a/images/virt-api/debug/dlv.Dockerfile
+++ b/images/virt-api/debug/dlv.Dockerfile
@@ -1,0 +1,31 @@
+FROM golang:1.22.7 AS builder
+
+ENV VERSION="1.3.1"
+ENV GOVERSION="1.22.7"
+
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
+
+RUN git clone --depth 1 --branch v$VERSION https://github.com/kubevirt/kubevirt.git /kubevirt
+COPY ./images/virt-artifact/patches /patches
+WORKDIR /kubevirt
+RUN for p in /patches/*.patch ; do git apply  --ignore-space-change --ignore-whitespace ${p} && echo OK || (echo FAIL ; exit 1) ; done
+
+RUN go mod edit -go=$GOVERSION && \
+    go mod download
+
+RUN go mod vendor
+
+ENV GO111MODULE=on
+ENV GOOS=linux
+ENV CGO_ENABLED=0
+ENV GOARCH=amd64
+
+RUN go build -o /kubevirt-binaries/virt-api ./cmd/virt-api/
+
+FROM busybox
+
+WORKDIR /app
+COPY --from=builder /kubevirt-binaries/virt-api /app/virt-api
+COPY --from=builder /go/bin/dlv /app/dlv
+USER 65532:65532
+ENTRYPOINT ["./dlv", "--listen=:2345", "--headless=true", "--continue", "--log=true", "--log-output=debugger,debuglineerr,gdbwire,lldbout,rpc", "--accept-multiclient", "--api-version=2", "exec", "/app/virt-api", "--"]

--- a/images/virt-artifact/patches/034-allow-update-kvvmi-for-virtualization-sas.patch
+++ b/images/virt-artifact/patches/034-allow-update-kvvmi-for-virtualization-sas.patch
@@ -1,0 +1,27 @@
+diff --git a/pkg/virt-api/webhooks/utils.go b/pkg/virt-api/webhooks/utils.go
+index e6ee54431f..5c68ce992d 100644
+--- a/pkg/virt-api/webhooks/utils.go
++++ b/pkg/virt-api/webhooks/utils.go
+@@ -100,7 +100,9 @@ func IsKubeVirtServiceAccount(serviceAccount string) bool {
+ 
+ 	return IsComponentServiceAccount(serviceAccount, ns, components.ApiServiceAccountName) ||
+ 		IsComponentServiceAccount(serviceAccount, ns, components.HandlerServiceAccountName) ||
+-		IsComponentServiceAccount(serviceAccount, ns, components.ControllerServiceAccountName)
++		IsComponentServiceAccount(serviceAccount, ns, components.ControllerServiceAccountName) ||
++		IsComponentServiceAccount(serviceAccount, ns, components.VirtualizationController) ||
++		IsComponentServiceAccount(serviceAccount, ns, components.VirtualizationApi)
+ }
+ 
+ func IsARM64(vmiSpec *v1.VirtualMachineInstanceSpec) bool {
+diff --git a/pkg/virt-operator/resource/generate/components/serviceaccountnames.go b/pkg/virt-operator/resource/generate/components/serviceaccountnames.go
+index 9aca3b3bd2..4ed51d98b5 100644
+--- a/pkg/virt-operator/resource/generate/components/serviceaccountnames.go
++++ b/pkg/virt-operator/resource/generate/components/serviceaccountnames.go
+@@ -6,4 +6,7 @@ const (
+ 	ExportProxyServiceAccountName = "kubevirt-internal-virtualization-exportproxy"
+ 	HandlerServiceAccountName     = "kubevirt-internal-virtualization-handler"
+ 	OperatorServiceAccountName    = "kubevirt-operator"
++
++	VirtualizationController = "virtualization-controller"
++	VirtualizationApi        = "virtualization-api"
+ )

--- a/images/virt-artifact/patches/035-allow-change-serial-on-kvvmi.patch
+++ b/images/virt-artifact/patches/035-allow-change-serial-on-kvvmi.patch
@@ -1,0 +1,49 @@
+diff --git a/pkg/virt-api/webhooks/validating-webhook/admitters/util.go b/pkg/virt-api/webhooks/validating-webhook/admitters/util.go
+new file mode 100644
+index 0000000000..6d0699b12d
+--- /dev/null
++++ b/pkg/virt-api/webhooks/validating-webhook/admitters/util.go
+@@ -0,0 +1,19 @@
++package admitters
++
++import (
++	"k8s.io/apimachinery/pkg/api/equality"
++	v1 "kubevirt.io/api/core/v1"
++)
++
++func equalDiskIgnoreSerial(newDisk, oldDisk v1.Disk) bool {
++	return equality.Semantic.DeepEqual(newDisk.Name, oldDisk.Name) &&
++		equality.Semantic.DeepEqual(newDisk.DiskDevice, oldDisk.DiskDevice) &&
++		equality.Semantic.DeepEqual(newDisk.BootOrder, oldDisk.BootOrder) &&
++		equality.Semantic.DeepEqual(newDisk.DedicatedIOThread, oldDisk.DedicatedIOThread) &&
++		equality.Semantic.DeepEqual(newDisk.Cache, oldDisk.Cache) &&
++		equality.Semantic.DeepEqual(newDisk.IO, oldDisk.IO) &&
++		equality.Semantic.DeepEqual(newDisk.Tag, oldDisk.Tag) &&
++		equality.Semantic.DeepEqual(newDisk.BlockSize, oldDisk.BlockSize) &&
++		equality.Semantic.DeepEqual(newDisk.Shareable, oldDisk.Shareable) &&
++		equality.Semantic.DeepEqual(newDisk.ErrorPolicy, oldDisk.ErrorPolicy)
++}
+diff --git a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter.go b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter.go
+index b984ff4262..8201d9375b 100644
+--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter.go
++++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter.go
+@@ -189,7 +189,8 @@ func verifyHotplugVolumes(newHotplugVolumeMap, oldHotplugVolumeMap map[string]v1
+ 						},
+ 					})
+ 				}
+-				if !equality.Semantic.DeepEqual(newDisks[k], oldDisks[k]) {
++
++				if !equalDiskIgnoreSerial(newDisks[k], oldDisks[k]) {
+ 					return webhookutils.ToAdmissionResponse([]metav1.StatusCause{
+ 						{
+ 							Type:    metav1.CauseTypeFieldValueInvalid,
+@@ -292,7 +293,8 @@ func verifyPermanentVolumes(newPermanentVolumeMap, oldPermanentVolumeMap map[str
+ 				},
+ 			})
+ 		}
+-		if !equality.Semantic.DeepEqual(newDisks[k], oldDisks[k]) {
++
++		if !equalDiskIgnoreSerial(newDisks[k], oldDisks[k]) {
+ 			return webhookutils.ToAdmissionResponse([]metav1.StatusCause{
+ 				{
+ 					Type:    metav1.CauseTypeFieldValueInvalid,

--- a/images/virt-artifact/patches/README.md
+++ b/images/virt-artifact/patches/README.md
@@ -202,3 +202,12 @@ Network traffic will be directed to the pod with the higher priority. Absence of
    while the source pod retains the default behavior (no label).
 
 Thus, packets are delivered as expected: initially only to the source pod during migration, and after migration completes, only to the target pod.
+
+#### `034-allow-update-kvvmi-for-virtualization-sas.patch`
+
+By default, the KVVMI spec can update only KubeVirt service accounts. This patch adds our virtualization accounts to the allowed list.  
+(`virtualization-controller`, `virtualization-api`)
+
+#### `035-allow-change-serial-on-kvvmi.patch`
+
+By default, the disk specification is immutable, but for backward compatibility, we need to allow modifying the serial. 

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -63,7 +63,7 @@ shell:
 
     - echo "Create .version file"
     - echo "v{{ $version }}-dirty" > /kubevirt-config-files/.version
-    
+
     - echo "Create group file"
     - |
       GROUP_FILE=/kubevirt-config-files/group
@@ -71,7 +71,7 @@ shell:
       echo "root:x:0:" >> $GROUP_FILE
       echo "nonroot-user:x:1001:" >> $GROUP_FILE
       chmod 0644 $GROUP_FILE
-    
+
     - echo "Create passwd file"
     - |
       PASSWD_FILE=/kubevirt-config-files/passwd
@@ -93,42 +93,42 @@ shell:
 
     - echo ============== Build virt-handler =====================
     - CGO_ENABLED=1 go build -o /kubevirt-binaries/virt-handler ./cmd/virt-handler/
-    
+
     - echo ============== Build virt-launcher-monitor ============
     - go build -o /kubevirt-binaries/virt-launcher-monitor ./cmd/virt-launcher-monitor/
-    
+
     - echo ============== Build virt-tail ========================
     - go build -o /kubevirt-binaries/virt-tail ./cmd/virt-tail/
-    
+
     - echo ============== Build virt-freezer =====================
     - go build -o /kubevirt-binaries/virt-freezer ./cmd/virt-freezer/
-    
+
     - echo ============== Build virt-probe =======================
     - go build -o /kubevirt-binaries/virt-probe ./cmd/virt-probe/
-    
+
     - echo ============== Build virt-api =========================
     - go build -o /kubevirt-binaries/virt-api ./cmd/virt-api/
-    
+
     - echo ============== Build virt-chroot ======================
     - go build -o /kubevirt-binaries/virt-chroot ./cmd/virt-chroot/
-    
+
     - echo ============== Build virt-exportproxy =================
     - go build -o /kubevirt-binaries/virt-exportproxy ./cmd/virt-exportproxy/
-    
+
     - echo ============== Build virt-exportserver ================
     - go build -o /kubevirt-binaries/virt-exportserver ./cmd/virt-exportserver/
-   
+
     - echo ============== Build virt-controller ==================
     - go build -o /kubevirt-binaries/virt-controller ./cmd/virt-controller/
-    
+
     - echo ============== Build virt-operator ====================
     - go build -o /kubevirt-binaries/virt-operator ./cmd/virt-operator/
-    
+
     - echo ============== Build csv-generator ====================
     - go build -o /kubevirt-binaries/csv-generator ./tools/csv-generator
-    
+
     - echo ============== Build sidecars =========================
     - go build -o /kubevirt-binaries/sidecars ./cmd/sidecars/
-    
+
     - echo ============== Build virtctl ==========================
     - go build -o /kubevirt-binaries/virtctl ./cmd/virtctl/

--- a/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/add_volume.go
+++ b/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/add_volume.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	virtv1 "kubevirt.io/api/core/v1"
 
+	"github.com/deckhouse/virtualization-controller/pkg/controller/kvbuilder"
 	"github.com/deckhouse/virtualization-controller/pkg/tls/certmanager"
 	virtlisters "github.com/deckhouse/virtualization/api/client/generated/listers/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/subresources"
@@ -119,7 +120,7 @@ func (r AddVolumeREST) genMutateRequestHook(opts *subresources.VirtualMachineAdd
 		Disk: &virtv1.Disk{
 			Name:       opts.Name,
 			DiskDevice: dd,
-			Serial:     opts.Name,
+			Serial:     kvbuilder.GenerateSerial(opts.Name),
 		},
 	}
 	switch opts.VolumeKind {

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
@@ -17,6 +17,8 @@ limitations under the License.
 package kvbuilder
 
 import (
+	"crypto/md5"
+	"encoding/hex"
 	"fmt"
 	"strings"
 
@@ -60,6 +62,13 @@ func GetOriginalDiskName(prefixedName string) (string, bool) {
 	}
 
 	return prefixedName, false
+}
+
+func GenerateSerial(input string) string {
+	hasher := md5.New()
+	hasher.Write([]byte(input))
+	hashInBytes := hasher.Sum(nil)
+	return hex.EncodeToString(hashInBytes)
 }
 
 type HotPlugDeviceSettings struct {
@@ -139,7 +148,7 @@ func ApplyVirtualMachineSpec(
 				if err := kvvm.SetDisk(name, SetDiskOptions{
 					PersistentVolumeClaim: pointer.GetPointer(vi.Status.Target.PersistentVolumeClaim),
 					IsEphemeral:           true,
-					Serial:                name,
+					Serial:                GenerateSerial(name),
 					BootOrder:             bootOrder,
 				}); err != nil {
 					return err
@@ -148,7 +157,7 @@ func ApplyVirtualMachineSpec(
 				if err := kvvm.SetDisk(name, SetDiskOptions{
 					ContainerDisk: pointer.GetPointer(vi.Status.Target.RegistryURL),
 					IsCdrom:       imageformat.IsISO(vi.Status.Format),
-					Serial:        name,
+					Serial:        GenerateSerial(name),
 					BootOrder:     bootOrder,
 				}); err != nil {
 					return err
@@ -167,7 +176,7 @@ func ApplyVirtualMachineSpec(
 			if err := kvvm.SetDisk(name, SetDiskOptions{
 				ContainerDisk: pointer.GetPointer(cvi.Status.Target.RegistryURL),
 				IsCdrom:       imageformat.IsISO(cvi.Status.Format),
-				Serial:        name,
+				Serial:        GenerateSerial(name),
 				BootOrder:     bootOrder,
 			}); err != nil {
 				return err
@@ -186,7 +195,7 @@ func ApplyVirtualMachineSpec(
 			name := GenerateVMDDiskName(bd.Name)
 			if err := kvvm.SetDisk(name, SetDiskOptions{
 				PersistentVolumeClaim: pointer.GetPointer(vd.Status.Target.PersistentVolumeClaim),
-				Serial:                name,
+				Serial:                GenerateSerial(name),
 				BootOrder:             bootOrder,
 			}); err != nil {
 				return err

--- a/images/virtualization-artifact/pkg/logger/attrs.go
+++ b/images/virtualization-artifact/pkg/logger/attrs.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package logger
 
-import "log/slog"
+import (
+	"encoding/json"
+	"log/slog"
+)
 
 const (
 	errAttr        = "err"
@@ -54,4 +57,12 @@ func SlogController(controller string) slog.Attr {
 
 func SlogCollector(collector string) slog.Attr {
 	return slog.String(collectorAttr, collector)
+}
+
+func SlogTryJson(key string, i interface{}) slog.Attr {
+	bytes, err := json.Marshal(i)
+	if err == nil {
+		return slog.String(key, string(bytes))
+	}
+	return slog.Any(key, i)
 }

--- a/images/virtualization-artifact/pkg/migration/README.md
+++ b/images/virtualization-artifact/pkg/migration/README.md
@@ -1,0 +1,9 @@
+# Migrations
+
+## qemu-max-length-36
+
+Fix disk serial handling for successful migration:
+
+Previously, we set the disk serial to match the disk name, relying on Kubernetes to ensure the uniqueness of names. However, after this [commit](https://github.com/qemu/qemu/commit/75997e182b695f2e3f0a2d649734952af5caf3ee) on QEMU, we can no longer do this, as QEMU no longer truncates the serial to 36 characters and now returns an error. We must handle the truncation ourselves. However, truncation does not guarantee uniqueness, so we switched to generating an MD5 hash of the disk name. The MD5 hash is easy to reproduce and fits the required 32-character length.
+
+To ensure a successful migration, existing `kvvm` and `kvvmi` resources need to be patched to reflect the new serial format.

--- a/images/virtualization-artifact/pkg/migration/migration.go
+++ b/images/virtualization-artifact/pkg/migration/migration.go
@@ -24,7 +24,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
-
 	"github.com/deckhouse/virtualization-controller/pkg/logger"
 )
 

--- a/images/virtualization-artifact/pkg/migration/migration.go
+++ b/images/virtualization-artifact/pkg/migration/migration.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migration
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
+
+	"github.com/deckhouse/virtualization-controller/pkg/logger"
+)
+
+type constructor func(client client.Client, logger *log.Logger) (Migration, error)
+
+var newMigrations = []constructor{
+	newQEMUMaxLength36,
+}
+
+type Migration interface {
+	Name() string
+	Migrate(ctx context.Context) error
+}
+
+type Controller struct {
+	client client.Client
+	log    *log.Logger
+
+	migrations []Migration
+}
+
+func NewController(client client.Client, log *log.Logger) (*Controller, error) {
+	migrations := make([]Migration, len(newMigrations))
+	for i, newMigration := range newMigrations {
+		m, err := newMigration(client, log)
+		if err != nil {
+			return nil, err
+		}
+		migrations[i] = m
+	}
+
+	return &Controller{
+		client:     client,
+		log:        log,
+		migrations: migrations,
+	}, nil
+}
+
+func (c *Controller) Run(ctx context.Context) {
+	wg := &sync.WaitGroup{}
+
+	c.run(ctx, wg, c.migrations)
+	wg.Wait()
+}
+
+func (c *Controller) run(ctx context.Context, wg *sync.WaitGroup, migrations []Migration) {
+	for _, m := range migrations {
+		if wg != nil {
+			wg.Add(1)
+		}
+		lg := c.log.With("name", m.Name())
+		lg.Info("Running migration")
+
+		go func() {
+			if wg != nil {
+				defer wg.Done()
+			}
+
+			for {
+				select {
+				case <-ctx.Done():
+					lg.Info("Cancelled migration")
+					return
+				default:
+					if err := m.Migrate(ctx); err != nil {
+						lg.Error("Failed to run migration, retry after 5s...", logger.SlogErr(err))
+						time.Sleep(5 * time.Second)
+						continue
+					}
+					lg.Info("Finished migration")
+					return
+				}
+			}
+		}()
+	}
+}

--- a/images/virtualization-artifact/pkg/migration/qemu_max_length_36.go
+++ b/images/virtualization-artifact/pkg/migration/qemu_max_length_36.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migration
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"k8s.io/apimachinery/pkg/types"
+	virtv1 "kubevirt.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
+
+	"github.com/deckhouse/virtualization-controller/pkg/common/patch"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/kvbuilder"
+)
+
+const (
+	// https://github.com/qemu/qemu/commit/75997e182b695f2e3f0a2d649734952af5caf3ee
+	qemuMaxLength36ControllerName = "qemu-max-length-36"
+)
+
+func newQEMUMaxLength36(client client.Client, logger *log.Logger) (Migration, error) {
+	return &qemuMaxLength36{
+		client: client,
+		logger: logger,
+	}, nil
+}
+
+type qemuMaxLength36 struct {
+	client client.Client
+	logger *log.Logger
+}
+
+func (r *qemuMaxLength36) Name() string {
+	return qemuMaxLength36ControllerName
+}
+
+func (r *qemuMaxLength36) Migrate(ctx context.Context) error {
+	kvvmList := &virtv1.VirtualMachineList{}
+	err := r.client.List(ctx, kvvmList)
+	if err != nil {
+		return err
+	}
+
+	for i := range kvvmList.Items {
+		kvvm := &kvvmList.Items[i]
+
+		needUpdate, genPatch, err := r.genPatch("/spec/template/spec", &kvvm.Spec.Template.Spec)
+		if err != nil {
+			return err
+		}
+		if !needUpdate {
+			continue
+		}
+
+		r.logger.Info("Patch kvvm", slog.String("name", kvvm.Name), slog.String("namespace", kvvm.Namespace))
+
+		if r.logger.GetLevel() <= log.LevelDebug {
+			if data, err := genPatch.Data(kvvm); err == nil {
+				r.logger.Debug("Patch kvvm",
+					slog.String("name", kvvm.Name),
+					slog.String("namespace", kvvm.Namespace),
+					slog.String("data", string(data)),
+				)
+			}
+		}
+
+		if err = r.client.Patch(ctx, kvvm, genPatch); err != nil {
+			return err
+		}
+	}
+
+	kvvmiList := &virtv1.VirtualMachineInstanceList{}
+	err = r.client.List(ctx, kvvmiList)
+	if err != nil {
+		return err
+	}
+
+	for i := range kvvmiList.Items {
+		kvvmi := &kvvmiList.Items[i]
+
+		needUpdate, genPatch, err := r.genPatch("/spec", &kvvmi.Spec)
+		if err != nil {
+			return err
+		}
+		if !needUpdate {
+			continue
+		}
+
+		r.logger.Info("Patch kvvmi", slog.String("name", kvvmi.Name), slog.String("namespace", kvvmi.Namespace))
+
+		if r.logger.GetLevel() <= log.LevelDebug {
+			if data, err := genPatch.Data(kvvmi); err == nil {
+				r.logger.Debug("Patch kvvmi",
+					slog.String("name", kvvmi.Name),
+					slog.String("namespace", kvvmi.Namespace),
+					slog.String("data", string(data)),
+				)
+			}
+		}
+
+		if err = r.client.Patch(ctx, kvvmi, genPatch); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *qemuMaxLength36) genPatch(base string, spec *virtv1.VirtualMachineInstanceSpec) (bool, client.Patch, error) {
+	var ops []patch.JsonPatchOperation
+	for i, d := range spec.Domain.Devices.Disks {
+		newSerial := kvbuilder.GenerateSerial(d.Name)
+		if d.Serial != "" && d.Serial != newSerial {
+			ops = append(ops, patch.NewJsonPatchOperation(
+				patch.PatchReplaceOp,
+				fmt.Sprintf("%s/domain/devices/disks/%d/serial", base, i),
+				newSerial,
+			))
+		}
+	}
+	if len(ops) == 0 {
+		return false, nil, nil
+	}
+	bytes, err := patch.NewJsonPatch(ops...).Bytes()
+	if err != nil {
+		return false, nil, err
+	}
+	return true, client.RawPatch(types.JSONPatchType, bytes), nil
+}

--- a/images/virtualization-artifact/pkg/migration/qemu_max_length_36.go
+++ b/images/virtualization-artifact/pkg/migration/qemu_max_length_36.go
@@ -26,7 +26,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
-
 	"github.com/deckhouse/virtualization-controller/pkg/common/patch"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/kvbuilder"
 )


### PR DESCRIPTION
## Description
Previously, we set the disk serial to match the disk name, relying on Kubernetes to ensure the uniqueness of names. However, after this [commit](https://github.com/qemu/qemu/commit/75997e182b695f2e3f0a2d649734952af5caf3ee) on QEMU, we can no longer do this, as QEMU no longer truncates the serial to 36 characters and now returns an error. We must handle the truncation ourselves. However, truncation does not guarantee uniqueness, so we switched to generating an MD5 hash of the disk name. The MD5 hash is easy to reproduce and fits the required 32-character length.

To ensure a successful migration, existing `kvvm` and `kvvmi` resources need to be patched to reflect the new serial format.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: vm  
type: fix  
summary: Disk serials are now generated using the MD5 hash of the disk name instead of the disk name itself. This prevents errors caused by recent QEMU changes enforcing a strict 36-character limit on serial numbers.
```
