### PR TITLE
feat: enhance CMD instruction for the Bounder image

### DIFF
--- a/images/bounder/werf.inc.yaml
+++ b/images/bounder/werf.inc.yaml
@@ -1,3 +1,19 @@
 ---
 image: {{ $.ImageName }}
-from: {{ $.Images.BASE_SCRATCH }}
+fromImage: distroless
+import:
+  - image: {{ $.ImageName }}-binaries
+    add: /relocate
+    to: /
+    after: setup
+docker:
+  CMD: ["echo", "Hi, my name is Bounder. I’m here to fulfill my destiny… to mount PVCs and vanish into the void."]
+---
+{{- $binaries := "/usr/bin/echo" }}
+
+image: {{ $.ImageName }}-binaries
+final: false
+fromImage: base-alt-p11-binaries
+shell:
+  setup:
+    - ./relocate_binaries.sh -i "{{ $binaries }}" -o /relocate

--- a/images/virtualization-artifact/pkg/controller/bounder/bounder.go
+++ b/images/virtualization-artifact/pkg/controller/bounder/bounder.go
@@ -54,6 +54,7 @@ type PodSettings struct {
 	PriorityClassName    string
 	PVCName              string
 	NodePlacement        *provisioner.NodePlacement
+	Finalizer            string
 }
 
 // CreatePod creates and returns a pointer to a pod which is created based on the passed-in endpoint, secret
