### PR TITLE
test: fix panic caused by incorrect error formatting

### DIFF
--- a/tests/e2e/sizing_policy_test.go
+++ b/tests/e2e/sizing_policy_test.go
@@ -61,9 +61,9 @@ func CompareVirtualMachineClassReadyStatus(vmName, expectedStatus string) {
 	GinkgoHelper()
 	vm := virtv2.VirtualMachine{}
 	err := GetObject(kc.ResourceVM, vmName, &vm, kc.GetOptions{Namespace: conf.Namespace})
-	Expect(err).NotTo(HaveOccurred(), err)
+	Expect(err).NotTo(HaveOccurred(), err.Error())
 	status, err := GetConditionStatus(&vm, "VirtualMachineClassReady")
-	Expect(err).NotTo(HaveOccurred(), err)
+	Expect(err).NotTo(HaveOccurred(), err.Error())
 	Expect(status).To(Equal(expectedStatus), fmt.Sprintf("VirtualMachineClassReady status should be '%s'", expectedStatus))
 }
 

--- a/tests/e2e/vm_configuration_test.go
+++ b/tests/e2e/vm_configuration_test.go
@@ -99,7 +99,7 @@ func CheckCPUCoresNumber(approvalMode, stage string, requiredValue int, virtualM
 		By(fmt.Sprintf("Checking the number of processor cores %s changing", stage))
 		vmResource := virtv2.VirtualMachine{}
 		err := GetObject(kc.ResourceVM, vm, &vmResource, kc.GetOptions{Namespace: conf.Namespace})
-		Expect(err).NotTo(HaveOccurred(), err)
+		Expect(err).NotTo(HaveOccurred(), err.Error())
 		Expect(vmResource.Spec.CPU.Cores).To(Equal(requiredValue))
 		switch {
 		case approvalMode == ManualMode && stage == StageAfter:
@@ -285,7 +285,7 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 
 				vmResource := virtv2.VirtualMachine{}
 				err := GetObject(kc.ResourceVM, vms[0], &vmResource, kc.GetOptions{Namespace: conf.Namespace})
-				Expect(err).NotTo(HaveOccurred(), err)
+				Expect(err).NotTo(HaveOccurred(), err.Error())
 
 				oldCpuCores = vmResource.Spec.CPU.Cores
 				newCPUCores = 1 + (vmResource.Spec.CPU.Cores & 1)

--- a/tests/e2e/vm_disk_attachment_test.go
+++ b/tests/e2e/vm_disk_attachment_test.go
@@ -54,7 +54,7 @@ type BlockDevice struct {
 func AttachBlockDevice(virtualMachine, blockDeviceName string, blockDeviceType virtv2.VMBDAObjectRefKind, labels map[string]string, testDataPath string) {
 	vmbdaFilePath := fmt.Sprintf("%s/vmbda/%s.yaml", testDataPath, blockDeviceName)
 	err := CreateVMBDAManifest(vmbdaFilePath, virtualMachine, blockDeviceName, blockDeviceType, labels)
-	Expect(err).NotTo(HaveOccurred(), err)
+	Expect(err).NotTo(HaveOccurred(), err.Error())
 
 	res := kubectl.Apply(kc.ApplyOptions{
 		Filename:       []string{vmbdaFilePath},

--- a/tests/e2e/vm_disk_resizing_test.go
+++ b/tests/e2e/vm_disk_resizing_test.go
@@ -77,11 +77,11 @@ func ResizeDisks(addedSize *resource.Quantity, config *cfg.Config, virtualDisks 
 			defer wg.Done()
 			diskObject := virtv2.VirtualDisk{}
 			err := GetObject(kc.ResourceVD, vd, &diskObject, kc.GetOptions{Namespace: config.Namespace})
-			Expect(err).NotTo(HaveOccurred(), err)
+			Expect(err).NotTo(HaveOccurred(), err.Error())
 			newValue := resource.NewQuantity(diskObject.Spec.PersistentVolumeClaim.Size.Value()+addedSize.Value(), resource.BinarySI)
 			mergePatch := fmt.Sprintf("{\"spec\":{\"persistentVolumeClaim\":{\"size\":\"%s\"}}}", newValue.String())
 			err = MergePatchResource(kc.ResourceVD, vd, mergePatch)
-			Expect(err).NotTo(HaveOccurred(), err)
+			Expect(err).NotTo(HaveOccurred(), err.Error())
 		}()
 	}
 	wg.Wait()
@@ -127,7 +127,7 @@ func GetSizeByLsblk(vmName, diskIdPath string) (*resource.Quantity, error) {
 func GetDiskSize(vmName, vdName, diskIdPath string, config *cfg.Config, disk *DiskMetaData) {
 	GinkgoHelper()
 	sizeFromObject, err := GetSizeFromObject(vdName, config.Namespace)
-	Expect(err).NotTo(HaveOccurred(), err)
+	Expect(err).NotTo(HaveOccurred(), err.Error())
 	var sizeByLsblk *resource.Quantity
 	Eventually(func() error {
 		sizeByLsblk, err = GetSizeByLsblk(vmName, diskIdPath)

--- a/tests/e2e/vm_migration_test.go
+++ b/tests/e2e/vm_migration_test.go
@@ -42,7 +42,7 @@ func MigrateVirtualMachines(label map[string]string, templatePath string, virtua
 	for _, vm := range virtualMachines {
 		migrationFilePath := fmt.Sprintf("%s/%s.yaml", migrationFilesPath, vm)
 		err := CreateMigrationManifest(vm, migrationFilePath, label)
-		Expect(err).NotTo(HaveOccurred(), err)
+		Expect(err).NotTo(HaveOccurred(), err.Error())
 		res := kubectl.Apply(kc.ApplyOptions{
 			Filename:       []string{migrationFilePath},
 			FilenameOption: kc.Filename,


### PR DESCRIPTION
## Description  
This PR fixes a panic occurring in E2E tests due to improper error handling in `Expect` statements.  
The issue was caused by passing `err` directly as an additional argument:  

```go
Expect(err).NotTo(HaveOccurred(), err)
```  

Since `err` is an interface (`error`), `fmt.Sprintf()` attempted to format it incorrectly, leading to a type assertion panic:  

```go
interface conversion: interface {} is *errors.errorString, not string
```  

To resolve this, `err` is now explicitly converted to a string using `err.Error()`, ensuring proper formatting and avoiding panics.  

## Why do we need it, and what problem does it solve?
- Fixes test stability by preventing runtime panics.  
- Ensures error messages are correctly formatted and displayed.  
- Improves the reliability of test failure diagnostics.  



```changes
section: test
type: fix
summary: fix panic caused by incorrect error formatting
impact_level: low
```
