### PR TITLE
fix(vm): set disk serial by uid resource

### DIFF
--- a/api/client/kubeclient/vm.go
+++ b/api/client/kubeclient/vm.go
@@ -159,6 +159,7 @@ func (v vm) AddVolume(ctx context.Context, name string, opts v1alpha2.VirtualMac
 		Param("volumeKind", opts.VolumeKind).
 		Param("pvcName", opts.PVCName).
 		Param("image", opts.Image).
+		Param("serial", opts.Serial).
 		Param("isCdrom", strconv.FormatBool(opts.IsCdrom)).
 		Do(ctx).
 		Error()

--- a/api/pkg/apiserver/api/generated/openapi/zz_generated.openapi.go
+++ b/api/pkg/apiserver/api/generated/openapi/zz_generated.openapi.go
@@ -5263,6 +5263,13 @@ func schema_virtualization_api_subresources_v1alpha2_VirtualMachineAddVolume(ref
 							Format:  "",
 						},
 					},
+					"serial": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
 					"isCdrom": {
 						SchemaProps: spec.SchemaProps{
 							Default: false,
@@ -5271,7 +5278,7 @@ func schema_virtualization_api_subresources_v1alpha2_VirtualMachineAddVolume(ref
 						},
 					},
 				},
-				Required: []string{"name", "volumeKind", "pvcName", "image", "isCdrom"},
+				Required: []string{"name", "volumeKind", "pvcName", "image", "serial", "isCdrom"},
 			},
 		},
 	}

--- a/api/subresources/types.go
+++ b/api/subresources/types.go
@@ -57,6 +57,7 @@ type VirtualMachineAddVolume struct {
 	VolumeKind string
 	PVCName    string
 	Image      string
+	Serial     string
 	IsCdrom    bool
 }
 

--- a/api/subresources/v1alpha2/types.go
+++ b/api/subresources/v1alpha2/types.go
@@ -59,6 +59,7 @@ type VirtualMachineAddVolume struct {
 	VolumeKind      string `json:"volumeKind"`
 	PVCName         string `json:"pvcName"`
 	Image           string `json:"image"`
+	Serial          string `json:"serial"`
 	IsCdrom         bool   `json:"isCdrom"`
 }
 

--- a/api/subresources/v1alpha2/zz_generated.conversion.go
+++ b/api/subresources/v1alpha2/zz_generated.conversion.go
@@ -166,6 +166,7 @@ func autoConvert_v1alpha2_VirtualMachineAddVolume_To_subresources_VirtualMachine
 	out.VolumeKind = in.VolumeKind
 	out.PVCName = in.PVCName
 	out.Image = in.Image
+	out.Serial = in.Serial
 	out.IsCdrom = in.IsCdrom
 	return nil
 }
@@ -180,6 +181,7 @@ func autoConvert_subresources_VirtualMachineAddVolume_To_v1alpha2_VirtualMachine
 	out.VolumeKind = in.VolumeKind
 	out.PVCName = in.PVCName
 	out.Image = in.Image
+	out.Serial = in.Serial
 	out.IsCdrom = in.IsCdrom
 	return nil
 }
