### PR TITLE
fix(images): vdsnapshot immediate disk provisioning

### DIFF
--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref_vdsnapshot.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref_vdsnapshot.go
@@ -258,7 +258,7 @@ func (ds ObjectRefVirtualDiskSnapshot) Sync(ctx context.Context, cvi *virtv2.Clu
 
 			switch {
 			case errors.Is(err, service.ErrNotInitialized), errors.Is(err, service.ErrNotScheduled):
-				if pvc.Status.Phase != corev1.ClaimBound {
+				if strings.Contains(err.Error(), "pod has unbound immediate PersistentVolumeClaims") {
 					cvi.Status.Phase = virtv2.ImageProvisioning
 					cb.
 						Status(metav1.ConditionFalse).

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vdsnapshot.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vdsnapshot.go
@@ -260,7 +260,7 @@ func (ds ObjectRefVirtualDiskSnapshot) StoreToDVCR(ctx context.Context, vi *virt
 
 			switch {
 			case errors.Is(err, service.ErrNotInitialized), errors.Is(err, service.ErrNotScheduled):
-				if pvc.Status.Phase != corev1.ClaimBound {
+				if strings.Contains(err.Error(), "pod has unbound immediate PersistentVolumeClaims") {
 					vi.Status.Phase = virtv2.ImageProvisioning
 					cb.
 						Status(metav1.ConditionFalse).


### PR DESCRIPTION
## Description
Fix for VI/CVI with VDSnapshot ObjectRef, when provisioning becomes failed with immediate storage class. 

## Why do we need it, and what problem does it solve?
Correct CVI/VI operation

## What is the expected result?
VI/CVI can be successfully created from images on immediate storage class

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: images
type: fix
summary: vi/cvi can be successfully created from images on immediate storage class
```
