### PR TITLE
feat(vi): add network policy creation in UploaderService

### DIFF
--- a/images/virtualization-artifact/pkg/common/network_policy/network_policy.go
+++ b/images/virtualization-artifact/pkg/common/network_policy/network_policy.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/deckhouse/virtualization-controller/pkg/common/annotations"
 	"github.com/deckhouse/virtualization-controller/pkg/common/object"
-	"github.com/deckhouse/virtualization-controller/pkg/controller/supplements"
 )
 
 func CreateNetworkPolicy(ctx context.Context, c client.Client, obj metav1.Object) error {
@@ -59,8 +58,8 @@ func CreateNetworkPolicy(ctx context.Context, c client.Client, obj metav1.Object
 	return client.IgnoreAlreadyExists(err)
 }
 
-func GetNetworkPolicy(ctx context.Context, client client.Client, sup *supplements.Generator) (*netv1.NetworkPolicy, error) {
-	return object.FetchObject(ctx, sup.ImporterPod(), client, &netv1.NetworkPolicy{})
+func GetNetworkPolicy(ctx context.Context, client client.Client, name types.NamespacedName) (*netv1.NetworkPolicy, error) {
+	return object.FetchObject(ctx, name, client, &netv1.NetworkPolicy{})
 }
 
 func GetNetworkPolicyFromObject(ctx context.Context, client client.Client, obj metav1.Object) (*netv1.NetworkPolicy, error) {

--- a/images/virtualization-artifact/pkg/common/network_policy/network_policy.go
+++ b/images/virtualization-artifact/pkg/common/network_policy/network_policy.go
@@ -28,7 +28,7 @@ import (
 	"github.com/deckhouse/virtualization-controller/pkg/common/object"
 )
 
-func CreateNetworkPolicy(ctx context.Context, c client.Client, obj metav1.Object) error {
+func CreateNetworkPolicy(ctx context.Context, c client.Client, obj metav1.Object, finalizer string) error {
 	networkPolicy := netv1.NetworkPolicy{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "NetworkPolicy",
@@ -38,6 +38,7 @@ func CreateNetworkPolicy(ctx context.Context, c client.Client, obj metav1.Object
 			Name:            obj.GetName(),
 			Namespace:       obj.GetNamespace(),
 			OwnerReferences: obj.GetOwnerReferences(),
+			Finalizers:      []string{finalizer},
 		},
 		Spec: netv1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{

--- a/images/virtualization-artifact/pkg/controller/service/disk_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/disk_service.go
@@ -28,7 +28,6 @@ import (
 
 	vsv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
-	netv1 "k8s.io/api/networking/v1"
 	storev1 "k8s.io/api/storage/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -264,7 +263,7 @@ func (s DiskService) CleanUpSupplements(ctx context.Context, sup *supplements.Ge
 			return false, err
 		}
 
-		networkPolicy, err := s.getNetworkPolicy(ctx, sup.DataVolume())
+		networkPolicy, err := networkpolicy.GetNetworkPolicy(ctx, s.client, sup.DataVolume())
 		if err != nil {
 			return false, err
 		}
@@ -313,7 +312,7 @@ func (s DiskService) Protect(ctx context.Context, owner client.Object, dv *cdiv1
 	}
 
 	if dv != nil {
-		networkPolicy, err := s.getNetworkPolicy(ctx, types.NamespacedName{Namespace: dv.Namespace, Name: dv.Name})
+		networkPolicy, err := networkpolicy.GetNetworkPolicy(ctx, s.client, types.NamespacedName{Namespace: dv.Namespace, Name: dv.Name})
 		if err != nil {
 			return fmt.Errorf("failed to get networkPolicy for disk's supplements protection: %w", err)
 		}
@@ -336,7 +335,7 @@ func (s DiskService) Unprotect(ctx context.Context, dv *cdiv1.DataVolume) error 
 	}
 
 	if dv != nil {
-		networkPolicy, err := s.getNetworkPolicy(ctx, types.NamespacedName{Namespace: dv.Namespace, Name: dv.Name})
+		networkPolicy, err := networkpolicy.GetNetworkPolicy(ctx, s.client, types.NamespacedName{Namespace: dv.Namespace, Name: dv.Name})
 		if err != nil {
 			return fmt.Errorf("failed to get networkPolicy for removing disk's supplements protection: %w", err)
 		}
@@ -647,10 +646,6 @@ func (s DiskService) getStorageClass(ctx context.Context, storageClassName strin
 	}
 
 	return &sc, nil
-}
-
-func (s DiskService) getNetworkPolicy(ctx context.Context, name types.NamespacedName) (*netv1.NetworkPolicy, error) {
-	return object.FetchObject(ctx, name, s.client, &netv1.NetworkPolicy{})
 }
 
 var ErrInsufficientPVCSize = errors.New("the specified pvc size is insufficient")

--- a/images/virtualization-artifact/pkg/controller/service/disk_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/disk_service.go
@@ -132,7 +132,7 @@ func (s DiskService) Start(
 		return err
 	}
 
-	err = networkpolicy.CreateNetworkPolicy(ctx, s.client, dv)
+	err = networkpolicy.CreateNetworkPolicy(ctx, s.client, dv, s.protection.GetFinalizer())
 	if err != nil {
 		return fmt.Errorf("failed to create NetworkPolicy: %w", err)
 	}
@@ -169,7 +169,7 @@ func (s DiskService) StartImmediate(
 		return err
 	}
 
-	err = networkpolicy.CreateNetworkPolicy(ctx, s.client, dv)
+	err = networkpolicy.CreateNetworkPolicy(ctx, s.client, dv, s.protection.GetFinalizer())
 	if err != nil {
 		return fmt.Errorf("failed to create NetworkPolicy: %w", err)
 	}

--- a/images/virtualization-artifact/pkg/controller/service/importer_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/importer_service.go
@@ -104,7 +104,7 @@ func (s ImporterService) Start(
 		return err
 	}
 
-	err = networkpolicy.CreateNetworkPolicy(ctx, s.client, pod)
+	err = networkpolicy.CreateNetworkPolicy(ctx, s.client, pod, s.protection.GetFinalizer())
 	if err != nil {
 		return fmt.Errorf("failed to create NetworkPolicy: %w", err)
 	}

--- a/images/virtualization-artifact/pkg/controller/service/importer_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/importer_service.go
@@ -174,7 +174,7 @@ func (s ImporterService) DeletePod(ctx context.Context, obj ObjectKind, controll
 }
 
 func (s ImporterService) CleanUpSupplements(ctx context.Context, sup *supplements.Generator) (bool, error) {
-	networkPolicy, err := networkpolicy.GetNetworkPolicy(ctx, s.client, sup)
+	networkPolicy, err := networkpolicy.GetNetworkPolicy(ctx, s.client, sup.ImporterPod())
 	if err != nil {
 		return false, err
 	}

--- a/images/virtualization-artifact/pkg/controller/service/importer_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/importer_service.go
@@ -21,16 +21,13 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	netv1 "k8s.io/api/networking/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/deckhouse/virtualization-controller/pkg/common/annotations"
 	"github.com/deckhouse/virtualization-controller/pkg/common/datasource"
 	networkpolicy "github.com/deckhouse/virtualization-controller/pkg/common/network_policy"
-	"github.com/deckhouse/virtualization-controller/pkg/common/object"
 	"github.com/deckhouse/virtualization-controller/pkg/common/provisioner"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/importer"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/supplements"
@@ -142,7 +139,7 @@ func (s ImporterService) DeletePod(ctx context.Context, obj ObjectKind, controll
 	for _, pod := range podList.Items {
 		for _, ownerRef := range pod.OwnerReferences {
 			if ownerRef.Kind == obj.GroupVersionKind().Kind && ownerRef.Name == obj.GetName() && ownerRef.UID == obj.GetUID() {
-				networkPolicy, err := s.getNetworkPolicyFromPod(ctx, &pod)
+				networkPolicy, err := networkpolicy.GetNetworkPolicyFromObject(ctx, s.client, &pod)
 				if err != nil {
 					return false, err
 				}
@@ -177,7 +174,7 @@ func (s ImporterService) DeletePod(ctx context.Context, obj ObjectKind, controll
 }
 
 func (s ImporterService) CleanUpSupplements(ctx context.Context, sup *supplements.Generator) (bool, error) {
-	networkPolicy, err := s.getNetworkPolicy(ctx, sup)
+	networkPolicy, err := networkpolicy.GetNetworkPolicy(ctx, s.client, sup)
 	if err != nil {
 		return false, err
 	}
@@ -224,7 +221,7 @@ func (s ImporterService) Protect(ctx context.Context, pod *corev1.Pod) error {
 	}
 
 	if pod != nil {
-		networkPolicy, err := s.getNetworkPolicyFromPod(ctx, pod)
+		networkPolicy, err := networkpolicy.GetNetworkPolicyFromObject(ctx, s.client, pod)
 		if err != nil {
 			return fmt.Errorf("failed to get networkPolicy for importer's supplements protection: %w", err)
 		}
@@ -247,7 +244,7 @@ func (s ImporterService) Unprotect(ctx context.Context, pod *corev1.Pod) error {
 	}
 
 	if pod != nil {
-		networkPolicy, err := s.getNetworkPolicyFromPod(ctx, pod)
+		networkPolicy, err := networkpolicy.GetNetworkPolicyFromObject(ctx, s.client, pod)
 		if err != nil {
 			return fmt.Errorf("failed to get networkPolicy for removing importer's supplements protection: %w", err)
 		}
@@ -270,14 +267,6 @@ func (s ImporterService) GetPod(ctx context.Context, sup *supplements.Generator)
 	}
 
 	return pod, nil
-}
-
-func (s ImporterService) getNetworkPolicy(ctx context.Context, sup *supplements.Generator) (*netv1.NetworkPolicy, error) {
-	return object.FetchObject(ctx, sup.ImporterPod(), s.client, &netv1.NetworkPolicy{})
-}
-
-func (s ImporterService) getNetworkPolicyFromPod(ctx context.Context, pod *corev1.Pod) (*netv1.NetworkPolicy, error) {
-	return object.FetchObject(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, s.client, &netv1.NetworkPolicy{})
 }
 
 func (s ImporterService) getPodSettings(ownerRef *metav1.OwnerReference, sup *supplements.Generator) *importer.PodSettings {

--- a/images/virtualization-artifact/pkg/controller/service/uploader_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/uploader_service.go
@@ -95,7 +95,7 @@ func (s UploaderService) Start(
 		return err
 	}
 
-	err = networkpolicy.CreateNetworkPolicy(ctx, s.client, pod)
+	err = networkpolicy.CreateNetworkPolicy(ctx, s.client, pod, s.protection.GetFinalizer())
 	if err != nil {
 		return fmt.Errorf("failed to create NetworkPolicy: %w", err)
 	}
@@ -140,7 +140,7 @@ func (s UploaderService) CleanUpSupplements(ctx context.Context, sup *supplement
 		return false, err
 	}
 
-	err = s.protection.RemoveProtection(ctx, pod, svc, ing)
+	err = s.protection.RemoveProtection(ctx, pod, svc, ing, networkPolicy)
 	if err != nil {
 		return false, err
 	}

--- a/images/virtualization-artifact/pkg/controller/service/uploader_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/uploader_service.go
@@ -135,7 +135,7 @@ func (s UploaderService) CleanUpSupplements(ctx context.Context, sup *supplement
 	if err != nil {
 		return false, err
 	}
-	networkPolicy, err := networkpolicy.GetNetworkPolicy(ctx, s.client, sup)
+	networkPolicy, err := networkpolicy.GetNetworkPolicy(ctx, s.client, sup.UploaderPod())
 	if err != nil {
 		return false, err
 	}

--- a/images/virtualization-artifact/pkg/controller/service/uploader_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/uploader_service.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/deckhouse/virtualization-controller/pkg/common/annotations"
 	"github.com/deckhouse/virtualization-controller/pkg/common/datasource"
+	networkpolicy "github.com/deckhouse/virtualization-controller/pkg/common/network_policy"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/supplements"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/uploader"
 	"github.com/deckhouse/virtualization-controller/pkg/dvcr"
@@ -94,6 +95,11 @@ func (s UploaderService) Start(
 		return err
 	}
 
+	err = networkpolicy.CreateNetworkPolicy(ctx, s.client, pod)
+	if err != nil {
+		return fmt.Errorf("failed to create NetworkPolicy: %w", err)
+	}
+
 	err = supplements.EnsureForPod(ctx, s.client, sup, pod, caBundle, s.dvcrSettings)
 	if err != nil {
 		return err
@@ -129,6 +135,10 @@ func (s UploaderService) CleanUpSupplements(ctx context.Context, sup *supplement
 	if err != nil {
 		return false, err
 	}
+	networkPolicy, err := networkpolicy.GetNetworkPolicy(ctx, s.client, sup)
+	if err != nil {
+		return false, err
+	}
 
 	err = s.protection.RemoveProtection(ctx, pod, svc, ing)
 	if err != nil {
@@ -140,6 +150,14 @@ func (s UploaderService) CleanUpSupplements(ctx context.Context, sup *supplement
 	if pod != nil {
 		haveDeleted = true
 		err = s.client.Delete(ctx, pod)
+		if err != nil && !k8serrors.IsNotFound(err) {
+			return false, err
+		}
+	}
+
+	if networkPolicy != nil {
+		haveDeleted = true
+		err = s.client.Delete(ctx, networkPolicy)
 		if err != nil && !k8serrors.IsNotFound(err) {
 			return false, err
 		}
@@ -165,7 +183,12 @@ func (s UploaderService) CleanUpSupplements(ctx context.Context, sup *supplement
 }
 
 func (s UploaderService) Protect(ctx context.Context, pod *corev1.Pod, svc *corev1.Service, ing *netv1.Ingress) error {
-	err := s.protection.AddProtection(ctx, pod, svc, ing)
+	networkPolicy, err := networkpolicy.GetNetworkPolicyFromObject(ctx, s.client, pod)
+	if err != nil {
+		return err
+	}
+
+	err = s.protection.AddProtection(ctx, pod, svc, ing, networkPolicy)
 	if err != nil {
 		return fmt.Errorf("failed to add protection for uploader's supplements: %w", err)
 	}
@@ -174,7 +197,12 @@ func (s UploaderService) Protect(ctx context.Context, pod *corev1.Pod, svc *core
 }
 
 func (s UploaderService) Unprotect(ctx context.Context, pod *corev1.Pod, svc *corev1.Service, ing *netv1.Ingress) error {
-	err := s.protection.RemoveProtection(ctx, pod, svc, ing)
+	networkPolicy, err := networkpolicy.GetNetworkPolicyFromObject(ctx, s.client, pod)
+	if err != nil {
+		return err
+	}
+
+	err = s.protection.RemoveProtection(ctx, pod, svc, ing, networkPolicy)
 	if err != nil {
 		return fmt.Errorf("failed to remove protection for uploader's supplements: %w", err)
 	}

--- a/images/virtualization-artifact/pkg/controller/uploader/uploader_pod.go
+++ b/images/virtualization-artifact/pkg/controller/uploader/uploader_pod.go
@@ -94,10 +94,10 @@ func (p *Pod) makeSpec() (*corev1.Pod, error) {
 			Name:      p.PodSettings.Name,
 			Namespace: p.PodSettings.Namespace,
 			Annotations: map[string]string{
-				annotations.AppLabel:     annotations.DVCRLabelValue,
 				annotations.AnnCreatedBy: "yes",
 			},
 			Labels: map[string]string{
+				annotations.AppLabel:             annotations.DVCRLabelValue,
 				annotations.UploaderServiceLabel: p.PodSettings.ServiceName,
 			},
 			OwnerReferences: []metav1.OwnerReference{

--- a/images/virtualization-artifact/pkg/controller/uploader/uploader_pod.go
+++ b/images/virtualization-artifact/pkg/controller/uploader/uploader_pod.go
@@ -94,6 +94,7 @@ func (p *Pod) makeSpec() (*corev1.Pod, error) {
 			Name:      p.PodSettings.Name,
 			Namespace: p.PodSettings.Namespace,
 			Annotations: map[string]string{
+				annotations.AppLabel:     annotations.DVCRLabelValue,
 				annotations.AnnCreatedBy: "yes",
 			},
 			Labels: map[string]string{


### PR DESCRIPTION
## Description
Create a network policy for the uploader to avoid restrictions during import to dvcr


## Why do we need it, and what problem does it solve?
Give uploader pod access to dvcr when using projects


## What is the expected result?
When uplodaer is created, a NetworkPolicy with egress rules will be created

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: api
type: feat
summary:  create a network policy for the uploader to avoid restrictions during import to dvcr
```