@@ -219,6 +221,13 @@ func autoConvert_url_Values_To_v1alpha2_VirtualMachineAddVolume(in *url.Values, 
 		}
 	} else {
 		out.Image = ""
+	}
+	if values, ok := map[string][]string(*in)["serial"]; ok && len(values) > 0 {
+		if err := runtime.Convert_Slice_string_To_string(&values, &out.Serial, s); err != nil {
+			return err
+		}
+	} else {
+		out.Serial = ""
 	}
 	if values, ok := map[string][]string(*in)["isCdrom"]; ok && len(values) > 0 {
 		if err := runtime.Convert_Slice_string_To_bool(&values, &out.IsCdrom, s); err != nil {

--- a/images/virt-artifact/patches/036-enhance-SCSI-disk-serial-validation.patch
+++ b/images/virt-artifact/patches/036-enhance-SCSI-disk-serial-validation.patch
@@ -1,0 +1,123 @@
+diff --git a/pkg/util/hardware/hw_utils.go b/pkg/util/hardware/hw_utils.go
+index a3bb25c3ab..cb38f3667a 100644
+--- a/pkg/util/hardware/hw_utils.go
++++ b/pkg/util/hardware/hw_utils.go
+@@ -35,6 +35,7 @@ import (
+ 
+ const (
+ 	PCI_ADDRESS_PATTERN = `^([\da-fA-F]{4}):([\da-fA-F]{2}):([\da-fA-F]{2})\.([0-7]{1})$`
++	MaxSCSISerialLen    = 36
+ )
+ 
+ // Parse linux cpuset into an array of ints
+@@ -178,3 +179,10 @@ func LookupDeviceVCPUAffinity(pciAddress string, domainSpec *api.DomainSpec) ([]
+ 	}
+ 	return alignedVCPUList, nil
+ }
++
++func TruncateSCSIDiskSerial(serial string) string {
++	if len(serial) <= MaxSCSISerialLen {
++		return serial
++	}
++	return string([]byte(serial)[:MaxSCSISerialLen])
++}
+diff --git a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
+index 2747d6b7ea..65a861b3fe 100644
+--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
++++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
+@@ -36,6 +36,7 @@ import (
+ 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
+ 	kvpointer "kubevirt.io/kubevirt/pkg/pointer"
+ 	"kubevirt.io/kubevirt/pkg/util"
++	hwutil "kubevirt.io/kubevirt/pkg/util/hardware"
+ 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
+ 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
+ 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+@@ -98,6 +99,22 @@ func (mutator *VMIsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1
+ 			addNodeSelector(newVMI, v1.SEVESLabel)
+ 		}
+ 
++		// To maintain backward compatibility, a mutation webhook was added.
++		// This ensures that if a VMI is created by another controller within KubeVirt (instead of a user), the serial number is automatically truncated to MaxSCSISerialLen.
++		// This prevents issues where an existing VM with an invalid serial length would fail validation when starting a VMI.
++		// Without this, such a VM could break due to the validation webhook rejecting the creation of VMI, effectively blocking its startup.
++		for _, ref := range newVMI.OwnerReferences {
++			if ref.APIVersion == v1.SchemeGroupVersion.String() {
++				for i := range newVMI.Spec.Domain.Devices.Disks {
++					d := &newVMI.Spec.Domain.Devices.Disks[i]
++					if d.Disk != nil && d.Disk.Bus == v1.DiskBusSCSI {
++						d.Serial = hwutil.TruncateSCSIDiskSerial(d.Serial)
++					}
++				}
++				break
++			}
++		}
++
+ 		if newVMI.Spec.Domain.CPU.IsolateEmulatorThread {
+ 			_, emulatorThreadCompleteToEvenParityAnnotationExists := mutator.ClusterConfig.GetConfigFromKubeVirtCR().Annotations[v1.EmulatorThreadCompleteToEvenParity]
+ 			if emulatorThreadCompleteToEvenParityAnnotationExists &&
+diff --git a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+index edcdd358bb..b008cd40ae 100644
+--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
++++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+@@ -2034,13 +2034,22 @@ func validateSerialNumValue(field *k8sfield.Path, idx int, disk v1.Disk) []metav
+ 
+ func validateSerialNumLength(field *k8sfield.Path, idx int, disk v1.Disk) []metav1.StatusCause {
+ 	var causes []metav1.StatusCause
+-	if disk.Serial != "" && len([]rune(disk.Serial)) > maxStrLen {
++
++	if disk.Disk != nil && disk.Disk.Bus == v1.DiskBusSCSI && len(disk.Serial) > hwutil.MaxSCSISerialLen {
+ 		causes = append(causes, metav1.StatusCause{
+ 			Type:    metav1.CauseTypeFieldValueInvalid,
+-			Message: fmt.Sprintf("%s must be less than or equal to %d in length, if specified", field.Index(idx).String(), maxStrLen),
++			Message: fmt.Sprintf("SCSI device serial should not be more than %d symbols. Got %d (%s) for disk %s", hwutil.MaxSCSISerialLen, len(disk.Serial), disk.Serial, field.Index(idx).String()),
++			Field:   field.Index(idx).Child("serial").String(),
++		})
++
++	} else if len(disk.Serial) > maxStrLen {
++		causes = append(causes, metav1.StatusCause{
++			Type:    metav1.CauseTypeFieldValueInvalid,
++			Message: fmt.Sprintf("disk serial should not be more than %d symbols. Got %d (%s) for disk %s.", maxStrLen, len(disk.Serial), disk.Serial, field.Index(idx).String()),
+ 			Field:   field.Index(idx).Child("serial").String(),
+ 		})
+ 	}
++
+ 	return causes
+ }
+ 
+diff --git a/pkg/virt-launcher/virtwrap/converter/converter.go b/pkg/virt-launcher/virtwrap/converter/converter.go
+index 393415c36c..cc09800afc 100644
+--- a/pkg/virt-launcher/virtwrap/converter/converter.go
++++ b/pkg/virt-launcher/virtwrap/converter/converter.go
+@@ -37,6 +37,7 @@ import (
+ 	"syscall"
+ 
+ 	"kubevirt.io/kubevirt/pkg/storage/reservation"
++	hwutil "kubevirt.io/kubevirt/pkg/util/hardware"
+ 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
+ 
+ 	"golang.org/x/sys/unix"
+@@ -168,10 +169,15 @@ func Convert_v1_Disk_To_api_Disk(c *ConverterContext, diskDevice *v1.Disk, disk
+ 	if diskDevice.Disk != nil {
+ 		var unit int
+ 		disk.Device = "disk"
++		disk.Serial = diskDevice.Serial
+ 		disk.Target.Bus = diskDevice.Disk.Bus
+ 		disk.Target.Device, unit = makeDeviceName(diskDevice.Name, diskDevice.Disk.Bus, prefixMap)
+ 		if diskDevice.Disk.Bus == "scsi" {
+ 			assignDiskToSCSIController(disk, unit)
++			// Force truncation of serial number to MaxSCSISerialLen characters, as QEMU no longer does this automatically.
++			// This is required to maintain backward compatibility. Specifying devices with serial numbers longer than MaxSCSISerialLen
++			// characters is not allowed now.
++			disk.Serial = hwutil.TruncateSCSIDiskSerial(diskDevice.Serial)
+ 		}
+ 		if diskDevice.Disk.PciAddress != "" {
+ 			if diskDevice.Disk.Bus != v1.DiskBusVirtio {
+@@ -187,7 +193,6 @@ func Convert_v1_Disk_To_api_Disk(c *ConverterContext, diskDevice *v1.Disk, disk
+ 			disk.Model = InterpretTransitionalModelType(&c.UseVirtioTransitional, c.Architecture)
+ 		}
+ 		disk.ReadOnly = toApiReadOnly(diskDevice.Disk.ReadOnly)
+-		disk.Serial = diskDevice.Serial
+ 		if diskDevice.Shareable != nil {
+ 			if *diskDevice.Shareable {
+ 				if diskDevice.Cache == "" {

--- a/images/virt-artifact/patches/README.md
+++ b/images/virt-artifact/patches/README.md
@@ -211,3 +211,17 @@ By default, the KVVMI spec can update only KubeVirt service accounts. This patch
 #### `035-allow-change-serial-on-kvvmi.patch`
 
 By default, the disk specification is immutable, but for backward compatibility, we need to allow modifying the serial. 
+
+#### `036-enhance-SCSI-disk-serial-validation.patch`
+
+**Related Issue:** [#13858](https://github.com/kubevirt/kubevirt/issues/13858)  
+**Pull Request:** [#13859](https://github.com/kubevirt/kubevirt/pull/13859)
+
+##### What this PR does
+- **Before:** A virtual machine (VM) launched by QEMU could fail if a disk's serial number exceeded 36 characters, as QEMU enforces this limit. KubeVirt did not validate this beforehand, leading to runtime errors.
+- **After:**
+  - The API now validates disk serial numbers, preventing users from setting values longer than 36 characters and avoiding VM startup failures in QEMU.
+  - For existing VMs, serial numbers exceeding this limit will be automatically truncated to maintain backward compatibility.
+
+##### Why this change?
+This update ensures compatibility with recent QEMU changes and prevents runtime errors by enforcing validation at the API level while preserving support for existing VMs through automatic serial number truncation.

--- a/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/add_volume.go
+++ b/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/add_volume.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	virtv1 "kubevirt.io/api/core/v1"
 
-	"github.com/deckhouse/virtualization-controller/pkg/controller/kvbuilder"
 	"github.com/deckhouse/virtualization-controller/pkg/tls/certmanager"
 	virtlisters "github.com/deckhouse/virtualization/api/client/generated/listers/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/subresources"
@@ -114,13 +113,18 @@ func (r AddVolumeREST) genMutateRequestHook(opts *subresources.VirtualMachineAdd
 			Bus: virtv1.DiskBusSCSI,
 		}
 	}
+	// Skip set serial for CDROM
+	serial := ""
+	if !opts.IsCdrom {
+		serial = opts.Serial
+	}
 
 	hotplugRequest := AddVolumeOptions{
 		Name: opts.Name,
 		Disk: &virtv1.Disk{
 			Name:       opts.Name,
 			DiskDevice: dd,
-			Serial:     kvbuilder.GenerateSerial(opts.Name),
+			Serial:     serial,
 		},
 	}
 	switch opts.VolumeKind {

--- a/images/virtualization-artifact/pkg/common/testutil/testutil.go
+++ b/images/virtualization-artifact/pkg/common/testutil/testutil.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutil
+
+import (
+	"github.com/deckhouse/deckhouse/pkg/log"
+	corev1 "k8s.io/api/core/v1"
+	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	virtv1 "kubevirt.io/api/core/v1"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+)
+
+func NewFakeClientWithObjects(objs ...client.Object) (client.WithWatch, error) {
+	scheme := apiruntime.NewScheme()
+	for _, f := range []func(*apiruntime.Scheme) error{
+		virtv2.AddToScheme,
+		virtv1.AddToScheme,
+		cdiv1.AddToScheme,
+		corev1.AddToScheme,
+	} {
+		err := f(scheme)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build(), nil
+}
+
+func NewNoOpLogger() *log.Logger {
+	return log.NewNop()
+}

--- a/images/virtualization-artifact/pkg/common/testutil/testutil.go
+++ b/images/virtualization-artifact/pkg/common/testutil/testutil.go
@@ -17,7 +17,6 @@ limitations under the License.
 package testutil
 
 import (
-	"github.com/deckhouse/deckhouse/pkg/log"
 	corev1 "k8s.io/api/core/v1"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	virtv1 "kubevirt.io/api/core/v1"
@@ -25,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/deckhouse/deckhouse/pkg/log"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 

--- a/images/virtualization-artifact/pkg/migration/README.md
+++ b/images/virtualization-artifact/pkg/migration/README.md
@@ -4,6 +4,10 @@
 
 Fix disk serial handling for successful migration:
 
-Previously, we set the disk serial to match the disk name, relying on Kubernetes to ensure the uniqueness of names. However, after this [commit](https://github.com/qemu/qemu/commit/75997e182b695f2e3f0a2d649734952af5caf3ee) on QEMU, we can no longer do this, as QEMU no longer truncates the serial to 36 characters and now returns an error. We must handle the truncation ourselves. However, truncation does not guarantee uniqueness, so we switched to generating an MD5 hash of the disk name. The MD5 hash is easy to reproduce and fits the required 32-character length.
+Previously, we set the disk serial to match the disk name, relying on Kubernetes to ensure the uniqueness of names. 
+However, after this [commit](https://github.com/qemu/qemu/commit/75997e182b695f2e3f0a2d649734952af5caf3ee) on QEMU, we can no longer do this, as QEMU no longer truncates the serial to 36 characters and now returns an error.
+We must handle the truncation ourselves. 
+However, truncation does not guarantee uniqueness, so we switched to generating an MD5 hash of the disk UID. 
+The MD5 hash is easy to reproduce and fits the required 32-character length.
 
-To ensure a successful migration, existing `kvvm` and `kvvmi` resources need to be patched to reflect the new serial format.
+To ensure a successful migration, existing `kvvm` resource need to be patched to reflect the new serial format.

--- a/images/virtualization-artifact/pkg/migration/qemu_max_length_36.go
+++ b/images/virtualization-artifact/pkg/migration/qemu_max_length_36.go
@@ -27,7 +27,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
-
 	"github.com/deckhouse/virtualization-controller/pkg/common/patch"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/kvbuilder"
 )

--- a/images/virtualization-artifact/pkg/migration/qemu_max_length_36_test.go
+++ b/images/virtualization-artifact/pkg/migration/qemu_max_length_36_test.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migration
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	virtv1 "kubevirt.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/deckhouse/virtualization-controller/pkg/common/testutil"
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+)
+
+func TestMigrationSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Migration Suite")
+}
+
+var _ = Describe("Migration Qemu Max Length 36", func() {
+	newMigration := func(client client.WithWatch) (Migration, error) {
+		return newQEMUMaxLength36(client, testutil.NewNoOpLogger())
+	}
+
+	DescribeTable("#MaxLength", func(expectFunc func(kvvmi *virtv1.VirtualMachineList), objs ...client.Object) {
+		fakeClient, err := testutil.NewFakeClientWithObjects(objs...)
+		Expect(err).NotTo(HaveOccurred())
+
+		m, err := newMigration(fakeClient)
+		Expect(err).ToNot(HaveOccurred())
+		err = m.Migrate(context.Background())
+		Expect(err).ToNot(HaveOccurred())
+
+		vmList := &virtv1.VirtualMachineList{}
+		err = fakeClient.List(context.TODO(), vmList)
+		Expect(err).ToNot(HaveOccurred())
+
+		expectFunc(vmList)
+
+	},
+		Entry("should replace all disks serial",
+			func(kvvmList *virtv1.VirtualMachineList) {
+				GinkgoHelper()
+				Expect(kvvmList).NotTo(BeNil())
+				Expect(kvvmList.Items).To(HaveLen(1))
+				kvvm := kvvmList.Items[0]
+				Expect(kvvm.Spec.Template).ToNot(BeNil())
+				for _, d := range kvvm.Spec.Template.Spec.Domain.Devices.Disks {
+					Expect(len(d.Serial)).To(BeNumerically("<=", 36))
+					switch d.Name {
+					case vdQemu36DiskName:
+						Expect(d.Serial).To(Equal(vdQemu36UIDMD5))
+					case viQemu36DiskName:
+						Expect(d.Serial).To(Equal(viQemu36MD5))
+					case cviQemu36DiskName:
+						Expect(d.Serial).To(Equal(cviQemu36UIDMD5))
+					default:
+						Fail("unknown disk name")
+					}
+				}
+			},
+			kvvmQemu36,
+			vdQemu36,
+			viQemu36,
+			cviQemu36,
+		))
+})
+
+const (
+	namespaceQemu36 = "qemu-36"
+
+	vdQemu36Name     = "vd-qemu-36"
+	vdQemu36DiskName = "vd-vd-qemu-36"
+	vdQemu36UID      = types.UID("vd-qemu-36-uid")
+	vdQemu36UIDMD5   = "150668731cbbc66aa0364f4a9055e496"
+
+	viQemu36Name     = "vi-qemu-36"
+	viQemu36DiskName = "vi-vi-qemu-36"
+	viQemu36UID      = types.UID("vi-qemu-36-uid")
+	viQemu36MD5      = "35dc821cd41a4013d11c15fb9b15f2f0"
+
+	cviQemu36Name     = "cvi-qemu-36"
+	cviQemu36DiskName = "cvi-cvi-qemu-36"
+	cviQemu36UID      = types.UID("cvi-qemu-36-uid")
+	cviQemu36UIDMD5   = "ccc3c60cd0e60b9edfb67cf6e1c8af54"
+
+	kvvmTest01Name = "vm-test-01"
+)
+
+var (
+	vdQemu36 = &virtv2.VirtualDisk{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: virtv2.SchemeGroupVersion.String(),
+			Kind:       virtv2.VirtualDiskKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      vdQemu36Name,
+			Namespace: namespaceQemu36,
+			UID:       vdQemu36UID,
+		},
+	}
+	viQemu36 = &virtv2.VirtualImage{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: virtv2.SchemeGroupVersion.String(),
+			Kind:       virtv2.VirtualImageKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      viQemu36Name,
+			Namespace: namespaceQemu36,
+			UID:       viQemu36UID,
+		},
+	}
+	cviQemu36 = &virtv2.ClusterVirtualImage{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: virtv2.SchemeGroupVersion.String(),
+			Kind:       virtv2.ClusterVirtualImageKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cviQemu36Name,
+			Namespace: namespaceQemu36,
+			UID:       cviQemu36UID,
+		},
+	}
+
+	kvvmQemu36 = &virtv1.VirtualMachine{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: virtv1.GroupVersion.String(),
+			Kind:       "VirtualMachine",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kvvmTest01Name,
+			Namespace: namespaceQemu36,
+		},
+		Spec: virtv1.VirtualMachineSpec{
+			Template: &virtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: virtv1.VirtualMachineInstanceSpec{
+					Domain: virtv1.DomainSpec{
+						Devices: virtv1.Devices{
+							Disks: []virtv1.Disk{
+								generateDiskWithInvalidSerial(vdQemu36DiskName),
+								generateDiskWithInvalidSerial(viQemu36DiskName),
+								generateDiskWithInvalidSerial(cviQemu36DiskName),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+)
+
+func generateDiskWithInvalidSerial(name string) virtv1.Disk {
+	return virtv1.Disk{
+		Name: name,
+		DiskDevice: virtv1.DiskDevice{
+			Disk: &virtv1.DiskTarget{
+				Bus: virtv1.DiskBusSCSI,
+			},
+		},
+		Serial: "should replace because the serial is invalid",
+	}
+}

--- a/images/virtualization-artifact/pkg/migration/qemu_max_length_36_test.go
+++ b/images/virtualization-artifact/pkg/migration/qemu_max_length_36_test.go
@@ -55,7 +55,6 @@ var _ = Describe("Migration Qemu Max Length 36", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		expectFunc(vmList)
-
 	},
 		Entry("should replace all disks serial",
 			func(kvvmList *virtv1.VirtualMachineList) {


### PR DESCRIPTION
## Description
Disk serials are now generated using the MD5 hash of the disk uid instead of the disk name itself. This prevents errors caused by recent QEMU changes enforcing a strict 36-character limit on serial numbers.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [X] The code is covered by unit tests.
- [X] e2e tests passed.
- [X] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: vm  
type: fix  
summary: Disk serials are now generated using the MD5 hash of the disk uid instead of the disk name itself. This prevents errors caused by recent QEMU changes enforcing a strict 36-character limit on serial numbers.
```
