### PR TITLE
test(api): fix e2e panics

### DIFF
--- a/tests/e2e/sizing_policy_test.go
+++ b/tests/e2e/sizing_policy_test.go
@@ -61,9 +61,9 @@ func CompareVirtualMachineClassReadyStatus(vmName, expectedStatus string) {
 	GinkgoHelper()
 	vm := virtv2.VirtualMachine{}
 	err := GetObject(kc.ResourceVM, vmName, &vm, kc.GetOptions{Namespace: conf.Namespace})
-	Expect(err).NotTo(HaveOccurred(), err.Error())
+	Expect(err).NotTo(HaveOccurred(), "%v", err)
 	status, err := GetConditionStatus(&vm, "VirtualMachineClassReady")
-	Expect(err).NotTo(HaveOccurred(), err.Error())
+	Expect(err).NotTo(HaveOccurred(), "%v", err)
 	Expect(status).To(Equal(expectedStatus), fmt.Sprintf("VirtualMachineClassReady status should be '%s'", expectedStatus))
 }
 

--- a/tests/e2e/vm_configuration_test.go
+++ b/tests/e2e/vm_configuration_test.go
@@ -99,7 +99,7 @@ func CheckCPUCoresNumber(approvalMode, stage string, requiredValue int, virtualM
 		By(fmt.Sprintf("Checking the number of processor cores %s changing", stage))
 		vmResource := virtv2.VirtualMachine{}
 		err := GetObject(kc.ResourceVM, vm, &vmResource, kc.GetOptions{Namespace: conf.Namespace})
-		Expect(err).NotTo(HaveOccurred(), err.Error())
+		Expect(err).NotTo(HaveOccurred(), "%v", err)
 		Expect(vmResource.Spec.CPU.Cores).To(Equal(requiredValue))
 		switch {
 		case approvalMode == ManualMode && stage == StageAfter:
@@ -285,7 +285,7 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 
 				vmResource := virtv2.VirtualMachine{}
 				err := GetObject(kc.ResourceVM, vms[0], &vmResource, kc.GetOptions{Namespace: conf.Namespace})
-				Expect(err).NotTo(HaveOccurred(), err.Error())
+				Expect(err).NotTo(HaveOccurred(), "%v", err)
 
 				oldCpuCores = vmResource.Spec.CPU.Cores
 				newCPUCores = 1 + (vmResource.Spec.CPU.Cores & 1)

--- a/tests/e2e/vm_disk_attachment_test.go
+++ b/tests/e2e/vm_disk_attachment_test.go
@@ -54,7 +54,7 @@ type BlockDevice struct {
 func AttachBlockDevice(virtualMachine, blockDeviceName string, blockDeviceType virtv2.VMBDAObjectRefKind, labels map[string]string, testDataPath string) {
 	vmbdaFilePath := fmt.Sprintf("%s/vmbda/%s.yaml", testDataPath, blockDeviceName)
 	err := CreateVMBDAManifest(vmbdaFilePath, virtualMachine, blockDeviceName, blockDeviceType, labels)
-	Expect(err).NotTo(HaveOccurred(), err.Error())
+	Expect(err).NotTo(HaveOccurred(), "%v", err)
 
 	res := kubectl.Apply(kc.ApplyOptions{
 		Filename:       []string{vmbdaFilePath},

--- a/tests/e2e/vm_disk_resizing_test.go
+++ b/tests/e2e/vm_disk_resizing_test.go
@@ -77,11 +77,11 @@ func ResizeDisks(addedSize *resource.Quantity, config *cfg.Config, virtualDisks 
 			defer wg.Done()
 			diskObject := virtv2.VirtualDisk{}
 			err := GetObject(kc.ResourceVD, vd, &diskObject, kc.GetOptions{Namespace: config.Namespace})
-			Expect(err).NotTo(HaveOccurred(), err.Error())
+			Expect(err).NotTo(HaveOccurred(), "%v", err)
 			newValue := resource.NewQuantity(diskObject.Spec.PersistentVolumeClaim.Size.Value()+addedSize.Value(), resource.BinarySI)
 			mergePatch := fmt.Sprintf("{\"spec\":{\"persistentVolumeClaim\":{\"size\":\"%s\"}}}", newValue.String())
 			err = MergePatchResource(kc.ResourceVD, vd, mergePatch)
-			Expect(err).NotTo(HaveOccurred(), err.Error())
+			Expect(err).NotTo(HaveOccurred(), "%v", err)
 		}()
 	}
 	wg.Wait()
@@ -127,7 +127,7 @@ func GetSizeByLsblk(vmName, diskIdPath string) (*resource.Quantity, error) {
 func GetDiskSize(vmName, vdName, diskIdPath string, config *cfg.Config, disk *DiskMetaData) {
 	GinkgoHelper()
 	sizeFromObject, err := GetSizeFromObject(vdName, config.Namespace)
-	Expect(err).NotTo(HaveOccurred(), err.Error())
+	Expect(err).NotTo(HaveOccurred(), "%v", err)
 	var sizeByLsblk *resource.Quantity
 	Eventually(func() error {
 		sizeByLsblk, err = GetSizeByLsblk(vmName, diskIdPath)

--- a/tests/e2e/vm_migration_test.go
+++ b/tests/e2e/vm_migration_test.go
@@ -42,7 +42,7 @@ func MigrateVirtualMachines(label map[string]string, templatePath string, virtua
 	for _, vm := range virtualMachines {
 		migrationFilePath := fmt.Sprintf("%s/%s.yaml", migrationFilesPath, vm)
 		err := CreateMigrationManifest(vm, migrationFilePath, label)
-		Expect(err).NotTo(HaveOccurred(), err.Error())
+		Expect(err).NotTo(HaveOccurred(), "%v", err)
 		res := kubectl.Apply(kc.ApplyOptions{
 			Filename:       []string{migrationFilePath},
 			FilenameOption: kc.Filename,


### PR DESCRIPTION
## Description
Fix e2e panics caused by nil pointer of optional assert description.


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: test
type: fix
summary: "fix panic caused by incorrect error formatting"
impact_level: low
```
