### PR TITLE
fix(api): add validation for short block device names

### DIFF
--- a/images/virtualization-artifact/pkg/common/blockdevice/block_device.go
+++ b/images/virtualization-artifact/pkg/common/blockdevice/block_device.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blockdevice
+
+// MaxDiskNameLen determines the max len of vd.
+// Disk and volume name in kubevirt can be a valid container name (len 63) since disk name can become a container name which will fail to schedule if invalid.
+// We add prefix "vd-" for the vd name, so max len reduced to 60.
+const MaxDiskNameLen = 60
+
+// MaxVirtualImageNameLen determines the max len of vi.
+// Disk and volume name in kubevirt can be a valid container name (len 63) since disk name can become a container name which will fail to schedule if invalid.
+// We and kubevirt add prefixes "vi-", "volume" and suffix "-init", so max len reduced to 49.
+const MaxVirtualImageNameLen = 49
+
+// MaxClusterVirtualImageNameLen determines the max len of cvi.
+// Disk and volume name in kubevirt can be a valid container name (len 63) since disk name can become a container name which will fail to schedule if invalid.
+// We and kubevirt add prefixes "cvi-", "volume" and suffix "-init", so max len reduced to 48.
+const MaxClusterVirtualImageNameLen = 48

--- a/images/virtualization-artifact/pkg/controller/vi/vi_webhook.go
+++ b/images/virtualization-artifact/pkg/controller/vi/vi_webhook.go
@@ -18,7 +18,6 @@ package vi
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -28,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
+	"github.com/deckhouse/virtualization-controller/pkg/common/blockdevice"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vicondition"
@@ -49,8 +49,12 @@ func (v *Validator) ValidateCreate(_ context.Context, obj runtime.Object) (admis
 		return nil, fmt.Errorf("expected a new VirtualMachine but got a %T", obj)
 	}
 