@@ -85,6 +86,9 @@ func (imp *Bounder) makeBounderPodSpec() (*corev1.Pod, error) {
 			Namespace: imp.PodSettings.Namespace,
 			Annotations: map[string]string{
 				annotations.AnnCreatedBy: "yes",
+			},
+			Finalizers: []string{
+				imp.PodSettings.Finalizer,
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				imp.PodSettings.OwnerReference,

--- a/images/virtualization-artifact/pkg/controller/service/bounder_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/bounder_service.go
@@ -184,5 +184,6 @@ func (s BounderPodService) GetPodSettings(ownerRef *metav1.OwnerReference, sup *
 		InstallerLabels:      map[string]string{},
 		ResourceRequirements: &s.requirements,
 		PVCName:              sup.PersistentVolumeClaim().Name,
+		Finalizer:            s.protection.GetFinalizer(),
 	}
 }

--- a/images/virtualization-artifact/pkg/controller/vi/internal/mock.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/mock.go
@@ -161,7 +161,7 @@ var _ Sources = &SourcesMock{}
 //
 //		// make and configure a mocked Sources
 //		mockedSources := &SourcesMock{
-//			ChangedFunc: func(contextMoqParam context.Context, vi *virtv2.VirtualImage) bool {
+//			ChangedFunc: func(ctx context.Context, vi *virtv2.VirtualImage) bool {
 //				panic("mock out the Changed method")
 //			},
 //			CleanUpFunc: func(ctx context.Context, vd *virtv2.VirtualImage) (bool, error) {
@@ -178,7 +178,7 @@ var _ Sources = &SourcesMock{}
 //	}
 type SourcesMock struct {
 	// ChangedFunc mocks the Changed method.
-	ChangedFunc func(contextMoqParam context.Context, vi *virtv2.VirtualImage) bool
+	ChangedFunc func(ctx context.Context, vi *virtv2.VirtualImage) bool
 
 	// CleanUpFunc mocks the CleanUp method.
 	CleanUpFunc func(ctx context.Context, vd *virtv2.VirtualImage) (bool, error)
@@ -190,8 +190,8 @@ type SourcesMock struct {
 	calls struct {
 		// Changed holds details about calls to the Changed method.
 		Changed []struct {
-			// ContextMoqParam is the contextMoqParam argument value.
-			ContextMoqParam context.Context
+			// Ctx is the ctx argument value.
+			Ctx context.Context
 			// Vi is the vi argument value.
 			Vi *virtv2.VirtualImage
 		}
@@ -214,21 +214,21 @@ type SourcesMock struct {
 }
 
 // Changed calls ChangedFunc.
-func (mock *SourcesMock) Changed(contextMoqParam context.Context, vi *virtv2.VirtualImage) bool {
+func (mock *SourcesMock) Changed(ctx context.Context, vi *virtv2.VirtualImage) bool {
 	if mock.ChangedFunc == nil {
 		panic("SourcesMock.ChangedFunc: method is nil but Sources.Changed was just called")
 	}
 	callInfo := struct {
-		ContextMoqParam context.Context
-		Vi              *virtv2.VirtualImage
+		Ctx context.Context
+		Vi  *virtv2.VirtualImage
 	}{
-		ContextMoqParam: contextMoqParam,
-		Vi:              vi,
+		Ctx: ctx,
+		Vi:  vi,
 	}
 	mock.lockChanged.Lock()
 	mock.calls.Changed = append(mock.calls.Changed, callInfo)
 	mock.lockChanged.Unlock()
-	return mock.ChangedFunc(contextMoqParam, vi)
+	return mock.ChangedFunc(ctx, vi)
 }
 
 // ChangedCalls gets all the calls that were made to Changed.
@@ -236,12 +236,12 @@ func (mock *SourcesMock) Changed(contextMoqParam context.Context, vi *virtv2.Vir
 //
 //	len(mockedSources.ChangedCalls())
 func (mock *SourcesMock) ChangedCalls() []struct {
-	ContextMoqParam context.Context
-	Vi              *virtv2.VirtualImage
+	Ctx context.Context
+	Vi  *virtv2.VirtualImage
 } {
 	var calls []struct {
-		ContextMoqParam context.Context
-		Vi              *virtv2.VirtualImage
+		Ctx context.Context
+		Vi  *virtv2.VirtualImage
 	}
 	mock.lockChanged.RLock()
 	calls = mock.calls.Changed

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/interfaces.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/interfaces.go
@@ -32,7 +32,7 @@ import (
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
-//go:generate moq -rm -out mock.go . Importer Uploader Stat Bounder Handler
+//go:generate moq -rm -out mock.go . Importer Uploader Stat Bounder Handler Disk
 
 type Importer interface {
 	step.CreatePodStepImporter
@@ -70,5 +70,9 @@ type Stat interface {
 type Bounder interface {
 	step.CreateBounderPodStepBounder
 	CleanUp(ctx context.Context, sup *supplements.Generator) (bool, error)
+	CleanUpSupplements(ctx context.Context, sup *supplements.Generator) (bool, error)
+}
+
+type Disk interface {
 	CleanUpSupplements(ctx context.Context, sup *supplements.Generator) (bool, error)
 }

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/mock.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/mock.go
@@ -21,6 +21,8 @@ package source
 
 import (
 	"context"
+	"sync"
+
 	"github.com/deckhouse/virtualization-controller/pkg/common/datasource"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/importer"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
@@ -32,7 +34,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sync"
 )
 
 // Ensure, that ImporterMock does implement Importer.
@@ -1944,5 +1945,77 @@ func (mock *HandlerMock) ValidateCalls() []struct {
 	mock.lockValidate.RLock()
 	calls = mock.calls.Validate
 	mock.lockValidate.RUnlock()
+	return calls
+}
+
+// Ensure, that DiskMock does implement Disk.
+// If this is not the case, regenerate this file with moq.
+var _ Disk = &DiskMock{}
+
+// DiskMock is a mock implementation of Disk.
+//
+//	func TestSomethingThatUsesDisk(t *testing.T) {
+//
+//		// make and configure a mocked Disk
+//		mockedDisk := &DiskMock{
+//			CleanUpSupplementsFunc: func(ctx context.Context, sup *supplements.Generator) (bool, error) {
+//				panic("mock out the CleanUpSupplements method")
+//			},
+//		}
+//
+//		// use mockedDisk in code that requires Disk
+//		// and then make assertions.
+//
+//	}
+type DiskMock struct {
+	// CleanUpSupplementsFunc mocks the CleanUpSupplements method.
+	CleanUpSupplementsFunc func(ctx context.Context, sup *supplements.Generator) (bool, error)
+
+	// calls tracks calls to the methods.
+	calls struct {
+		// CleanUpSupplements holds details about calls to the CleanUpSupplements method.
+		CleanUpSupplements []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Sup is the sup argument value.
+			Sup *supplements.Generator
+		}
+	}
+	lockCleanUpSupplements sync.RWMutex
+}
+
+// CleanUpSupplements calls CleanUpSupplementsFunc.
+func (mock *DiskMock) CleanUpSupplements(ctx context.Context, sup *supplements.Generator) (bool, error) {
+	if mock.CleanUpSupplementsFunc == nil {
+		panic("DiskMock.CleanUpSupplementsFunc: method is nil but Disk.CleanUpSupplements was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+		Sup *supplements.Generator
+	}{
+		Ctx: ctx,
+		Sup: sup,
+	}
+	mock.lockCleanUpSupplements.Lock()
+	mock.calls.CleanUpSupplements = append(mock.calls.CleanUpSupplements, callInfo)
+	mock.lockCleanUpSupplements.Unlock()
+	return mock.CleanUpSupplementsFunc(ctx, sup)
+}
+
+// CleanUpSupplementsCalls gets all the calls that were made to CleanUpSupplements.
+// Check the length with:
+//
+//	len(mockedDisk.CleanUpSupplementsCalls())
+func (mock *DiskMock) CleanUpSupplementsCalls() []struct {
+	Ctx context.Context
+	Sup *supplements.Generator
+} {
+	var calls []struct {
+		Ctx context.Context
+		Sup *supplements.Generator
+	}
+	mock.lockCleanUpSupplements.RLock()
+	calls = mock.calls.CleanUpSupplements
+	mock.lockCleanUpSupplements.RUnlock()
 	return calls
 }

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref.go
@@ -86,7 +86,7 @@ func NewObjectRefDataSource(
 		recorder:            recorder,
 		viObjectRefOnPvc:    NewObjectRefDataVirtualImageOnPVC(recorder, statService, importerService, dvcrSettings, client, diskService, storageClassService),
 		vdSyncer:            NewObjectRefVirtualDisk(recorder, importerService, client, diskService, dvcrSettings, statService, storageClassService),
-		vdSnapshotCRSyncer:  NewObjectRefVirtualDiskSnapshotCR(importerService, statService, client, dvcrSettings, recorder),
+		vdSnapshotCRSyncer:  NewObjectRefVirtualDiskSnapshotCR(importerService, statService, diskService, client, dvcrSettings, recorder),
 		vdSnapshotPVCSyncer: NewObjectRefVirtualDiskSnapshotPVC(importerService, statService, bounderService, client, dvcrSettings, recorder),
 	}
 }

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vdsnapshot_cr.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vdsnapshot_cr.go
@@ -45,12 +45,14 @@ type ObjectRefVirtualDiskSnapshotCR struct {
 	stat         Stat
 	client       client.Client
 	dvcrSettings *dvcr.Settings
+	diskService  Disk
 	recorder     eventrecord.EventRecorderLogger
 }
 
 func NewObjectRefVirtualDiskSnapshotCR(
 	importer Importer,
 	statService Stat,
+	diskService Disk,
 	client client.Client,
 	dvcrSettings *dvcr.Settings,
 	recorder eventrecord.EventRecorderLogger,
@@ -60,6 +62,7 @@ func NewObjectRefVirtualDiskSnapshotCR(
 		client:       client,
 		recorder:     recorder,
 		stat:         statService,
+		diskService:  diskService,
 		dvcrSettings: dvcrSettings,
 	}
 }
@@ -85,7 +88,7 @@ func (ds ObjectRefVirtualDiskSnapshotCR) Sync(ctx context.Context, vi *virtv2.Vi
 	}
 
 	return blockdevice.NewStepTakers[*virtv2.VirtualImage](
-		step.NewReadyContainerRegistryStep(pod, ds.importer, ds.stat, ds.recorder, cb),
+		step.NewReadyContainerRegistryStep(pod, ds.importer, ds.diskService, ds.stat, ds.recorder, cb),
 		step.NewTerminatingStep(pvc),
 		step.NewCreatePersistentVolumeClaimStep(pvc, ds.recorder, ds.client, cb),
 		step.NewCreatePodStep(pod, ds.dvcrSettings, ds.recorder, ds.importer, ds.stat, cb),

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vdsnapshot_cr_test.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vdsnapshot_cr_test.go
@@ -54,18 +54,19 @@ func TestHandlers(t *testing.T) {
 
 var _ = Describe("ObjectRef VirtualImageSnapshot ContainerRegistry", func() {
 	var (
-		ctx        context.Context
-		scheme     *runtime.Scheme
-		vi         *virtv2.VirtualImage
-		vs         *vsv1.VolumeSnapshot
-		sc         *storagev1.StorageClass
-		vdSnapshot *virtv2.VirtualDiskSnapshot
-		pvc        *corev1.PersistentVolumeClaim
-		pod        *corev1.Pod
-		settings   *dvcr.Settings
-		recorder   eventrecord.EventRecorderLogger
-		importer   *ImporterMock
-		stat       *StatMock
+		ctx         context.Context
+		scheme      *runtime.Scheme
+		vi          *virtv2.VirtualImage
+		vs          *vsv1.VolumeSnapshot
+		sc          *storagev1.StorageClass
+		vdSnapshot  *virtv2.VirtualDiskSnapshot
+		pvc         *corev1.PersistentVolumeClaim
+		pod         *corev1.Pod
+		settings    *dvcr.Settings
+		recorder    eventrecord.EventRecorderLogger
+		diskService *DiskMock
+		importer    *ImporterMock
+		stat        *StatMock
 	)
 
 	BeforeEach(func() {
@@ -106,6 +107,13 @@ var _ = Describe("ObjectRef VirtualImageSnapshot ContainerRegistry", func() {
 				return "N%"
 			},
 		}
+
+		diskService = &DiskMock{
+			CleanUpSupplementsFunc: func(ctx context.Context, sup *supplements.Generator) (bool, error) {
+				return false, nil
+			},
+		}
+
 		settings = &dvcr.Settings{}
 
 		sc = &storagev1.StorageClass{
@@ -199,7 +207,7 @@ var _ = Describe("ObjectRef VirtualImageSnapshot ContainerRegistry", func() {
 					},
 				}).Build()
 
-			syncer := NewObjectRefVirtualDiskSnapshotCR(importer, stat, client, settings, recorder)
+			syncer := NewObjectRefVirtualDiskSnapshotCR(importer, stat, diskService, client, settings, recorder)
 
 			res, err := syncer.Sync(ctx, vi)
 			Expect(err).ToNot(HaveOccurred())
@@ -222,7 +230,7 @@ var _ = Describe("ObjectRef VirtualImageSnapshot ContainerRegistry", func() {
 			pod.Status.Phase = corev1.PodPending
 			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc, pod).Build()
 
-			syncer := NewObjectRefVirtualDiskSnapshotCR(importer, stat, client, nil, recorder)
+			syncer := NewObjectRefVirtualDiskSnapshotCR(importer, stat, diskService, client, nil, recorder)
 
 			res, err := syncer.Sync(ctx, vi)
 			Expect(err).ToNot(HaveOccurred())
@@ -236,7 +244,7 @@ var _ = Describe("ObjectRef VirtualImageSnapshot ContainerRegistry", func() {
 			pod.Status.Phase = corev1.PodPending
 			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc, pod).Build()
 
-			syncer := NewObjectRefVirtualDiskSnapshotCR(importer, stat, client, nil, recorder)
+			syncer := NewObjectRefVirtualDiskSnapshotCR(importer, stat, diskService, client, nil, recorder)
 
 			res, err := syncer.Sync(ctx, vi)
 			Expect(err).ToNot(HaveOccurred())
@@ -250,7 +258,7 @@ var _ = Describe("ObjectRef VirtualImageSnapshot ContainerRegistry", func() {
 			pod.Status.Phase = corev1.PodRunning
 			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc, pod).Build()
 
-			syncer := NewObjectRefVirtualDiskSnapshotCR(importer, stat, client, nil, recorder)
+			syncer := NewObjectRefVirtualDiskSnapshotCR(importer, stat, diskService, client, nil, recorder)
 
 			res, err := syncer.Sync(ctx, vi)
 			Expect(err).ToNot(HaveOccurred())
@@ -266,7 +274,7 @@ var _ = Describe("ObjectRef VirtualImageSnapshot ContainerRegistry", func() {
 			pod.Status.Phase = corev1.PodSucceeded
 			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
 
-			syncer := NewObjectRefVirtualDiskSnapshotCR(importer, stat, client, nil, recorder)
+			syncer := NewObjectRefVirtualDiskSnapshotCR(importer, stat, diskService, client, nil, recorder)
 
 			res, err := syncer.Sync(ctx, vi)
 			Expect(err).ToNot(HaveOccurred())
@@ -287,7 +295,7 @@ var _ = Describe("ObjectRef VirtualImageSnapshot ContainerRegistry", func() {
 
 			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects().Build()
 
-			syncer := NewObjectRefVirtualDiskSnapshotCR(importer, stat, client, nil, recorder)
+			syncer := NewObjectRefVirtualDiskSnapshotCR(importer, stat, diskService, client, nil, recorder)
 
 			res, err := syncer.Sync(ctx, vi)
 			Expect(err).ToNot(HaveOccurred())

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vdsnapshot_pvc.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vdsnapshot_pvc.go
@@ -80,7 +80,7 @@ func (ds ObjectRefVirtualDiskSnapshotPVC) Sync(ctx context.Context, vi *virtv2.V
 	}
 
 	return blockdevice.NewStepTakers[*virtv2.VirtualImage](
-		step.NewReadyPersistentVolumeClaimStep(pvc, ds.recorder, cb),
+		step.NewReadyPersistentVolumeClaimStep(pvc, ds.bounder, ds.recorder, cb),
 		step.NewTerminatingStep(pvc),
 		step.NewCreatePersistentVolumeClaimStep(pvc, ds.recorder, ds.client, cb),
 		step.NewCreateBounderPodStep(pvc, ds.bounder, ds.client, ds.recorder, cb),

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vdsnapshot_pvc_test.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vdsnapshot_pvc_test.go
@@ -55,6 +55,7 @@ var _ = Describe("ObjectRef VirtualImageSnapshot PersistentVolumeClaim", func() 
 		settings   *dvcr.Settings
 		recorder   eventrecord.EventRecorderLogger
 		importer   *ImporterMock
+		bounder    *BounderMock
 		stat       *StatMock
 	)
 
@@ -72,6 +73,11 @@ var _ = Describe("ObjectRef VirtualImageSnapshot PersistentVolumeClaim", func() 
 		}
 
 		importer = &ImporterMock{
+			CleanUpSupplementsFunc: func(_ context.Context, _ *supplements.Generator) (bool, error) {
+				return false, nil
+			},
+		}
+		bounder = &BounderMock{
 			CleanUpSupplementsFunc: func(_ context.Context, _ *supplements.Generator) (bool, error) {
 				return false, nil
 			},
@@ -196,7 +202,7 @@ var _ = Describe("ObjectRef VirtualImageSnapshot PersistentVolumeClaim", func() 
 			pvc.Status.Phase = corev1.ClaimBound
 			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc).Build()
 
-			syncer := NewObjectRefVirtualDiskSnapshotPVC(importer, stat, nil, client, nil, recorder)
+			syncer := NewObjectRefVirtualDiskSnapshotPVC(importer, stat, bounder, client, nil, recorder)
 
 			res, err := syncer.Sync(ctx, vi)
 			Expect(err).ToNot(HaveOccurred())

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/step/ready_pvc_step.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/step/ready_pvc_step.go
@@ -50,12 +50,13 @@ type ReadyPersistentVolumeClaimStep struct {
 
 func NewReadyPersistentVolumeClaimStep(
 	pvc *corev1.PersistentVolumeClaim,
-	bounder CreateBounderPodStepBounder,
+	bounder ReadyPersistentVolumeClaimStepBounder,
 	recorder eventrecord.EventRecorderLogger,
 	cb *conditions.ConditionBuilder,
 ) *ReadyPersistentVolumeClaimStep {
 	return &ReadyPersistentVolumeClaimStep{
 		pvc:      pvc,
+		bounder:  bounder,
 		recorder: recorder,
 		cb:       cb,
 	}

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/step/ready_pvc_step.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/step/ready_pvc_step.go
@@ -27,7 +27,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/deckhouse/virtualization-controller/pkg/common/annotations"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/supplements"
 	"github.com/deckhouse/virtualization-controller/pkg/eventrecord"
 	"github.com/deckhouse/virtualization-controller/pkg/logger"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
@@ -35,14 +37,20 @@ import (
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vicondition"
 )
 
+type ReadyPersistentVolumeClaimStepBounder interface {
+	CleanUpSupplements(ctx context.Context, sup *supplements.Generator) (bool, error)
+}
+
 type ReadyPersistentVolumeClaimStep struct {
 	pvc      *corev1.PersistentVolumeClaim
+	bounder  ReadyPersistentVolumeClaimStepBounder
 	recorder eventrecord.EventRecorderLogger
 	cb       *conditions.ConditionBuilder
 }
 
 func NewReadyPersistentVolumeClaimStep(
 	pvc *corev1.PersistentVolumeClaim,
+	bounder CreateBounderPodStepBounder,
 	recorder eventrecord.EventRecorderLogger,
 	cb *conditions.ConditionBuilder,
 ) *ReadyPersistentVolumeClaimStep {
@@ -85,6 +93,11 @@ func (s ReadyPersistentVolumeClaimStep) Take(ctx context.Context, vi *virtv2.Vir
 	case corev1.ClaimBound:
 		log.Debug("Image is Ready")
 
+		err := s.cleanUpSupplements(ctx, vi)
+		if err != nil {
+			return nil, fmt.Errorf("clean up supplements: %w", err)
+		}
+
 		if vi.Status.Phase != virtv2.ImageReady {
 			s.recorder.Event(
 				vi,
@@ -123,4 +136,15 @@ func (s ReadyPersistentVolumeClaimStep) Take(ctx context.Context, vi *virtv2.Vir
 	default:
 		return nil, nil
 	}
+}
+
+func (s ReadyPersistentVolumeClaimStep) cleanUpSupplements(ctx context.Context, vi *virtv2.VirtualImage) error {
+	supgen := supplements.NewGenerator(annotations.VIShortName, vi.Name, vi.Namespace, vi.UID)
+
+	_, err := s.bounder.CleanUpSupplements(ctx, supgen)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Description
Bug fixes related to VirtualImage and VDSnapshot ObjectRef:
- Added CMD for Bounder image
- Introduced finalizer for Bounder
- Cleaned up resources after Bounder completes its work
- Removed temporary PVC for DVCR target

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: vi
type: fix
summary: bug fixes related to VirtualImage and VDSnapshot ObjectRef
```
