### PR TITLE
feat(e2e): verifying vm launching by qemu agent ready status

### DIFF
--- a/tests/e2e/affinity_toleration_test.go
+++ b/tests/e2e/affinity_toleration_test.go
@@ -98,8 +98,8 @@ var _ = Describe("Virtual machine affinity and toleration", ginkgoutil.CommonE2E
 
 	Context("When virtual machines are applied:", func() {
 		It("checks VMs phases", func() {
-			By(fmt.Sprintf("VMs should be in %s phases", PhaseRunning))
-			WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, kc.WaitOptions{
+			By("VMs should be running")
+			WaitVmRunning(true, kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,

--- a/tests/e2e/affinity_toleration_test.go
+++ b/tests/e2e/affinity_toleration_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Virtual machine affinity and toleration", ginkgoutil.CommonE2E
 
 	Context("When virtual machines are applied:", func() {
 		It("checks VMs phases", func() {
-			By("VMs should be running")
+			By("VMs should be ready")
 			WaitVmReady(kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,

--- a/tests/e2e/affinity_toleration_test.go
+++ b/tests/e2e/affinity_toleration_test.go
@@ -99,7 +99,7 @@ var _ = Describe("Virtual machine affinity and toleration", ginkgoutil.CommonE2E
 	Context("When virtual machines are applied:", func() {
 		It("checks VMs phases", func() {
 			By("VMs should be running")
-			WaitVmRunning(true, kc.WaitOptions{
+			WaitVmReady(true, kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,

--- a/tests/e2e/affinity_toleration_test.go
+++ b/tests/e2e/affinity_toleration_test.go
@@ -99,7 +99,7 @@ var _ = Describe("Virtual machine affinity and toleration", ginkgoutil.CommonE2E
 	Context("When virtual machines are applied:", func() {
 		It("checks VMs phases", func() {
 			By("VMs should be running")
-			WaitVmReady(true, kc.WaitOptions{
+			WaitVmReady(kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -174,7 +174,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 	Context("When virtual machines are applied", func() {
 		It("checks VMs phases", func() {
 			By("VMs should be running")
-			WaitVmRunning(true, kc.WaitOptions{
+			WaitVmReady(true, kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -173,7 +173,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 
 	Context("When virtual machines are applied", func() {
 		It("checks VMs phases", func() {
-			By("VMs should be running")
+			By("VMs should be ready")
 			WaitVmReady(kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -174,7 +174,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 	Context("When virtual machines are applied", func() {
 		It("checks VMs phases", func() {
 			By("VMs should be running")
-			WaitVmReady(true, kc.WaitOptions{
+			WaitVmReady(kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -173,8 +173,8 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 
 	Context("When virtual machines are applied", func() {
 		It("checks VMs phases", func() {
-			By(fmt.Sprintf("VMs should be in %s phases", PhaseRunning))
-			WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, kc.WaitOptions{
+			By("VMs should be running")
+			WaitVmRunning(true, kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,

--- a/tests/e2e/sizing_policy_test.go
+++ b/tests/e2e/sizing_policy_test.go
@@ -186,7 +186,7 @@ var _ = Describe("Sizing policy", ginkgoutil.CommonE2ETestDecorators(), func() {
 			})
 
 			It("checks VM phase and condition status after changing", func() {
-				By("VM should be in ready")
+				By("VM should be ready")
 				WaitVmReady(kc.WaitOptions{
 					Labels:    notExistingVmClassChanging,
 					Namespace: conf.Namespace,

--- a/tests/e2e/sizing_policy_test.go
+++ b/tests/e2e/sizing_policy_test.go
@@ -164,7 +164,7 @@ var _ = Describe("Sizing policy", ginkgoutil.CommonE2ETestDecorators(), func() {
 
 		It(fmt.Sprintf("checks VMs phases with %s label", existingVmClass), func() {
 			By("VMs should be running")
-			WaitVmRunning(true, kc.WaitOptions{
+			WaitVmReady(true, kc.WaitOptions{
 				Labels:    existingVmClass,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,
@@ -187,7 +187,7 @@ var _ = Describe("Sizing policy", ginkgoutil.CommonE2ETestDecorators(), func() {
 
 			It("checks VM phase and condition status after changing", func() {
 				By("VM should be in running")
-				WaitVmRunning(true, kc.WaitOptions{
+				WaitVmReady(true, kc.WaitOptions{
 					Labels:    notExistingVmClassChanging,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
@@ -226,7 +226,7 @@ var _ = Describe("Sizing policy", ginkgoutil.CommonE2ETestDecorators(), func() {
 
 			It("checks VM phase and condition after creating", func() {
 				By("VM should be running")
-				WaitVmRunning(true, kc.WaitOptions{
+				WaitVmReady(true, kc.WaitOptions{
 					Labels:    notExistingVmClassCreating,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,

--- a/tests/e2e/sizing_policy_test.go
+++ b/tests/e2e/sizing_policy_test.go
@@ -163,7 +163,7 @@ var _ = Describe("Sizing policy", ginkgoutil.CommonE2ETestDecorators(), func() {
 		})
 
 		It(fmt.Sprintf("checks VMs phases with %s label", existingVmClass), func() {
-			By("VMs should be running")
+			By("VMs should be ready")
 			WaitVmReady(kc.WaitOptions{
 				Labels:    existingVmClass,
 				Namespace: conf.Namespace,
@@ -186,7 +186,7 @@ var _ = Describe("Sizing policy", ginkgoutil.CommonE2ETestDecorators(), func() {
 			})
 
 			It("checks VM phase and condition status after changing", func() {
-				By("VM should be in running")
+				By("VM should be in ready")
 				WaitVmReady(kc.WaitOptions{
 					Labels:    notExistingVmClassChanging,
 					Namespace: conf.Namespace,
@@ -225,7 +225,7 @@ var _ = Describe("Sizing policy", ginkgoutil.CommonE2ETestDecorators(), func() {
 			})
 
 			It("checks VM phase and condition after creating", func() {
-				By("VM should be running")
+				By("VM should be ready")
 				WaitVmReady(kc.WaitOptions{
 					Labels:    notExistingVmClassCreating,
 					Namespace: conf.Namespace,

--- a/tests/e2e/sizing_policy_test.go
+++ b/tests/e2e/sizing_policy_test.go
@@ -164,7 +164,7 @@ var _ = Describe("Sizing policy", ginkgoutil.CommonE2ETestDecorators(), func() {
 
 		It(fmt.Sprintf("checks VMs phases with %s label", existingVmClass), func() {
 			By("VMs should be running")
-			WaitVmReady(true, kc.WaitOptions{
+			WaitVmReady(kc.WaitOptions{
 				Labels:    existingVmClass,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,
@@ -187,7 +187,7 @@ var _ = Describe("Sizing policy", ginkgoutil.CommonE2ETestDecorators(), func() {
 
 			It("checks VM phase and condition status after changing", func() {
 				By("VM should be in running")
-				WaitVmReady(true, kc.WaitOptions{
+				WaitVmReady(kc.WaitOptions{
 					Labels:    notExistingVmClassChanging,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
@@ -226,7 +226,7 @@ var _ = Describe("Sizing policy", ginkgoutil.CommonE2ETestDecorators(), func() {
 
 			It("checks VM phase and condition after creating", func() {
 				By("VM should be running")
-				WaitVmReady(true, kc.WaitOptions{
+				WaitVmReady(kc.WaitOptions{
 					Labels:    notExistingVmClassCreating,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,

--- a/tests/e2e/sizing_policy_test.go
+++ b/tests/e2e/sizing_policy_test.go
@@ -163,8 +163,8 @@ var _ = Describe("Sizing policy", ginkgoutil.CommonE2ETestDecorators(), func() {
 		})
 
 		It(fmt.Sprintf("checks VMs phases with %s label", existingVmClass), func() {
-			By(fmt.Sprintf("VMs should be in %s phases", PhaseRunning))
-			WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, kc.WaitOptions{
+			By("VMs should be running")
+			WaitVmRunning(true, kc.WaitOptions{
 				Labels:    existingVmClass,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,
@@ -186,8 +186,8 @@ var _ = Describe("Sizing policy", ginkgoutil.CommonE2ETestDecorators(), func() {
 			})
 
 			It("checks VM phase and condition status after changing", func() {
-				By(fmt.Sprintf("VM should be in %s phase", PhaseRunning))
-				WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, kc.WaitOptions{
+				By("VM should be in running")
+				WaitVmRunning(true, kc.WaitOptions{
 					Labels:    notExistingVmClassChanging,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
@@ -225,8 +225,8 @@ var _ = Describe("Sizing policy", ginkgoutil.CommonE2ETestDecorators(), func() {
 			})
 
 			It("checks VM phase and condition after creating", func() {
-				By(fmt.Sprintf("VM should be in %s phase", PhaseRunning))
-				WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, kc.WaitOptions{
+				By("VM should be running")
+				WaitVmRunning(true, kc.WaitOptions{
 					Labels:    notExistingVmClassCreating,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,

--- a/tests/e2e/tests_suite_test.go
+++ b/tests/e2e/tests_suite_test.go
@@ -49,7 +49,6 @@ const (
 	PhaseRunning              = "Running"
 	PhaseWaitForUserUpload    = "WaitForUserUpload"
 	PhaseWaitForFirstConsumer = "WaitForFirstConsumer"
-	AgentReadyCondition       = "AgentReady"
 )
 
 var (

--- a/tests/e2e/tests_suite_test.go
+++ b/tests/e2e/tests_suite_test.go
@@ -49,6 +49,7 @@ const (
 	PhaseRunning              = "Running"
 	PhaseWaitForUserUpload    = "WaitForUserUpload"
 	PhaseWaitForFirstConsumer = "WaitForFirstConsumer"
+	AgentReadyCondition       = "AgentReady"
 )
 
 var (

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -253,11 +253,11 @@ func ChmodFile(pathFile string, permission os.FileMode) {
 	}
 }
 
-func WaitVmOsStarted(resource kc.Resource, waitAgent bool, opts kc.WaitOptions) {
+func WaitVmRunning(waitAgent bool, opts kc.WaitOptions) {
 	GinkgoHelper()
-	WaitPhaseByLabel(resource, PhaseRunning, opts)
+	WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, opts)
 	if waitAgent {
-		WaitConditionIsTrueByLabel(resource, AgentReadyCondition, opts)
+		WaitConditionIsTrueByLabel(kc.ResourceVM, AgentReadyCondition, opts)
 	}
 }
 

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -253,6 +253,20 @@ func ChmodFile(pathFile string, permission os.FileMode) {
 	}
 }
 
+func WaitVmOsStarted(resource kc.Resource, waitAgent bool, opts kc.WaitOptions) {
+	GinkgoHelper()
+	WaitPhaseByLabel(resource, PhaseRunning, opts)
+	if waitAgent {
+		WaitConditionIsTrueByLabel(resource, AgentReadyCondition, opts)
+	}
+}
+
+func WaitConditionIsTrueByLabel(resource kc.Resource, conditionName string, opts kc.WaitOptions) {
+	GinkgoHelper()
+	opts.For = fmt.Sprintf("condition=%s=True", conditionName)
+	WaitByLabel(resource, opts)
+}
+
 // Useful when require to async await resources filtered by labels.
 //
 //	Static condition `wait --for`: `jsonpath={.status.phase}=phase`.

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmcondition"
 	. "github.com/deckhouse/virtualization/tests/e2e/config"
 	"github.com/deckhouse/virtualization/tests/e2e/executor"
 	"github.com/deckhouse/virtualization/tests/e2e/helper"
@@ -253,11 +254,11 @@ func ChmodFile(pathFile string, permission os.FileMode) {
 	}
 }
 
-func WaitVmRunning(waitAgent bool, opts kc.WaitOptions) {
+func WaitVmReady(waitAgent bool, opts kc.WaitOptions) {
 	GinkgoHelper()
 	WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, opts)
 	if waitAgent {
-		WaitConditionIsTrueByLabel(kc.ResourceVM, AgentReadyCondition, opts)
+		WaitConditionIsTrueByLabel(kc.ResourceVM, vmcondition.TypeAgentReady.String(), opts)
 	}
 }
 

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -254,12 +254,10 @@ func ChmodFile(pathFile string, permission os.FileMode) {
 	}
 }
 
-func WaitVmReady(waitAgent bool, opts kc.WaitOptions) {
+func WaitVmReady(opts kc.WaitOptions) {
 	GinkgoHelper()
 	WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, opts)
-	if waitAgent {
-		WaitConditionIsTrueByLabel(kc.ResourceVM, vmcondition.TypeAgentReady.String(), opts)
-	}
+	WaitConditionIsTrueByLabel(kc.ResourceVM, vmcondition.TypeAgentReady.String(), opts)
 }
 
 func WaitConditionIsTrueByLabel(resource kc.Resource, conditionName string, opts kc.WaitOptions) {

--- a/tests/e2e/vd_snapshots_test.go
+++ b/tests/e2e/vd_snapshots_test.go
@@ -316,8 +316,8 @@ var _ = Describe("Virtual disk snapshots", ginkgoutil.CommonE2ETestDecorators(),
 
 	Context("When virtual machines are applied:", func() {
 		It("checks VMs phases", func() {
-			By(fmt.Sprintf("VMs should be in %s phases", PhaseRunning))
-			WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, kc.WaitOptions{
+			By("VMs should be running")
+			WaitVmRunning(true, kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,

--- a/tests/e2e/vd_snapshots_test.go
+++ b/tests/e2e/vd_snapshots_test.go
@@ -316,8 +316,8 @@ var _ = Describe("Virtual disk snapshots", ginkgoutil.CommonE2ETestDecorators(),
 
 	Context("When virtual machines are applied:", func() {
 		It("checks VMs phases", func() {
-			By("VMs should be running")
-			WaitVmRunning(true, kc.WaitOptions{
+			By("VMs should be ready")
+			WaitVmReady(true, kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,

--- a/tests/e2e/vd_snapshots_test.go
+++ b/tests/e2e/vd_snapshots_test.go
@@ -317,7 +317,7 @@ var _ = Describe("Virtual disk snapshots", ginkgoutil.CommonE2ETestDecorators(),
 	Context("When virtual machines are applied:", func() {
 		It("checks VMs phases", func() {
 			By("VMs should be ready")
-			WaitVmReady(true, kc.WaitOptions{
+			WaitVmReady(kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,

--- a/tests/e2e/vm_configuration_test.go
+++ b/tests/e2e/vm_configuration_test.go
@@ -180,7 +180,7 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 
 	Context("When virtual machines are applied", func() {
 		It("should be running", func() {
-			WaitVmRunning(true, kc.WaitOptions{
+			WaitVmReady(true, kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,

--- a/tests/e2e/vm_configuration_test.go
+++ b/tests/e2e/vm_configuration_test.go
@@ -179,8 +179,8 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 	})
 
 	Context("When virtual machines are applied", func() {
-		It("should be running and OS started", func() {
-			WaitVmOsStarted(kc.ResourceVM, true, kc.WaitOptions{
+		It("should be running", func() {
+			WaitVmRunning(true, kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,

--- a/tests/e2e/vm_configuration_test.go
+++ b/tests/e2e/vm_configuration_test.go
@@ -180,7 +180,7 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 
 	Context("When virtual machines are applied", func() {
 		It("should be running", func() {
-			WaitVmReady(true, kc.WaitOptions{
+			WaitVmReady(kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,

--- a/tests/e2e/vm_configuration_test.go
+++ b/tests/e2e/vm_configuration_test.go
@@ -179,7 +179,7 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 	})
 
 	Context("When virtual machines are applied", func() {
-		It("should be running", func() {
+		It("should be ready", func() {
 			WaitVmReady(kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
@@ -231,7 +231,7 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 		})
 
 		Context("When virtual machine is restarted", func() {
-			It(fmt.Sprintf("should be in %s phase", PhaseRunning), func() {
+			It("should be ready", func() {
 				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 					Labels:    manualLabel,
 					Namespace: conf.Namespace,
@@ -244,7 +244,7 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 					cmd := "sudo reboot"
 					ExecSshCommand(vm, cmd)
 				}
-				WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, kc.WaitOptions{
+				WaitVmReady(kc.WaitOptions{
 					Labels:    manualLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
@@ -310,8 +310,8 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 		})
 
 		Context("When virtual machine is restarted", func() {
-			It(fmt.Sprintf("should be in %s phase", PhaseRunning), func() {
-				WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, kc.WaitOptions{
+			It("should be ready", func() {
+				WaitVmReady(kc.WaitOptions{
 					Labels:    automaticLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,

--- a/tests/e2e/vm_configuration_test.go
+++ b/tests/e2e/vm_configuration_test.go
@@ -179,8 +179,8 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 	})
 
 	Context("When virtual machines are applied", func() {
-		It(fmt.Sprintf("should be in %s phase", PhaseRunning), func() {
-			WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, kc.WaitOptions{
+		It("should be running and OS started", func() {
+			WaitVmOsStarted(kc.ResourceVM, true, kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,

--- a/tests/e2e/vm_connectivity_test.go
+++ b/tests/e2e/vm_connectivity_test.go
@@ -162,7 +162,7 @@ var _ = Describe("VM connectivity", ginkgoutil.CommonE2ETestDecorators(), func()
 
 	Context("When virtual machines are applied", func() {
 		It("checks VMs phases", func() {
-			By("VMs should be running")
+			By("VMs should be ready")
 			WaitVmReady(kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,

--- a/tests/e2e/vm_connectivity_test.go
+++ b/tests/e2e/vm_connectivity_test.go
@@ -163,7 +163,7 @@ var _ = Describe("VM connectivity", ginkgoutil.CommonE2ETestDecorators(), func()
 	Context("When virtual machines are applied", func() {
 		It("checks VMs phases", func() {
 			By("VMs should be running")
-			WaitVmRunning(true, kc.WaitOptions{
+			WaitVmReady(true, kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,

--- a/tests/e2e/vm_connectivity_test.go
+++ b/tests/e2e/vm_connectivity_test.go
@@ -163,7 +163,7 @@ var _ = Describe("VM connectivity", ginkgoutil.CommonE2ETestDecorators(), func()
 	Context("When virtual machines are applied", func() {
 		It("checks VMs phases", func() {
 			By("VMs should be running")
-			WaitVmReady(true, kc.WaitOptions{
+			WaitVmReady(kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,

--- a/tests/e2e/vm_connectivity_test.go
+++ b/tests/e2e/vm_connectivity_test.go
@@ -162,8 +162,8 @@ var _ = Describe("VM connectivity", ginkgoutil.CommonE2ETestDecorators(), func()
 
 	Context("When virtual machines are applied", func() {
 		It("checks VMs phases", func() {
-			By(fmt.Sprintf("VMs should be in %s phase", PhaseRunning))
-			WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, kc.WaitOptions{
+			By("VMs should be running")
+			WaitVmRunning(true, kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,

--- a/tests/e2e/vm_disk_attachment_test.go
+++ b/tests/e2e/vm_disk_attachment_test.go
@@ -178,7 +178,7 @@ var _ = Describe("Virtual disk attachment", ginkgoutil.CommonE2ETestDecorators()
 	Context("When virtual machines are applied", func() {
 		It("checks VMs phases", func() {
 			By("VMs should be running")
-			WaitVmRunning(true, kc.WaitOptions{
+			WaitVmReady(true, kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,
@@ -204,7 +204,7 @@ var _ = Describe("Virtual disk attachment", ginkgoutil.CommonE2ETestDecorators()
 					Timeout:   MaxWaitTimeout,
 				})
 				By("Virtual machines should be running")
-				WaitVmRunning(true, kc.WaitOptions{
+				WaitVmReady(true, kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
@@ -241,7 +241,7 @@ var _ = Describe("Virtual disk attachment", ginkgoutil.CommonE2ETestDecorators()
 			})
 			It("checks VM phase", func() {
 				By("Virtual machines should be running")
-				WaitVmRunning(true, kc.WaitOptions{
+				WaitVmReady(true, kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,

--- a/tests/e2e/vm_disk_attachment_test.go
+++ b/tests/e2e/vm_disk_attachment_test.go
@@ -177,7 +177,7 @@ var _ = Describe("Virtual disk attachment", ginkgoutil.CommonE2ETestDecorators()
 
 	Context("When virtual machines are applied", func() {
 		It("checks VMs phases", func() {
-			By("VMs should be running")
+			By("VMs should be ready")
 			WaitVmReady(kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
@@ -203,7 +203,7 @@ var _ = Describe("Virtual disk attachment", ginkgoutil.CommonE2ETestDecorators()
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
 				})
-				By("Virtual machines should be running")
+				By("Virtual machines should be ready")
 				WaitVmReady(kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
@@ -240,7 +240,7 @@ var _ = Describe("Virtual disk attachment", ginkgoutil.CommonE2ETestDecorators()
 				Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
 			})
 			It("checks VM phase", func() {
-				By("Virtual machines should be running")
+				By("Virtual machines should be ready")
 				WaitVmReady(kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,

--- a/tests/e2e/vm_disk_attachment_test.go
+++ b/tests/e2e/vm_disk_attachment_test.go
@@ -178,7 +178,7 @@ var _ = Describe("Virtual disk attachment", ginkgoutil.CommonE2ETestDecorators()
 	Context("When virtual machines are applied", func() {
 		It("checks VMs phases", func() {
 			By("VMs should be running")
-			WaitVmReady(true, kc.WaitOptions{
+			WaitVmReady(kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,
@@ -204,7 +204,7 @@ var _ = Describe("Virtual disk attachment", ginkgoutil.CommonE2ETestDecorators()
 					Timeout:   MaxWaitTimeout,
 				})
 				By("Virtual machines should be running")
-				WaitVmReady(true, kc.WaitOptions{
+				WaitVmReady(kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
@@ -241,7 +241,7 @@ var _ = Describe("Virtual disk attachment", ginkgoutil.CommonE2ETestDecorators()
 			})
 			It("checks VM phase", func() {
 				By("Virtual machines should be running")
-				WaitVmReady(true, kc.WaitOptions{
+				WaitVmReady(kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,

--- a/tests/e2e/vm_disk_attachment_test.go
+++ b/tests/e2e/vm_disk_attachment_test.go
@@ -177,8 +177,8 @@ var _ = Describe("Virtual disk attachment", ginkgoutil.CommonE2ETestDecorators()
 
 	Context("When virtual machines are applied", func() {
 		It("checks VMs phases", func() {
-			By(fmt.Sprintf("VMs should be in %s phases", PhaseRunning))
-			WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, kc.WaitOptions{
+			By("VMs should be running")
+			WaitVmRunning(true, kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,
@@ -203,8 +203,8 @@ var _ = Describe("Virtual disk attachment", ginkgoutil.CommonE2ETestDecorators()
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
 				})
-				By(fmt.Sprintf("Virtual machines should be in %s phase", PhaseRunning))
-				WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, kc.WaitOptions{
+				By("Virtual machines should be running")
+				WaitVmRunning(true, kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
@@ -240,8 +240,8 @@ var _ = Describe("Virtual disk attachment", ginkgoutil.CommonE2ETestDecorators()
 				Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
 			})
 			It("checks VM phase", func() {
-				By(fmt.Sprintf("Virtual machines should be in %s phase", PhaseRunning))
-				WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, kc.WaitOptions{
+				By("Virtual machines should be running")
+				WaitVmRunning(true, kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,

--- a/tests/e2e/vm_disk_resizing_test.go
+++ b/tests/e2e/vm_disk_resizing_test.go
@@ -212,7 +212,7 @@ var _ = Describe("Virtual disk resizing", ginkgoutil.CommonE2ETestDecorators(), 
 	Context("When virtual machines are applied", func() {
 		It("checks VMs phases", func() {
 			By("VMs should be running")
-			WaitVmReady(true, kc.WaitOptions{
+			WaitVmReady(kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,
@@ -269,7 +269,7 @@ var _ = Describe("Virtual disk resizing", ginkgoutil.CommonE2ETestDecorators(), 
 				})
 
 				By("VMs should be running")
-				WaitVmReady(true, kc.WaitOptions{
+				WaitVmReady(kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,

--- a/tests/e2e/vm_disk_resizing_test.go
+++ b/tests/e2e/vm_disk_resizing_test.go
@@ -211,7 +211,7 @@ var _ = Describe("Virtual disk resizing", ginkgoutil.CommonE2ETestDecorators(), 
 
 	Context("When virtual machines are applied", func() {
 		It("checks VMs phases", func() {
-			By("VMs should be running")
+			By("VMs should be ready")
 			WaitVmReady(kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
@@ -268,7 +268,7 @@ var _ = Describe("Virtual disk resizing", ginkgoutil.CommonE2ETestDecorators(), 
 					Timeout:   MaxWaitTimeout,
 				})
 
-				By("VMs should be running")
+				By("VMs should be ready")
 				WaitVmReady(kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,

--- a/tests/e2e/vm_disk_resizing_test.go
+++ b/tests/e2e/vm_disk_resizing_test.go
@@ -212,7 +212,7 @@ var _ = Describe("Virtual disk resizing", ginkgoutil.CommonE2ETestDecorators(), 
 	Context("When virtual machines are applied", func() {
 		It("checks VMs phases", func() {
 			By("VMs should be running")
-			WaitVmRunning(true, kc.WaitOptions{
+			WaitVmReady(true, kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,
@@ -269,7 +269,7 @@ var _ = Describe("Virtual disk resizing", ginkgoutil.CommonE2ETestDecorators(), 
 				})
 
 				By("VMs should be running")
-				WaitVmRunning(true, kc.WaitOptions{
+				WaitVmReady(true, kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,

--- a/tests/e2e/vm_disk_resizing_test.go
+++ b/tests/e2e/vm_disk_resizing_test.go
@@ -211,8 +211,8 @@ var _ = Describe("Virtual disk resizing", ginkgoutil.CommonE2ETestDecorators(), 
 
 	Context("When virtual machines are applied", func() {
 		It("checks VMs phases", func() {
-			By(fmt.Sprintf("VMs should be in %s phases", PhaseRunning))
-			WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, kc.WaitOptions{
+			By("VMs should be running")
+			WaitVmRunning(true, kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,
@@ -268,8 +268,8 @@ var _ = Describe("Virtual disk resizing", ginkgoutil.CommonE2ETestDecorators(), 
 					Timeout:   MaxWaitTimeout,
 				})
 
-				By(fmt.Sprintf("VMs should be in %s phases", PhaseRunning))
-				WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, kc.WaitOptions{
+				By("VMs should be running")
+				WaitVmRunning(true, kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,

--- a/tests/e2e/vm_label_annotation_test.go
+++ b/tests/e2e/vm_label_annotation_test.go
@@ -152,8 +152,8 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 
 	Context("When virtual machines are applied", func() {
 		It("checks VMs phases", func() {
-			By(fmt.Sprintf("VMs should be in %s phases", PhaseRunning))
-			WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, kc.WaitOptions{
+			By("VMs should be running")
+			WaitVmRunning(true, kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,

--- a/tests/e2e/vm_label_annotation_test.go
+++ b/tests/e2e/vm_label_annotation_test.go
@@ -153,7 +153,7 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 	Context("When virtual machines are applied", func() {
 		It("checks VMs phases", func() {
 			By("VMs should be running")
-			WaitVmRunning(true, kc.WaitOptions{
+			WaitVmReady(true, kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,

--- a/tests/e2e/vm_label_annotation_test.go
+++ b/tests/e2e/vm_label_annotation_test.go
@@ -152,7 +152,7 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 
 	Context("When virtual machines are applied", func() {
 		It("checks VMs phases", func() {
-			By("VMs should be running")
+			By("VMs should be ready")
 			WaitVmReady(kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,

--- a/tests/e2e/vm_label_annotation_test.go
+++ b/tests/e2e/vm_label_annotation_test.go
@@ -153,7 +153,7 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 	Context("When virtual machines are applied", func() {
 		It("checks VMs phases", func() {
 			By("VMs should be running")
-			WaitVmReady(true, kc.WaitOptions{
+			WaitVmReady(kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,

--- a/tests/e2e/vm_migration_test.go
+++ b/tests/e2e/vm_migration_test.go
@@ -135,7 +135,7 @@ var _ = Describe("Virtual machine migration", ginkgoutil.CommonE2ETestDecorators
 	Context("When virtual machines are applied", func() {
 		It("checks VMs phases", func() {
 			By("VMs should be running")
-			WaitVmRunning(true, kc.WaitOptions{
+			WaitVmReady(true, kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,

--- a/tests/e2e/vm_migration_test.go
+++ b/tests/e2e/vm_migration_test.go
@@ -134,8 +134,8 @@ var _ = Describe("Virtual machine migration", ginkgoutil.CommonE2ETestDecorators
 
 	Context("When virtual machines are applied", func() {
 		It("checks VMs phases", func() {
-			By(fmt.Sprintf("VMs should be in %s phases", PhaseRunning))
-			WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, kc.WaitOptions{
+			By("VMs should be running")
+			WaitVmRunning(true, kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,

--- a/tests/e2e/vm_migration_test.go
+++ b/tests/e2e/vm_migration_test.go
@@ -135,7 +135,7 @@ var _ = Describe("Virtual machine migration", ginkgoutil.CommonE2ETestDecorators
 	Context("When virtual machines are applied", func() {
 		It("checks VMs phases", func() {
 			By("VMs should be running")
-			WaitVmReady(true, kc.WaitOptions{
+			WaitVmReady(kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,

--- a/tests/e2e/vm_migration_test.go
+++ b/tests/e2e/vm_migration_test.go
@@ -134,7 +134,7 @@ var _ = Describe("Virtual machine migration", ginkgoutil.CommonE2ETestDecorators
 
 	Context("When virtual machines are applied", func() {
 		It("checks VMs phases", func() {
-			By("VMs should be running")
+			By("VMs should be ready")
 			WaitVmReady(kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,


### PR DESCRIPTION
## Description
This pull request enhances the reliability of our end-to-end (E2E) tests by updating the verification process for virtual machine (VM) readiness. Instead of merely waiting for the VM to reach the "running" phase, the test now explicitly checks the VM's status and optionally confirms the successful launch of the QEMU agent. This change aims to reduce false positives and ensure that the VM is fully operational and ready for subsequent testing steps. Adjustments are reflected in the affected test scripts to incorporate these additional validation checks.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: e2e
type: feat
summary:  verifying vm launching by qemu agent ready status
```
