### PR TITLE
feat(api): add message to snapshot condition about virtual machine cannot be frozen

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/life_cycle.go
+++ b/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/life_cycle.go
@@ -180,7 +180,7 @@ func (h LifeCycleHandler) Handle(ctx context.Context, vdSnapshot *virtv2.Virtual
 					cb.Message(fmt.Sprintf(
 						"The virtual machine %q with an attached virtual disk %q is %s: "+
 							"the snapshotting of virtual disk might result in an inconsistent snapshot: "+
-							"virtual machine agent is not ready and virtual machine can not be frozen: "+
+							"virtual machine agent is not ready and virtual machine cannot be frozen: "+
 							"waiting for virtual machine agent to be ready",
 						vm.Name, vd.Name, vm.Status.Phase,
 					))

--- a/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/life_cycle.go
+++ b/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/life_cycle.go
@@ -170,30 +170,27 @@ func (h LifeCycleHandler) Handle(ctx context.Context, vdSnapshot *virtv2.Virtual
 
 			if vdSnapshot.Spec.RequiredConsistency {
 				vdSnapshot.Status.Phase = virtv2.VirtualDiskSnapshotPhasePending
+				cb.
+					Status(metav1.ConditionFalse).
+					Reason(vdscondition.PotentiallyInconsistent)
 
 				agentReadyCondition, _ := conditions.GetCondition(vmcondition.TypeAgentReady, vm.Status.Conditions)
 				switch {
 				case agentReadyCondition.Status != metav1.ConditionTrue:
-					cb.
-						Status(metav1.ConditionFalse).
-						Reason(vdscondition.PotentiallyInconsistent).
-						Message(fmt.Sprintf(
-							"The virtual machine %q with an attached virtual disk %q is %s: "+
-								"the snapshotting of virtual disk might result in an inconsistent snapshot: "+
-								"virtual machine agent is not ready and virtual machine can not be frozen: "+
-								"waiting for virtual machine agent to be ready",
-							vm.Name, vd.Name, vm.Status.Phase,
-						))
+					cb.Message(fmt.Sprintf(
+						"The virtual machine %q with an attached virtual disk %q is %s: "+
+							"the snapshotting of virtual disk might result in an inconsistent snapshot: "+
+							"virtual machine agent is not ready and virtual machine can not be frozen: "+
+							"waiting for virtual machine agent to be ready",
+						vm.Name, vd.Name, vm.Status.Phase,
+					))
 				default:
-					cb.
-						Status(metav1.ConditionFalse).
-						Reason(vdscondition.PotentiallyInconsistent).
-						Message(fmt.Sprintf(
-							"The virtual machine %q with an attached virtual disk %q is %s: "+
-								"the snapshotting of virtual disk might result in an inconsistent snapshot: "+
-								"waiting for the virtual machine to be %s or the disk to be detached",
-							vm.Name, vd.Name, vm.Status.Phase, virtv2.MachineStopped,
-						))
+					cb.Message(fmt.Sprintf(
+						"The virtual machine %q with an attached virtual disk %q is %s: "+
+							"the snapshotting of virtual disk might result in an inconsistent snapshot: "+
+							"waiting for the virtual machine to be %s or the disk to be detached",
+						vm.Name, vd.Name, vm.Status.Phase, virtv2.MachineStopped,
+					))
 				}
 
 				return reconcile.Result{}, nil

--- a/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/life_cycle.go
+++ b/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/life_cycle.go
@@ -181,7 +181,7 @@ func (h LifeCycleHandler) Handle(ctx context.Context, vdSnapshot *virtv2.Virtual
 						"The virtual machine %q with an attached virtual disk %q is %s: "+
 							"the snapshotting of virtual disk might result in an inconsistent snapshot: "+
 							"virtual machine agent is not ready and virtual machine cannot be frozen: "+
-							"waiting for virtual machine agent to be ready",
+							"waiting for virtual machine agent to be ready, or virtual machine will stop",
 						vm.Name, vd.Name, vm.Status.Phase,
 					))
 				default:

--- a/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/life_cycle.go
+++ b/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/life_cycle.go
@@ -32,6 +32,7 @@ import (
 	"github.com/deckhouse/virtualization-controller/pkg/logger"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdscondition"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmcondition"
 )
 
 type LifeCycleHandler struct {
@@ -169,15 +170,32 @@ func (h LifeCycleHandler) Handle(ctx context.Context, vdSnapshot *virtv2.Virtual
 
 			if vdSnapshot.Spec.RequiredConsistency {
 				vdSnapshot.Status.Phase = virtv2.VirtualDiskSnapshotPhasePending
-				cb.
-					Status(metav1.ConditionFalse).
-					Reason(vdscondition.PotentiallyInconsistent).
-					Message(fmt.Sprintf(
-						"The virtual machine %q with an attached virtual disk %q is %s: "+
-							"the snapshotting of virtual disk might result in an inconsistent snapshot: "+
-							"waiting for the virtual machine to be %s or the disk to be detached",
-						vm.Name, vd.Name, vm.Status.Phase, virtv2.MachineStopped,
-					))
+
+				agentReadyCondition, _ := conditions.GetCondition(vmcondition.TypeAgentReady, vm.Status.Conditions)
+				switch {
+				case agentReadyCondition.Status != metav1.ConditionTrue:
+					cb.
+						Status(metav1.ConditionFalse).
+						Reason(vdscondition.PotentiallyInconsistent).
+						Message(fmt.Sprintf(
+							"The virtual machine %q with an attached virtual disk %q is %s: "+
+								"the snapshotting of virtual disk might result in an inconsistent snapshot: "+
+								"virtual machine agent is not ready and virtual machine can not be frozen: "+
+								"waiting for virtual machine agent to be ready",
+							vm.Name, vd.Name, vm.Status.Phase,
+						))
+				default:
+					cb.
+						Status(metav1.ConditionFalse).
+						Reason(vdscondition.PotentiallyInconsistent).
+						Message(fmt.Sprintf(
+							"The virtual machine %q with an attached virtual disk %q is %s: "+
+								"the snapshotting of virtual disk might result in an inconsistent snapshot: "+
+								"waiting for the virtual machine to be %s or the disk to be detached",
+							vm.Name, vd.Name, vm.Status.Phase, virtv2.MachineStopped,
+						))
+				}
+
 				return reconcile.Result{}, nil
 			}
 		}

--- a/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/life_cycle.go
+++ b/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/life_cycle.go
@@ -220,7 +220,7 @@ func (h LifeCycleHandler) Handle(ctx context.Context, vmSnapshot *virtv2.Virtual
 			msg = fmt.Sprintf(
 				"The snapshotting of virtual machine %q might result in an inconsistent snapshot: "+
 					"virtual machine agent is not ready and virtual machine cannot be frozen: "+
-					"waiting for virtual machine agent to be ready",
+					"waiting for virtual machine agent to be ready or virtual machine will stop",
 				vm.Name,
 			)
 		}

--- a/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/life_cycle.go
+++ b/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/life_cycle.go
@@ -214,6 +214,17 @@ func (h LifeCycleHandler) Handle(ctx context.Context, vmSnapshot *virtv2.Virtual
 				"waiting for the virtual machine to be %s",
 			vm.Name, virtv2.MachineStopped,
 		)
+
+		agentReadyCondition, _ := conditions.GetCondition(vmcondition.TypeAgentReady, vm.Status.Conditions)
+		if agentReadyCondition.Status != metav1.ConditionTrue {
+			msg = fmt.Sprintf(
+				"The snapshotting of virtual machine %q might result in an inconsistent snapshot: "+
+					"virtual machine agent is not ready and virtual machine can not be frozen: "+
+					"waiting for virtual machine agent to be ready",
+				vm.Name,
+			)
+		}
+
 		h.recorder.Event(
 			vmSnapshot,
 			corev1.EventTypeNormal,

--- a/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/life_cycle.go
+++ b/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/life_cycle.go
@@ -219,7 +219,7 @@ func (h LifeCycleHandler) Handle(ctx context.Context, vmSnapshot *virtv2.Virtual
 		if agentReadyCondition.Status != metav1.ConditionTrue {
 			msg = fmt.Sprintf(
 				"The snapshotting of virtual machine %q might result in an inconsistent snapshot: "+
-					"virtual machine agent is not ready and virtual machine can not be frozen: "+
+					"virtual machine agent is not ready and virtual machine cannot be frozen: "+
 					"waiting for virtual machine agent to be ready",
 				vm.Name,
 			)


### PR DESCRIPTION
## Description
Introduces a new error message that appears when a virtual machine is unable to freeze its filesystem because the agent is not ready to perform this operation.

## Why do we need it, and what problem does it solve?

## What is the expected result?

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: vm
type: feat
summary: introduces a new error message that appears when a virtual machine is unable to freeze its filesystem because the agent is not ready to perform this operation.
```
