### PR TITLE
test(images): add e2e image attachment test case

### DIFF
--- a/tests/e2e/config/config.go
+++ b/tests/e2e/config/config.go
@@ -138,6 +138,7 @@ type TestData struct {
 	DiskResizing          string `yaml:"diskResizing"`
 	SizingPolicy          string `yaml:"sizingPolicy"`
 	ImporterNetworkPolicy string `yaml:"importerNetworkPolicy"`
+	ImageHotplug          string `yaml:"imageHotplug"`
 	ImagesCreation        string `yaml:"imagesCreation"`
 	VmConfiguration       string `yaml:"vmConfiguration"`
 	VmLabelAnnotation     string `yaml:"vmLabelAnnotation"`

--- a/tests/e2e/default_config.yaml
+++ b/tests/e2e/default_config.yaml
@@ -23,6 +23,7 @@ testData:
   complexTest: "/tmp/testdata/complex-test"
   connectivity: "/tmp/testdata/connectivity"
   diskResizing: "/tmp/testdata/disk-resizing"
+  imageHotplug: "/tmp/testdata/image-hotplug"
   sizingPolicy: "/tmp/testdata/sizing-policy"
   imagesCreation: "/tmp/testdata/images-creation"
   importerNetworkPolicy: "/tmp/testdata/importer-network-policy"

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -12,7 +12,6 @@ require (
 	k8s.io/api v0.31.0
 	k8s.io/apimachinery v0.31.0
 	k8s.io/utils v0.0.0-20240921022957-49e7df575cb6
-	kubevirt.io/api v1.3.1
 	sigs.k8s.io/controller-runtime v0.19.0
 	sigs.k8s.io/yaml v1.4.0
 )
@@ -59,6 +58,7 @@ require (
 	k8s.io/client-go v0.31.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
+	kubevirt.io/api v1.3.1 // indirect
 	kubevirt.io/containerized-data-importer-api v1.60.3 // indirect
 	kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/tests/e2e/image_hotplug_test.go
+++ b/tests/e2e/image_hotplug_test.go
@@ -1,0 +1,442 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/tests/e2e/config"
+	d8 "github.com/deckhouse/virtualization/tests/e2e/d8"
+	kc "github.com/deckhouse/virtualization/tests/e2e/kubectl"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	virtv1 "kubevirt.io/api/core/v1"
+)
+
+const (
+	viCount     = 2
+	cviCount    = 2
+	vmCount     = 1
+	vdCount     = 1
+	vmbdaCount  = 0
+	imgCount    = viCount + cviCount
+	cdRom       = "rom"
+	readOnlyOpt = "ro"
+)
+
+type Image struct {
+	Kind string
+	Name string
+}
+
+func IsBlockDeviceCdRom(vmName, blockDeviceName string) (bool, error) {
+	GinkgoHelper()
+	var blockDevices *BlockDevices
+	bdIdPath := fmt.Sprintf("/dev/disk/by-id/%s-%s", CdRomIdPrefix, blockDeviceName)
+	cmd := fmt.Sprintf("lsblk --json --nodeps --output name,type %s", bdIdPath)
+	res := d8Virtualization.SshCommand(vmName, cmd, d8.SshOptions{
+		Namespace:   conf.Namespace,
+		Username:    conf.TestData.SshUser,
+		IdenityFile: conf.TestData.Sshkey,
+	})
+	if res.Error() != nil {
+		return false, errors.New(res.StdErr())
+	}
+	err := json.Unmarshal(res.StdOutBytes(), &blockDevices)
+	if err != nil {
+		return false, err
+	}
+	if len(blockDevices.BlockDevices) != 1 {
+		return false, fmt.Errorf("`blockDevices` length should be 1")
+	}
+	blockDevice := &blockDevices.BlockDevices[0]
+	return blockDevice.Type == cdRom, nil
+}
+
+func MountBlockDevice(vmName, blockDeviceId string) error {
+	GinkgoHelper()
+	bdIdPath := fmt.Sprintf("/dev/disk/by-id/%s", blockDeviceId)
+	cmd := fmt.Sprintf("sudo mount --read-only %s /mnt", bdIdPath)
+	res := d8Virtualization.SshCommand(vmName, cmd, d8.SshOptions{
+		Namespace:   conf.Namespace,
+		Username:    conf.TestData.SshUser,
+		IdenityFile: conf.TestData.Sshkey,
+	})
+	if res.Error() != nil {
+		return errors.New(res.StdErr())
+	}
+	return nil
+}
+
+func IsBlockDeviceReadOnly(vmName, blockDeviceId string) (bool, error) {
+	GinkgoHelper()
+	bdIdPath := fmt.Sprintf("/dev/disk/by-id/%s", blockDeviceId)
+	cmd := fmt.Sprintf("findmnt --noheadings --output options %s", bdIdPath)
+	res := d8Virtualization.SshCommand(vmName, cmd, d8.SshOptions{
+		Namespace:   conf.Namespace,
+		Username:    conf.TestData.SshUser,
+		IdenityFile: conf.TestData.Sshkey,
+	})
+	if res.Error() != nil {
+		return false, errors.New(res.StdErr())
+	}
+	options := strings.Split(res.StdOut(), ",")
+	roOpt := options[0]
+	return roOpt == readOnlyOpt, nil
+}
+
+var _ = Describe("Image hotplug", func() {
+	var (
+		vmObj         virtv2.VirtualMachine
+		disksBefore   Disks
+		disksAfter    Disks
+		testCaseLabel = map[string]string{"testcase": "image-hotplug"}
+		isoLabel      = "iso"
+		blockDevices  = make([]Image, 0)
+	)
+
+	Context("Preparing the environment", func() {
+		It("sets the namespace", func() {
+			kustomization := fmt.Sprintf("%s/%s", conf.TestData.ImageHotplug, "kustomization.yaml")
+			ns, err := kustomize.GetNamespace(kustomization)
+			Expect(err).NotTo(HaveOccurred(), "%w", err)
+			conf.SetNamespace(ns)
+		})
+	})
+
+	Context("When virtualization resources are applied", func() {
+		It("result should be succeeded", func() {
+			if config.IsReusable() {
+				vms := &virtv2.VirtualMachineList{}
+				err := GetObjects(virtv2.VirtualMachineResource, vms, kc.GetOptions{
+					Labels:         testCaseLabel,
+					Namespace:      conf.Namespace,
+					IgnoreNotFound: true,
+				})
+				Expect(err).NotTo(HaveOccurred(), "failed to check reusable `VirtualMachine`", err)
+
+				vds := &virtv2.VirtualDiskList{}
+				err = GetObjects(virtv2.VirtualDiskResource, vds, kc.GetOptions{
+					Labels:         testCaseLabel,
+					Namespace:      conf.Namespace,
+					IgnoreNotFound: true,
+				})
+				Expect(err).NotTo(HaveOccurred(), "failed to check reusable `VirtualDisk`", err)
+
+				vis := &virtv2.VirtualImageList{}
+				err = GetObjects(virtv2.VirtualImageResource, vis, kc.GetOptions{
+					Labels:         testCaseLabel,
+					Namespace:      conf.Namespace,
+					IgnoreNotFound: true,
+				})
+				Expect(err).NotTo(HaveOccurred(), "failed to check reusable `VirtualImages`", err)
+
+				cvis := &virtv2.ClusterVirtualImageList{}
+				err = GetObjects(virtv2.ClusterVirtualImageResource, cvis, kc.GetOptions{
+					Labels:         testCaseLabel,
+					IgnoreNotFound: true,
+				})
+				Expect(err).NotTo(HaveOccurred(), "failed to check reusable `ClusterVirtualImages`", err)
+
+				vmbdas := &virtv2.VirtualMachineBlockDeviceAttachmentList{}
+				err = GetObjects(virtv2.VirtualMachineBlockDeviceAttachmentResource, vmbdas, kc.GetOptions{
+					Labels:         testCaseLabel,
+					IgnoreNotFound: true,
+				})
+				Expect(err).NotTo(HaveOccurred(), "failed to check reusable `VirtualMachineBlockDeviceAttachments`", err)
+
+				if len(vms.Items) == vmCount &&
+					len(vds.Items) == vdCount &&
+					len(vis.Items) == viCount &&
+					len(cvis.Items) == cviCount &&
+					len(vmbdas.Items) == vmbdaCount {
+					fmt.Println("all reusable resources have been found")
+					return
+				}
+
+				if len(vms.Items) == 0 &&
+					len(vds.Items) == 0 &&
+					len(vis.Items) == 0 &&
+					len(cvis.Items) == 0 &&
+					len(vmbdas.Items) == 0 {
+					fmt.Println("no found reusable resources in `REUSABLE` mode")
+				}
+			}
+
+			res := kubectl.Apply(kc.ApplyOptions{
+				Filename:       []string{conf.TestData.ImageHotplug},
+				FilenameOption: kc.Kustomize,
+			})
+			Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
+		})
+	})
+
+	Context("When virtual images are applied", func() {
+		It("checks the `VirtualImages` phase", func() {
+			By(fmt.Sprintf("`VirtualImages` should be in the %q phase", virtv2.ImageReady), func() {
+				WaitPhaseByLabel(kc.ResourceVI, PhaseReady, kc.WaitOptions{
+					Labels:    testCaseLabel,
+					Namespace: conf.Namespace,
+					Timeout:   MaxWaitTimeout,
+				})
+			})
+		})
+
+		It("retrieves `VirtualImages`", func() {
+			viObjs := &virtv2.VirtualImageList{}
+			err := GetObjects(virtv2.VirtualImageResource, viObjs, kc.GetOptions{
+				Labels:    testCaseLabel,
+				Namespace: conf.Namespace,
+			})
+			Expect(err).NotTo(HaveOccurred(), "failed to get `VirtualImages`: %s", err)
+
+			for _, viObj := range viObjs.Items {
+				blockDevices = append(blockDevices, Image{
+					Kind: viObj.Kind,
+					Name: viObj.Name,
+				})
+			}
+		})
+	})
+
+	Context("When cluster virtual images are applied", func() {
+		It("checks the `ClusterVirtualImages` phase", func() {
+			By(fmt.Sprintf("`ClusterVirtualImages` should be in the %q phase", virtv2.ImageReady), func() {
+				WaitPhaseByLabel(kc.ResourceCVI, PhaseReady, kc.WaitOptions{
+					Labels:    testCaseLabel,
+					Namespace: conf.Namespace,
+					Timeout:   MaxWaitTimeout,
+				})
+			})
+		})
+
+		It("retrieves `ClusterVirtualImages`", func() {
+			cviObjs := &virtv2.ClusterVirtualImageList{}
+			err := GetObjects(virtv2.ClusterVirtualImageResource, cviObjs, kc.GetOptions{
+				Labels:    testCaseLabel,
+				Namespace: conf.Namespace,
+			})
+			Expect(err).NotTo(HaveOccurred(), "failed to get `ClusterVirtualImages`: %s", err)
+
+			for _, cviObj := range cviObjs.Items {
+				blockDevices = append(blockDevices, Image{
+					Kind: cviObj.Kind,
+					Name: cviObj.Name,
+				})
+			}
+		})
+	})
+
+	Context("When the virtual disk is applied", func() {
+		It("checks the `VirtualDisk` phase", func() {
+			By(fmt.Sprintf("`VirtualDisk` should be in the %q phase", virtv2.DiskReady), func() {
+				WaitPhaseByLabel(kc.ResourceVD, PhaseReady, kc.WaitOptions{
+					Labels:    testCaseLabel,
+					Namespace: conf.Namespace,
+					Timeout:   MaxWaitTimeout,
+				})
+			})
+		})
+	})
+
+	Context("When the virtual machine is applied", func() {
+		It("checks the `VirtualMachine` status", func() {
+			By("`VirtualMachine` should be ready", func() {
+				WaitVmReady(kc.WaitOptions{
+					Labels:    testCaseLabel,
+					Namespace: conf.Namespace,
+					Timeout:   MaxWaitTimeout,
+				})
+			})
+		})
+
+		It("retrieves `VirtualMachine` object", func() {
+			vmObjs := &virtv2.VirtualMachineList{}
+			err := GetObjects(virtv2.VirtualMachineResource, vmObjs, kc.GetOptions{
+				Labels:    testCaseLabel,
+				Namespace: conf.Namespace,
+			})
+			Expect(err).NotTo(HaveOccurred(), "failed to get `VirtualMachines`: %s", err)
+			Expect(len(vmObjs.Items)).To(BeNumerically("==", vmCount), "there is only %d `VirtualMachine` in this test case", vmCount)
+			vmObj = vmObjs.Items[0]
+		})
+	})
+
+	Context("When the virtual machine is ready", func() {
+		It("retrieves the disk count before attachment", func() {
+			Eventually(func() error {
+				return GetDisksMetadata(vmObj.Name, &disksBefore)
+			}).WithTimeout(Timeout).WithPolling(Interval).ShouldNot(HaveOccurred(), "virtualMachine: %s", vmObj.Name)
+		})
+
+		It("attaches images into `VirtualMachine`", func() {
+			for _, bd := range blockDevices {
+				AttachBlockDevice(vmObj.Name, bd.Name, virtv2.VMBDAObjectRefKind(bd.Kind), testCaseLabel, conf.TestData.ImageHotplug)
+			}
+		})
+
+		It("checks `VirtualMachine` and `VirtualMachineBlockDeviceAttachments` phases", func() {
+			By(fmt.Sprintf("`VirtualMachineBlockDeviceAttachments` should be in the %q phase", virtv2.BlockDeviceAttachmentPhaseAttached), func() {
+				WaitPhaseByLabel(kc.ResourceVMBDA, PhaseAttached, kc.WaitOptions{
+					Labels:    testCaseLabel,
+					Namespace: conf.Namespace,
+					Timeout:   MaxWaitTimeout,
+				})
+			})
+			By("`VirtualMachine` should be ready", func() {
+				WaitVmReady(kc.WaitOptions{
+					Labels:    testCaseLabel,
+					Namespace: conf.Namespace,
+					Timeout:   MaxWaitTimeout,
+				})
+			})
+			By("`BlockDevices` should be attached", func() {
+				WaitBlockDeviceRefsAttached(conf.Namespace, vmObj.Name)
+			})
+		})
+
+		It("compares the disk count before and after attachment", func() {
+			diskCountBefore := len(disksBefore.BlockDevices)
+			Eventually(func() (int, error) {
+				err := GetDisksMetadata(vmObj.Name, &disksAfter)
+				if err != nil {
+					return unacceptableCount, err
+				}
+				diskCountAfter := len(disksAfter.BlockDevices)
+				return diskCountAfter, nil
+			}).WithTimeout(Timeout).WithPolling(Interval).Should(Equal(diskCountBefore+imgCount), "comparing error: 'after' must be equal 'before + %d'", imgCount)
+		})
+
+		It("checks that `ISO` image is attached as `CD-ROM`", func() {
+			var (
+				isoBlockDeviceName string
+				isolockDeviceCount int
+			)
+			intVirtVmi := &virtv1.VirtualMachineInstance{}
+			err := GetObject(kc.ResourceKubevirtVMI, vmObj.Name, intVirtVmi, kc.GetOptions{
+				Namespace: conf.Namespace,
+			})
+			Expect(err).NotTo(HaveOccurred(), "failed to get `InternalVirtualMachineInstance`: %s", err)
+			for _, disk := range intVirtVmi.Spec.Domain.Devices.Disks {
+				if disk.CDRom != nil {
+					isoBlockDeviceName = disk.Name
+					isolockDeviceCount += 1
+				}
+			}
+			Expect(isolockDeviceCount).To(BeNumerically("==", 1), "there is only one `ISO` block device in this case")
+			isCdRom, err := IsBlockDeviceCdRom(vmObj.Name, isoBlockDeviceName)
+			Expect(err).NotTo(HaveOccurred(), "failed to get `BlockDeviceType` of %q: %s", isoBlockDeviceName, err)
+			Expect(isCdRom).Should(BeTrue(), "wrong type of block device: %s", isoBlockDeviceName)
+		})
+
+		It("check that images are attached as `ReadOnly` devices", func() {
+			imgs := make(map[string]string, 0)
+
+			cviImgs := &virtv2.ClusterVirtualImageList{}
+			err := GetObjects(virtv2.ClusterVirtualImageResource, cviImgs, kc.GetOptions{
+				Labels: testCaseLabel,
+			})
+			Expect(err).NotTo(HaveOccurred(), "failed to get `ClusterVirtualImages`: %s", err)
+			for _, cvi := range cviImgs.Items {
+				diskName := fmt.Sprintf("cvi-%s", cvi.Name)
+				imgs[diskName] = "value"
+			}
+
+			viImgs := &virtv2.VirtualImageList{}
+			err = GetObjects(virtv2.VirtualImageResource, viImgs, kc.GetOptions{
+				Labels:    testCaseLabel,
+				Namespace: conf.Namespace,
+			})
+			Expect(err).NotTo(HaveOccurred(), "failed to get `ClusterVirtualImages`: %s", err)
+			for _, vi := range viImgs.Items {
+				diskName := fmt.Sprintf("vi-%s", vi.Name)
+				imgs[diskName] = "value"
+			}
+
+			intVirtVmi := &virtv1.VirtualMachineInstance{}
+			err = GetObject(kc.ResourceKubevirtVMI, vmObj.Name, intVirtVmi, kc.GetOptions{
+				Namespace: conf.Namespace,
+			})
+			Expect(err).NotTo(HaveOccurred(), "failed to get `InternalVirtulMachineInstance`: %s", err)
+			for _, disk := range intVirtVmi.Spec.Domain.Devices.Disks {
+				if _, ok := imgs[disk.Name]; ok {
+					if strings.HasSuffix(disk.Name, isoLabel) {
+						imgs[disk.Name] = fmt.Sprintf("%s-%s", CdRomIdPrefix, disk.Name)
+					} else {
+						imgs[disk.Name] = fmt.Sprintf("%s_%s", DiskIdPrefix, disk.Serial)
+					}
+				}
+			}
+
+			Expect(len(imgs)).To(BeNumerically("==", imgCount), "there are only %d `blockDevices` in this case", imgCount)
+			for img, diskId := range imgs {
+				err := MountBlockDevice(vmObj.Name, diskId)
+				Expect(err).NotTo(HaveOccurred(), "failed to mount %q into `VirtualMachine`: %s", img, err)
+				isReadOnly, err := IsBlockDeviceReadOnly(vmObj.Name, diskId)
+				Expect(err).NotTo(HaveOccurred(), "failed to check `ReadOnly` status: %s", img)
+				Expect(isReadOnly).Should(BeTrue(), "mounted disk should be `ReadOnly`")
+			}
+		})
+	})
+
+	Context("When the virtual machine is ready", func() {
+		It("detaches images", func() {
+			res := kubectl.Delete(kc.DeleteOptions{
+				FilenameOption: kc.Filename,
+				Filename:       []string{fmt.Sprintf("%s/vmbda", conf.TestData.ImageHotplug)},
+				Namespace:      conf.Namespace,
+				Labels:         testCaseLabel,
+			})
+			Expect(res.Error()).NotTo(HaveOccurred(), "failed to delete `VirtualMachineBlockDeviceAttachments`: %s", res.StdErr())
+		})
+		It("compares the disk count after detachment", func() {
+			diskCountBefore := len(disksBefore.BlockDevices)
+			Expect(diskCountBefore).NotTo(BeZero(), "the disk count `before` should not be zero")
+			Eventually(func() (int, error) {
+				err := GetDisksMetadata(vmObj.Name, &disksAfter)
+				if err != nil {
+					return unacceptableCount, err
+				}
+				diskCountAfter := len(disksAfter.BlockDevices)
+				return diskCountAfter, nil
+			}).WithTimeout(Timeout).WithPolling(Interval).Should(Equal(diskCountBefore), "comparing error: 'after' must be equal 'before'")
+		})
+	})
+
+	Context("When test is completed", func() {
+		It("deletes test case resources", func() {
+			resourcesToDelete := ResourcesToDelete{
+				AdditionalResources: []AdditionalResource{
+					{
+						kc.ResourceVMBDA,
+						testCaseLabel,
+					},
+				},
+			}
+
+			if config.IsCleanUpNeeded() {
+				resourcesToDelete.KustomizationDir = conf.TestData.ImageHotplug
+			}
+
+			DeleteTestCaseResources(resourcesToDelete)
+		})
+	})
+})

--- a/tests/e2e/testdata/image-hotplug/base/cfg/cloudinit.yaml
+++ b/tests/e2e/testdata/image-hotplug/base/cfg/cloudinit.yaml
@@ -1,0 +1,12 @@
+#cloud-config
+users:
+  - name: cloud
+    # passwd: cloud
+    passwd: $6$rounds=4096$vln/.aPHBOI7BMYR$bBMkqQvuGs5Gyd/1H5DP4m9HjQSy.kgrxpaGEHwkX7KEFV8BS.HZWPitAtZ2Vd8ZqIZRqmlykRCagTgPejt1i.
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    chpasswd: { expire: False }
+    lock_passwd: false
+    ssh_authorized_keys:
+      # testcases
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFxcXHmwaGnJ8scJaEN5RzklBPZpVSic4GdaAsKjQoeA your_email@example.com

--- a/tests/e2e/testdata/image-hotplug/base/kustomization.yaml
+++ b/tests/e2e/testdata/image-hotplug/base/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./vm.yaml
+  - ./vd-root.yaml
+configurations:
+  - transformer.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+secretGenerator:
+  - files:
+      - userData=cfg/cloudinit.yaml
+    name: cloud-init
+    type: provisioning.virtualization.deckhouse.io/cloud-init

--- a/tests/e2e/testdata/image-hotplug/base/transformer.yaml
+++ b/tests/e2e/testdata/image-hotplug/base/transformer.yaml
@@ -1,0 +1,54 @@
+# https://github.com/kubernetes-sigs/kustomize/blob/master/examples/transformerconfigs/README.md#transformer-configurations
+
+namespace:
+  - kind: ClusterVirtualImage
+    path: spec/dataSource/objectRef/namespace
+nameReference:
+  - kind: VirtualImage
+    version: v1alpha2 # optional
+    fieldSpecs:
+      - path: spec/dataSource/objectRef/name
+        kind: ClusterVirtualImage
+      - path: spec/dataSource/objectRef/name
+        kind: VirtualImage
+      - path: spec/dataSource/objectRef/name
+        kind: VirtualDisk
+      - path: spec/blockDeviceRefs/name
+        kind: VirtualMachine
+  - kind: ClusterVirtualImage
+    version: v1alpha2 # optional
+    fieldSpecs:
+      - path: spec/dataSource/objectRef/name
+        kind: ClusterVirtualImage
+      - path: spec/dataSource/objectRef/name
+        kind: VirtualImage
+      - path: spec/dataSource/objectRef/name
+        kind: VirtualDisk
+      - path: spec/blockDeviceRefs/name
+        kind: VirtualMachine
+  - kind: VirtualDisk
+    version: v1alpha2 # optional
+    fieldSpecs:
+      - path: spec/blockDeviceRefs/name
+        kind: VirtualMachine
+      - path: spec/blockDeviceRef/name
+        kind: VirtualMachineBlockDeviceAttachment
+  - kind: Secret
+    fieldSpecs:
+      - path: spec/provisioning/userDataRef/name
+        kind: VirtualMachine
+  - kind: VirtualMachineIPAddress
+    version: v1alpha2
+    fieldSpecs:
+      - path: spec/virtualMachineIPAddressName
+        kind: VirtualMachine
+  - kind: VirtualMachine
+    version: v1alpha2
+    fieldSpecs:
+      - path: spec/virtualMachineName
+        kind: VirtualMachineBlockDeviceAttachment
+  - kind: VirtualMachineClass
+    version: v1alpha2
+    fieldSpecs:
+      - path: spec/virtualMachineClassName
+        kind: VirtualMachine

--- a/tests/e2e/testdata/image-hotplug/base/vd-root.yaml
+++ b/tests/e2e/testdata/image-hotplug/base/vd-root.yaml
@@ -1,0 +1,12 @@
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualDisk
+metadata:
+  name: vd-root
+spec:
+  persistentVolumeClaim:
+    size: 512Mi
+  dataSource:
+    type: ObjectRef
+    objectRef:
+      kind: VirtualImage
+      name: vi-alpine-http

--- a/tests/e2e/testdata/image-hotplug/base/vm.yaml
+++ b/tests/e2e/testdata/image-hotplug/base/vm.yaml
@@ -1,0 +1,21 @@
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualMachine
+metadata:
+  name: vm
+spec:
+  virtualMachineClassName: generic
+  cpu:
+    cores: 1
+    coreFraction: 5%
+  memory:
+    size: 256Mi
+  disruptions:
+    restartApprovalMode: Manual
+  provisioning:
+    type: UserDataRef
+    userDataRef:
+      kind: Secret
+      name: cloud-init
+  blockDeviceRefs:
+    - kind: VirtualDisk
+      name: vd-root

--- a/tests/e2e/testdata/image-hotplug/cvi/cvi-alpine-http.yaml
+++ b/tests/e2e/testdata/image-hotplug/cvi/cvi-alpine-http.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: ClusterVirtualImage
+metadata:
+  name: cvi-alpine-http
+spec:
+  dataSource:
+    type: HTTP
+    http:
+      url: https://0e773854-6b4e-4e76-a65b-d9d81675451a.selstorage.ru/alpine/alpine-v3-20.qcow2

--- a/tests/e2e/testdata/image-hotplug/cvi/cvi-ubuntu-2204-iso.yaml
+++ b/tests/e2e/testdata/image-hotplug/cvi/cvi-ubuntu-2204-iso.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: ClusterVirtualImage
+metadata:
+  name: cvi-ubuntu-2204-iso
+spec:
+  dataSource:
+    type: HTTP
+    http:
+      url: https://0e773854-6b4e-4e76-a65b-d9d81675451a.selstorage.ru/ubuntu/ubuntu-22.04.3-live-server-amd64.iso

--- a/tests/e2e/testdata/image-hotplug/cvi/kustomization.yaml
+++ b/tests/e2e/testdata/image-hotplug/cvi/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cvi-alpine-http.yaml
+  - cvi-ubuntu-2204-iso.yaml

--- a/tests/e2e/testdata/image-hotplug/kustomization.yaml
+++ b/tests/e2e/testdata/image-hotplug/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: testcases
+namePrefix: pr-number-or-commit-hash-
+resources:
+  - ns.yaml
+  - vi
+  - cvi
+  - overlays/image-hotplug
+configurations:
+  - transformer.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      id: pr-number-or-commit-hash
+      testcase: image-hotplug

--- a/tests/e2e/testdata/image-hotplug/ns.yaml
+++ b/tests/e2e/testdata/image-hotplug/ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default

--- a/tests/e2e/testdata/image-hotplug/overlays/image-hotplug/kustomization.yaml
+++ b/tests/e2e/testdata/image-hotplug/overlays/image-hotplug/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+nameSuffix: -image-hotplug
+resources:
+  - ../../base
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/runPolicy
+        value: AlwaysOn
+    target:
+      kind: VirtualMachine
+      name: vm
+  - patch: |-
+      - op: replace
+        path: /spec/disruptions/restartApprovalMode
+        value: Automatic
+    target:
+      kind: VirtualMachine
+      name: vm

--- a/tests/e2e/testdata/image-hotplug/transformer.yaml
+++ b/tests/e2e/testdata/image-hotplug/transformer.yaml
@@ -1,0 +1,52 @@
+namespace:
+  - kind: ClusterVirtualImage
+    path: spec/dataSource/objectRef/namespace
+nameReference:
+  - kind: VirtualImage
+    version: v1alpha2 # optional
+    fieldSpecs:
+      - path: spec/dataSource/objectRef/name
+        kind: ClusterVirtualImage
+      - path: spec/dataSource/objectRef/name
+        kind: VirtualImage
+      - path: spec/dataSource/objectRef/name
+        kind: VirtualDisk
+      - path: spec/blockDeviceRefs/name
+        kind: VirtualMachine
+  - kind: ClusterVirtualImage
+    version: v1alpha2 # optional
+    fieldSpecs:
+      - path: spec/dataSource/objectRef/name
+        kind: ClusterVirtualImage
+      - path: spec/dataSource/objectRef/name
+        kind: VirtualImage
+      - path: spec/dataSource/objectRef/name
+        kind: VirtualDisk
+      - path: spec/blockDeviceRefs/name
+        kind: VirtualMachine
+  - kind: VirtualDisk
+    version: v1alpha2 # optional
+    fieldSpecs:
+      - path: spec/blockDeviceRefs/name
+        kind: VirtualMachine
+      - path: spec/blockDeviceRef/name
+        kind: VirtualMachineBlockDeviceAttachment
+  - kind: Secret
+    fieldSpecs:
+      - path: spec/provisioning/userDataRef/name
+        kind: VirtualMachine
+  - kind: VirtualMachineIPAddress
+    version: v1alpha2
+    fieldSpecs:
+      - path: spec/virtualMachineIPAddressName
+        kind: VirtualMachine
+  - kind: VirtualMachine
+    version: v1alpha2
+    fieldSpecs:
+      - path: spec/virtualMachineName
+        kind: VirtualMachineBlockDeviceAttachment
+  - kind: VirtualMachineClass
+    version: v1alpha2
+    fieldSpecs:
+      - path: spec/virtualMachineClassName
+        kind: VirtualMachine

--- a/tests/e2e/testdata/image-hotplug/vi/kustomization.yaml
+++ b/tests/e2e/testdata/image-hotplug/vi/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - vi-alpine-http.yaml
+  - vi-pvc-alpine-http.yaml

--- a/tests/e2e/testdata/image-hotplug/vi/vi-alpine-http.yaml
+++ b/tests/e2e/testdata/image-hotplug/vi/vi-alpine-http.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-alpine-http
+spec:
+  storage: ContainerRegistry
+  dataSource:
+    type: HTTP
+    http:
+      url: https://0e773854-6b4e-4e76-a65b-d9d81675451a.selstorage.ru/alpine/alpine-v3-20.qcow2

--- a/tests/e2e/testdata/image-hotplug/vi/vi-pvc-alpine-http.yaml
+++ b/tests/e2e/testdata/image-hotplug/vi/vi-pvc-alpine-http.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-pvc-alpine-http
+spec:
+  storage: PersistentVolumeClaim
+  dataSource:
+    type: HTTP
+    http:
+      url: https://0e773854-6b4e-4e76-a65b-d9d81675451a.selstorage.ru/alpine/alpine-v3-20.qcow2

--- a/tests/e2e/tests_suite_test.go
+++ b/tests/e2e/tests_suite_test.go
@@ -103,6 +103,7 @@ func init() {
 		fmt.Sprintf("%s/%s", conf.TestData.ComplexTest, "kustomization.yaml"),
 		fmt.Sprintf("%s/%s", conf.TestData.Connectivity, "kustomization.yaml"),
 		fmt.Sprintf("%s/%s", conf.TestData.DiskResizing, "kustomization.yaml"),
+		fmt.Sprintf("%s/%s", conf.TestData.ImageHotplug, "kustomization.yaml"),
 		fmt.Sprintf("%s/%s", conf.TestData.SizingPolicy, "kustomization.yaml"),
 		fmt.Sprintf("%s/%s", conf.TestData.ImporterNetworkPolicy, "kustomization.yaml"),
 		fmt.Sprintf("%s/%s", conf.TestData.VdSnapshots, "kustomization.yaml"),

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -229,13 +229,21 @@ func GetObjects(resource kc.Resource, object client.ObjectList, opts kc.GetOptio
 	if opts.Labels != nil {
 		cmdOpts.Labels = opts.Labels
 	}
+	if opts.ExcludedLabels != nil {
+		cmdOpts.ExcludedLabels = opts.ExcludedLabels
+	}
+	if opts.IgnoreNotFound {
+		cmdOpts.IgnoreNotFound = opts.IgnoreNotFound
+	}
 	cmd := kubectl.List(resource, cmdOpts)
 	if cmd.Error() != nil {
 		return fmt.Errorf("cmd: %s\nstderr: %s", cmd.GetCmd(), cmd.StdErr())
 	}
-	err := json.Unmarshal(cmd.StdOutBytes(), object)
-	if err != nil {
-		return err
+	if cmd.StdOut() != "" {
+		err := json.Unmarshal(cmd.StdOutBytes(), object)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
- refactor e2e disk attachment test case
- refactor e2e disk resizing test case


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
It fixes test cases where we use blockDeviceId and adds a new test case for the image attachment flow.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: images
type: test
summary: "It fixes test cases where we use blockDeviceId and adds a new test case for the image attachment flow."
```
