### PR TITLE
fix(kubevirt): add limits for init container `etc-libvirt-init`

### DIFF
--- a/images/virt-artifact/patches/037-set-ReadOnlyRootFilesystem-to-virt-launcher.patch
+++ b/images/virt-artifact/patches/037-set-ReadOnlyRootFilesystem-to-virt-launcher.patch
@@ -70,7 +70,7 @@ index e112967eec..f954d90d94 100644
  		{Name: "public", MountPath: "/var/run/kubevirt"},
  		{Name: "ephemeral-disks", MountPath: "disk1"},
 diff --git a/pkg/virt-controller/services/template.go b/pkg/virt-controller/services/template.go
-index f607c24786..6ba24d1634 100644
+index f607c24786..38a2141d3e 100644
 --- a/pkg/virt-controller/services/template.go
 +++ b/pkg/virt-controller/services/template.go
 @@ -64,15 +64,24 @@ import (
@@ -115,16 +115,7 @@ index f607c24786..6ba24d1634 100644
  	if util.IsNonRootVMI(vmi) {
  		nonRootUser := int64(util.NonRootUID)
  		psc.RunAsUser = &nonRootUser
-@@ -531,6 +539,8 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
- 
- 	var initContainers []k8sv1.Container
- 
-+	initContainers = append(initContainers, t.newEtcLibvirtCopierInitContainer(vmi, userId))
-+
- 	if HaveContainerDiskVolume(vmi.Spec.Volumes) || util.HasKernelBootContainerImage(vmi) {
- 		initContainerCommand := []string{"/usr/bin/cp",
- 			"/usr/bin/container-disk",
-@@ -573,6 +583,19 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
+@@ -573,6 +581,21 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
  		}
  
  	}
@@ -140,6 +131,8 @@ index f607c24786..6ba24d1634 100644
 +	}
 +	setReadOnlyRootFilesystem(initContainers)
 +	setReadOnlyRootFilesystem(containers)
++
++	initContainers = append(initContainers, t.newEtcLibvirtCopierInitContainer(vmi, userId))
 +
  	pod := k8sv1.Pod{
  		ObjectMeta: metav1.ObjectMeta{

--- a/images/virt-artifact/patches/037-set-ReadOnlyRootFilesystem-to-virt-launcher.patch
+++ b/images/virt-artifact/patches/037-set-ReadOnlyRootFilesystem-to-virt-launcher.patch
@@ -70,7 +70,7 @@ index e112967eec..f954d90d94 100644
  		{Name: "public", MountPath: "/var/run/kubevirt"},
  		{Name: "ephemeral-disks", MountPath: "disk1"},
 diff --git a/pkg/virt-controller/services/template.go b/pkg/virt-controller/services/template.go
-index f607c24786..38a2141d3e 100644
+index f607c24786..c239e9f8bd 100644
 --- a/pkg/virt-controller/services/template.go
 +++ b/pkg/virt-controller/services/template.go
 @@ -64,15 +64,24 @@ import (
@@ -119,6 +119,8 @@ index f607c24786..38a2141d3e 100644
  		}
  
  	}
++	initContainers = append(initContainers, t.newEtcLibvirtCopierInitContainer(vmi, userId))
++
 +	// Set ReadOnlyRootFilesystem
 +	setReadOnlyRootFilesystem := func(ctrs []k8sv1.Container) {
 +		for i := range ctrs {
@@ -131,8 +133,6 @@ index f607c24786..38a2141d3e 100644
 +	}
 +	setReadOnlyRootFilesystem(initContainers)
 +	setReadOnlyRootFilesystem(containers)
-+
-+	initContainers = append(initContainers, t.newEtcLibvirtCopierInitContainer(vmi, userId))
 +
  	pod := k8sv1.Pod{
  		ObjectMeta: metav1.ObjectMeta{

--- a/images/virt-artifact/patches/037-set-ReadOnlyRootFilesystem-to-virt-launcher.patch
+++ b/images/virt-artifact/patches/037-set-ReadOnlyRootFilesystem-to-virt-launcher.patch
@@ -70,7 +70,7 @@ index e112967eec..f954d90d94 100644
  		{Name: "public", MountPath: "/var/run/kubevirt"},
  		{Name: "ephemeral-disks", MountPath: "disk1"},
 diff --git a/pkg/virt-controller/services/template.go b/pkg/virt-controller/services/template.go
-index f607c24786..e1bac784b5 100644
+index f607c24786..6ba24d1634 100644
 --- a/pkg/virt-controller/services/template.go
 +++ b/pkg/virt-controller/services/template.go
 @@ -64,15 +64,24 @@ import (
@@ -115,7 +115,16 @@ index f607c24786..e1bac784b5 100644
  	if util.IsNonRootVMI(vmi) {
  		nonRootUser := int64(util.NonRootUID)
  		psc.RunAsUser = &nonRootUser
-@@ -573,6 +581,19 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
+@@ -531,6 +539,8 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
+ 
+ 	var initContainers []k8sv1.Container
+ 
++	initContainers = append(initContainers, t.newEtcLibvirtCopierInitContainer(vmi, userId))
++
+ 	if HaveContainerDiskVolume(vmi.Spec.Volumes) || util.HasKernelBootContainerImage(vmi) {
+ 		initContainerCommand := []string{"/usr/bin/cp",
+ 			"/usr/bin/container-disk",
+@@ -573,6 +583,19 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
  		}
  
  	}
@@ -135,66 +144,42 @@ index f607c24786..e1bac784b5 100644
  	pod := k8sv1.Pod{
  		ObjectMeta: metav1.ObjectMeta{
  			GenerateName: "virt-launcher-" + domain + "-",
-@@ -603,6 +624,8 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
- 		},
- 	}
- 
-+	t.addEtcLibvirtCopier(&pod)
-+
- 	alignPodMultiCategorySecurity(&pod, t.clusterConfig.GetSELinuxLauncherType(), t.clusterConfig.DockerSELinuxMCSWorkaroundEnabled())
- 
- 	// If we have a runtime class specified, use it, otherwise don't set a runtimeClassName
-@@ -639,6 +662,55 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
+@@ -639,6 +662,40 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
  	return &pod, nil
  }
  
-+const compute = "compute"
-+
-+func (t *templateService) addEtcLibvirtCopier(pod *k8sv1.Pod) {
-+	if pod == nil {
-+		return
-+	}
-+	var (
-+		image      string
-+		pullPolicy k8sv1.PullPolicy
-+		secContext *k8sv1.SecurityContext
-+		found      bool
++func (t *templateService) newEtcLibvirtCopierInitContainer(vmi *v1.VirtualMachineInstance, userID int64) k8sv1.Container {
++	const (
++		initPath      = "/init"
++		containerName = etcLibvirtVolumeName + "-init"
 +	)
-+	for i := range pod.Spec.Containers {
-+		ctr := &pod.Spec.Containers[i]
-+		if ctr.Name == compute {
-+			image = ctr.Image
-+			pullPolicy = ctr.ImagePullPolicy
-+			secContext = ctr.SecurityContext.DeepCopy()
-+			found = true
-+			break
-+		}
-+	}
-+	if !found {
-+		return
-+	}
++	command := []string{"sh", "-c", fmt.Sprintf("cp -a %s/. %s", etcLibvirt, initPath+"/")}
 +
-+	const initPath = "/init"
-+	pod.Spec.InitContainers = append(pod.Spec.InitContainers, k8sv1.Container{
-+		Name:            etcLibvirtVolumeName + "-init",
-+		Image:           image,
-+		ImagePullPolicy: pullPolicy,
-+		Resources: k8sv1.ResourceRequirements{
++	cpInitContainerOpts := []Option{
++		WithVolumeMounts(k8sv1.VolumeMount{
++			Name:      etcLibvirtVolumeName,
++			MountPath: initPath,
++		}),
++		WithResourceRequirements(k8sv1.ResourceRequirements{
 +			Requests: k8sv1.ResourceList{
-+				"memory": resource.MustParse("10Mi"),
-+				"cpu":    resource.MustParse("10m"),
++				k8sv1.ResourceCPU:    resource.MustParse("10m"),
++				k8sv1.ResourceMemory: resource.MustParse("1M"),
 +			},
-+		},
++			Limits: k8sv1.ResourceList{
++				k8sv1.ResourceCPU:    resource.MustParse("100m"),
++				k8sv1.ResourceMemory: resource.MustParse("40M"),
++			},
++		}),
++		WithNoCapabilities(),
++	}
++	if util.IsNonRootVMI(vmi) {
++		cpInitContainerOpts = append(cpInitContainerOpts, WithNonRoot(userID))
++	}
++	if t.IsPPC64() {
++		cpInitContainerOpts = append(cpInitContainerOpts, WithPrivileged())
++	}
 +
-+		Command: []string{"sh", "-c", fmt.Sprintf("cp -a %s/. %s", etcLibvirt, initPath+"/")},
-+		VolumeMounts: []k8sv1.VolumeMount{
-+			{
-+				Name:      etcLibvirtVolumeName,
-+				MountPath: initPath,
-+			},
-+		},
-+		SecurityContext: secContext,
-+	})
++	return NewContainerSpecRenderer(containerName, t.launcherImage, t.clusterConfig.GetImagePullPolicy(), cpInitContainerOpts...).Render(command)
 +}
 +
  func (t *templateService) newNodeSelectorRenderer(vmi *v1.VirtualMachineInstance) *NodeSelectorRenderer {


### PR DESCRIPTION
## Description
add limits for init container `etc-libvirt-init`
<!---
  Describe your changes with technical details.
-->


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [X] The code is covered by unit tests.
- [X] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: kubevirt
type: fix
summary: add limits for init container `etc-libvirt-init` 
impact_level: low
```
