### PR TITLE
fix(vmop): resolve resource hang in 'InProgress' state for Evict/Migrate

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vmop/internal/lifecycle.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/internal/lifecycle.go
@@ -116,7 +116,7 @@ func (h LifecycleHandler) Handle(ctx context.Context, s state.VMOperationState) 
 
 	if changed.Status.Phase == virtv2.VMOPPhaseInProgress {
 		log.Debug("Operation in progress, check if VM is completed", "vm.phase", vm.Status.Phase, "vmop.phase", changed.Status.Phase)
-		return h.checkOperationComplete(ctx, changed, vm)
+		return h.syncOperationComplete(ctx, changed, vm)
 	}
 
 	// At this point VMOP is in Pending phase, do some validation checks.
@@ -175,9 +175,9 @@ func (h LifecycleHandler) Name() string {
 	return lifecycleHandlerName
 }
 
-// checkOperationComplete detects if operation is completed and VM has desired phase.
+// syncOperationComplete detects if operation is completed and VM has desired phase.
 // TODO detect if VM is stuck to prevent infinite InProgress state.
-func (h LifecycleHandler) checkOperationComplete(ctx context.Context, changed *virtv2.VirtualMachineOperation, vm *virtv2.VirtualMachine) (reconcile.Result, error) {
+func (h LifecycleHandler) syncOperationComplete(ctx context.Context, changed *virtv2.VirtualMachineOperation, vm *virtv2.VirtualMachine) (reconcile.Result, error) {
 	completedCond := conditions.NewConditionBuilder(vmopcondition.TypeCompleted).
 		Generation(changed.GetGeneration())
 

--- a/images/virtualization-artifact/pkg/controller/vmop/vmop_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/vmop_reconciler.go
@@ -88,7 +88,7 @@ func (r *Reconciler) SetupController(_ context.Context, mgr manager.Manager, ctr
 			UpdateFunc: func(e event.UpdateEvent) bool {
 				oldVM := e.ObjectOld.(*virtv2.VirtualMachine)
 				newVM := e.ObjectNew.(*virtv2.VirtualMachine)
-				return oldVM.Status.Phase != newVM.Status.Phase
+				return oldVM.Status.Phase != newVM.Status.Phase || newVM.Status.MigrationState != nil
 			},
 		},
 	); err != nil {


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Resolved an issue where the VMOP (Virtual Machine Operation) resource remained stuck in the 'InProgress' state. The problem was reproducible only for the 'Evict' and 'Migrate' operation types.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [X] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: vmop
type: fix
summary: Resolve resource hang in 'InProgress' state for Evict/Migrate
```
