### PR TITLE
test(vm): fix "no waiting" error

### DIFF
--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -623,3 +623,23 @@ func RebootVirtualMachinesByDeletePods(labels map[string]string, cmdResult *exec
 
 	wg.Done()
 }
+
+func IsContainsAnnotation(obj client.Object, annotation string) bool {
+	_, ok := obj.GetAnnotations()[annotation]
+	return ok
+}
+
+func IsContainsAnnotationWithValue(obj client.Object, annotation, value string) bool {
+	val, ok := obj.GetAnnotations()[annotation]
+	return ok && val == value
+}
+
+func IsContainsLabel(obj client.Object, label string) bool {
+	_, ok := obj.GetLabels()[label]
+	return ok
+}
+
+func IsContainsLabelWithValue(obj client.Object, label, value string) bool {
+	val, ok := obj.GetLabels()[label]
+	return ok && val == value
+}

--- a/tests/e2e/vm_label_annotation_test.go
+++ b/tests/e2e/vm_label_annotation_test.go
@@ -190,11 +190,9 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 					return err
 				}
 
-				var errors []error
-
 				for _, vm := range vms.Items {
 					if !IsContainsLabelWithValue(&vm, specialKey, specialValue) {
-						errors = append(errors, fmt.Errorf("vm label %q with value %q was not found in %s", specialKey, specialValue, vm.Name))
+						return fmt.Errorf("vm label %q with value %q was not found in %s", specialKey, specialValue, vm.Name)
 					}
 
 					activePodName := GetActiveVirtualMachinePod(&vm)
@@ -205,12 +203,8 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 					}
 
 					if !IsContainsLabelWithValue(&vmPod, specialKey, specialValue) {
-						errors = append(errors, fmt.Errorf("vm pod label %q with value %q was not found in %s", specialKey, specialValue, vmPod.Name))
+						return fmt.Errorf("vm pod label %q with value %q was not found in %s", specialKey, specialValue, vmPod.Name)
 					}
-				}
-
-				if len(errors) > 0 {
-					return fmt.Errorf("%v", errors)
 				}
 
 				return nil
@@ -241,11 +235,9 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 					return err
 				}
 
-				var errors []error
-
 				for _, vm := range vms.Items {
 					if IsContainsLabel(&vm, specialKey) {
-						errors = append(errors, fmt.Errorf("vm label %q was found in %s", specialKey, vm.Name))
+						return fmt.Errorf("vm label %q was found in %s", specialKey, vm.Name)
 					}
 
 					activePodName := GetActiveVirtualMachinePod(&vm)
@@ -256,12 +248,8 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 					}
 
 					if IsContainsLabel(&vmPod, specialKey) {
-						errors = append(errors, fmt.Errorf("vm pod label %q was found in %s", specialKey, vmPod.Name))
+						return fmt.Errorf("vm pod label %q was found in %s", specialKey, vmPod.Name)
 					}
-				}
-
-				if len(errors) > 0 {
-					return fmt.Errorf("%v", errors)
 				}
 
 				return nil
@@ -294,11 +282,9 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 					return err
 				}
 
-				var errors []error
-
 				for _, vm := range vms.Items {
 					if !IsContainsAnnotationWithValue(&vm, specialKey, specialValue) {
-						errors = append(errors, fmt.Errorf("vm annotation %q with value %q was not found in %s", specialKey, specialValue, vm.Name))
+						return fmt.Errorf("vm annotation %q with value %q was not found in %s", specialKey, specialValue, vm.Name)
 					}
 
 					activePodName := GetActiveVirtualMachinePod(&vm)
@@ -309,12 +295,8 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 					}
 
 					if !IsContainsAnnotationWithValue(&vmPod, specialKey, specialValue) {
-						errors = append(errors, fmt.Errorf("vm pod annotation %q with value %q was not found in %s", specialKey, specialValue, vmPod.Name))
+						return fmt.Errorf("vm pod annotation %q with value %q was not found in %s", specialKey, specialValue, vmPod.Name)
 					}
-				}
-
-				if len(errors) > 0 {
-					return fmt.Errorf("%v", errors)
 				}
 
 				return nil
@@ -345,11 +327,9 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 					return err
 				}
 
-				var errors []error
-
 				for _, vm := range vms.Items {
 					if IsContainsAnnotation(&vm, specialKey) {
-						errors = append(errors, fmt.Errorf("vm annotation %q was found in %s", specialKey, vm.Name))
+						return fmt.Errorf("vm annotation %q was found in %s", specialKey, vm.Name)
 					}
 
 					activePodName := GetActiveVirtualMachinePod(&vm)
@@ -360,12 +340,8 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 					}
 
 					if IsContainsAnnotation(&vmPod, specialKey) {
-						errors = append(errors, fmt.Errorf("vm pod annotation %q was found in %s", specialKey, vmPod.Name))
+						return fmt.Errorf("vm pod annotation %q was found in %s", specialKey, vmPod.Name)
 					}
-				}
-
-				if len(errors) > 0 {
-					return fmt.Errorf("%v", errors)
 				}
 
 				return nil

--- a/tests/e2e/vm_label_annotation_test.go
+++ b/tests/e2e/vm_label_annotation_test.go
@@ -112,7 +112,6 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 	)
 	testCaseLabel := map[string]string{"testcase": "vm-label-annotation"}
 	specialKeyValue := map[string]string{specialKey: specialValue}
