### PR TITLE
test(vm): add powerstate check

### DIFF
--- a/api/core/v1alpha2/virtual_machine.go
+++ b/api/core/v1alpha2/virtual_machine.go
@@ -384,6 +384,10 @@ const (
 	MachineDegraded    MachinePhase = "Degraded"
 )
 
+func (p MachinePhase) String() string {
+	return string(p)
+}
+
 // VirtualMachineList contains a list of VirtualMachine
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type VirtualMachineList struct {

--- a/api/core/v1alpha2/virtual_machine.go
+++ b/api/core/v1alpha2/virtual_machine.go
@@ -384,10 +384,6 @@ const (
 	MachineDegraded    MachinePhase = "Degraded"
 )
 
-func (p MachinePhase) String() string {
-	return string(p)
-}
-
 // VirtualMachineList contains a list of VirtualMachine
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type VirtualMachineList struct {

--- a/tests/e2e/affinity_toleration_test.go
+++ b/tests/e2e/affinity_toleration_test.go
@@ -98,8 +98,8 @@ var _ = Describe("Virtual machine affinity and toleration", ginkgoutil.CommonE2E
 
 	Context("When virtual machines are applied:", func() {
 		It("checks VMs phases", func() {
-			By("VMs should be ready")
-			WaitVmReady(kc.WaitOptions{
+			By("Virtual machine agents should be ready")
+			WaitVmAgentReady(kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,
@@ -107,7 +107,7 @@ var _ = Describe("Virtual machine affinity and toleration", ginkgoutil.CommonE2E
 		})
 	})
 
-	Context(fmt.Sprintf("When virtual machines in %s phase", PhaseRunning), func() {
+	Context("When virtual machine agents are ready", func() {
 		It("checks VMs `status.nodeName`", func() {
 			vmObjects := virtv2.VirtualMachineList{}
 			err := GetObjects(kc.ResourceVM, &vmObjects, kc.GetOptions{

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -253,25 +253,21 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 			It("checks VMOPs and VMs phases", func() {
 				By(fmt.Sprintf("AlwaysOn VM VMOPs should be in %s phases", virtv2.VMOPPhaseFailed))
 				WaitResourcesByPhase(alwaysOnVMStopVMOPs, kc.ResourceVMOP, string(virtv2.VMOPPhaseFailed), kc.WaitOptions{
-					Labels:    alwaysOnLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
 				})
 				By(fmt.Sprintf("Not AlwaysOn VM VMOPs should be in %s phases", virtv2.VMOPPhaseCompleted))
 				WaitResourcesByPhase(notAlwaysOnVMStopVMs, kc.ResourceVMOP, string(virtv2.VMOPPhaseCompleted), kc.WaitOptions{
-					Labels:    notAlwaysOnLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
 				})
 				By(fmt.Sprintf("AlwaysOn VMs should be in %s phases", virtv2.MachineRunning))
 				WaitResourcesByPhase(alwaysOnVMs, kc.ResourceVM, string(virtv2.MachineRunning), kc.WaitOptions{
-					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
 				})
 				By(fmt.Sprintf("Not AlwaysOn VMs should be in %s phases", virtv2.MachineStopped))
 				WaitResourcesByPhase(notAlwaysOnVMs, kc.ResourceVM, string(virtv2.MachineStopped), kc.WaitOptions{
-					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
 				})
@@ -351,13 +347,11 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 			It("checks VMs phases", func() {
 				By(fmt.Sprintf("Not AlwaysOn VMs should be in %s phases", virtv2.MachineStopped))
 				WaitResourcesByPhase(notAlwaysOnVMs, kc.ResourceVM, string(virtv2.MachineStopped), kc.WaitOptions{
-					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
 				})
 				By(fmt.Sprintf("AlwaysOn VMs should be in %s phases", virtv2.MachineRunning))
 				WaitResourcesByPhase(alwaysOnVMs, kc.ResourceVM, string(virtv2.MachineRunning), kc.WaitOptions{
-					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
 				})

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -215,79 +215,95 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 			cmdResult *executor.CMDResult
 		)
 
-		//Context(fmt.Sprintf("When VMs are in %s phases", PhaseRunning), func() {
-		//	It("stop VMs by VMOP", func() {
-		//		res := kubectl.List(kc.ResourceVM, kc.GetOptions{
-		//			Labels:    testCaseLabel,
-		//			Namespace: conf.Namespace,
-		//			Output:    "jsonpath='{.items[*].metadata.name}'",
-		//		})
-		//		Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
-		//
-		//		vms := strings.Split(res.StdOut(), " ")
-		//
-		//		StopVirtualMachinesByVMOP(testCaseLabel, conf.TestData.ComplexTest, vms...)
-		//	})
-		//})
-		//
-		//Context("When stop VMOPs are applied", func() {
-		//	It("checks VMs and VMOPs phases", func() {
-		//		By(fmt.Sprintf("VMOPs should be in %s phases", virtv2.VMOPPhaseCompleted))
-		//		WaitPhaseByLabel(kc.ResourceVMOP, string(virtv2.VMOPPhaseCompleted), kc.WaitOptions{
-		//			Labels:    testCaseLabel,
-		//			Namespace: conf.Namespace,
-		//			Timeout:   MaxWaitTimeout,
-		//		})
-		//	})
-		//})
-		//
-		//Context(fmt.Sprintf("When VMs are in %s phases", PhaseStopped), func() {
-		//	It("start VMs by VMOP", func() {
-		//		res := kubectl.List(kc.ResourceVM, kc.GetOptions{
-		//			Labels:    testCaseLabel,
-		//			Namespace: conf.Namespace,
-		//			Output:    "jsonpath='{.items[*].metadata.name}'",
-		//		})
-		//		Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
-		//
-		//		vms := strings.Split(res.StdOut(), " ")
-		//
-		//		StartVirtualMachinesByVMOP(testCaseLabel, conf.TestData.ComplexTest, vms...)
-		//	})
-		//})
-		//
-		//Context("When start VMOPs are applied", func() {
-		//	It("checks VMs and VMOPs phases", func() {
-		//		By(fmt.Sprintf("VMOPs should be in %s phases", virtv2.VMOPPhaseCompleted))
-		//		WaitPhaseByLabel(kc.ResourceVMOP, string(virtv2.VMOPPhaseCompleted), kc.WaitOptions{
-		//			Labels:    testCaseLabel,
-		//			Namespace: conf.Namespace,
-		//			Timeout:   MaxWaitTimeout,
-		//		})
-		//		By("Virtual machines should be ready")
-		//		WaitVmReady(kc.WaitOptions{
-		//			Labels:    testCaseLabel,
-		//			Namespace: conf.Namespace,
-		//			Timeout:   MaxWaitTimeout,
-		//		})
-		//	})
-		//
-		//	It("checks VMs external connection after stopped and started", func() {
-		//		res := kubectl.List(kc.ResourceVM, kc.GetOptions{
-		//			Labels:    testCaseLabel,
-		//			Namespace: conf.Namespace,
-		//			Output:    "jsonpath='{.items[*].metadata.name}'",
-		//		})
-		//		Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
-		//
-		//		var vms []string
-		//		for _, vm := range strings.Split(res.StdOut(), " ") {
-		//			vms = append(vms, vm)
-		//		}
-		//
-		//		CheckExternalConnection(externalHost, httpStatusOk, vms...)
-		//	})
-		//})
+		Context("When VMs are ready", func() {
+			It("stop VMs by VMOP", func() {
+				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
+					Labels:    testCaseLabel,
+					Namespace: conf.Namespace,
+					Output:    "jsonpath='{.items[*].metadata.name}'",
+				})
+				Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
+
+				vms := strings.Split(res.StdOut(), " ")
+				var notAlwaysOnVMs []string
+				for _, vm := range vms {
+					vmObj := virtv2.VirtualMachine{}
+					err := GetObject(kc.ResourceVM, vm, &vmObj, kc.GetOptions{Namespace: conf.Namespace})
+					Expect(err).NotTo(HaveOccurred(), "%w", err)
+
+					if vmObj.Spec.RunPolicy != virtv2.AlwaysOnPolicy {
+						notAlwaysOnVMs = append(notAlwaysOnVMs, vm)
+					}
+				}
+
+				StopVirtualMachinesByVMOP(testCaseLabel, conf.TestData.ComplexTest, notAlwaysOnVMs...)
+			})
+		})
+
+		Context("When stop VMOPs are applied", func() {
+			It("checks VMs and VMOPs phases", func() {
+				By(fmt.Sprintf("VMOPs should be in %s phases", virtv2.VMOPPhaseCompleted))
+				WaitPhaseByLabel(kc.ResourceVMOP, string(virtv2.VMOPPhaseCompleted), kc.WaitOptions{
+					Labels:    testCaseLabel,
+					Namespace: conf.Namespace,
+					Timeout:   MaxWaitTimeout,
+				})
+				By("Virtual machines should be stopped")
+				WaitPhaseByLabel(kc.ResourceVM, PhaseStopped, kc.WaitOptions{
+					Labels:    testCaseLabel,
+					Namespace: conf.Namespace,
+					Timeout:   MaxWaitTimeout,
+				})
+			})
+		})
+
+		Context(fmt.Sprintf("When VMs are in %s phases", PhaseStopped), func() {
+			It("start VMs by VMOP", func() {
+				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
+					Labels:    testCaseLabel,
+					Namespace: conf.Namespace,
+					Output:    "jsonpath='{.items[*].metadata.name}'",
+				})
+				Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
+
+				vms := strings.Split(res.StdOut(), " ")
+
+				StartVirtualMachinesByVMOP(testCaseLabel, conf.TestData.ComplexTest, vms...)
+			})
+		})
+
+		Context("When start VMOPs are applied", func() {
+			It("checks VMs and VMOPs phases", func() {
+				By(fmt.Sprintf("VMOPs should be in %s phases", virtv2.VMOPPhaseCompleted))
+				WaitPhaseByLabel(kc.ResourceVMOP, string(virtv2.VMOPPhaseCompleted), kc.WaitOptions{
+					Labels:    testCaseLabel,
+					Namespace: conf.Namespace,
+					Timeout:   MaxWaitTimeout,
+				})
+				By("Virtual machines should be ready")
+				WaitVmReady(kc.WaitOptions{
+					Labels:    testCaseLabel,
+					Namespace: conf.Namespace,
+					Timeout:   MaxWaitTimeout,
+				})
+			})
+
+			It("checks VMs external connection after stopped and started", func() {
+				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
+					Labels:    testCaseLabel,
+					Namespace: conf.Namespace,
+					Output:    "jsonpath='{.items[*].metadata.name}'",
+				})
+				Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
+
+				var vms []string
+				for _, vm := range strings.Split(res.StdOut(), " ") {
+					vms = append(vms, vm)
+				}
+
+				CheckExternalConnection(externalHost, httpStatusOk, vms...)
+			})
+		})
 
 		Context(fmt.Sprintf("When VMs are in %s phases", PhaseRunning), func() {
 			It("reboot VMs by VMOP", func() {

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -245,7 +245,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 			})
 		})
 
-		Context(fmt.Sprintf("When VMs are in %s phases", virtv2.MachineStopped.String()), func() {
+		Context(fmt.Sprintf("When VMs are in %s phases", string(virtv2.MachineStopped)), func() {
 			It("starts VMs by VMOP", func() {
 				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 					Labels:    testCaseLabel,
@@ -277,7 +277,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
 				})
-				By("Virtual machines should be ready")
+				By("Virtual machine agents should be ready")
 				WaitVmAgentReady(kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
@@ -307,7 +307,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
 				})
-				By("Virtual machines should be ready")
+				By("Virtual machine agents should be ready")
 				WaitVmAgentReady(kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
@@ -331,13 +331,13 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 			})
 
 			It("checks VMs phases", func() {
-				By("Virtual machines should be stopped")
-				WaitPhaseByLabel(kc.ResourceVM, virtv2.MachineStopped.String(), kc.WaitOptions{
+				By("Virtual machine should be stopped")
+				WaitPhaseByLabel(kc.ResourceVM, string(virtv2.MachineStopped), kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
 				})
-				By("Virtual machines should be ready")
+				By("Virtual machine agents should be ready")
 				WaitVmAgentReady(kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
@@ -355,12 +355,12 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 
 			It("checks VMs phases", func() {
 				By("Virtual machines should be stopped")
-				WaitPhaseByLabel(kc.ResourceVM, virtv2.MachineStopped.String(), kc.WaitOptions{
+				WaitPhaseByLabel(kc.ResourceVM, string(virtv2.MachineStopped), kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
 				})
-				By("Virtual machines should be ready")
+				By("Virtual machine agents should be ready")
 				WaitVmAgentReady(kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -219,7 +219,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 		)
 
 		Context("When VMs are ready", func() {
-			It("stop VMs by VMOP", func() {
+			It("stop VMs by VMOPs", func() {
 				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
@@ -244,7 +244,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 		})
 
 		Context("When stop VMOPs are applied", func() {
-			It("checks VMs and VMOPs phases", func() {
+			It("checks VMOPs phases", func() {
 				By(fmt.Sprintf("VMOPs should be in %s phases", virtv2.VMOPPhaseCompleted))
 				WaitPhaseByLabel(kc.ResourceVMOP, string(virtv2.VMOPPhaseCompleted), kc.WaitOptions{
 					Labels:    testCaseLabel,
@@ -304,10 +304,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 				})
 				Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
 
-				var vms []string
-				for _, vm := range strings.Split(res.StdOut(), " ") {
-					vms = append(vms, vm)
-				}
+				vms := strings.Split(res.StdOut(), " ")
 
 				CheckExternalConnection(externalHost, httpStatusOk, vms...)
 			})
@@ -352,16 +349,13 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 				})
 				Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
 
-				var vms []string
-				for _, vm := range strings.Split(res.StdOut(), " ") {
-					vms = append(vms, vm)
-				}
+				vms := strings.Split(res.StdOut(), " ")
 
 				CheckExternalConnection(externalHost, httpStatusOk, vms...)
 			})
 		})
 
-		Context("When VMs are is ready", func() {
+		Context("When VMs are ready", func() {
 			It("reboot VMs by ssh", func() {
 				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 					Labels:    testCaseLabel,
@@ -376,7 +370,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 			})
 		})
 
-		Context("When VM reboot command sent by ssh", func() {
+		Context("When VM reboot command has been sent by ssh", func() {
 			It("checks VMs phases", func() {
 				By("Virtual machines should be stopped")
 				WaitPhaseByLabel(kc.ResourceVM, PhaseStopped, kc.WaitOptions{
@@ -400,10 +394,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 				})
 				Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
 
-				var vms []string
-				for _, vm := range strings.Split(res.StdOut(), " ") {
-					vms = append(vms, vm)
-				}
+				vms := strings.Split(res.StdOut(), " ")
 
 				CheckExternalConnection(externalHost, httpStatusOk, vms...)
 			})
@@ -412,7 +403,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 		Context("When VMs are is ready", func() {
 			It("reboot VMs by ssh", func() {
 				wg.Add(1)
-				go RebootVirtualMachinesByKillPods(vmPodLabel, cmdResult, &wg)
+				go RebootVirtualMachinesByDeletePods(vmPodLabel, cmdResult, &wg)
 			})
 		})
 
@@ -441,10 +432,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 				})
 				Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
 
-				var vms []string
-				for _, vm := range strings.Split(res.StdOut(), " ") {
-					vms = append(vms, vm)
-				}
+				vms := strings.Split(res.StdOut(), " ")
 
 				CheckExternalConnection(externalHost, httpStatusOk, vms...)
 			})

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -208,7 +208,8 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 				CheckExternalConnection(externalHost, httpStatusOk, vms...)
 
 				fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-				RebootVirtualMachinesByVMOP(testCaseLabel, conf.TestData.ComplexTest, vms...)
+				RebootVirtualMachinesBySSH(vms...)
+				//RebootVirtualMachinesByVMOP(testCaseLabel, conf.TestData.ComplexTest, vms...)
 				time.Sleep(120 * time.Second)
 			})
 		})

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -350,7 +350,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 
 			It("checks VMs phases", func() {
 				By(fmt.Sprintf("Not AlwaysOn VMs should be in %s phases", virtv2.MachineStopped))
-				WaitResourcesByPhase(alwaysOnVMs, kc.ResourceVM, string(virtv2.MachineStopped), kc.WaitOptions{
+				WaitResourcesByPhase(notAlwaysOnVMs, kc.ResourceVM, string(virtv2.MachineStopped), kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -216,8 +216,10 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
 				})
+				time.Sleep(30 * time.Second)
+				fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!")
+				RebootVirtualMachinesByVMOP(testCaseLabel, conf.TestData.ComplexTest, vms...)
 				fmt.Println("!!!!!!1111111111111!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-				//RebootVirtualMachinesByVMOP(testCaseLabel, conf.TestData.ComplexTest, vms...)
 				time.Sleep(120 * time.Second)
 			})
 		})

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -289,23 +289,17 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 
 		Context("Verify that the virtual machines are starting", func() {
 			It("starts VMs by VMOP", func() {
-				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
-					Labels:    testCaseLabel,
+				var vms virtv2.VirtualMachineList
+				err := GetObjects(kc.ResourceVM, &vms, kc.GetOptions{
 					Namespace: conf.Namespace,
-					Output:    "jsonpath='{.items[*].metadata.name}'",
+					Labels:    testCaseLabel,
 				})
-				Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
-
-				vms := strings.Split(res.StdOut(), " ")
+				Expect(err).NotTo(HaveOccurred())
 
 				var notAlwaysOnVMs []string
-				for _, vm := range vms {
-					vmObj := virtv2.VirtualMachine{}
-					err := GetObject(kc.ResourceVM, vm, &vmObj, kc.GetOptions{Namespace: conf.Namespace})
-					Expect(err).NotTo(HaveOccurred(), "%w", err)
-
-					if vmObj.Spec.RunPolicy != virtv2.AlwaysOnPolicy {
-						notAlwaysOnVMs = append(notAlwaysOnVMs, vm)
+				for _, vm := range vms.Items {
+					if vm.Spec.RunPolicy != virtv2.AlwaysOnPolicy {
+						notAlwaysOnVMs = append(notAlwaysOnVMs, vm.Name)
 					}
 				}
 

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -423,7 +423,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 					Timeout:   MaxWaitTimeout,
 				})
 				wg.Wait()
-				Expect(cmdResult.Error()).NotTo(HaveOccurred(), cmdResult.StdErr())
+				Expect(cmdResult.Error()).ShouldNot(HaveOccurred())
 			})
 
 			It("checks VMs external connection after reboot", func() {

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -211,7 +211,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 				fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!")
 				time.Sleep(20 * time.Second)
 				fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-				RebootVirtualMachinesByKillPods(vmPodLabel)
+				go RebootVirtualMachinesByKillPods(vmPodLabel)
 				WaitPhaseByLabel(kc.ResourceVM, PhaseStopped, kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -210,7 +210,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 				fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!")
 				time.Sleep(20 * time.Second)
 				fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-				RebootVirtualMachinesBySSH(vms...)
+				RebootVirtualMachinesByKillPods(vms...)
 				WaitPhaseByLabel(kc.ResourceVM, PhaseStopped, kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -248,7 +248,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 				StopVirtualMachinesByVMOP(testCaseLabel, conf.TestData.ComplexTest, vms...)
 			})
 
-			It("checks VMOPs phases", func() {
+			It("checks VMOPs and VMs phases", func() {
 				By(fmt.Sprintf("AlwaysOn VM VMOPs should be in %s phases", virtv2.VMOPPhaseFailed))
 				WaitResourcesByPhase(alwaysOnVMStopVMOPs, kc.ResourceVMOP, string(virtv2.VMOPPhaseFailed), kc.WaitOptions{
 					Labels:    testCaseLabel,

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -207,6 +207,8 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 				vms := strings.Split(res.StdOut(), " ")
 				CheckExternalConnection(externalHost, httpStatusOk, vms...)
 
+				fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!")
+				time.Sleep(20 * time.Second)
 				fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
 				RebootVirtualMachinesBySSH(vms...)
 				//RebootVirtualMachinesByVMOP(testCaseLabel, conf.TestData.ComplexTest, vms...)

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -401,7 +401,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 			})
 		})
 
-		Context("When VM reboot command sent by kill pods", func() {
+		Context("When VM reboot command sent by delete pods", func() {
 			It("checks VMs phases", func() {
 				By("Virtual machines should be stopped")
 				WaitPhaseByLabel(kc.ResourceVM, virtv2.MachineStopped.String(), kc.WaitOptions{

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -238,12 +238,6 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
 				})
-				By("Virtual machines should be stopped")
-				WaitPhaseByLabel(kc.ResourceVM, PhaseStopped, kc.WaitOptions{
-					Labels:    testCaseLabel,
-					Namespace: conf.Namespace,
-					Timeout:   MaxWaitTimeout,
-				})
 			})
 		})
 
@@ -270,8 +264,8 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
 				})
-				By("Virtual machines should be running")
-				WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, kc.WaitOptions{
+				By("Virtual machines should be ready")
+				WaitVmReady(kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
@@ -318,8 +312,8 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
 				})
-				By("Virtual machines should be running")
-				WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, kc.WaitOptions{
+				By("Virtual machines should be ready")
+				WaitVmReady(kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
@@ -366,8 +360,8 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
 				})
-				By("Virtual machines should be running")
-				WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, kc.WaitOptions{
+				By("Virtual machines should be ready")
+				WaitVmReady(kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
@@ -406,8 +400,8 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
 				})
-				By("Virtual machines should be running")
-				WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, kc.WaitOptions{
+				By("Virtual machines should be ready")
+				WaitVmReady(kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -402,6 +402,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 
 		Context("When VMs are is ready", func() {
 			It("reboot VMs by ssh", func() {
+				// kubectl may not return control for too long, and we may miss the Stopped phase and get stuck without using goroutines.
 				wg.Add(1)
 				go RebootVirtualMachinesByDeletePods(vmPodLabel, cmdResult, &wg)
 			})

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -211,6 +211,12 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 				time.Sleep(20 * time.Second)
 				fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
 				RebootVirtualMachinesBySSH(vms...)
+				WaitPhaseByLabel(kc.ResourceVM, PhaseStopped, kc.WaitOptions{
+					Labels:    testCaseLabel,
+					Namespace: conf.Namespace,
+					Timeout:   MaxWaitTimeout,
+				})
+				fmt.Println("!!!!!!1111111111111!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
 				//RebootVirtualMachinesByVMOP(testCaseLabel, conf.TestData.ComplexTest, vms...)
 				time.Sleep(120 * time.Second)
 			})

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -205,6 +205,9 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 					Output:    "jsonpath='{.items[*].metadata.name}'",
 				})
 				Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
+
+				vms := strings.Split(res.StdOut(), " ")
+				CheckExternalConnection(externalHost, httpStatusOk, vms...)
 			})
 		})
 	})

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -218,13 +218,6 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 	Describe("Power state checks", func() {
 		Context("When VMs are ready", func() {
 			It("stop VMs by VMOPs", func() {
-				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
-					Labels:    testCaseLabel,
-					Namespace: conf.Namespace,
-					Output:    "jsonpath='{.items[*].metadata.name}'",
-				})
-				Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
-
 				var vmList virtv2.VirtualMachineList
 				err := GetObjects(kc.ResourceVM, &vmList, kc.GetOptions{
 					Labels:    testCaseLabel,

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -215,79 +215,79 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 			cmdResult *executor.CMDResult
 		)
 
-		Context(fmt.Sprintf("When VMs are in %s phases", PhaseRunning), func() {
-			It("stop VMs by VMOP", func() {
-				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
-					Labels:    testCaseLabel,
-					Namespace: conf.Namespace,
-					Output:    "jsonpath='{.items[*].metadata.name}'",
-				})
-				Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
-
-				vms := strings.Split(res.StdOut(), " ")
-
-				StopVirtualMachinesByVMOP(testCaseLabel, conf.TestData.ComplexTest, vms...)
-			})
-		})
-
-		Context("When stop VMOPs are applied", func() {
-			It("checks VMs and VMOPs phases", func() {
-				By(fmt.Sprintf("VMOPs should be in %s phases", virtv2.VMOPPhaseCompleted))
-				WaitPhaseByLabel(kc.ResourceVMOP, string(virtv2.VMOPPhaseCompleted), kc.WaitOptions{
-					Labels:    testCaseLabel,
-					Namespace: conf.Namespace,
-					Timeout:   MaxWaitTimeout,
-				})
-			})
-		})
-
-		Context(fmt.Sprintf("When VMs are in %s phases", PhaseStopped), func() {
-			It("start VMs by VMOP", func() {
-				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
-					Labels:    testCaseLabel,
-					Namespace: conf.Namespace,
-					Output:    "jsonpath='{.items[*].metadata.name}'",
-				})
-				Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
-
-				vms := strings.Split(res.StdOut(), " ")
-
-				StartVirtualMachinesByVMOP(testCaseLabel, conf.TestData.ComplexTest, vms...)
-			})
-		})
-
-		Context("When start VMOPs are applied", func() {
-			It("checks VMs and VMOPs phases", func() {
-				By(fmt.Sprintf("VMOPs should be in %s phases", virtv2.VMOPPhaseCompleted))
-				WaitPhaseByLabel(kc.ResourceVMOP, string(virtv2.VMOPPhaseCompleted), kc.WaitOptions{
-					Labels:    testCaseLabel,
-					Namespace: conf.Namespace,
-					Timeout:   MaxWaitTimeout,
-				})
-				By("Virtual machines should be ready")
-				WaitVmReady(kc.WaitOptions{
-					Labels:    testCaseLabel,
-					Namespace: conf.Namespace,
-					Timeout:   MaxWaitTimeout,
-				})
-			})
-
-			It("checks VMs external connection after stopped and started", func() {
-				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
-					Labels:    testCaseLabel,
-					Namespace: conf.Namespace,
-					Output:    "jsonpath='{.items[*].metadata.name}'",
-				})
-				Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
-
-				var vms []string
-				for _, vm := range strings.Split(res.StdOut(), " ") {
-					vms = append(vms, vm)
-				}
-
-				CheckExternalConnection(externalHost, httpStatusOk, vms...)
-			})
-		})
+		//Context(fmt.Sprintf("When VMs are in %s phases", PhaseRunning), func() {
+		//	It("stop VMs by VMOP", func() {
+		//		res := kubectl.List(kc.ResourceVM, kc.GetOptions{
+		//			Labels:    testCaseLabel,
+		//			Namespace: conf.Namespace,
+		//			Output:    "jsonpath='{.items[*].metadata.name}'",
+		//		})
+		//		Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
+		//
+		//		vms := strings.Split(res.StdOut(), " ")
+		//
+		//		StopVirtualMachinesByVMOP(testCaseLabel, conf.TestData.ComplexTest, vms...)
+		//	})
+		//})
+		//
+		//Context("When stop VMOPs are applied", func() {
+		//	It("checks VMs and VMOPs phases", func() {
+		//		By(fmt.Sprintf("VMOPs should be in %s phases", virtv2.VMOPPhaseCompleted))
+		//		WaitPhaseByLabel(kc.ResourceVMOP, string(virtv2.VMOPPhaseCompleted), kc.WaitOptions{
+		//			Labels:    testCaseLabel,
+		//			Namespace: conf.Namespace,
+		//			Timeout:   MaxWaitTimeout,
+		//		})
+		//	})
+		//})
+		//
+		//Context(fmt.Sprintf("When VMs are in %s phases", PhaseStopped), func() {
+		//	It("start VMs by VMOP", func() {
+		//		res := kubectl.List(kc.ResourceVM, kc.GetOptions{
+		//			Labels:    testCaseLabel,
+		//			Namespace: conf.Namespace,
+		//			Output:    "jsonpath='{.items[*].metadata.name}'",
+		//		})
+		//		Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
+		//
+		//		vms := strings.Split(res.StdOut(), " ")
+		//
+		//		StartVirtualMachinesByVMOP(testCaseLabel, conf.TestData.ComplexTest, vms...)
+		//	})
+		//})
+		//
+		//Context("When start VMOPs are applied", func() {
+		//	It("checks VMs and VMOPs phases", func() {
+		//		By(fmt.Sprintf("VMOPs should be in %s phases", virtv2.VMOPPhaseCompleted))
+		//		WaitPhaseByLabel(kc.ResourceVMOP, string(virtv2.VMOPPhaseCompleted), kc.WaitOptions{
+		//			Labels:    testCaseLabel,
+		//			Namespace: conf.Namespace,
+		//			Timeout:   MaxWaitTimeout,
+		//		})
+		//		By("Virtual machines should be ready")
+		//		WaitVmReady(kc.WaitOptions{
+		//			Labels:    testCaseLabel,
+		//			Namespace: conf.Namespace,
+		//			Timeout:   MaxWaitTimeout,
+		//		})
+		//	})
+		//
+		//	It("checks VMs external connection after stopped and started", func() {
+		//		res := kubectl.List(kc.ResourceVM, kc.GetOptions{
+		//			Labels:    testCaseLabel,
+		//			Namespace: conf.Namespace,
+		//			Output:    "jsonpath='{.items[*].metadata.name}'",
+		//		})
+		//		Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
+		//
+		//		var vms []string
+		//		for _, vm := range strings.Split(res.StdOut(), " ") {
+		//			vms = append(vms, vm)
+		//		}
+		//
+		//		CheckExternalConnection(externalHost, httpStatusOk, vms...)
+		//	})
+		//})
 
 		Context(fmt.Sprintf("When VMs are in %s phases", PhaseRunning), func() {
 			It("reboot VMs by VMOP", func() {
@@ -337,7 +337,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 			})
 		})
 
-		Context(fmt.Sprintf("When VMs are in %s phases", PhaseRunning), func() {
+		Context("When VMs are is ready", func() {
 			It("reboot VMs by ssh", func() {
 				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 					Labels:    testCaseLabel,
@@ -385,7 +385,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 			})
 		})
 
-		Context(fmt.Sprintf("When VMs are in %s phases", PhaseRunning), func() {
+		Context("When VMs are is ready", func() {
 			It("reboot VMs by ssh", func() {
 				wg.Add(1)
 				go RebootVirtualMachinesByKillPods(vmPodLabel, cmdResult, &wg)

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -19,6 +19,7 @@ package e2e
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -205,6 +206,10 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 
 				vms := strings.Split(res.StdOut(), " ")
 				CheckExternalConnection(externalHost, httpStatusOk, vms...)
+
+				fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+				RebootVirtualMachinesByVMOP(testCaseLabel, conf.TestData.ComplexTest, vms...)
+				time.Sleep(120 * time.Second)
 			})
 		})
 	})

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -262,7 +262,18 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 
 				vms := strings.Split(res.StdOut(), " ")
 
-				StartVirtualMachinesByVMOP(testCaseLabel, conf.TestData.ComplexTest, vms...)
+				var notAlwaysOnVMs []string
+				for _, vm := range vms {
+					vmObj := virtv2.VirtualMachine{}
+					err := GetObject(kc.ResourceVM, vm, &vmObj, kc.GetOptions{Namespace: conf.Namespace})
+					Expect(err).NotTo(HaveOccurred(), "%w", err)
+
+					if vmObj.Spec.RunPolicy != virtv2.AlwaysOnPolicy {
+						notAlwaysOnVMs = append(notAlwaysOnVMs, vm)
+					}
+				}
+
+				StartVirtualMachinesByVMOP(testCaseLabel, conf.TestData.ComplexTest, notAlwaysOnVMs...)
 			})
 		})
 

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -179,8 +179,8 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 
 	Context("When virtual machines are applied", func() {
 		It("checks VMs phases", func() {
-			By("VMs should be ready")
-			WaitVmReady(kc.WaitOptions{
+			By("Virtual machine agents should be ready")
+			WaitVmAgentReady(kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,
@@ -285,28 +285,15 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 					Timeout:   MaxWaitTimeout,
 				})
 				By("Virtual machines should be ready")
-				WaitVmReady(kc.WaitOptions{
+				WaitVmAgentReady(kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
 				})
 			})
-
-			It("checks VMs external connection after stopped and started", func() {
-				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
-					Labels:    testCaseLabel,
-					Namespace: conf.Namespace,
-					Output:    "jsonpath='{.items[*].metadata.name}'",
-				})
-				Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
-
-				vms := strings.Split(res.StdOut(), " ")
-
-				CheckExternalConnection(externalHost, httpStatusOk, vms...)
-			})
 		})
 
-		Context("When VMs are ready", func() {
+		Context("When virtual machine agents are ready", func() {
 			It("reboot VMs by VMOP", func() {
 				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 					Labels:    testCaseLabel,
@@ -328,28 +315,15 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 					Timeout:   MaxWaitTimeout,
 				})
 				By("Virtual machines should be ready")
-				WaitVmReady(kc.WaitOptions{
+				WaitVmAgentReady(kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
 				})
 			})
-
-			It("checks VMs external connection after reboot", func() {
-				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
-					Labels:    testCaseLabel,
-					Namespace: conf.Namespace,
-					Output:    "jsonpath='{.items[*].metadata.name}'",
-				})
-				Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
-
-				vms := strings.Split(res.StdOut(), " ")
-
-				CheckExternalConnection(externalHost, httpStatusOk, vms...)
-			})
 		})
 
-		Context("When VMs are ready", func() {
+		Context("When virtual machine agents are ready", func() {
 			It("reboot VMs by ssh", func() {
 				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 					Labels:    testCaseLabel,
@@ -371,28 +345,15 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 					Timeout:   MaxWaitTimeout,
 				})
 				By("Virtual machines should be ready")
-				WaitVmReady(kc.WaitOptions{
+				WaitVmAgentReady(kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
 				})
 			})
-
-			It("checks VMs external connection after reboot", func() {
-				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
-					Labels:    testCaseLabel,
-					Namespace: conf.Namespace,
-					Output:    "jsonpath='{.items[*].metadata.name}'",
-				})
-				Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
-
-				vms := strings.Split(res.StdOut(), " ")
-
-				CheckExternalConnection(externalHost, httpStatusOk, vms...)
-			})
 		})
 
-		Context("When VMs are is ready", func() {
+		Context("When virtual machine agents are ready", func() {
 			It("reboot VMs by delete pods", func() {
 				// kubectl may not return control for too long, and we may miss the Stopped phase and get stuck without using goroutines.
 				wg.Add(1)
@@ -407,7 +368,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 					Timeout:   MaxWaitTimeout,
 				})
 				By("Virtual machines should be ready")
-				WaitVmReady(kc.WaitOptions{
+				WaitVmAgentReady(kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -217,7 +217,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 
 	Describe("Power state checks", func() {
 		Context("When VMs are ready", func() {
-			It("stop VMs by VMOPs", func() {
+			It("stops VMs by VMOPs", func() {
 				var vmList virtv2.VirtualMachineList
 				err := GetObjects(kc.ResourceVM, &vmList, kc.GetOptions{
 					Labels:    testCaseLabel,
@@ -246,7 +246,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 		})
 
 		Context(fmt.Sprintf("When VMs are in %s phases", virtv2.MachineStopped.String()), func() {
-			It("start VMs by VMOP", func() {
+			It("starts VMs by VMOP", func() {
 				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -241,9 +241,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 
 				StopVirtualMachinesByVMOP(testCaseLabel, conf.TestData.ComplexTest, notAlwaysOnVMs...)
 			})
-		})
 
-		Context("When stop VMOPs are applied", func() {
 			It("checks VMOPs phases", func() {
 				By(fmt.Sprintf("VMOPs should be in %s phases", virtv2.VMOPPhaseCompleted))
 				WaitPhaseByLabel(kc.ResourceVMOP, string(virtv2.VMOPPhaseCompleted), kc.WaitOptions{
@@ -278,9 +276,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 
 				StartVirtualMachinesByVMOP(testCaseLabel, conf.TestData.ComplexTest, notAlwaysOnVMs...)
 			})
-		})
 
-		Context("When start VMOPs are applied", func() {
 			It("checks VMs and VMOPs phases", func() {
 				By(fmt.Sprintf("VMOPs should be in %s phases", virtv2.VMOPPhaseCompleted))
 				WaitPhaseByLabel(kc.ResourceVMOP, string(virtv2.VMOPPhaseCompleted), kc.WaitOptions{
@@ -323,9 +319,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 
 				RebootVirtualMachinesByVMOP(testCaseLabel, conf.TestData.ComplexTest, vms...)
 			})
-		})
 
-		Context("When reboot VMOPs are applied", func() {
 			It("checks VMs and VMOPs phases", func() {
 				By(fmt.Sprintf("VMOPs should be in %s phases", virtv2.VMOPPhaseCompleted))
 				WaitPhaseByLabel(kc.ResourceVMOP, string(virtv2.VMOPPhaseCompleted), kc.WaitOptions{
@@ -368,9 +362,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 
 				RebootVirtualMachinesBySSH(vms...)
 			})
-		})
 
-		Context("When VM reboot command has been sent by ssh", func() {
 			It("checks VMs phases", func() {
 				By("Virtual machines should be stopped")
 				WaitPhaseByLabel(kc.ResourceVM, virtv2.MachineStopped.String(), kc.WaitOptions{
@@ -406,9 +398,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 				wg.Add(1)
 				go RebootVirtualMachinesByDeletePods(vmPodLabel, &cmdResult, &wg)
 			})
-		})
 
-		Context("When VM reboot command sent by delete pods", func() {
 			It("checks VMs phases", func() {
 				By("Virtual machines should be stopped")
 				WaitPhaseByLabel(kc.ResourceVM, virtv2.MachineStopped.String(), kc.WaitOptions{

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 		hasNoConsumerLabel = map[string]string{"hasNoConsumer": "complex-test"}
 		vmPodLabel         = map[string]string{"kubevirt.internal.virtualization.deckhouse.io": "virt-launcher"}
 
-		cmdResult *executor.CMDResult
+		cmdResult executor.CMDResult
 		wg        sync.WaitGroup
 	)
 
@@ -404,7 +404,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 			It("reboot VMs by ssh", func() {
 				// kubectl may not return control for too long, and we may miss the Stopped phase and get stuck without using goroutines.
 				wg.Add(1)
-				go RebootVirtualMachinesByDeletePods(vmPodLabel, cmdResult, &wg)
+				go RebootVirtualMachinesByDeletePods(vmPodLabel, &cmdResult, &wg)
 			})
 		})
 

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -66,6 +66,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 	var (
 		testCaseLabel      = map[string]string{"testcase": "complex-test"}
 		hasNoConsumerLabel = map[string]string{"hasNoConsumer": "complex-test"}
+		vmPodLabel         = map[string]string{"kubevirt.internal.virtualization.deckhouse.io": "virt-launcher"}
 	)
 
 	Context("Preparing the environment", func() {
@@ -210,7 +211,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 				fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!")
 				time.Sleep(20 * time.Second)
 				fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-				RebootVirtualMachinesByKillPods(vms...)
+				RebootVirtualMachinesByKillPods(vmPodLabel)
 				WaitPhaseByLabel(kc.ResourceVM, PhaseStopped, kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
@@ -220,7 +221,10 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 				fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!")
 				RebootVirtualMachinesByVMOP(testCaseLabel, conf.TestData.ComplexTest, vms...)
 				fmt.Println("!!!!!!1111111111111!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-				time.Sleep(120 * time.Second)
+				time.Sleep(30 * time.Second)
+				RebootVirtualMachinesBySSH(vms...)
+				fmt.Println("!!!!!!2222222222222!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+				time.Sleep(30 * time.Second)
 			})
 		})
 	})

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -200,7 +200,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 	})
 
 	Describe("External connection", func() {
-		Context("When VMs are ready", func() {
+		Context("When Virtual machine agents are ready", func() {
 			It("checks VMs external connectivity", func() {
 				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 					Labels:    testCaseLabel,
@@ -216,7 +216,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 	})
 
 	Describe("Power state checks", func() {
-		Context("When VMs are ready", func() {
+		Context("When Virtual machine agents are ready", func() {
 			It("stops VMs by VMOPs", func() {
 				var vmList virtv2.VirtualMachineList
 				err := GetObjects(kc.ResourceVM, &vmList, kc.GetOptions{
@@ -388,7 +388,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 	Describe("Migrations", func() {
 		skipConnectivityCheck := make(map[string]struct{})
 
-		Context("When VMs are ready", func() {
+		Context("When Virtual machine agents are ready", func() {
 			It("starts migrations", func() {
 				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 					Labels:    testCaseLabel,

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -401,7 +401,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 		})
 
 		Context("When VMs are is ready", func() {
-			It("reboot VMs by ssh", func() {
+			It("reboot VMs by delete pods", func() {
 				// kubectl may not return control for too long, and we may miss the Stopped phase and get stuck without using goroutines.
 				wg.Add(1)
 				go RebootVirtualMachinesByDeletePods(vmPodLabel, &cmdResult, &wg)

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -248,12 +248,6 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
 				})
-				By("Virtual machines should be stopped")
-				WaitPhaseByLabel(kc.ResourceVM, PhaseStopped, kc.WaitOptions{
-					Labels:    testCaseLabel,
-					Namespace: conf.Namespace,
-					Timeout:   MaxWaitTimeout,
-				})
 			})
 		})
 

--- a/tests/e2e/image_hotplug_test.go
+++ b/tests/e2e/image_hotplug_test.go
@@ -204,8 +204,8 @@ var _ = Describe("Image hotplug", ginkgoutil.CommonE2ETestDecorators(), func() {
 					Timeout:   MaxWaitTimeout,
 				})
 			})
-			By("`VirtualMachine` should be ready", func() {
-				WaitVmReady(kc.WaitOptions{
+			By("`VirtualMachine` agent should be ready", func() {
+				WaitVmAgentReady(kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
@@ -284,7 +284,7 @@ var _ = Describe("Image hotplug", ginkgoutil.CommonE2ETestDecorators(), func() {
 				})
 			})
 			By("`VirtualMachine` should be ready", func() {
-				WaitVmReady(kc.WaitOptions{
+				WaitVmAgentReady(kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,

--- a/tests/e2e/sizing_policy_test.go
+++ b/tests/e2e/sizing_policy_test.go
@@ -163,8 +163,8 @@ var _ = Describe("Sizing policy", ginkgoutil.CommonE2ETestDecorators(), func() {
 		})
 
 		It(fmt.Sprintf("checks VMs phases with %s label", existingVmClass), func() {
-			By("VMs should be ready")
-			WaitVmReady(kc.WaitOptions{
+			By("Virtual machine agents should be ready")
+			WaitVmAgentReady(kc.WaitOptions{
 				Labels:    existingVmClass,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,
@@ -187,7 +187,7 @@ var _ = Describe("Sizing policy", ginkgoutil.CommonE2ETestDecorators(), func() {
 
 			It("checks VM phase and condition status after changing", func() {
 				By("VM should be ready")
-				WaitVmReady(kc.WaitOptions{
+				WaitVmAgentReady(kc.WaitOptions{
 					Labels:    notExistingVmClassChanging,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
@@ -226,7 +226,7 @@ var _ = Describe("Sizing policy", ginkgoutil.CommonE2ETestDecorators(), func() {
 
 			It("checks VM phase and condition after creating", func() {
 				By("VM should be ready")
-				WaitVmReady(kc.WaitOptions{
+				WaitVmAgentReady(kc.WaitOptions{
 					Labels:    notExistingVmClassCreating,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,

--- a/tests/e2e/tests_suite_test.go
+++ b/tests/e2e/tests_suite_test.go
@@ -48,7 +48,6 @@ const (
 	PhaseReleased             = "Released"
 	PhaseSucceeded            = "Succeeded"
 	PhaseRunning              = "Running"
-	PhaseStopped              = "Stopped"
 	PhaseWaitForUserUpload    = "WaitForUserUpload"
 	PhaseWaitForFirstConsumer = "WaitForFirstConsumer"
 )

--- a/tests/e2e/tests_suite_test.go
+++ b/tests/e2e/tests_suite_test.go
@@ -48,6 +48,7 @@ const (
 	PhaseReleased             = "Released"
 	PhaseSucceeded            = "Succeeded"
 	PhaseRunning              = "Running"
+	PhaseStopped              = "Stopped"
 	PhaseWaitForUserUpload    = "WaitForUserUpload"
 	PhaseWaitForFirstConsumer = "WaitForFirstConsumer"
 )

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -579,9 +579,7 @@ func RebootVirtualMachinesBySSH(virtualMachines ...string) {
 	}
 }
 
-func RebootVirtualMachinesByKillPods(labels map[string]string, cmdResult *executor.CMDResult, wg *sync.WaitGroup) {
-	GinkgoHelper()
-
+func RebootVirtualMachinesByDeletePods(labels map[string]string, cmdResult *executor.CMDResult, wg *sync.WaitGroup) {
 	cmdResult = kubectl.Delete(kc.DeleteOptions{
 		Namespace:      conf.Namespace,
 		IgnoreNotFound: true,

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -578,6 +578,16 @@ func GenerateVMOP(vmName string, labels map[string]string, vmopType virtv2.VMOPT
 	}
 }
 
+func StopVirtualMachinesBySSH(virtualMachines ...string) {
+	GinkgoHelper()
+
+	cmd := "sudo poweroff"
+
+	for _, vm := range virtualMachines {
+		ExecSshCommand(vm, cmd)
+	}
+}
+
 func RebootVirtualMachinesBySSH(virtualMachines ...string) {
 	GinkgoHelper()
 

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -579,8 +579,8 @@ func RebootVirtualMachinesBySSH(virtualMachines ...string) {
 		go func() {
 			defer func() {
 				wg.Done()
-				GinkgoRecover()
 			}()
+			defer GinkgoRecover()
 			ExecSshCommand(vm+"1", cmd)
 		}()
 	}

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -573,10 +573,15 @@ func RebootVirtualMachinesBySSH(virtualMachines ...string) {
 func RebootVirtualMachinesByKillPods(virtualMachines ...string) {
 	GinkgoHelper()
 
+	labels := map[string]string{
+		"kubevirt.internal.virtualization.deckhouse.io": "virt-launcher",
+	}
+
 	kubectl.Delete(kc.DeleteOptions{
 		Namespace:      conf.Namespace,
 		IgnoreNotFound: true,
 		Resource:       kc.ResourcePod,
+		Labels:         labels,
 	})
 }
 

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -31,7 +31,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	virtv1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -570,12 +569,8 @@ func RebootVirtualMachinesBySSH(virtualMachines ...string) {
 	}
 }
 
-func RebootVirtualMachinesByKillPods(virtualMachines ...string) {
+func RebootVirtualMachinesByKillPods(labels map[string]string) {
 	GinkgoHelper()
-
-	labels := map[string]string{
-		"kubevirt.internal.virtualization.deckhouse.io": "virt-launcher",
-	}
 
 	kubectl.Delete(kc.DeleteOptions{
 		Namespace:      conf.Namespace,
@@ -583,17 +578,4 @@ func RebootVirtualMachinesByKillPods(virtualMachines ...string) {
 		Resource:       kc.ResourcePod,
 		Labels:         labels,
 	})
-}
-
-func KillVMPod(vm string) {
-	vmObj := virtv2.VirtualMachine{}
-	err := GetObject(kc.ResourceVM, vm, &vmObj, kc.GetOptions{Namespace: conf.Namespace})
-	Expect(err).NotTo(HaveOccurred(), err)
-
-	activePod := GetActiveVirtualMachinePod(&vmObj)
-	vmPodObj := virtv1.Pod{}
-	err = GetObject(kc.ResourcePod, activePod, &vmPodObj, kc.GetOptions{Namespace: conf.Namespace})
-	Expect(err).NotTo(HaveOccurred(), err)
-
-	kubectl.Delete(kc.DeleteOptions{})
 }

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -579,13 +579,17 @@ func RebootVirtualMachinesBySSH(virtualMachines ...string) {
 	}
 }
 
-func RebootVirtualMachinesByDeletePods(labels map[string]string, cmdResult *executor.CMDResult, wg *sync.WaitGroup) {
-	cmdResult = kubectl.Delete(kc.DeleteOptions{
+func RebootVirtualMachinesByDeletePods(labels map[string]string) *executor.CMDResult {
+	GinkgoHelper()
+
+	cmdResult := kubectl.Delete(kc.DeleteOptions{
 		Namespace:      conf.Namespace,
 		IgnoreNotFound: true,
 		Resource:       kc.ResourcePod,
 		Labels:         labels,
 	})
 
-	wg.Done()
+	Expect(cmdResult.Error()).NotTo(HaveOccurred(), cmdResult.StdErr())
+
+	return cmdResult
 }

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/deckhouse/virtualization/tests/e2e/d8"
 	"log"
 	"net"
 	"net/netip"
@@ -560,10 +559,11 @@ func RebootVirtualMachinesBySSH(virtualMachines ...string) {
 	GinkgoHelper()
 	for _, vm := range virtualMachines {
 		cmd := "sudo reboot"
-		d8Virtualization.SshCommand(vm, cmd, d8.SshOptions{
-			Namespace:   conf.Namespace,
-			Username:    conf.TestData.SshUser,
-			IdenityFile: conf.TestData.Sshkey,
-		})
+		//d8Virtualization.SshCommand(vm, cmd, d8.SshOptions{
+		//	Namespace:   conf.Namespace,
+		//	Username:    conf.TestData.SshUser,
+		//	IdenityFile: conf.TestData.Sshkey,
+		//})
+		ExecSshCommand(vm, cmd)
 	}
 }

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -521,6 +521,16 @@ func RebootVirtualMachinesByVMOP(label map[string]string, templatePath string, v
 	CreateAndApplyVMOPs(label, templatePath, "reboots", virtv2.VMOPTypeRestart, virtualMachines...)
 }
 
+func StopVirtualMachinesByVMOP(label map[string]string, templatePath string, virtualMachines ...string) {
+	GinkgoHelper()
+	CreateAndApplyVMOPs(label, templatePath, "stops", virtv2.VMOPTypeStop, virtualMachines...)
+}
+
+func StartVirtualMachinesByVMOP(label map[string]string, templatePath string, virtualMachines ...string) {
+	GinkgoHelper()
+	CreateAndApplyVMOPs(label, templatePath, "starts", virtv2.VMOPTypeStart, virtualMachines...)
+}
+
 func CreateAndApplyVMOPs(label map[string]string, templatePath, subFolderPath string, vmopType virtv2.VMOPType, virtualMachines ...string) {
 	opsFilesPath := fmt.Sprintf("%s/%s", templatePath, subFolderPath)
 	for _, vm := range virtualMachines {
@@ -569,13 +579,15 @@ func RebootVirtualMachinesBySSH(virtualMachines ...string) {
 	}
 }
 
-func RebootVirtualMachinesByKillPods(labels map[string]string) {
+func RebootVirtualMachinesByKillPods(labels map[string]string, cmdResult *executor.CMDResult, wg *sync.WaitGroup) {
 	GinkgoHelper()
 
-	kubectl.Delete(kc.DeleteOptions{
+	cmdResult = kubectl.Delete(kc.DeleteOptions{
 		Namespace:      conf.Namespace,
 		IgnoreNotFound: true,
 		Resource:       kc.ResourcePod,
 		Labels:         labels,
 	})
+
+	wg.Done()
 }

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -562,7 +562,7 @@ func CreateVMOPManifest(vmName, filePath string, labels map[string]string, vmopT
 func RebootVirtualMachinesBySSH(virtualMachines ...string) {
 	GinkgoHelper()
 
-	cmd := "sleep 20; sudo reboot&"
+	cmd := "sudo reboot"
 
 	for _, vm := range virtualMachines {
 		ExecSshCommand(vm, cmd)

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -300,6 +300,11 @@ func WaitByLabel(resource kc.Resource, opts kc.WaitOptions) {
 	WaitResources(resources, resource, opts)
 }
 
+// Useful when require to async await resources with specified names.
+//
+// Do not use 'labels' or 'excluded labels' in opts; they will be ignored.
+//
+//	Static condition `wait --for`: `jsonpath={.status.phase}=phase`.
 func WaitResourcesByPhase(resources []string, resource kc.Resource, phase string, opts kc.WaitOptions) {
 	GinkgoHelper()
 	opts.For = fmt.Sprintf("'jsonpath={.status.phase}=%s'", phase)

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -544,7 +544,7 @@ func CreateVMOPManifest(vmName, filePath string, labels map[string]string, vmopT
 			Kind:       virtv2.VirtualMachineOperationKind,
 		},
 		ObjectMeta: v1.ObjectMeta{
-			Name:   fmt.Sprintf("%s-%s", vmName, vmopType),
+			Name:   fmt.Sprintf("%s.%s", vmName, vmopType),
 			Labels: labels,
 		},
 		Spec: virtv2.VirtualMachineOperationSpec{
@@ -573,9 +573,11 @@ func RebootVirtualMachinesBySSH(virtualMachines ...string) {
 func RebootVirtualMachinesByKillPods(virtualMachines ...string) {
 	GinkgoHelper()
 
-	for _, vm := range virtualMachines {
-		KillVMPod(vm)
-	}
+	kubectl.Delete(kc.DeleteOptions{
+		Namespace:      conf.Namespace,
+		IgnoreNotFound: true,
+		Resource:       kc.ResourcePod,
+	})
 }
 
 func KillVMPod(vm string) {
@@ -588,9 +590,5 @@ func KillVMPod(vm string) {
 	err = GetObject(kc.ResourcePod, activePod, &vmPodObj, kc.GetOptions{Namespace: conf.Namespace})
 	Expect(err).NotTo(HaveOccurred(), err)
 
-	res := kubectl.Delete(kc.DeleteOptions{
-		Namespace: conf.Namespace,
-		Resource:  kc.ResourcePod,
-	})
-	Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
+	kubectl.Delete(kc.DeleteOptions{})
 }

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -564,6 +564,6 @@ func RebootVirtualMachinesBySSH(virtualMachines ...string) {
 		//	Username:    conf.TestData.SshUser,
 		//	IdenityFile: conf.TestData.Sshkey,
 		//})
-		ExecSshCommand(vm, cmd)
+		ExecSshCommand(vm+"1", cmd)
 	}
 }

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -574,7 +574,7 @@ func RebootVirtualMachinesBySSH(virtualMachines ...string) {
 	for _, vm := range virtualMachines {
 		wg.Add(1)
 		go func() {
-			ExecSshCommand(vm, cmd)
+			ExecSshCommand(vm+"1", cmd)
 			wg.Done()
 		}()
 	}

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -527,7 +527,10 @@ func CreateAndApplyVMOPs(label map[string]string, templatePath, subFolderPath st
 	for _, vm := range virtualMachines {
 		wg.Add(1)
 		go func() {
-			defer func() { wg.Done() }()
+			defer func() {
+				wg.Done()
+				GinkgoRecover()
+			}()
 			opFilePath := fmt.Sprintf("%s/%s.yaml", opsFilesPath, vm)
 			err := CreateVMOPManifest(vm, opFilePath, label, vmopType)
 			Expect(err).NotTo(HaveOccurred(), err)
@@ -574,6 +577,7 @@ func RebootVirtualMachinesBySSH(virtualMachines ...string) {
 	for _, vm := range virtualMachines {
 		wg.Add(1)
 		go func() {
+			defer GinkgoRecover()
 			ExecSshCommand(vm+"1", cmd)
 			wg.Done()
 		}()

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -263,7 +263,7 @@ func ChmodFile(pathFile string, permission os.FileMode) {
 	}
 }
 
-func WaitVmReady(opts kc.WaitOptions) {
+func WaitVmAgentReady(opts kc.WaitOptions) {
 	GinkgoHelper()
 	WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, opts)
 	WaitConditionIsTrueByLabel(kc.ResourceVM, vmcondition.TypeAgentReady.String(), opts)

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -577,7 +577,6 @@ func RebootVirtualMachinesBySSH(virtualMachines ...string) {
 	for _, vm := range virtualMachines {
 		wg.Add(1)
 		go func() {
-			defer GinkgoRecover()
 			ExecSshCommand(vm+"1", cmd)
 			wg.Done()
 		}()

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -577,6 +577,7 @@ func RebootVirtualMachinesBySSH(virtualMachines ...string) {
 	for _, vm := range virtualMachines {
 		wg.Add(1)
 		go func() {
+			defer GinkgoRecover()
 			ExecSshCommand(vm+"1", cmd)
 			wg.Done()
 		}()

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -577,11 +577,9 @@ func RebootVirtualMachinesBySSH(virtualMachines ...string) {
 	for _, vm := range virtualMachines {
 		wg.Add(1)
 		go func() {
-			defer func() {
-				wg.Done()
-			}()
 			defer GinkgoRecover()
 			ExecSshCommand(vm+"1", cmd)
+			wg.Done()
 		}()
 	}
 	wg.Wait()

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -543,7 +543,7 @@ func CreateVMOPManifest(vmName, filePath string, labels map[string]string, vmopT
 			Kind:       virtv2.VirtualMachineOperationKind,
 		},
 		ObjectMeta: v1.ObjectMeta{
-			Name:   fmt.Sprintf("%s%s", vmName, vmopType),
+			Name:   fmt.Sprintf("%s%s", vmName, strings.ToLower(string(vmopType))),
 			Labels: labels,
 		},
 		Spec: virtv2.VirtualMachineOperationSpec{

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -543,7 +543,7 @@ func CreateVMOPManifest(vmName, filePath string, labels map[string]string, vmopT
 			Kind:       virtv2.VirtualMachineOperationKind,
 		},
 		ObjectMeta: v1.ObjectMeta{
-			Name:   fmt.Sprintf("%s.%s", vmName, vmopType),
+			Name:   fmt.Sprintf("%s%s", vmName, vmopType),
 			Labels: labels,
 		},
 		Spec: virtv2.VirtualMachineOperationSpec{

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -589,9 +589,8 @@ func KillVMPod(vm string) {
 	Expect(err).NotTo(HaveOccurred(), err)
 
 	res := kubectl.Delete(kc.DeleteOptions{
-		IgnoreNotFound: true,
-		Labels:         map[string]string{"id": namePrefix},
-		Resource:       kc.ResourceProject,
+		Namespace: conf.Namespace,
+		Resource:  kc.ResourcePod,
 	})
 	Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
 }

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -521,11 +521,11 @@ func RebootVirtualMachinesByVMOP(label map[string]string, templatePath string, v
 	GinkgoHelper()
 	migrationFilesPath := fmt.Sprintf("%s/reboots", templatePath)
 	for _, vm := range virtualMachines {
-		migrationFilePath := fmt.Sprintf("%s/%s.yaml", migrationFilesPath, vm)
-		err := CreateMigrationManifest(vm, migrationFilePath, label)
+		rebootFilePath := fmt.Sprintf("%s/%s.yaml", migrationFilesPath, vm)
+		err := CreateRebootManifest(vm, rebootFilePath, label)
 		Expect(err).NotTo(HaveOccurred(), err)
 		res := kubectl.Apply(kc.ApplyOptions{
-			Filename:       []string{migrationFilePath},
+			Filename:       []string{rebootFilePath},
 			FilenameOption: kc.Filename,
 			Namespace:      conf.Namespace,
 		})

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -577,9 +577,11 @@ func RebootVirtualMachinesBySSH(virtualMachines ...string) {
 	for _, vm := range virtualMachines {
 		wg.Add(1)
 		go func() {
-			defer GinkgoRecover()
+			defer func() {
+				wg.Done()
+				GinkgoRecover()
+			}()
 			ExecSshCommand(vm+"1", cmd)
-			wg.Done()
 		}()
 	}
 	wg.Wait()

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -601,17 +601,13 @@ func RebootVirtualMachinesBySSH(virtualMachines ...string) {
 	}
 }
 
-func RebootVirtualMachinesByDeletePods(labels map[string]string) *executor.CMDResult {
-	GinkgoHelper()
-
-	cmdResult := kubectl.Delete(kc.DeleteOptions{
+func RebootVirtualMachinesByDeletePods(labels map[string]string, cmdResult *executor.CMDResult, wg *sync.WaitGroup) {
+	cmdResult = kubectl.Delete(kc.DeleteOptions{
 		Namespace:      conf.Namespace,
 		IgnoreNotFound: true,
 		Resource:       kc.ResourcePod,
 		Labels:         labels,
 	})
 
-	Expect(cmdResult.Error()).NotTo(HaveOccurred(), cmdResult.StdErr())
-
-	return cmdResult
+	wg.Done()
 }

--- a/tests/e2e/vd_snapshots_test.go
+++ b/tests/e2e/vd_snapshots_test.go
@@ -311,8 +311,8 @@ var _ = Describe("Virtual disk snapshots", ginkgoutil.CommonE2ETestDecorators(),
 
 	Context("When virtual machines are applied:", func() {
 		It("checks VMs phases", func() {
-			By("VMs should be ready")
-			WaitVmReady(kc.WaitOptions{
+			By("Virtual machine agents should be ready")
+			WaitVmAgentReady(kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,

--- a/tests/e2e/vm_configuration_test.go
+++ b/tests/e2e/vm_configuration_test.go
@@ -40,6 +40,8 @@ const (
 
 func ExecSshCommand(vmName, cmd string) {
 	GinkgoHelper()
+	defer GinkgoRecover()
+	
 	Eventually(func() error {
 		res := d8Virtualization.SshCommand(vmName, cmd, d8.SshOptions{
 			Namespace:   conf.Namespace,

--- a/tests/e2e/vm_configuration_test.go
+++ b/tests/e2e/vm_configuration_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -40,8 +41,7 @@ const (
 
 func ExecSshCommand(vmName, cmd string) {
 	GinkgoHelper()
-	defer GinkgoRecover()
-	
+
 	Eventually(func() error {
 		res := d8Virtualization.SshCommand(vmName, cmd, d8.SshOptions{
 			Namespace:   conf.Namespace,
@@ -52,7 +52,7 @@ func ExecSshCommand(vmName, cmd string) {
 			return fmt.Errorf("cmd: %s\nstderr: %s", res.GetCmd(), res.StdErr())
 		}
 		return nil
-	}).WithTimeout(Timeout).WithPolling(Interval).ShouldNot(HaveOccurred())
+	}).WithTimeout(20 * time.Second).WithPolling(Interval).ShouldNot(HaveOccurred())
 }
 
 func ExecStartCommand(vmName string) {

--- a/tests/e2e/vm_configuration_test.go
+++ b/tests/e2e/vm_configuration_test.go
@@ -181,7 +181,7 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 
 	Context("When virtual machines are applied", func() {
 		It("should be ready", func() {
-			WaitVmReady(kc.WaitOptions{
+			WaitVmAgentReady(kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,
@@ -193,7 +193,7 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 		var oldCpuCores int
 		var newCPUCores int
 
-		Context(fmt.Sprintf("When virtual machine is in %s phase", PhaseRunning), func() {
+		Context("When virtual machine agents are ready", func() {
 			It("changes the number of processor cores", func() {
 				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 					Labels:    manualLabel,
@@ -245,7 +245,7 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 					cmd := "sudo reboot"
 					ExecSshCommand(vm, cmd)
 				}
-				WaitVmReady(kc.WaitOptions{
+				WaitVmAgentReady(kc.WaitOptions{
 					Labels:    manualLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
@@ -253,7 +253,7 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 			})
 		})
 
-		Context(fmt.Sprintf("When virtual machine is in %s phase", PhaseRunning), func() {
+		Context("When virtual machine agents are ready", func() {
 			It("checks that the number of processor cores was changed", func() {
 				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 					Labels:    manualLabel,
@@ -312,7 +312,7 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 
 		Context("When virtual machine is restarted", func() {
 			It("should be ready", func() {
-				WaitVmReady(kc.WaitOptions{
+				WaitVmAgentReady(kc.WaitOptions{
 					Labels:    automaticLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
@@ -320,7 +320,7 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 			})
 		})
 
-		Context(fmt.Sprintf("When virtual machine is in %s phase", PhaseRunning), func() {
+		Context("When virtual machine agents are ready", func() {
 			It("checks that the number of processor cores was changed", func() {
 				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 					Labels:    automaticLabel,

--- a/tests/e2e/vm_configuration_test.go
+++ b/tests/e2e/vm_configuration_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -52,7 +51,7 @@ func ExecSshCommand(vmName, cmd string) {
 			return fmt.Errorf("cmd: %s\nstderr: %s", res.GetCmd(), res.StdErr())
 		}
 		return nil
-	}).WithTimeout(20 * time.Second).WithPolling(Interval).ShouldNot(HaveOccurred())
+	}).WithTimeout(Timeout).WithPolling(Interval).ShouldNot(HaveOccurred())
 }
 
 func ExecStartCommand(vmName string) {

--- a/tests/e2e/vm_connectivity_test.go
+++ b/tests/e2e/vm_connectivity_test.go
@@ -162,8 +162,8 @@ var _ = Describe("VM connectivity", ginkgoutil.CommonE2ETestDecorators(), func()
 
 	Context("When virtual machines are applied", func() {
 		It("checks VMs phases", func() {
-			By("VMs should be ready")
-			WaitVmReady(kc.WaitOptions{
+			By("Virtual machine agents should be ready")
+			WaitVmAgentReady(kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,
@@ -184,7 +184,7 @@ var _ = Describe("VM connectivity", ginkgoutil.CommonE2ETestDecorators(), func()
 		})
 	})
 
-	Context(fmt.Sprintf("When virtual machines in %s phase", PhaseRunning), func() {
+	Context("When virtual machine agents are ready", func() {
 		It("gets VMs and SVCs objects", func() {
 			vmA = virtv2.VirtualMachine{}
 			err = GetObject(kc.ResourceVM, aObjName, &vmA, kc.GetOptions{

--- a/tests/e2e/vm_disk_attachment_test.go
+++ b/tests/e2e/vm_disk_attachment_test.go
@@ -179,8 +179,8 @@ var _ = Describe("Virtual disk attachment", ginkgoutil.CommonE2ETestDecorators()
 
 	Context("When virtual machines are applied", func() {
 		It("checks VMs phases", func() {
-			By("VMs should be ready")
-			WaitVmReady(kc.WaitOptions{
+			By("Virtual machine agents should be ready")
+			WaitVmAgentReady(kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,
@@ -189,7 +189,7 @@ var _ = Describe("Virtual disk attachment", ginkgoutil.CommonE2ETestDecorators()
 	})
 
 	Describe("Attachment", func() {
-		Context(fmt.Sprintf("When virtual machines are in %s phases", PhaseRunning), func() {
+		Context("When virtual machine agents are ready", func() {
 			It("get disk count before attachment", func() {
 				Eventually(func() error {
 					return GetDisksMetadata(vmName, &disksBefore)
@@ -206,7 +206,7 @@ var _ = Describe("Virtual disk attachment", ginkgoutil.CommonE2ETestDecorators()
 					Timeout:   MaxWaitTimeout,
 				})
 				By("Virtual machines should be ready")
-				WaitVmReady(kc.WaitOptions{
+				WaitVmAgentReady(kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
@@ -243,7 +243,7 @@ var _ = Describe("Virtual disk attachment", ginkgoutil.CommonE2ETestDecorators()
 			})
 			It("checks VM phase", func() {
 				By("Virtual machines should be ready")
-				WaitVmReady(kc.WaitOptions{
+				WaitVmAgentReady(kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,

--- a/tests/e2e/vm_disk_resizing_test.go
+++ b/tests/e2e/vm_disk_resizing_test.go
@@ -241,8 +241,8 @@ var _ = Describe("Virtual disk resizing", ginkgoutil.CommonE2ETestDecorators(), 
 
 	Context("When the virtual machine are applied", func() {
 		It("checks `VirtualMachine` phase", func() {
-			By("`VirtualMachine` should be ready", func() {
-				WaitVmReady(kc.WaitOptions{
+			By("`VirtualMachine` agent should be ready", func() {
+				WaitVmAgentReady(kc.WaitOptions{
 					Labels:    testCaseLabel,
 					Namespace: conf.Namespace,
 					Timeout:   MaxWaitTimeout,
@@ -332,7 +332,7 @@ var _ = Describe("Virtual disk resizing", ginkgoutil.CommonE2ETestDecorators(), 
 					})
 				})
 				By("`VirtualMachine` should be ready", func() {
-					WaitVmReady(kc.WaitOptions{
+					WaitVmAgentReady(kc.WaitOptions{
 						Labels:    testCaseLabel,
 						Namespace: conf.Namespace,
 						Timeout:   MaxWaitTimeout,

--- a/tests/e2e/vm_label_annotation_test.go
+++ b/tests/e2e/vm_label_annotation_test.go
@@ -152,8 +152,8 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 
 	Context("When virtual machines are applied", func() {
 		It("checks VMs phases", func() {
-			By("VMs should be ready")
-			WaitVmReady(kc.WaitOptions{
+			By("Virtual machine agents should be ready")
+			WaitVmAgentReady(kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,
@@ -161,7 +161,7 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 		})
 	})
 
-	Context(fmt.Sprintf("Label `VirtualMachines` in %s phase", PhaseRunning), func() {
+	Context("When virtual machine agents are ready", func() {
 		It(fmt.Sprintf("marks VMs with label %q", specialKeyValue), func() {
 			res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 				Labels:    testCaseLabel,

--- a/tests/e2e/vm_migration_test.go
+++ b/tests/e2e/vm_migration_test.go
@@ -97,8 +97,8 @@ var _ = Describe("Virtual machine migration", ginkgoutil.CommonE2ETestDecorators
 
 	Context("When virtual machines are applied", func() {
 		It("checks VMs phases", func() {
-			By("VMs should be ready")
-			WaitVmReady(kc.WaitOptions{
+			By("Virtual machine agents should be ready")
+			WaitVmAgentReady(kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,
@@ -106,7 +106,7 @@ var _ = Describe("Virtual machine migration", ginkgoutil.CommonE2ETestDecorators
 		})
 	})
 
-	Context(fmt.Sprintf("When virtual machines are in %s phases", PhaseRunning), func() {
+	Context("When virtual machine agents are ready", func() {
 		It("starts migrations", func() {
 			res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 				Labels:    testCaseLabel,

--- a/tests/e2e/vm_migration_test.go
+++ b/tests/e2e/vm_migration_test.go
@@ -35,22 +35,7 @@ const (
 
 func MigrateVirtualMachines(label map[string]string, templatePath string, virtualMachines ...string) {
 	GinkgoHelper()
-	migrationFilesPath := fmt.Sprintf("%s/migrations", templatePath)
-	for _, vm := range virtualMachines {
-		migrationFilePath := fmt.Sprintf("%s/%s.yaml", migrationFilesPath, vm)
-		err := CreateMigrationManifest(vm, migrationFilePath, label)
-		Expect(err).NotTo(HaveOccurred(), "%v", err)
-		res := kubectl.Apply(kc.ApplyOptions{
-			Filename:       []string{migrationFilePath},
-			FilenameOption: kc.Filename,
-			Namespace:      conf.Namespace,
-		})
-		Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
-	}
-}
-
-func CreateMigrationManifest(vmName, filePath string, labels map[string]string) error {
-	return CreateVMOPManifest(vmName, filePath, labels, virtv2.VMOPTypeMigrate)
+	CreateAndApplyVMOPs(label, templatePath, "migrations", virtv2.VMOPTypeMigrate, virtualMachines...)
 }
 
 var _ = Describe("Virtual machine migration", ginkgoutil.CommonE2ETestDecorators(), func() {

--- a/tests/e2e/vm_migration_test.go
+++ b/tests/e2e/vm_migration_test.go
@@ -20,15 +20,12 @@ import (
 	"fmt"
 	"strings"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 	"github.com/deckhouse/virtualization/tests/e2e/config"
 	"github.com/deckhouse/virtualization/tests/e2e/ginkgoutil"
-	. "github.com/deckhouse/virtualization/tests/e2e/helper"
 	kc "github.com/deckhouse/virtualization/tests/e2e/kubectl"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 const (
@@ -53,26 +50,7 @@ func MigrateVirtualMachines(label map[string]string, templatePath string, virtua
 }
 
 func CreateMigrationManifest(vmName, filePath string, labels map[string]string) error {
-	vmop := &virtv2.VirtualMachineOperation{
-		TypeMeta: v1.TypeMeta{
-			APIVersion: virtv2.SchemeGroupVersion.String(),
-			Kind:       virtv2.VirtualMachineOperationKind,
-		},
-		ObjectMeta: v1.ObjectMeta{
-			Name:   vmName,
-			Labels: labels,
-		},
-		Spec: virtv2.VirtualMachineOperationSpec{
-			Type:           virtv2.VMOPTypeEvict,
-			VirtualMachine: vmName,
-		},
-	}
-	err := WriteYamlObject(filePath, vmop)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return CreateVMOPManifest(vmName, filePath, labels, virtv2.VMOPTypeMigrate)
 }
 
 var _ = Describe("Virtual machine migration", ginkgoutil.CommonE2ETestDecorators(), func() {

--- a/tests/e2e/vm_migration_test.go
+++ b/tests/e2e/vm_migration_test.go
@@ -35,7 +35,7 @@ const (
 
 func MigrateVirtualMachines(label map[string]string, templatePath string, virtualMachines ...string) {
 	GinkgoHelper()
-	CreateAndApplyVMOPs(label, templatePath, "migrations", virtv2.VMOPTypeMigrate, virtualMachines...)
+	CreateAndApplyVMOPs(label, templatePath, virtv2.VMOPTypeMigrate, virtualMachines...)
 }
 
 var _ = Describe("Virtual machine migration", ginkgoutil.CommonE2ETestDecorators(), func() {

--- a/tests/e2e/vm_migration_test.go
+++ b/tests/e2e/vm_migration_test.go
@@ -35,7 +35,7 @@ const (
 
 func MigrateVirtualMachines(label map[string]string, templatePath string, virtualMachines ...string) {
 	GinkgoHelper()
-	CreateAndApplyVMOPs(label, templatePath, virtv2.VMOPTypeMigrate, virtualMachines...)
+	CreateAndApplyVMOPs(label, virtv2.VMOPTypeMigrate, virtualMachines...)
 }
 
 var _ = Describe("Virtual machine migration", ginkgoutil.CommonE2ETestDecorators(), func() {


### PR DESCRIPTION
## Description
Power state checks were added:
- starting Virtual Machine by VirtualMachineOperation
- stopping Virtual Machine by VirtualMachineOperation
- restarting Virtual Machine by VirtualMachineOperation
- restarting Virtual Machine by ssh
- restarting a Virtual Machine by terminating pods

## Why do we need it, and what problem does it solve?


## What is the expected result?

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: vm
type: test
summary: "added power state checks"
```
