### PR TITLE
fix(vm): fix filesystem frozen condition blinks

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm/internal/filesystem.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/filesystem.go
@@ -42,10 +42,6 @@ func (h *FilesystemHandler) Handle(ctx context.Context, s state.VirtualMachineSt
 
 	changed := s.VirtualMachine().Changed()
 
-	if update := addAllUnknown(changed, vmcondition.TypeFilesystemFrozen); update {
-		return reconcile.Result{Requeue: true}, nil
-	}
-
 	if isDeletion(changed) {
 		return reconcile.Result{}, nil
 	}

--- a/tests/e2e/vd_snapshots_test.go
+++ b/tests/e2e/vd_snapshots_test.go
@@ -384,8 +384,8 @@ var _ = Describe("Virtual disk snapshots", ginkgoutil.CommonE2ETestDecorators(),
 			for _, vm := range vmObjects.Items {
 				Eventually(func() error {
 					frozen, err := CheckFileSystemFrozen(vm.Name)
-					if !frozen {
-						return errors.New("file system of the Virtual Machine is not frozen")
+					if frozen {
+						return errors.New("file system of the Virtual Machine is frozen")
 					}
 					return err
 				}).WithTimeout(

--- a/tests/e2e/vd_snapshots_test.go
+++ b/tests/e2e/vd_snapshots_test.go
@@ -433,7 +433,7 @@ var _ = Describe("Virtual disk snapshots", ginkgoutil.CommonE2ETestDecorators(),
 				Eventually(func() error {
 					frozen, err := CheckFileSystemFrozen(vm.Name)
 					if frozen {
-						return errors.New("filesystem of the Virtual Machine is not frozen")
+						return errors.New("filesystem of the Virtual Machine is frozen")
 					}
 					return err
 				}).WithTimeout(

--- a/tests/e2e/vd_snapshots_test.go
+++ b/tests/e2e/vd_snapshots_test.go
@@ -384,8 +384,8 @@ var _ = Describe("Virtual disk snapshots", ginkgoutil.CommonE2ETestDecorators(),
 			for _, vm := range vmObjects.Items {
 				Eventually(func() error {
 					frozen, err := CheckFileSystemFrozen(vm.Name)
-					if frozen {
-						return errors.New("File system of the Virtual Machine is frozen")
+					if !frozen {
+						return errors.New("file system of the Virtual Machine is not frozen")
 					}
 					return err
 				}).WithTimeout(
@@ -433,7 +433,7 @@ var _ = Describe("Virtual disk snapshots", ginkgoutil.CommonE2ETestDecorators(),
 				Eventually(func() error {
 					frozen, err := CheckFileSystemFrozen(vm.Name)
 					if frozen {
-						return errors.New("Filesystem of the Virtual Machine is frozen")
+						return errors.New("filesystem of the Virtual Machine is not frozen")
 					}
 					return err
 				}).WithTimeout(


### PR DESCRIPTION
## Description
Fix filesystem frozen condition blinks.


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: vm
type: fix
summary: "fix filesystem frozen condition blinks"
impact_level: low
```
