### PR TITLE
fix(kubevirt): unblock queue when exist ghost records

### DIFF
--- a/images/virt-artifact/patches/031-hotplug-container-disk.patch
+++ b/images/virt-artifact/patches/031-hotplug-container-disk.patch
@@ -869,10 +869,10 @@ index fa4e86ee17..c40f1fad89 100644
  			pvcName := storagetypes.PVCNameFromVirtVolume(&volume)
 diff --git a/pkg/virt-handler/container-disk/hotplug.go b/pkg/virt-handler/container-disk/hotplug.go
 new file mode 100644
-index 0000000000..fa3a7c39af
+index 0000000000..993d1be31b
 --- /dev/null
 +++ b/pkg/virt-handler/container-disk/hotplug.go
-@@ -0,0 +1,667 @@
+@@ -0,0 +1,676 @@
 +package container_disk
 +
 +import (
@@ -1209,13 +1209,22 @@ index 0000000000..fa3a7c39af
 +}
 +
 +func (m *hotplugMounter) getMountedVolumesInWorld(vmi *v1.VirtualMachineInstance, virtLauncherUID types.UID) ([]vmiMountTargetEntry, error) {
++	if vmi == nil || virtLauncherUID == "" {
++		return nil, nil
++	}
 +	path, err := m.hotplugManager.GetHotplugTargetPodPathOnHost(virtLauncherUID)
 +	if err != nil {
++		if os.IsNotExist(err) {
++			return nil, nil
++		}
 +		return nil, err
 +	}
 +	rawPath := unsafepath.UnsafeAbsolute(path.Raw())
 +	entries, err := os.ReadDir(rawPath)
 +	if err != nil {
++		if os.IsNotExist(err) {
++			return nil, nil
++		}
 +		return nil, err
 +	}
 +	var volumes []string

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -93,43 +93,43 @@ shell:
 
     - echo ============== Build virt-handler =====================
     - CGO_ENABLED=1 go build -ldflags="-s -w" -o /kubevirt-binaries/virt-handler ./cmd/virt-handler/
-    
+
     - echo ============== Build virt-launcher-monitor ============
     # virt-launcher-monitor is wrapped in the final image. Add suffix here to prevent image size increasing as effect of file renaming.
     - go build -ldflags="-s -w" -o /kubevirt-binaries/virt-launcher-monitor-orig ./cmd/virt-launcher-monitor/
-    
+
     - echo ============== Build virt-tail ========================
     - go build -ldflags="-s -w" -o /kubevirt-binaries/virt-tail ./cmd/virt-tail/
-    
+
     - echo ============== Build virt-freezer =====================
     - go build -ldflags="-s -w" -o /kubevirt-binaries/virt-freezer ./cmd/virt-freezer/
-    
+
     - echo ============== Build virt-probe =======================
     - go build -ldflags="-s -w" -o /kubevirt-binaries/virt-probe ./cmd/virt-probe/
-    
+
     - echo ============== Build virt-api =========================
     - go build -ldflags="-s -w" -o /kubevirt-binaries/virt-api ./cmd/virt-api/
-    
+
     - echo ============== Build virt-chroot ======================
     - go build -ldflags="-s -w" -o /kubevirt-binaries/virt-chroot ./cmd/virt-chroot/
-    
+
     - echo ============== Build virt-exportproxy =================
     - go build -ldflags="-s -w" -o /kubevirt-binaries/virt-exportproxy ./cmd/virt-exportproxy/
-    
+
     - echo ============== Build virt-exportserver ================
     - go build -ldflags="-s -w" -o /kubevirt-binaries/virt-exportserver ./cmd/virt-exportserver/
-   
+
     - echo ============== Build virt-controller ==================
     - go build -ldflags="-s -w" -o /kubevirt-binaries/virt-controller ./cmd/virt-controller/
-    
+
     - echo ============== Build virt-operator ====================
     - go build -ldflags="-s -w" -o /kubevirt-binaries/virt-operator ./cmd/virt-operator/
-    
+
     - echo ============== Build csv-generator ====================
     - go build -ldflags="-s -w" -o /kubevirt-binaries/csv-generator ./tools/csv-generator
-    
+
     - echo ============== Build sidecars =========================
     - go build -ldflags="-s -w" -o /kubevirt-binaries/sidecars ./cmd/sidecars/
-    
+
     - echo ============== Build virtctl ==========================
     - go build -ldflags="-s -w" -o /kubevirt-binaries/virtctl ./cmd/virtctl/


### PR DESCRIPTION
## Description
Fix hotplug container disk mounter blocking the queue when virt-handler attempts to reconcile ghost records.
<!---
  Describe your changes with technical details.
-->


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [X] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: kubevirt
type: fix 
summary: Fix hotplug container disk mounter blocking the queue when virt-handler attempts to reconcile ghost records.
impact_level: low
```