-	vmPodLabel := map[string]string{"kubevirt.internal.virtualization.deckhouse.io": "virt-launcher"}
 
 	Context("Preparing the environment", func() {
 		It("sets the namespace", func() {
@@ -197,20 +196,16 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 					if !IsContainsLabelWithValue(&vm, specialKey, specialValue) {
 						errors = append(errors, fmt.Errorf("vm label %q with value %q was not found in %s", specialKey, specialValue, vm.Name))
 					}
-				}
 
-				var pods v1.PodList
-				err = GetObjects(kc.ResourcePod, &pods, kc.GetOptions{
-					Labels:    vmPodLabel,
-					Namespace: conf.Namespace,
-				})
-				if err != nil {
-					return err
-				}
+					activePodName := GetActiveVirtualMachinePod(&vm)
+					vmPod := v1.Pod{}
+					err = GetObject(kc.ResourcePod, activePodName, &vmPod, kc.GetOptions{Namespace: conf.Namespace})
+					if err != nil {
+						return err
+					}
 
-				for _, pod := range pods.Items {
-					if !IsContainsLabelWithValue(&pod, specialKey, specialValue) {
-						errors = append(errors, fmt.Errorf("pod label %q with value %q was not found in %s", specialKey, specialValue, pod.Name))
+					if !IsContainsLabelWithValue(&vmPod, specialKey, specialValue) {
+						errors = append(errors, fmt.Errorf("vm pod label %q with value %q was not found in %s", specialKey, specialValue, vmPod.Name))
 					}
 				}
 
@@ -252,20 +247,16 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 					if IsContainsLabel(&vm, specialKey) {
 						errors = append(errors, fmt.Errorf("vm label %q was found in %s", specialKey, vm.Name))
 					}
-				}
 
-				var pods v1.PodList
-				err = GetObjects(kc.ResourcePod, &pods, kc.GetOptions{
-					Labels:    vmPodLabel,
-					Namespace: conf.Namespace,
-				})
-				if err != nil {
-					return err
-				}
+					activePodName := GetActiveVirtualMachinePod(&vm)
+					vmPod := v1.Pod{}
+					err = GetObject(kc.ResourcePod, activePodName, &vmPod, kc.GetOptions{Namespace: conf.Namespace})
+					if err != nil {
+						return err
+					}
 
-				for _, pod := range pods.Items {
-					if IsContainsLabel(&pod, specialKey) {
-						errors = append(errors, fmt.Errorf("pod label %q was found in %s", specialKey, pod.Name))
+					if IsContainsLabel(&vmPod, specialKey) {
+						errors = append(errors, fmt.Errorf("vm pod label %q was found in %s", specialKey, vmPod.Name))
 					}
 				}
 
@@ -309,20 +300,16 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 					if !IsContainsAnnotationWithValue(&vm, specialKey, specialValue) {
 						errors = append(errors, fmt.Errorf("vm annotation %q with value %q was not found in %s", specialKey, specialValue, vm.Name))
 					}
-				}
 
-				var pods v1.PodList
-				err = GetObjects(kc.ResourcePod, &pods, kc.GetOptions{
-					Labels:    vmPodLabel,
-					Namespace: conf.Namespace,
-				})
-				if err != nil {
-					return err
-				}
+					activePodName := GetActiveVirtualMachinePod(&vm)
+					vmPod := v1.Pod{}
+					err = GetObject(kc.ResourcePod, activePodName, &vmPod, kc.GetOptions{Namespace: conf.Namespace})
+					if err != nil {
+						return err
+					}
 
-				for _, pod := range pods.Items {
-					if !IsContainsAnnotationWithValue(&pod, specialKey, specialValue) {
-						errors = append(errors, fmt.Errorf("pod annotation %q with value %q was not found in %s", specialKey, specialValue, pod.Name))
+					if !IsContainsAnnotationWithValue(&vmPod, specialKey, specialValue) {
+						errors = append(errors, fmt.Errorf("vm pod annotation %q with value %q was not found in %s", specialKey, specialValue, vmPod.Name))
 					}
 				}
 
@@ -364,20 +351,16 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 					if IsContainsAnnotation(&vm, specialKey) {
 						errors = append(errors, fmt.Errorf("vm annotation %q was found in %s", specialKey, vm.Name))
 					}
-				}
 
-				var pods v1.PodList
-				err = GetObjects(kc.ResourcePod, &pods, kc.GetOptions{
-					Labels:    vmPodLabel,
-					Namespace: conf.Namespace,
-				})
-				if err != nil {
-					return err
-				}
+					activePodName := GetActiveVirtualMachinePod(&vm)
+					vmPod := v1.Pod{}
+					err = GetObject(kc.ResourcePod, activePodName, &vmPod, kc.GetOptions{Namespace: conf.Namespace})
+					if err != nil {
+						return err
+					}
 
-				for _, pod := range pods.Items {
-					if IsContainsAnnotation(&pod, specialKey) {
-						errors = append(errors, fmt.Errorf("pod annotation %q was found in %s", specialKey, pod.Name))
+					if IsContainsAnnotation(&vmPod, specialKey) {
+						errors = append(errors, fmt.Errorf("vm pod annotation %q was found in %s", specialKey, vmPod.Name))
 					}
 				}
 


### PR DESCRIPTION
## Description
Fixed an issue where the resource state was not awaited and an immediate check was performed in the test for annotation and labeling.

## Why do we need it, and what problem does it solve?

## What is the expected result?

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: vm
type: test
summary: "fixed an issue where the resource state was not awaited and an immediate check was performed in the test for annotation and labeling" 
```
