### PR TITLE
refactor(vd): refactor handle inuse condition

### DIFF
--- a/api/core/v1alpha2/cvicondition/condition.go
+++ b/api/core/v1alpha2/cvicondition/condition.go
@@ -56,8 +56,8 @@ const (
 	ClusterImageNotReady DatasourceReadyReason = "ClusterImageNotReady"
 	// VirtualDiskNotReady indicates that the `VirtualDisk` datasource is not ready, which prevents the import process from starting.
 	VirtualDiskNotReady DatasourceReadyReason = "VirtualDiskNotReady"
-	// VirtualDiskInUseInRunningVirtualMachine indicates that the `VirtualDisk` attached to running `VirtualMachine`
-	VirtualDiskInUseInRunningVirtualMachine DatasourceReadyReason = "VirtualDiskInUseInRunningVirtualMachine"
+	// VirtualDiskNotReadyForUse indicates that the `VirtualDisk` not ready for use, which prevents the import process from starting.
+	VirtualDiskNotReadyForUse DatasourceReadyReason = "VirtualDiskNotReadyForUse"
 
 	// WaitForUserUpload indicates that the `ClusterVirtualImage` is waiting for the user to upload a datasource for the import process to continue.
 	WaitForUserUpload ReadyReason = "WaitForUserUpload"

--- a/api/core/v1alpha2/cvicondition/condition.go
+++ b/api/core/v1alpha2/cvicondition/condition.go
@@ -58,6 +58,8 @@ const (
 	VirtualDiskNotReady DatasourceReadyReason = "VirtualDiskNotReady"
 	// VirtualDiskNotReadyForUse indicates that the `VirtualDisk` not ready for use, which prevents the import process from starting.
 	VirtualDiskNotReadyForUse DatasourceReadyReason = "VirtualDiskNotReadyForUse"
+	// VirtualDiskAttachedToVirtualMachine indicates that the `VirtualDisk` attached to `VirtualMachine`.
+	VirtualDiskAttachedToVirtualMachine DatasourceReadyReason = "VirtualDiskAttachedToVirtualMachine"
 
 	// WaitForUserUpload indicates that the `ClusterVirtualImage` is waiting for the user to upload a datasource for the import process to continue.
 	WaitForUserUpload ReadyReason = "WaitForUserUpload"

--- a/api/core/v1alpha2/vdcondition/condition.go
+++ b/api/core/v1alpha2/vdcondition/condition.go
@@ -128,7 +128,31 @@ const (
 	StorageClassReady StorageClassReadyReason = "StorageClassReady"
 	// StorageClassNotReady indicates that the storage class is not ready
 	StorageClassNotReady StorageClassReadyReason = "StorageClassNotReady"
+)
 
+/*
+The status transitions of an 'InUse' condition depend on its current usage context:
+
+- If an image creation object (VI/CVI) is detected and its phase is `Pending` or `Provisioning`,
+the condition's reason is set to `UsedForImageCreation`.
+
+- If a VirtualMachine is detected and its phase is anything other than `Pending` or `Stopped`,
+the condition's reason is set to `AttachedToVirtualMachine`.
+
+- If the VirtualMachine is in the `Pending` phase:
+  - If any of the conditions `VirtualMachineIPAddressReady`, `ProvisioningReady`, or `VirtualMachineClassReady` are `False`,
+    the condition's reason is set to `NotInUse`.
+  - If all these conditions are `True`, the condition's reason is set to `AttachedToVirtualMachine`.
+
+- If the VirtualMachine is in the `Stopped` phase:
+  - If there is a state change in progress (indicating a restart) or if the Pod's phase is `Running`,
+    the condition's reason is set to `AttachedToVirtualMachine`.
+  - Otherwise, the condition's reason is set to `NotInUse`.
+
+- If both a VirtualMachine and an image are detected, it gives priority to the VirtualMachine and sets
+the `InUse` condition's reason to `AttachedToVirtualMachine`.
+*/
+const (
 	// UsedForImageCreation indicates that the VirtualDisk is used for create image.
 	UsedForImageCreation InUseReason = "UsedForImageCreation"
 	// AttachedToVirtualMachine indicates that the VirtualDisk is attached to VirtualMachine.

--- a/api/core/v1alpha2/vicondition/condition.go
+++ b/api/core/v1alpha2/vicondition/condition.go
@@ -68,6 +68,8 @@ const (
 	VirtualDiskSnapshotNotReady DatasourceReadyReason = "VirtualDiskSnapshotNotReady"
 	// VirtualDiskNotReadyForUse indicates that the `VirtualDisk` not ready for use, which prevents the import process from starting.
 	VirtualDiskNotReadyForUse DatasourceReadyReason = "VirtualDiskNotReadyForUse"
+	// VirtualDiskAttachedToVirtualMachine indicates that the `VirtualDisk` attached to `VirtualMachine`.
+	VirtualDiskAttachedToVirtualMachine DatasourceReadyReason = "VirtualDiskAttachedToVirtualMachine"
 
 	// WaitForUserUpload indicates that the `VirtualImage` is waiting for the user to upload a datasource for the import process to continue.
 	WaitForUserUpload ReadyReason = "WaitForUserUpload"

--- a/api/core/v1alpha2/vicondition/condition.go
+++ b/api/core/v1alpha2/vicondition/condition.go
@@ -66,8 +66,8 @@ const (
 	VirtualDiskNotReady DatasourceReadyReason = "VirtualDiskNotReady"
 	// VirtualDiskSnapshotNotReady indicates that the `VirtualDiskSnapshot` datasource is not ready, which prevents the import process from starting.
 	VirtualDiskSnapshotNotReady DatasourceReadyReason = "VirtualDiskSnapshotNotReady"
-	// VirtualDiskInUseInRunningVirtualMachine indicates that the `VirtualDisk` attached to running `VirtualMachine`
-	VirtualDiskInUseInRunningVirtualMachine DatasourceReadyReason = "VirtualDiskInUseInRunningVirtualMachine"
+	// VirtualDiskNotReadyForUse indicates that the `VirtualDisk` not ready for use, which prevents the import process from starting.
+	VirtualDiskNotReadyForUse DatasourceReadyReason = "VirtualDiskNotReadyForUse"
 
 	// WaitForUserUpload indicates that the `VirtualImage` is waiting for the user to upload a datasource for the import process to continue.
 	WaitForUserUpload ReadyReason = "WaitForUserUpload"

--- a/images/virtualization-artifact/pkg/controller/cvi/cvi_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/cvi_reconciler.go
@@ -170,7 +170,7 @@ func (r *Reconciler) SetupController(_ context.Context, mgr manager.Manager, ctr
 				oldInUseCondition, _ := conditions.GetCondition(vdcondition.InUseType, oldVD.Status.Conditions)
 				newInUseCondition, _ := conditions.GetCondition(vdcondition.InUseType, newVD.Status.Conditions)
 
-				if oldVD.Status.Phase != newVD.Status.Phase || len(oldVD.Status.AttachedToVirtualMachines) != len(newVD.Status.AttachedToVirtualMachines) || oldInUseCondition.Status != newInUseCondition.Status {
+				if oldVD.Status.Phase != newVD.Status.Phase || len(oldVD.Status.AttachedToVirtualMachines) != len(newVD.Status.AttachedToVirtualMachines) || oldInUseCondition != newInUseCondition {
 					return true
 				}
 

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/datasource_ready.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/datasource_ready.go
@@ -93,7 +93,13 @@ func (h DatasourceReadyHandler) Handle(ctx context.Context, cvi *virtv2.ClusterV
 		cb.
 			Status(metav1.ConditionFalse).
 			Reason(cvicondition.VirtualDiskNotReadyForUse).
-			Message(service.CapitalizeFirstLetter(err.Error()))
+			Message(service.CapitalizeFirstLetter(err.Error() + "."))
+		return reconcile.Result{}, nil
+	case errors.As(err, &source.VirtualDiskAttachedToVirtualMachineError{}):
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(cvicondition.VirtualDiskAttachedToVirtualMachine).
+			Message(service.CapitalizeFirstLetter(err.Error() + "."))
 		return reconcile.Result{}, nil
 	default:
 		return reconcile.Result{}, err

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/datasource_ready.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/datasource_ready.go
@@ -89,10 +89,10 @@ func (h DatasourceReadyHandler) Handle(ctx context.Context, cvi *virtv2.ClusterV
 			Reason(cvicondition.VirtualDiskNotReady).
 			Message(service.CapitalizeFirstLetter(err.Error()))
 		return reconcile.Result{}, nil
-	case errors.As(err, &source.VirtualDiskNotAllowedForUseError{}):
+	case errors.As(err, &source.VirtualDiskNotReadyForUseError{}):
 		cb.
 			Status(metav1.ConditionFalse).
-			Reason(cvicondition.VirtualDiskInUseInRunningVirtualMachine).
+			Reason(cvicondition.VirtualDiskNotReadyForUse).
 			Message(service.CapitalizeFirstLetter(err.Error()))
 		return reconcile.Result{}, nil
 	default:

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/errors.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/errors.go
@@ -65,16 +65,16 @@ func NewVirtualDiskNotReadyError(name string) error {
 	}
 }
 
-type VirtualDiskNotAllowedForUseError struct {
+type VirtualDiskNotReadyForUseError struct {
 	name string
 }
 
-func (e VirtualDiskNotAllowedForUseError) Error() string {
-	return fmt.Sprintf("the VirtualDisk %s attached to VirtualMachine", e.name)
+func (e VirtualDiskNotReadyForUseError) Error() string {
+	return fmt.Sprintf("the VirtualDisk %s not ready for use", e.name)
 }
 
 func NewVirtualDiskNotAllowedForUseError(name string) error {
-	return VirtualDiskNotAllowedForUseError{
+	return VirtualDiskNotReadyForUseError{
 		name: name,
 	}
 }

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/errors.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/errors.go
@@ -73,8 +73,22 @@ func (e VirtualDiskNotReadyForUseError) Error() string {
 	return fmt.Sprintf("the VirtualDisk %s not ready for use", e.name)
 }
 
-func NewVirtualDiskNotAllowedForUseError(name string) error {
+func NewVirtualDiskNotReadyForUseError(name string) error {
 	return VirtualDiskNotReadyForUseError{
+		name: name,
+	}
+}
+
+type VirtualDiskAttachedToVirtualMachineError struct {
+	name string
+}
+
+func (e VirtualDiskAttachedToVirtualMachineError) Error() string {
+	return fmt.Sprintf("the VirtualDisk %s attached to VirtualMachine", e.name)
+}
+
+func NewVirtualDiskAttachedToVirtualMachineError(name string) error {
+	return VirtualDiskAttachedToVirtualMachineError{
 		name: name,
 	}
 }

--- a/images/virtualization-artifact/pkg/controller/vd/internal/inuse.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/inuse.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,13 +37,7 @@ import (
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmcondition"
 )
 
-type reasonString struct {
-	value string
-}
-
-func (rs reasonString) String() string {
-	return rs.value
-}
+var imagePhasesUsingDisk = []virtv2.ImagePhase{virtv2.ImageProvisioning, virtv2.ImagePending}
 
 type InUseHandler struct {
 	client client.Client
@@ -66,130 +61,55 @@ func (h InUseHandler) Handle(ctx context.Context, vd *virtv2.VirtualDisk) (recon
 	}
 
 	usedByVM, usedByImage := false, false
+	var err error
 
-	var vms virtv2.VirtualMachineList
-	err := h.client.List(ctx, &vms, &client.ListOptions{
-		Namespace: vd.GetNamespace(),
-	})
-	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("error getting virtual machines: %w", err)
-	}
+	if inUseCondition.Reason != vdcondition.UsedForImageCreation.String() {
+		usedByVM, err = h.checkUsageByVM(ctx, vd)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
 
-	for _, vm := range vms.Items {
-		if h.isVDAttachedToVM(vd.GetName(), vm) {
-			if vm.Status.Phase != virtv2.MachineStopped {
-				usedByVM = isVMCanStart(vm.Status.Conditions)
-
-				if usedByVM {
-					break
-				}
-			} else {
-				kvvm, err := object.FetchObject(ctx, types.NamespacedName{Name: vm.Name, Namespace: vm.Namespace}, h.client, &virtv1.VirtualMachine{})
-				if err != nil {
-					return reconcile.Result{}, fmt.Errorf("error getting kvvms: %w", err)
-				}
-
-				if kvvm != nil && kvvm.Status.StateChangeRequests != nil {
-					usedByVM = true
-					break
-				}
-
-				podList := corev1.PodList{}
-				err = h.client.List(ctx, &podList, &client.ListOptions{
-					Namespace:     vm.GetNamespace(),
-					LabelSelector: labels.SelectorFromSet(map[string]string{virtv1.VirtualMachineNameLabel: vm.GetName()}),
-				})
-				if err != nil {
-					return reconcile.Result{}, fmt.Errorf("unable to list virt-launcher Pod for VM %q: %w", vm.GetName(), err)
-				}
-
-				for _, pod := range podList.Items {
-					if pod.Status.Phase == corev1.PodRunning {
-						usedByVM = true
-						break
-					}
-				}
+		if !usedByVM {
+			usedByImage, err = h.checkImageUsage(ctx, vd)
+			if err != nil {
+				return reconcile.Result{}, err
 			}
 		}
-	}
-
-	var vis virtv2.VirtualImageList
-	err = h.client.List(ctx, &vis, &client.ListOptions{
-		Namespace: vd.GetNamespace(),
-	})
-	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("error getting virtual images: %w", err)
-	}
-
-	allowedPhases := []virtv2.ImagePhase{virtv2.ImageProvisioning, virtv2.ImagePending}
-
-	for _, vi := range vis.Items {
-		if slices.Contains(allowedPhases, vi.Status.Phase) &&
-			vi.Spec.DataSource.Type == virtv2.DataSourceTypeObjectRef &&
-			vi.Spec.DataSource.ObjectRef != nil &&
-			vi.Spec.DataSource.ObjectRef.Kind == virtv2.VirtualDiskKind &&
-			vi.Spec.DataSource.ObjectRef.Name == vd.Name {
-			usedByImage = true
-			break
+	} else {
+		usedByImage, err = h.checkImageUsage(ctx, vd)
+		if err != nil {
+			return reconcile.Result{}, err
 		}
-	}
 
-	var cvis virtv2.ClusterVirtualImageList
-	err = h.client.List(ctx, &cvis, &client.ListOptions{})
-	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("error getting cluster virtual images: %w", err)
-	}
-	for _, cvi := range cvis.Items {
-		if slices.Contains(allowedPhases, cvi.Status.Phase) &&
-			cvi.Spec.DataSource.Type == virtv2.DataSourceTypeObjectRef &&
-			cvi.Spec.DataSource.ObjectRef != nil &&
-			cvi.Spec.DataSource.ObjectRef.Kind == virtv2.VirtualDiskKind &&
-			cvi.Spec.DataSource.ObjectRef.Name == vd.Name {
-			usedByImage = true
+		if !usedByImage {
+			usedByVM, err = h.checkUsageByVM(ctx, vd)
+			if err != nil {
+				return reconcile.Result{}, err
+			}
 		}
 	}
 
 	cb := conditions.NewConditionBuilder(vdcondition.InUseType)
 	switch {
-	case usedByVM && inUseCondition.Status != metav1.ConditionTrue:
-		cb.
-			Generation(vd.Generation).
+	case usedByVM:
+		cb.Generation(vd.Generation).
 			Status(metav1.ConditionTrue).
 			Reason(vdcondition.AttachedToVirtualMachine).
-			Message("")
-		conditions.SetCondition(cb, &vd.Status.Conditions)
-		return reconcile.Result{}, nil
-	case usedByImage && inUseCondition.Status != metav1.ConditionTrue:
-		cb.
-			Generation(vd.Generation).
+			Message("").
+			LastTransitionTime(time.Now())
+	case usedByImage:
+		cb.Generation(vd.Generation).
 			Status(metav1.ConditionTrue).
 			Reason(vdcondition.UsedForImageCreation).
-			Message("")
-		conditions.SetCondition(cb, &vd.Status.Conditions)
-		return reconcile.Result{}, nil
+			Message("").
+			LastTransitionTime(time.Now())
 	default:
-		setNotInUse := false
-
-		if inUseCondition.Reason == vdcondition.AttachedToVirtualMachine.String() && !usedByVM {
-			setNotInUse = true
-		}
-
-		if inUseCondition.Reason == vdcondition.UsedForImageCreation.String() && !usedByImage {
-			setNotInUse = true
-		}
-
-		if setNotInUse {
-			cb.Generation(vd.Generation).Status(metav1.ConditionFalse).Reason(vdcondition.NotInUse).Message("")
-			conditions.SetCondition(cb, &vd.Status.Conditions)
-			// TODO redesign the handler's operation to change the logic for updating the Reason on the fly without intermediate switching to False and remove the requeue.
-			return reconcile.Result{Requeue: true}, nil
-		}
+		cb.Generation(vd.Generation).
+			Status(metav1.ConditionFalse).
+			Reason(vdcondition.NotInUse).
+			Message("")
 	}
 
-	cb.Generation(vd.Generation).
-		Status(inUseCondition.Status).
-		Message(inUseCondition.Message).
-		Reason(reasonString{inUseCondition.Reason})
 	conditions.SetCondition(cb, &vd.Status.Conditions)
 	return reconcile.Result{}, nil
 }
@@ -204,10 +124,11 @@ func (h InUseHandler) isVDAttachedToVM(vdName string, vm virtv2.VirtualMachine) 
 	return false
 }
 
-func isVMCanStart(conditions []metav1.Condition) bool {
+func canStartVM(conditions []metav1.Condition) bool {
 	critConditions := []string{
 		vmcondition.TypeIPAddressReady.String(),
 		vmcondition.TypeClassReady.String(),
+		vmcondition.TypeProvisioningReady.String(),
 	}
 
 	for _, c := range conditions {
@@ -217,4 +138,116 @@ func isVMCanStart(conditions []metav1.Condition) bool {
 	}
 
 	return true
+}
+
+func (h InUseHandler) checkImageUsage(ctx context.Context, vd *virtv2.VirtualDisk) (bool, error) {
+	usedByImage, err := h.checkUsageByVI(ctx, vd)
+	if err != nil {
+		return false, err
+	}
+	if !usedByImage {
+		usedByImage, err = h.checkUsageByCVI(ctx, vd)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	return usedByImage, nil
+}
+
+func (h InUseHandler) checkUsageByVM(ctx context.Context, vd *virtv2.VirtualDisk) (bool, error) {
+	var vms virtv2.VirtualMachineList
+	err := h.client.List(ctx, &vms, &client.ListOptions{
+		Namespace: vd.GetNamespace(),
+	})
+	if err != nil {
+		return false, fmt.Errorf("error getting virtual machines: %w", err)
+	}
+
+	for _, vm := range vms.Items {
+		if !h.isVDAttachedToVM(vd.GetName(), vm) {
+			continue
+		}
+
+		switch vm.Status.Phase {
+		case "":
+			return false, nil
+
+		case virtv2.MachinePending:
+			usedByVM := canStartVM(vm.Status.Conditions)
+
+			if usedByVM {
+				return true, nil
+			}
+		case virtv2.MachineStopped:
+			kvvm, err := object.FetchObject(ctx, types.NamespacedName{Name: vm.Name, Namespace: vm.Namespace}, h.client, &virtv1.VirtualMachine{})
+			if err != nil {
+				return false, fmt.Errorf("error getting kvvms: %w", err)
+			}
+
+			if kvvm != nil && kvvm.Status.StateChangeRequests != nil {
+				return true, nil
+			}
+
+			podList := corev1.PodList{}
+			err = h.client.List(ctx, &podList, &client.ListOptions{
+				Namespace:     vm.GetNamespace(),
+				LabelSelector: labels.SelectorFromSet(map[string]string{virtv1.VirtualMachineNameLabel: vm.GetName()}),
+			})
+			if err != nil {
+				return false, fmt.Errorf("unable to list virt-launcher Pod for VM %q: %w", vm.GetName(), err)
+			}
+
+			for _, pod := range podList.Items {
+				if pod.Status.Phase == corev1.PodRunning {
+					return true, nil
+				}
+			}
+		default:
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (h InUseHandler) checkUsageByVI(ctx context.Context, vd *virtv2.VirtualDisk) (bool, error) {
+	var vis virtv2.VirtualImageList
+	err := h.client.List(ctx, &vis, &client.ListOptions{
+		Namespace: vd.GetNamespace(),
+	})
+	if err != nil {
+		return false, fmt.Errorf("error getting virtual images: %w", err)
+	}
+
+	for _, vi := range vis.Items {
+		if slices.Contains(imagePhasesUsingDisk, vi.Status.Phase) &&
+			vi.Spec.DataSource.Type == virtv2.DataSourceTypeObjectRef &&
+			vi.Spec.DataSource.ObjectRef != nil &&
+			vi.Spec.DataSource.ObjectRef.Kind == virtv2.VirtualDiskKind &&
+			vi.Spec.DataSource.ObjectRef.Name == vd.Name {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (h InUseHandler) checkUsageByCVI(ctx context.Context, vd *virtv2.VirtualDisk) (bool, error) {
+	var cvis virtv2.ClusterVirtualImageList
+	err := h.client.List(ctx, &cvis, &client.ListOptions{})
+	if err != nil {
+		return false, fmt.Errorf("error getting cluster virtual images: %w", err)
+	}
+	for _, cvi := range cvis.Items {
+		if slices.Contains(imagePhasesUsingDisk, cvi.Status.Phase) &&
+			cvi.Spec.DataSource.Type == virtv2.DataSourceTypeObjectRef &&
+			cvi.Spec.DataSource.ObjectRef != nil &&
+			cvi.Spec.DataSource.ObjectRef.Kind == virtv2.VirtualDiskKind &&
+			cvi.Spec.DataSource.ObjectRef.Name == vd.Name {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }

--- a/images/virtualization-artifact/pkg/controller/vi/internal/datasource_ready.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/datasource_ready.go
@@ -101,6 +101,12 @@ func (h DatasourceReadyHandler) Handle(ctx context.Context, vi *virtv2.VirtualIm
 			Reason(vicondition.VirtualDiskNotReadyForUse).
 			Message(service.CapitalizeFirstLetter(err.Error() + "."))
 		return reconcile.Result{}, nil
+	case errors.As(err, &source.VirtualDiskAttachedToVirtualMachineError{}):
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(vicondition.VirtualDiskAttachedToVirtualMachine).
+			Message(service.CapitalizeFirstLetter(err.Error() + "."))
+		return reconcile.Result{}, nil
 	default:
 		return reconcile.Result{}, err
 	}

--- a/images/virtualization-artifact/pkg/controller/vi/internal/datasource_ready.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/datasource_ready.go
@@ -95,10 +95,10 @@ func (h DatasourceReadyHandler) Handle(ctx context.Context, vi *virtv2.VirtualIm
 			Reason(vicondition.VirtualDiskSnapshotNotReady).
 			Message(service.CapitalizeFirstLetter(err.Error() + "."))
 		return reconcile.Result{}, nil
-	case errors.As(err, &source.VirtualDiskNotAllowedForUseError{}):
+	case errors.As(err, &source.VirtualDiskNotReadyForUseError{}):
 		cb.
 			Status(metav1.ConditionFalse).
-			Reason(vicondition.VirtualDiskInUseInRunningVirtualMachine).
+			Reason(vicondition.VirtualDiskNotReadyForUse).
 			Message(service.CapitalizeFirstLetter(err.Error() + "."))
 		return reconcile.Result{}, nil
 	default:

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/errors.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/errors.go
@@ -65,16 +65,16 @@ func NewVirtualDiskNotReadyError(name string) error {
 	}
 }
 
-type VirtualDiskNotAllowedForUseError struct {
+type VirtualDiskNotReadyForUseError struct {
 	name string
 }
 
-func (e VirtualDiskNotAllowedForUseError) Error() string {
-	return fmt.Sprintf("the VirtualDisk %s attached to VirtualMachine", e.name)
+func (e VirtualDiskNotReadyForUseError) Error() string {
+	return fmt.Sprintf("the VirtualDisk %s not ready for use", e.name)
 }
 
 func NewVirtualDiskNotAllowedForUseError(name string) error {
-	return VirtualDiskNotAllowedForUseError{
+	return VirtualDiskNotReadyForUseError{
 		name: name,
 	}
 }

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/errors.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/errors.go
@@ -73,8 +73,22 @@ func (e VirtualDiskNotReadyForUseError) Error() string {
 	return fmt.Sprintf("the VirtualDisk %s not ready for use", e.name)
 }
 
-func NewVirtualDiskNotAllowedForUseError(name string) error {
+func NewVirtualDiskNotReadyForUseError(name string) error {
 	return VirtualDiskNotReadyForUseError{
+		name: name,
+	}
+}
+
+type VirtualDiskAttachedToVirtualMachineError struct {
+	name string
+}
+
+func (e VirtualDiskAttachedToVirtualMachineError) Error() string {
+	return fmt.Sprintf("the VirtualDisk %s attached to VirtualMachine", e.name)
+}
+
+func NewVirtualDiskAttachedToVirtualMachineError(name string) error {
+	return VirtualDiskAttachedToVirtualMachineError{
 		name: name,
 	}
 }

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vd.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vd.go
@@ -436,11 +436,16 @@ func (ds ObjectRefVirtualDisk) Validate(ctx context.Context, vi *virtv2.VirtualI
 	}
 
 	inUseCondition, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
-	if inUseCondition.Status == metav1.ConditionTrue &&
-		inUseCondition.Reason == vdcondition.UsedForImageCreation.String() &&
-		inUseCondition.ObservedGeneration == vd.Generation {
-		return nil
+	if inUseCondition.Status != metav1.ConditionTrue || inUseCondition.ObservedGeneration != vd.Generation {
+		return NewVirtualDiskNotReadyForUseError(vd.Name)
 	}
 
-	return NewVirtualDiskNotAllowedForUseError(vd.Name)
+	switch inUseCondition.Reason {
+	case vdcondition.UsedForImageCreation.String():
+		return nil
+	case vdcondition.AttachedToVirtualMachine.String():
+		return NewVirtualDiskAttachedToVirtualMachineError(vd.Name)
+	default:
+		return NewVirtualDiskNotReadyForUseError(vd.Name)
+	}
 }

--- a/images/virtualization-artifact/pkg/controller/vi/vi_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/vi/vi_reconciler.go
@@ -229,7 +229,7 @@ func (r *Reconciler) SetupController(_ context.Context, mgr manager.Manager, ctr
 				oldInUseCondition, _ := conditions.GetCondition(vdcondition.InUseType, oldVD.Status.Conditions)
 				newInUseCondition, _ := conditions.GetCondition(vdcondition.InUseType, newVD.Status.Conditions)
 
-				if oldVD.Status.Phase != newVD.Status.Phase || len(oldVD.Status.AttachedToVirtualMachines) != len(newVD.Status.AttachedToVirtualMachines) || oldInUseCondition.Status != newInUseCondition.Status {
+				if oldVD.Status.Phase != newVD.Status.Phase || len(oldVD.Status.AttachedToVirtualMachines) != len(newVD.Status.AttachedToVirtualMachines) || oldInUseCondition != newInUseCondition {
 					return true
 				}
 

--- a/images/virtualization-artifact/pkg/controller/vm/internal/block_devices_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/block_devices_test.go
@@ -109,8 +109,8 @@ var _ = Describe("func areVirtualDisksAllowedToUse", func() {
 				anyVd.Name: anyVd,
 			}
 
-			allowed := h.areVirtualDisksAllowedToUse(vds)
-			Expect(allowed).To(BeFalse())
+			allowedCount := h.areVirtualDisksAllowedToUse(vds)
+			Expect(allowedCount).To(Equal(2))
 		})
 	})
 
@@ -143,7 +143,7 @@ var _ = Describe("func areVirtualDisksAllowedToUse", func() {
 			}
 
 			allowed := h.areVirtualDisksAllowedToUse(vds)
-			Expect(allowed).To(BeFalse())
+			Expect(allowed).To(Equal(2))
 		})
 	})
 
@@ -155,7 +155,7 @@ var _ = Describe("func areVirtualDisksAllowedToUse", func() {
 			}
 
 			allowed := h.areVirtualDisksAllowedToUse(vds)
-			Expect(allowed).To(BeTrue())
+			Expect(allowed).To(Equal(2))
 		})
 	})
 })

--- a/images/virtualization-artifact/pkg/controller/vm/internal/util.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/util.go
@@ -103,7 +103,7 @@ var mapPhases = map[virtv1.VirtualMachinePrintableStatus]PhaseGetter{
 			}
 		}
 
-		if vm.Status.Phase == virtv2.MachinePending &&
+		if vm != nil && vm.Status.Phase == virtv2.MachinePending &&
 			(vm.Spec.RunPolicy == virtv2.AlwaysOnPolicy || vm.Spec.RunPolicy == virtv2.AlwaysOnUnlessStoppedManually) {
 			return virtv2.MachinePending
 		}

--- a/images/virtualization-artifact/pkg/controller/vm/internal/util.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/util.go
@@ -103,6 +103,11 @@ var mapPhases = map[virtv1.VirtualMachinePrintableStatus]PhaseGetter{
 			}
 		}
 
+		if vm.Status.Phase == virtv2.MachinePending &&
+			(vm.Spec.RunPolicy == virtv2.AlwaysOnPolicy || vm.Spec.RunPolicy == virtv2.AlwaysOnUnlessStoppedManually) {
+			return virtv2.MachinePending
+		}
+
 		return virtv2.MachineStopped
 	},
 	// VirtualMachineStatusProvisioning indicates that cluster resources associated with the virtual machine

--- a/images/virtualization-artifact/pkg/controller/vm/vm_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/vm/vm_reconciler.go
@@ -225,7 +225,7 @@ func (r *Reconciler) SetupController(_ context.Context, mgr manager.Manager, ctr
 				oldInUseCondition, _ := conditions.GetCondition(vdcondition.InUseType, oldVd.Status.Conditions)
 				newInUseCondition, _ := conditions.GetCondition(vdcondition.InUseType, newVd.Status.Conditions)
 
-				if oldVd.Status.Phase != newVd.Status.Phase || oldInUseCondition.Status != newInUseCondition.Status {
+				if oldVd.Status.Phase != newVd.Status.Phase || oldInUseCondition != newInUseCondition {
 					return true
 				}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->

• Optimize the operation of the handler inUse.

• Improve the message in the BlockDeviceReady condition for the VM.

• Remove the phase 'Stopped' during startup when launching a VirtualMachine with the run policies AlwaysOn and AlwaysOnUnlessStopManually.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: vd
type: refactor
summary: refactor handle inUse condition 
```
