### PR TITLE
chore(ci): move to distroless virt-api

### DIFF
--- a/images/virt-api/werf.inc.yaml
+++ b/images/virt-api/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ $.ImageName }}
-fromImage: base-alt-p11
+fromImage: distroless
 import:
 - image: virt-artifact
   add: /kubevirt-binaries/
@@ -17,4 +17,4 @@ import:
 # Source https://github.com/kubevirt/kubevirt/blob/v1.3.1/cmd/virt-api/BUILD.bazel
 docker:
   ENTRYPOINT: ["/usr/bin/virt-api"]
-  USER: 1001
+  USER: 64535

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -110,7 +110,7 @@ shell:
     - echo ============== Build virt-api =========================
     - go build -ldflags="-s -w" -o /kubevirt-binaries/virt-api ./cmd/virt-api/
     - chown 64535:64535 /kubevirt-binaries/virt-api
-    
+
     - echo ============== Build virt-chroot ======================
     - go build -ldflags="-s -w" -o /kubevirt-binaries/virt-chroot ./cmd/virt-chroot/
 

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -109,7 +109,8 @@ shell:
 
     - echo ============== Build virt-api =========================
     - go build -ldflags="-s -w" -o /kubevirt-binaries/virt-api ./cmd/virt-api/
-
+    - chown 64535:64535 /kubevirt-binaries/virt-api
+    
     - echo ============== Build virt-chroot ======================
     - go build -ldflags="-s -w" -o /kubevirt-binaries/virt-chroot ./cmd/virt-chroot/
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Change virt-api base image to distroless.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
We want our images to be distroless-based

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: ci
type: chore
summary: move to distroless virt-api
```
