### PR TITLE
chore(ci): fix-distroless-cdi

### DIFF
--- a/images/cdi-cloner/werf.inc.yaml
+++ b/images/cdi-cloner/werf.inc.yaml
@@ -3,12 +3,23 @@ image: {{ $.ImageName }}
 fromImage: distroless
 import:
 - image: {{ $.ImageName }}-bins
+  add: /relocate/usr/bin
+  to: /bin
+  before: setup
+- image: {{ $.ImageName }}-bins
+  add: /relocate/usr/sbin
+  to: /sbin
+  before: setup
+- image: {{ $.ImageName }}-bins
   add: /relocate
   to: /
   before: setup
+  excludePaths:
+  - usr/sbin
+  - usr/bin
 - image: cdi-artifact
   add: /cdi-binaries
-  to: /usr/sbin
+  to: /usr/bin
   includePaths:
   - cdi-cloner
   - cloner_startup.sh
@@ -18,7 +29,7 @@ docker:
   ENTRYPOINT: ["/usr/bin/cloner_startup.sh"]
   USER: 64535
 ---
-{{- $binaries := "/usr/bin/sh /usr/sbin/blockdev /usr/bin/mount /usr/bin/umount /usr/sbin/fsck /usr/sbin/blkid /usr/sbin/mkfs /usr/sbin/mkfs.ext4 /usr/sbin/mkfs.xfs /usr/sbin/dumpe2fs /usr/sbin/xfs_io /usr/sbin/xfs_growfs /usr/sbin/resize2fs" }}
+{{- $binaries := "/usr/bin/sh /usr/bin/bash /usr/sbin/blockdev /usr/bin/mount /usr/bin/umount /usr/sbin/fsck /usr/sbin/blkid /usr/sbin/mkfs /usr/sbin/mkfs.ext4 /usr/sbin/mkfs.xfs /usr/sbin/dumpe2fs /usr/sbin/xfs_io /usr/sbin/xfs_growfs /usr/sbin/resize2fs" }}
 
 image: {{ $.ImageName }}-bins
 final: false

--- a/images/cdi-controller/werf.inc.yaml
+++ b/images/cdi-controller/werf.inc.yaml
@@ -21,7 +21,7 @@ docker:
   ENTRYPOINT: ["/usr/bin/cdi-controller", "-alsologtostderr"]
   USER: 64535
 ---
-{{- $binaries := "/usr/bin/cat" }}
+{{- $binaries := "/usr/bin/cat /usr/bin/bash /usr/bin/echo" }}
 
 image: {{ $.ImageName }}-bins
 final: false


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Fix (PR #700) import path cdi images (cloner,controller)

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: ci
type: fix
summary: fix import path for cdi images (cloner,controller)
```