-	if strings.Contains(vi.ObjectMeta.Name, ".") {
-		return nil, errors.New("VirtualImage name is invalid: '.' is forbidden, allowed name symbols are [0-9a-zA-Z-]")
+	if strings.Contains(vi.Name, ".") {
+		return nil, fmt.Errorf("the VirtualImage name %q is invalid: '.' is forbidden, allowed name symbols are [0-9a-zA-Z-]", vi.Name)
+	}
+
+	if len(vi.Name) > blockdevice.MaxVirtualImageNameLen {
+		return nil, fmt.Errorf("the VirtualImage name %q is too long: it must be no more than %d characters", vi.Name, blockdevice.MaxVirtualImageNameLen)
 	}
 
 	if vi.Spec.Storage == virtv2.StorageKubernetes {
@@ -94,8 +98,12 @@ func (v *Validator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Obj
 		}
 	}
 
-	if strings.Contains(newVI.ObjectMeta.Name, ".") {
-		warnings = append(warnings, "VirtualImage name is invalid as it contains now forbidden symbol '.', allowed symbols for name are [0-9a-zA-Z-]. Create another image with valid name to avoid problems with future updates.")
+	if strings.Contains(newVI.Name, ".") {
+		warnings = append(warnings, fmt.Sprintf(" the VirtualImage name %q is invalid as it contains now forbidden symbol '.', allowed symbols for name are [0-9a-zA-Z-]. Create another image with valid name to avoid problems with future updates.", newVI.Name))
+	}
+
+	if len(newVI.Name) > blockdevice.MaxVirtualImageNameLen {
+		warnings = append(warnings, fmt.Sprintf("the VirtualImage name %q is too long: it must be no more than %d characters", newVI.Name, blockdevice.MaxVirtualImageNameLen))
 	}
 
 	return warnings, nil

--- a/tests/e2e/testdata/images-creation/cvi/cvi_objectref_cvi.yaml
+++ b/tests/e2e/testdata/images-creation/cvi/cvi_objectref_cvi.yaml
@@ -1,7 +1,7 @@
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: ClusterVirtualImage
 metadata:
-  name: cvi-objectref-cvi
+  name: cvi-oref-cvi
 spec:
   dataSource:
     type: "ObjectRef"

--- a/tests/e2e/testdata/images-creation/cvi/cvi_objectref_vd.yaml
+++ b/tests/e2e/testdata/images-creation/cvi/cvi_objectref_vd.yaml
@@ -1,7 +1,7 @@
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: ClusterVirtualImage
 metadata:
-  name: cvi-objectref-vd
+  name: cvi-oref-vd
 spec:
   dataSource:
     type: "ObjectRef"

--- a/tests/e2e/testdata/images-creation/cvi/cvi_objectref_vdsnapshot.yaml
+++ b/tests/e2e/testdata/images-creation/cvi/cvi_objectref_vdsnapshot.yaml
@@ -1,7 +1,7 @@
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: ClusterVirtualImage
 metadata:
-  name: cvi-objectref-vdsnapshot
+  name: cvi-oref-vdsnapshot
 spec:
   dataSource:
     type: "ObjectRef"

--- a/tests/e2e/testdata/images-creation/cvi/cvi_objectref_vi.yaml
+++ b/tests/e2e/testdata/images-creation/cvi/cvi_objectref_vi.yaml
@@ -2,7 +2,7 @@
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: ClusterVirtualImage
 metadata:
-  name: cvi-objectref-vi-http
+  name: cvi-oref-vi-http
 spec:
   dataSource:
     type: "ObjectRef"
@@ -14,7 +14,7 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: ClusterVirtualImage
 metadata:
-  name: cvi-objectref-vi-containerimage
+  name: cvi-oref-vi-containerimage
 spec:
   dataSource:
     type: "ObjectRef"
@@ -26,37 +26,37 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: ClusterVirtualImage
 metadata:
-  name: cvi-objectref-vi-objectref-cvi
+  name: cvi-oref-vi-oref-cvi
 spec:
   dataSource:
     type: "ObjectRef"
     objectRef:
       kind: "VirtualImage"
-      name: vi-objectref-cvi
+      name: vi-oref-cvi
       namespace: test-d8-virtualization
 ---
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: ClusterVirtualImage
 metadata:
-  name: cvi-objectref-vi-objectref-vd
+  name: cvi-oref-vi-oref-vd
 spec:
   dataSource:
     type: "ObjectRef"
     objectRef:
       kind: "VirtualImage"
-      name: vi-objectref-vd
+      name: vi-oref-vd
       namespace: test-d8-virtualization
 ---
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: ClusterVirtualImage
 metadata:
-  name: cvi-objectref-vi-objectref-vdsnapshot
+  name: cvi-oref-vi-oref-vdsnapshot
 spec:
   dataSource:
     type: "ObjectRef"
     objectRef:
       kind: "VirtualImage"
-      name: vi-objectref-vdsnapshot
+      name: vi-oref-vdsnapshot
       namespace: test-d8-virtualization
 
 # PVC SOURCE
@@ -64,7 +64,7 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: ClusterVirtualImage
 metadata:
-  name: cvi-objectref-vi-http-pvc
+  name: cvi-oref-vi-http-pvc
 spec:
   dataSource:
     type: "ObjectRef"
@@ -76,7 +76,7 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: ClusterVirtualImage
 metadata:
-  name: cvi-objectref-vi-containerimage-pvc
+  name: cvi-oref-vi-containerimage-pvc
 spec:
   dataSource:
     type: "ObjectRef"
@@ -88,35 +88,35 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: ClusterVirtualImage
 metadata:
-  name: cvi-objectref-vi-objectref-cvi-pvc
+  name: cvi-oref-vi-oref-cvi-pvc
 spec:
   dataSource:
     type: "ObjectRef"
     objectRef:
       kind: "VirtualImage"
-      name: vi-pvc-objectref-cvi
+      name: vi-pvc-oref-cvi
       namespace: test-d8-virtualization
 ---
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: ClusterVirtualImage
 metadata:
-  name: cvi-objectref-vi-objectref-vd-pvc
+  name: cvi-oref-vi-oref-vd-pvc
 spec:
   dataSource:
     type: "ObjectRef"
     objectRef:
       kind: "VirtualImage"
-      name: vi-pvc-objectref-vd
+      name: vi-pvc-oref-vd
       namespace: test-d8-virtualization
 ---
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: ClusterVirtualImage
 metadata:
-  name: cvi-objectref-vi-objectref-vdsnapshot-pvc
+  name: cvi-oref-vi-oref-vdsnapshot-pvc
 spec:
   dataSource:
     type: "ObjectRef"
     objectRef:
       kind: "VirtualImage"
-      name: vi-pvc-objectref-vdsnapshot
+      name: vi-pvc-oref-vdsnapshot
       namespace: test-d8-virtualization

--- a/tests/e2e/testdata/images-creation/vi/vi_objectref_cvi.yaml
+++ b/tests/e2e/testdata/images-creation/vi/vi_objectref_cvi.yaml
@@ -1,7 +1,7 @@
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-objectref-cvi
+  name: vi-oref-cvi
   namespace: test-d8-virtualization
 spec:
   storage: ContainerRegistry
@@ -14,7 +14,7 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-pvc-objectref-cvi
+  name: vi-pvc-oref-cvi
   namespace: test-d8-virtualization
 spec:
   storage: PersistentVolumeClaim

--- a/tests/e2e/testdata/images-creation/vi/vi_objectref_vd.yaml
+++ b/tests/e2e/testdata/images-creation/vi/vi_objectref_vd.yaml
@@ -1,7 +1,7 @@
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-objectref-vd
+  name: vi-oref-vd
   namespace: test-d8-virtualization
 spec:
   storage: ContainerRegistry
@@ -14,7 +14,7 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-pvc-objectref-vd
+  name: vi-pvc-oref-vd
   namespace: test-d8-virtualization
 spec:
   storage: PersistentVolumeClaim

--- a/tests/e2e/testdata/images-creation/vi/vi_objectref_vdsnapshot.yaml
+++ b/tests/e2e/testdata/images-creation/vi/vi_objectref_vdsnapshot.yaml
@@ -1,7 +1,7 @@
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-objectref-vdsnapshot
+  name: vi-oref-vdsnapshot
   namespace: test-d8-virtualization
 spec:
   storage: ContainerRegistry
@@ -14,7 +14,7 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-pvc-objectref-vdsnapshot
+  name: vi-pvc-oref-vdsnapshot
   namespace: test-d8-virtualization
 spec:
   storage: PersistentVolumeClaim

--- a/tests/e2e/testdata/images-creation/vi/vi_objectref_vi.yaml
+++ b/tests/e2e/testdata/images-creation/vi/vi_objectref_vi.yaml
@@ -2,7 +2,7 @@
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-objectref-vi-http
+  name: vi-oref-vi-http
   namespace: test-d8-virtualization
 spec:
   storage: ContainerRegistry
@@ -15,7 +15,7 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-objectref-vi-containerimage
+  name: vi-oref-vi-containerimage
   namespace: test-d8-virtualization
 spec:
   storage: ContainerRegistry
@@ -28,7 +28,7 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-objectref-vi-objectref-cvi
+  name: vi-oref-vi-oref-cvi
   namespace: test-d8-virtualization
 spec:
   storage: ContainerRegistry
@@ -36,12 +36,12 @@ spec:
     type: "ObjectRef"
     objectRef:
       kind: "VirtualImage"
-      name: vi-objectref-cvi
+      name: vi-oref-cvi
 ---
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-objectref-vi-objectref-vd
+  name: vi-oref-vi-oref-vd
   namespace: test-d8-virtualization
 spec:
   storage: ContainerRegistry
@@ -49,12 +49,12 @@ spec:
     type: "ObjectRef"
     objectRef:
       kind: "VirtualImage"
-      name: vi-objectref-vd
+      name: vi-oref-vd
 ---
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-objectref-vi-objectref-vdsnapshot
+  name: vi-oref-vi-oref-vdsnapshot
   namespace: test-d8-virtualization
 spec:
   storage: ContainerRegistry
@@ -62,14 +62,14 @@ spec:
     type: "ObjectRef"
     objectRef:
       kind: "VirtualImage"
-      name: vi-objectref-vdsnapshot
+      name: vi-oref-vdsnapshot
 
 # PVC SOURCE
 ---
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-objectref-vi-http-pvc
+  name: vi-oref-vi-http-pvc
   namespace: test-d8-virtualization
 spec:
   storage: ContainerRegistry
@@ -82,7 +82,7 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-objectref-vi-containerimage-pvc
+  name: vi-oref-vi-containerimage-pvc
   namespace: test-d8-virtualization
 spec:
   storage: ContainerRegistry
@@ -95,7 +95,7 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-objectref-vi-objectref-cvi-pvc
+  name: vi-oref-vi-oref-cvi-pvc
   namespace: test-d8-virtualization
 spec:
   storage: ContainerRegistry
@@ -103,12 +103,12 @@ spec:
     type: "ObjectRef"
     objectRef:
       kind: "VirtualImage"
-      name: vi-pvc-objectref-cvi
+      name: vi-pvc-oref-cvi
 ---
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-objectref-vi-objectref-vd-pvc
+  name: vi-oref-vi-oref-vd-pvc
   namespace: test-d8-virtualization
 spec:
   storage: ContainerRegistry
@@ -116,12 +116,12 @@ spec:
     type: "ObjectRef"
     objectRef:
       kind: "VirtualImage"
-      name: vi-pvc-objectref-vd
+      name: vi-pvc-oref-vd
 ---
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-objectref-vi-objectref-vdsnapshot-pvc
+  name: vi-oref-vi-oref-vdsnapshot-pvc
   namespace: test-d8-virtualization
 spec:
   storage: ContainerRegistry
@@ -129,4 +129,4 @@ spec:
     type: "ObjectRef"
     objectRef:
       kind: "VirtualImage"
-      name: vi-pvc-objectref-vdsnapshot
+      name: vi-pvc-oref-vdsnapshot

--- a/tests/e2e/testdata/images-creation/vi/vi_pvc_objectref_vi.yaml
+++ b/tests/e2e/testdata/images-creation/vi/vi_pvc_objectref_vi.yaml
@@ -2,7 +2,7 @@
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-pvc-objectref-vi-http
+  name: vi-pvc-oref-vi-http
   namespace: test-d8-virtualization
 spec:
   storage: PersistentVolumeClaim
@@ -15,7 +15,7 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-pvc-objectref-vi-containerimage
+  name: vi-pvc-oref-vi-containerimage
   namespace: test-d8-virtualization
 spec:
   storage: PersistentVolumeClaim
@@ -28,7 +28,7 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-pvc-objectref-vi-objectref-cvi
+  name: vi-pvc-oref-vi-oref-cvi
   namespace: test-d8-virtualization
 spec:
   storage: PersistentVolumeClaim
@@ -36,12 +36,12 @@ spec:
     type: "ObjectRef"
     objectRef:
       kind: "VirtualImage"
-      name: vi-objectref-cvi
+      name: vi-oref-cvi
 ---
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-pvc-objectref-vi-objectref-vd
+  name: vi-pvc-oref-vi-oref-vd
   namespace: test-d8-virtualization
 spec:
   storage: PersistentVolumeClaim
@@ -49,12 +49,12 @@ spec:
     type: "ObjectRef"
     objectRef:
       kind: "VirtualImage"
-      name: vi-objectref-vd
+      name: vi-oref-vd
 ---
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-pvc-objectref-vi-objectref-vdsnapshot
+  name: vi-pvc-oref-vi-oref-vdsnapshot
   namespace: test-d8-virtualization
 spec:
   storage: PersistentVolumeClaim
@@ -62,14 +62,14 @@ spec:
     type: "ObjectRef"
     objectRef:
       kind: "VirtualImage"
-      name: vi-objectref-vdsnapshot
+      name: vi-oref-vdsnapshot
 
 ### PVC
 ---
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-pvc-objectref-vi-http-pvc
+  name: vi-pvc-oref-vi-http-pvc
   namespace: test-d8-virtualization
 spec:
   storage: PersistentVolumeClaim
@@ -82,7 +82,7 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-pvc-objectref-vi-containerimage-pvc
+  name: vi-pvc-oref-vi-containerimage-pvc
   namespace: test-d8-virtualization
 spec:
   storage: PersistentVolumeClaim
@@ -95,7 +95,7 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-pvc-objectref-vi-objectref-vd-pvc
+  name: vi-pvc-oref-vi-oref-vd-pvc
   namespace: test-d8-virtualization
 spec:
   storage: PersistentVolumeClaim
@@ -103,12 +103,12 @@ spec:
     type: "ObjectRef"
     objectRef:
       kind: "VirtualImage"
-      name: vi-pvc-objectref-vd
+      name: vi-pvc-oref-vd
 ---
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-pvc-objectref-vi-objectref-vdsnapshot-pvc
+  name: vi-pvc-oref-vi-oref-vdsnapshot-pvc
   namespace: test-d8-virtualization
 spec:
   storage: PersistentVolumeClaim
@@ -116,4 +116,4 @@ spec:
     type: "ObjectRef"
     objectRef:
       kind: "VirtualImage"
-      name: vi-pvc-objectref-vdsnapshot
+      name: vi-pvc-oref-vdsnapshot


### PR DESCRIPTION
## Description

Add validation for short block device names.

Disk and volume name in kubevirt can be a valid container name (len 63) since disk name can become a container name which will fail to schedule if invalid.
We add prefix "vd-" for the vd name, so max len of vd is reduced to 60.
We and kubevirt add prefixes  "vi-", "volume" and suffix "-init", so max len for vi and is reduced to 49.
We and kubevirt add prefixes "cvi-", "volume" and suffix "-init", so max len for cvi and is reduced to 48.


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries


```changes
section: api
type: fix
summary: reduce max len of block devices to avoid errors during vm creation
```
