### PR TITLE
fix(vm): rename filesystemReady condition to filesystemFrozen

### DIFF
--- a/api/core/v1alpha2/vmcondition/condition.go
+++ b/api/core/v1alpha2/vmcondition/condition.go
@@ -91,6 +91,7 @@ const (
 
 	ReasonFilesystemFrozen    Reason = "Frozen"
 	ReasonFilesystemNotFrozen Reason = "NotFrozen"
+	ReasonFilesystemNotReady  Reason = "NotReady"
 
 	WaitingForTheSnapshotToStart Reason = "WaitingForTheSnapshotToStart"
 	ReasonSnapshottingInProgress Reason = "SnapshottingInProgress"

--- a/api/core/v1alpha2/vmcondition/condition.go
+++ b/api/core/v1alpha2/vmcondition/condition.go
@@ -35,9 +35,10 @@ const (
 	TypeAgentVersionNotSupported            Type = "AgentVersionNotSupported"
 	TypeConfigurationApplied                Type = "ConfigurationApplied"
 	TypeAwaitingRestartToApplyConfiguration Type = "AwaitingRestartToApplyConfiguration"
-	TypeFilesystemFrozen                    Type = "FilesystemFrozen"
-	TypeSizingPolicyMatched                 Type = "SizingPolicyMatched"
-	TypeSnapshotting                        Type = "Snapshotting"
+	// TypeFilesystemFrozen indicates whether the filesystem is currently frozen, a necessary condition for creating a snapshot.
+	TypeFilesystemFrozen    Type = "FilesystemFrozen"
+	TypeSizingPolicyMatched Type = "SizingPolicyMatched"
+	TypeSnapshotting        Type = "Snapshotting"
 )
 
 type Reason string
@@ -89,9 +90,8 @@ const (
 	ReasonVmIsRunning                    Reason = "VirtualMachineRunning"
 	ReasonInternalVirtualMachineError    Reason = "InternalVirtualMachineError"
 
-	ReasonFilesystemFrozen    Reason = "Frozen"
-	ReasonFilesystemNotFrozen Reason = "NotFrozen"
-	ReasonFilesystemNotReady  Reason = "NotReady"
+	// 	ReasonFilesystemFrozen indicates that virtual machine's filesystem has been successfully frozen.
+	ReasonFilesystemFrozen Reason = "Frozen"
 
 	WaitingForTheSnapshotToStart Reason = "WaitingForTheSnapshotToStart"
 	ReasonSnapshottingInProgress Reason = "SnapshottingInProgress"

--- a/api/core/v1alpha2/vmcondition/condition.go
+++ b/api/core/v1alpha2/vmcondition/condition.go
@@ -35,7 +35,7 @@ const (
 	TypeAgentVersionNotSupported            Type = "AgentVersionNotSupported"
 	TypeConfigurationApplied                Type = "ConfigurationApplied"
 	TypeAwaitingRestartToApplyConfiguration Type = "AwaitingRestartToApplyConfiguration"
-	TypeFilesystemReady                     Type = "FilesystemReady"
+	TypeFilesystemFrozen                    Type = "FilesystemFrozen"
 	TypeSizingPolicyMatched                 Type = "SizingPolicyMatched"
 	TypeSnapshotting                        Type = "Snapshotting"
 )
@@ -89,9 +89,8 @@ const (
 	ReasonVmIsRunning                    Reason = "VirtualMachineRunning"
 	ReasonInternalVirtualMachineError    Reason = "InternalVirtualMachineError"
 
-	ReasonFilesystemReady    Reason = "Ready"
-	ReasonFilesystemFrozen   Reason = "Frozen"
-	ReasonFilesystemNotReady Reason = "NotReady"
+	ReasonFilesystemFrozen    Reason = "Frozen"
+	ReasonFilesystemNotFrozen Reason = "NotFrozen"
 
 	WaitingForTheSnapshotToStart Reason = "WaitingForTheSnapshotToStart"
 	ReasonSnapshottingInProgress Reason = "SnapshottingInProgress"

--- a/images/virtualization-artifact/pkg/controller/service/snapshot_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/snapshot_service.go
@@ -54,9 +54,9 @@ func (s *SnapshotService) IsFrozen(vm *virtv2.VirtualMachine) bool {
 		return false
 	}
 
-	filesystemReady, _ := conditions.GetCondition(vmcondition.TypeFilesystemReady, vm.Status.Conditions)
+	filesystemFrozen, _ := conditions.GetCondition(vmcondition.TypeFilesystemFrozen, vm.Status.Conditions)
 
-	return filesystemReady.Status == metav1.ConditionFalse && filesystemReady.Reason == vmcondition.ReasonFilesystemFrozen.String()
+	return filesystemFrozen.Status == metav1.ConditionTrue && filesystemFrozen.Reason == vmcondition.ReasonFilesystemFrozen.String()
 }
 
 func (s *SnapshotService) CanFreeze(vm *virtv2.VirtualMachine) bool {

--- a/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/watcher/kvvmi_watcher.go
+++ b/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/watcher/kvvmi_watcher.go
@@ -117,8 +117,8 @@ func (w VirtualMachineWatcher) filterUpdateEvents(e event.UpdateEvent) bool {
 		return false
 	}
 
-	oldFSReady, _ := conditions.GetCondition(vmcondition.TypeFilesystemReady, oldKVVMI.Status.Conditions)
-	newFSReady, _ := conditions.GetCondition(vmcondition.TypeFilesystemReady, newKVVMI.Status.Conditions)
+	oldFSReady, _ := conditions.GetCondition(vmcondition.TypeFilesystemFrozen, oldKVVMI.Status.Conditions)
+	newFSReady, _ := conditions.GetCondition(vmcondition.TypeFilesystemFrozen, newKVVMI.Status.Conditions)
 
 	return oldFSReady.Status != newFSReady.Status
 }

--- a/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/watcher/kvvmi_watcher.go
+++ b/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/watcher/kvvmi_watcher.go
@@ -117,8 +117,8 @@ func (w VirtualMachineWatcher) filterUpdateEvents(e event.UpdateEvent) bool {
 		return false
 	}
 
-	oldFSReady, _ := conditions.GetCondition(vmcondition.TypeFilesystemFrozen, oldKVVMI.Status.Conditions)
-	newFSReady, _ := conditions.GetCondition(vmcondition.TypeFilesystemFrozen, newKVVMI.Status.Conditions)
+	oldFSFrozen, _ := conditions.GetCondition(vmcondition.TypeFilesystemFrozen, oldKVVMI.Status.Conditions)
+	newFSFrozen, _ := conditions.GetCondition(vmcondition.TypeFilesystemFrozen, newKVVMI.Status.Conditions)
 
-	return oldFSReady.Status != newFSReady.Status
+	return oldFSFrozen.Status != newFSFrozen.Status
 }

--- a/images/virtualization-artifact/pkg/controller/vm/internal/filesystem.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/filesystem.go
@@ -75,7 +75,7 @@ func (h *FilesystemHandler) Handle(ctx context.Context, s state.VirtualMachineSt
 	}
 
 	if kvvmi.Status.FSFreezeStatus == "frozen" {
-		cb.Status(metav1.ConditionFalse).
+		cb.Status(metav1.ConditionTrue).
 			Reason(vmcondition.ReasonFilesystemFrozen).
 			Message("The virtual machine is frozen.")
 		return reconcile.Result{}, nil

--- a/images/virtualization-artifact/pkg/controller/vm/internal/filesystem.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/filesystem.go
@@ -42,7 +42,7 @@ func (h *FilesystemHandler) Handle(ctx context.Context, s state.VirtualMachineSt
 
 	changed := s.VirtualMachine().Changed()
 
-	if update := addAllUnknown(changed, vmcondition.TypeFilesystemReady); update {
+	if update := addAllUnknown(changed, vmcondition.TypeFilesystemFrozen); update {
 		return reconcile.Result{Requeue: true}, nil
 	}
 
@@ -55,15 +55,15 @@ func (h *FilesystemHandler) Handle(ctx context.Context, s state.VirtualMachineSt
 		return reconcile.Result{}, err
 	}
 
-	cb := conditions.NewConditionBuilder(vmcondition.TypeFilesystemReady).
+	cb := conditions.NewConditionBuilder(vmcondition.TypeFilesystemFrozen).
 		Status(metav1.ConditionUnknown).
 		Generation(changed.GetGeneration())
 
 	defer func() { conditions.SetCondition(cb, &changed.Status.Conditions) }()
 
 	if kvvmi == nil {
-		cb.Status(metav1.ConditionFalse).
-			Reason(vmcondition.ReasonFilesystemNotReady).
+		cb.Status(metav1.ConditionTrue).
+			Reason(vmcondition.ReasonFilesystemFrozen).
 			Message("The virtual machine is not running.")
 		return reconcile.Result{}, nil
 	}
@@ -81,8 +81,8 @@ func (h *FilesystemHandler) Handle(ctx context.Context, s state.VirtualMachineSt
 		return reconcile.Result{}, nil
 	}
 
-	cb.Status(metav1.ConditionTrue).
-		Reason(vmcondition.ReasonFilesystemReady)
+	cb.Status(metav1.ConditionFalse).
+		Reason(vmcondition.ReasonFilesystemNotFrozen)
 	return reconcile.Result{}, nil
 }
 

--- a/images/virtualization-artifact/pkg/controller/vm/internal/filesystem.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/filesystem.go
@@ -62,8 +62,8 @@ func (h *FilesystemHandler) Handle(ctx context.Context, s state.VirtualMachineSt
 	defer func() { conditions.SetCondition(cb, &changed.Status.Conditions) }()
 
 	if kvvmi == nil {
-		cb.Status(metav1.ConditionTrue).
-			Reason(vmcondition.ReasonFilesystemFrozen).
+		cb.Status(metav1.ConditionFalse).
+			Reason(vmcondition.ReasonFilesystemNotReady).
 			Message("The virtual machine is not running.")
 		return reconcile.Result{}, nil
 	}

--- a/images/virtualization-artifact/pkg/controller/vm/internal/filesystem.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/filesystem.go
@@ -80,7 +80,7 @@ func (h *FilesystemHandler) Handle(ctx context.Context, s state.VirtualMachineSt
 	if kvvmi.Status.FSFreezeStatus == "frozen" {
 		cb.Status(metav1.ConditionTrue).
 			Reason(vmcondition.ReasonFilesystemFrozen).
-			Message("The virtual machine is frozen.")
+			Message("File system of the Virtual Machine is frozen.")
 		return reconcile.Result{}, nil
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/watcher/vm_watcher.go
+++ b/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/watcher/vm_watcher.go
@@ -98,8 +98,8 @@ func (w VirtualMachineWatcher) filterUpdateEvents(e event.UpdateEvent) bool {
 		return false
 	}
 
-	oldFSReady, _ := conditions.GetCondition(vmcondition.TypeFilesystemReady, oldVM.Status.Conditions)
-	newFSReady, _ := conditions.GetCondition(vmcondition.TypeFilesystemReady, newVM.Status.Conditions)
+	oldFSReady, _ := conditions.GetCondition(vmcondition.TypeFilesystemFrozen, oldVM.Status.Conditions)
+	newFSReady, _ := conditions.GetCondition(vmcondition.TypeFilesystemFrozen, newVM.Status.Conditions)
 
 	if oldFSReady.Reason != newFSReady.Reason {
 		return true

--- a/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/watcher/vm_watcher.go
+++ b/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/watcher/vm_watcher.go
@@ -98,10 +98,10 @@ func (w VirtualMachineWatcher) filterUpdateEvents(e event.UpdateEvent) bool {
 		return false
 	}
 
-	oldFSReady, _ := conditions.GetCondition(vmcondition.TypeFilesystemFrozen, oldVM.Status.Conditions)
-	newFSReady, _ := conditions.GetCondition(vmcondition.TypeFilesystemFrozen, newVM.Status.Conditions)
+	oldFSFrozen, _ := conditions.GetCondition(vmcondition.TypeFilesystemFrozen, oldVM.Status.Conditions)
+	newFSFrozen, _ := conditions.GetCondition(vmcondition.TypeFilesystemFrozen, newVM.Status.Conditions)
 
-	if oldFSReady.Reason != newFSReady.Reason {
+	if oldFSFrozen.Reason != newFSFrozen.Reason {
 		return true
 	}
 

--- a/tests/e2e/vd_snapshots_test.go
+++ b/tests/e2e/vd_snapshots_test.go
@@ -506,7 +506,7 @@ var _ = Describe("Virtual disk snapshots", ginkgoutil.CommonE2ETestDecorators(),
 		})
 
 		It("checks `FileSystemFrozen` status of VMs", func() {
-			By(fmt.Sprintf("Status should be %s", PhaseReady))
+			By("Status should not be `Frozen`")
 			vmObjects := virtv2.VirtualMachineList{}
 			err := GetObjects(kc.ResourceVM, &vmObjects, kc.GetOptions{Namespace: conf.Namespace})
 			Expect(err).NotTo(HaveOccurred(), "cannot get virtual machines\nstderr: %s", err)

--- a/tests/e2e/vd_snapshots_test.go
+++ b/tests/e2e/vd_snapshots_test.go
@@ -500,11 +500,7 @@ var _ = Describe("Virtual disk snapshots", ginkgoutil.CommonE2ETestDecorators(),
 
 				for _, snapshot := range vdSnapshots.Items {
 					Expect(snapshot.Status.Consistent).ToNot(BeNil())
-					consistent := false
-					if snapshot.Status.Consistent != nil {
-						consistent = *snapshot.Status.Consistent
-					}
-					Expect(consistent).To(BeTrue(), "consistent field should be `true`: %s", snapshot.Name)
+					Expect(*snapshot.Status.Consistent).To(BeTrue(), "consistent field should be `true`: %s", snapshot.Name)
 				}
 			})
 		})

--- a/tests/e2e/vd_snapshots_test.go
+++ b/tests/e2e/vd_snapshots_test.go
@@ -508,7 +508,7 @@ var _ = Describe("Virtual disk snapshots", ginkgoutil.CommonE2ETestDecorators(),
 			})
 		})
 
-		It("checks `FileSystemReady` status of VMs", func() {
+		It("checks `FileSystemFrozen` status of VMs", func() {
 			By(fmt.Sprintf("Status should be %s", PhaseReady))
 			vmObjects := virtv2.VirtualMachineList{}
 			err := GetObjects(kc.ResourceVM, &vmObjects, kc.GetOptions{Namespace: conf.Namespace})

--- a/tests/e2e/vd_snapshots_test.go
+++ b/tests/e2e/vd_snapshots_test.go
@@ -499,6 +499,7 @@ var _ = Describe("Virtual disk snapshots", ginkgoutil.CommonE2ETestDecorators(),
 				Expect(err).NotTo(HaveOccurred(), "cannot get `vdSnapshots`\nstderr: %s", err)
 
 				for _, snapshot := range vdSnapshots.Items {
+					Expect(snapshot.Status.Consistent).ToNot(BeNil())
 					consistent := false
 					if snapshot.Status.Consistent != nil {
 						consistent = *snapshot.Status.Consistent
@@ -516,7 +517,7 @@ var _ = Describe("Virtual disk snapshots", ginkgoutil.CommonE2ETestDecorators(),
 
 			for _, vm := range vmObjects.Items {
 				Eventually(func() error {
-					reason, err := CheckFileSystemFrozen(vm.Name, v1.ConditionTrue)
+					reason, err := CheckFileSystemFrozen(vm.Name, v1.ConditionFalse)
 					if err != nil {
 						return fmt.Errorf("vmName: %s\nstderr: %s\nreason: %s", vm.Name, err, reason)
 					}

--- a/tests/e2e/vd_snapshots_test.go
+++ b/tests/e2e/vd_snapshots_test.go
@@ -207,7 +207,6 @@ func GetVolumeSnapshotClassName(storageClass *storagev1.StorageClass) (string, e
 }
 
 func CheckFileSystemFrozen(vmName string) (bool, error) {
-	GinkgoHelper()
 	vmObj := virtv2.VirtualMachine{}
 	err := GetObject(kc.ResourceVM, vmName, &vmObj, kc.GetOptions{Namespace: conf.Namespace})
 	if err != nil {
@@ -386,7 +385,7 @@ var _ = Describe("Virtual disk snapshots", ginkgoutil.CommonE2ETestDecorators(),
 				Eventually(func() error {
 					frozen, err := CheckFileSystemFrozen(vm.Name)
 					if frozen {
-						return errors.New("VM is frozen")
+						return errors.New("File system of the Virtual Machine is frozen")
 					}
 					return err
 				}).WithTimeout(
@@ -434,7 +433,7 @@ var _ = Describe("Virtual disk snapshots", ginkgoutil.CommonE2ETestDecorators(),
 				Eventually(func() error {
 					frozen, err := CheckFileSystemFrozen(vm.Name)
 					if frozen {
-						return errors.New("VM is frozen")
+						return errors.New("Filesystem of the Virtual Machine is frozen")
 					}
 					return err
 				}).WithTimeout(
@@ -520,7 +519,7 @@ var _ = Describe("Virtual disk snapshots", ginkgoutil.CommonE2ETestDecorators(),
 						return nil
 					}
 					if frozen {
-						return errors.New("VM is frozen")
+						return errors.New("Filesystem of the Virtual Machine is frozen")
 					}
 					return nil
 				}).WithTimeout(

--- a/tests/e2e/vd_snapshots_test.go
+++ b/tests/e2e/vd_snapshots_test.go
@@ -32,6 +32,7 @@ import (
 	sdsrepvolv1 "github.com/deckhouse/sds-replicated-volume/api/v1alpha1"
 
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmcondition"
 	"github.com/deckhouse/virtualization/tests/e2e/config"
 	"github.com/deckhouse/virtualization/tests/e2e/ginkgoutil"
 	. "github.com/deckhouse/virtualization/tests/e2e/helper"
@@ -215,7 +216,7 @@ func CheckFileSystemFrozen(vmName string, status v1.ConditionStatus) (string, er
 	}
 
 	for _, condition := range vmObj.Status.Conditions {
-		if condition.Type == "FilesystemFrozen" {
+		if condition.Type == vmcondition.TypeFilesystemFrozen.String() {
 			if condition.Status != status {
 				return condition.Reason, fmt.Errorf("`FilesystemFrozen` status of %q is not %q: %s", vmName, status, condition.Reason)
 			} else {

--- a/tests/e2e/vm_label_annotation_test.go
+++ b/tests/e2e/vm_label_annotation_test.go
@@ -19,7 +19,6 @@ package e2e
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -107,8 +106,12 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 		}
 	})
 
+	const (
+		specialKey   = "specialKey"
+		specialValue = "specialValue"
+	)
 	testCaseLabel := map[string]string{"testcase": "vm-label-annotation"}
-	specialKeyValue := map[string]string{"specialKey": "specialValue"}
+	specialKeyValue := map[string]string{specialKey: specialValue}
 
 	Context("Preparing the environment", func() {
 		It("sets the namespace", func() {
@@ -177,27 +180,36 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 		})
 
 		It("checks VMs and pods labels after VMs labeling", func() {
-			time.Sleep(5 * time.Second)
-			res := kubectl.List(kc.ResourceVM, kc.GetOptions{
-				Labels:    testCaseLabel,
-				Namespace: conf.Namespace,
-				Output:    "jsonpath='{.items[*].metadata.name}'",
-			})
-			Expect(res.Error()).NotTo(HaveOccurred(), "cmd: %s\nstderr: %s", res.GetCmd(), res.StdErr())
+			Eventually(func() error {
+				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
+					Labels:    testCaseLabel,
+					Namespace: conf.Namespace,
+					Output:    "jsonpath='{.items[*].metadata.name}'",
+				})
+				Expect(res.Error()).NotTo(HaveOccurred(), "cmd: %s\nstderr: %s", res.GetCmd(), res.StdErr())
 
-			vms := strings.Split(res.StdOut(), " ")
-			for _, vm := range vms {
-				vmObj := virtv2.VirtualMachine{}
-				err := GetObject(kc.ResourceVM, vm, &vmObj, kc.GetOptions{Namespace: conf.Namespace})
-				Expect(err).NotTo(HaveOccurred(), err)
-				Expect(vmObj.Labels).Should(HaveKeyWithValue("specialKey", "specialValue"))
+				vms := strings.Split(res.StdOut(), " ")
+				for _, vm := range vms {
+					vmObj := virtv2.VirtualMachine{}
+					err := GetObject(kc.ResourceVM, vm, &vmObj, kc.GetOptions{Namespace: conf.Namespace})
+					Expect(err).NotTo(HaveOccurred(), err)
+					value, ok := vmObj.Labels[specialKey]
+					if !ok || value != specialValue {
+						return fmt.Errorf("vm label %q with value %q not found in %s", specialKey, specialValue, vmObj.Name)
+					}
 
-				activePod := GetActiveVirtualMachinePod(&vmObj)
-				vmPodObj := v1.Pod{}
-				err = GetObject(kc.ResourcePod, activePod, &vmPodObj, kc.GetOptions{Namespace: conf.Namespace})
-				Expect(err).NotTo(HaveOccurred(), err)
-				Expect(vmPodObj.Labels).Should(HaveKeyWithValue("specialKey", "specialValue"))
-			}
+					activePod := GetActiveVirtualMachinePod(&vmObj)
+					vmPodObj := v1.Pod{}
+					err = GetObject(kc.ResourcePod, activePod, &vmPodObj, kc.GetOptions{Namespace: conf.Namespace})
+					Expect(err).NotTo(HaveOccurred(), err)
+					value, ok = vmPodObj.Labels[specialKey]
+					if !ok || value != specialValue {
+						return fmt.Errorf("pod label %q with value %q not found in %s", specialKey, specialValue, vmPodObj.Name)
+					}
+				}
+
+				return nil
+			}).WithTimeout(Timeout).WithPolling(Interval).Should(Succeed())
 		})
 
 		It(fmt.Sprintf("removes label %s from VMs", specialKeyValue), func() {
@@ -214,27 +226,36 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 		})
 
 		It("checks VMs and pods labels after VMs unlabeling", func() {
-			time.Sleep(5 * time.Second)
-			res := kubectl.List(kc.ResourceVM, kc.GetOptions{
-				Labels:    testCaseLabel,
-				Namespace: conf.Namespace,
-				Output:    "jsonpath='{.items[*].metadata.name}'",
-			})
-			Expect(res.Error()).NotTo(HaveOccurred(), "cmd: %s\nstderr: %s", res.GetCmd(), res.StdErr())
+			Eventually(func() error {
+				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
+					Labels:    testCaseLabel,
+					Namespace: conf.Namespace,
+					Output:    "jsonpath='{.items[*].metadata.name}'",
+				})
+				Expect(res.Error()).NotTo(HaveOccurred(), "cmd: %s\nstderr: %s", res.GetCmd(), res.StdErr())
 
-			vms := strings.Split(res.StdOut(), " ")
-			for _, vm := range vms {
-				vmObj := virtv2.VirtualMachine{}
-				err := GetObject(kc.ResourceVM, vm, &vmObj, kc.GetOptions{Namespace: conf.Namespace})
-				Expect(err).NotTo(HaveOccurred(), err)
-				Expect(vmObj.Labels).ShouldNot(HaveKey("specialKey"))
+				vms := strings.Split(res.StdOut(), " ")
+				for _, vm := range vms {
+					vmObj := virtv2.VirtualMachine{}
+					err := GetObject(kc.ResourceVM, vm, &vmObj, kc.GetOptions{Namespace: conf.Namespace})
+					Expect(err).NotTo(HaveOccurred(), err)
+					_, ok := vmObj.Labels[specialKey]
+					if ok {
+						return fmt.Errorf("vm label %q found in %s", specialKey, vmObj.Name)
+					}
 
-				activePod := GetActiveVirtualMachinePod(&vmObj)
-				vmPodObj := v1.Pod{}
-				err = GetObject(kc.ResourcePod, activePod, &vmPodObj, kc.GetOptions{Namespace: conf.Namespace})
-				Expect(err).NotTo(HaveOccurred(), err)
-				Expect(vmPodObj.Labels).ShouldNot(HaveKey("specialKey"))
-			}
+					activePod := GetActiveVirtualMachinePod(&vmObj)
+					vmPodObj := v1.Pod{}
+					err = GetObject(kc.ResourcePod, activePod, &vmPodObj, kc.GetOptions{Namespace: conf.Namespace})
+					Expect(err).NotTo(HaveOccurred(), err)
+					_, ok = vmPodObj.Labels[specialKey]
+					if ok {
+						return fmt.Errorf("pod label %q found in %s", specialKey, vmPodObj.Name)
+					}
+				}
+
+				return nil
+			}).WithTimeout(Timeout).WithPolling(Interval).Should(Succeed())
 		})
 	})
 
@@ -253,27 +274,36 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 		})
 
 		It("checks VMs and pods annotations after VMs annotating", func() {
-			time.Sleep(5 * time.Second)
-			res := kubectl.List(kc.ResourceVM, kc.GetOptions{
-				Labels:    testCaseLabel,
-				Namespace: conf.Namespace,
-				Output:    "jsonpath='{.items[*].metadata.name}'",
-			})
-			Expect(res.Error()).NotTo(HaveOccurred(), "cmd: %s\nstderr: %s", res.GetCmd(), res.StdErr())
+			Eventually(func() error {
+				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
+					Labels:    testCaseLabel,
+					Namespace: conf.Namespace,
+					Output:    "jsonpath='{.items[*].metadata.name}'",
+				})
+				Expect(res.Error()).NotTo(HaveOccurred(), "cmd: %s\nstderr: %s", res.GetCmd(), res.StdErr())
 
-			vms := strings.Split(res.StdOut(), " ")
-			for _, vm := range vms {
-				vmObj := virtv2.VirtualMachine{}
-				err := GetObject(kc.ResourceVM, vm, &vmObj, kc.GetOptions{Namespace: conf.Namespace})
-				Expect(err).NotTo(HaveOccurred(), err)
-				Expect(vmObj.Annotations).Should(HaveKeyWithValue("specialKey", "specialValue"))
+				vms := strings.Split(res.StdOut(), " ")
+				for _, vm := range vms {
+					vmObj := virtv2.VirtualMachine{}
+					err := GetObject(kc.ResourceVM, vm, &vmObj, kc.GetOptions{Namespace: conf.Namespace})
+					Expect(err).NotTo(HaveOccurred(), err)
+					value, ok := vmObj.Annotations[specialKey]
+					if !ok || value != specialValue {
+						return fmt.Errorf("vm annotation %q with value %q not found in %s", specialKey, specialValue, vmObj.Name)
+					}
 
-				activePod := GetActiveVirtualMachinePod(&vmObj)
-				vmPodObj := v1.Pod{}
-				err = GetObject(kc.ResourcePod, activePod, &vmPodObj, kc.GetOptions{Namespace: conf.Namespace})
-				Expect(err).NotTo(HaveOccurred(), err)
-				Expect(vmPodObj.Annotations).Should(HaveKeyWithValue("specialKey", "specialValue"))
-			}
+					activePod := GetActiveVirtualMachinePod(&vmObj)
+					vmPodObj := v1.Pod{}
+					err = GetObject(kc.ResourcePod, activePod, &vmPodObj, kc.GetOptions{Namespace: conf.Namespace})
+					Expect(err).NotTo(HaveOccurred(), err)
+					value, ok = vmPodObj.Annotations[specialKey]
+					if !ok || value != specialValue {
+						return fmt.Errorf("pod annotation %q with value %q not found in %s", specialKey, specialValue, vmPodObj.Name)
+					}
+				}
+
+				return nil
+			}).WithTimeout(Timeout).WithPolling(Interval).Should(Succeed())
 		})
 
 		It(fmt.Sprintf("removes annotation %s from VMs", specialKeyValue), func() {
@@ -290,27 +320,36 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 		})
 
 		It("checks VMs and pods annotations after VMs unannotating", func() {
-			time.Sleep(5 * time.Second)
-			res := kubectl.List(kc.ResourceVM, kc.GetOptions{
-				Labels:    testCaseLabel,
-				Namespace: conf.Namespace,
-				Output:    "jsonpath='{.items[*].metadata.name}'",
-			})
-			Expect(res.Error()).NotTo(HaveOccurred(), "cmd: %s\nstderr: %s", res.GetCmd(), res.StdErr())
+			Eventually(func() error {
+				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
+					Labels:    testCaseLabel,
+					Namespace: conf.Namespace,
+					Output:    "jsonpath='{.items[*].metadata.name}'",
+				})
+				Expect(res.Error()).NotTo(HaveOccurred(), "cmd: %s\nstderr: %s", res.GetCmd(), res.StdErr())
 
-			vms := strings.Split(res.StdOut(), " ")
-			for _, vm := range vms {
-				vmObj := virtv2.VirtualMachine{}
-				err := GetObject(kc.ResourceVM, vm, &vmObj, kc.GetOptions{Namespace: conf.Namespace})
-				Expect(err).NotTo(HaveOccurred(), err)
-				Expect(vmObj.Annotations).ShouldNot(HaveKey("specialKey"))
+				vms := strings.Split(res.StdOut(), " ")
+				for _, vm := range vms {
+					vmObj := virtv2.VirtualMachine{}
+					err := GetObject(kc.ResourceVM, vm, &vmObj, kc.GetOptions{Namespace: conf.Namespace})
+					Expect(err).NotTo(HaveOccurred(), err)
+					_, ok := vmObj.Annotations[specialKey]
+					if ok {
+						return fmt.Errorf("vm annotation %q found in %s", specialKey, vmObj.Name)
+					}
 
-				activePod := GetActiveVirtualMachinePod(&vmObj)
-				vmPodObj := v1.Pod{}
-				err = GetObject(kc.ResourcePod, activePod, &vmPodObj, kc.GetOptions{Namespace: conf.Namespace})
-				Expect(err).NotTo(HaveOccurred(), err)
-				Expect(vmPodObj.Annotations).ShouldNot(HaveKey("specialKey"))
-			}
+					activePod := GetActiveVirtualMachinePod(&vmObj)
+					vmPodObj := v1.Pod{}
+					err = GetObject(kc.ResourcePod, activePod, &vmPodObj, kc.GetOptions{Namespace: conf.Namespace})
+					Expect(err).NotTo(HaveOccurred(), err)
+					_, ok = vmPodObj.Annotations[specialKey]
+					if ok {
+						return fmt.Errorf("pod annotation %q found in %s", specialKey, vmPodObj.Name)
+					}
+				}
+
+				return nil
+			}).WithTimeout(Timeout).WithPolling(Interval).Should(Succeed())
 		})
 	})
 

--- a/tests/e2e/vm_label_annotation_test.go
+++ b/tests/e2e/vm_label_annotation_test.go
@@ -19,6 +19,7 @@ package e2e
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -176,6 +177,7 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 		})
 
 		It("checks VMs and pods labels after VMs labeling", func() {
+			time.Sleep(5 * time.Second)
 			res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
@@ -212,6 +214,7 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 		})
 
 		It("checks VMs and pods labels after VMs unlabeling", func() {
+			time.Sleep(5 * time.Second)
 			res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
@@ -250,6 +253,7 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 		})
 
 		It("checks VMs and pods annotations after VMs annotating", func() {
+			time.Sleep(5 * time.Second)
 			res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
@@ -286,6 +290,7 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 		})
 
 		It("checks VMs and pods annotations after VMs unannotating", func() {
+			time.Sleep(5 * time.Second)
 			res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,


### PR DESCRIPTION
## Description
Rename `FilesystemReady` condition to `FilesystemFrozen`.

## Why do we need it, and what problem does it solve?

## What is the expected result?

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: vm
type: fix
summary: rename filesystemReady condition to filesystemFrozen
```
