### PR TITLE
chore(ci): fix distroless image certificate path, add envs

### DIFF
--- a/images/distroless/werf.inc.yaml
+++ b/images/distroless/werf.inc.yaml
@@ -8,6 +8,10 @@ import:
     to: /
     before: setup
 docker:
+  ENV:
+    PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    LANG: ""
+    LC_ALL: POSIX
   USER: 64535
 ---
 image: {{ $.ImageName }}-artifact
@@ -19,13 +23,14 @@ shell:
   - apt-get clean
   - rm --recursive --force /var/lib/apt/lists/ftp.altlinux.org* /var/cache/apt/*.bin
   install:
-  - mkdir -p /relocate/bin /relocate/sbin /relocate/etc /relocate/etc/ssl /relocate/usr/bin /relocate/usr/sbin /relocate/usr/share
+  - mkdir -p /relocate/{usr,bin,sbin,etc} /relocate/etc/{pki,ssl} /relocate/usr/{bin,sbin,share}
   - cp -pr /tmp /relocate
   - cp -pr /etc/passwd /etc/group /etc/hostname /etc/hosts /etc/shadow /etc/protocols /etc/services /etc/nsswitch.conf /relocate/etc
   - cp -pr /usr/share/ca-certificates /relocate/usr/share
   - cp -pr /usr/share/zoneinfo /relocate/usr/share
   - cp -pr /etc/pki/tls/cert.pem /relocate/etc/ssl
   - cp -pr /etc/pki/tls/certs /relocate/etc/ssl
+  - cp -pr /etc/pki/ca-trust/ /relocate/etc/
   - echo "deckhouse:x:64535:64535:deckhouse:/:/sbin/nologin" >> /relocate/etc/passwd
   - echo "deckhouse:x:64535:" >> /relocate/etc/group
   - echo "deckhouse:!::0:::::" >> /relocate/etc/shadow


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Fix path to CA certificates.
Add envs for locale and `PATH`

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
To run the binary without fuul path to file, we need to have a PATH environment variable in the image
Prevent warning like `warning: setlocale: LC_CTYPE: cannot change locale (C.UTF-8): No such file or directory`

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: ci
type: chore
summary: fix distroless image certificate path, add envs
```
