### PR TITLE
fix(kubevirt): Add new emptydirs mounted to `/tmp` and  `/var/lib/swtpm-localca` for virt-launcher 

### DIFF
--- a/images/virt-artifact/patches/037-set-ReadOnlyRootFilesystem-to-virt-launcher.patch
+++ b/images/virt-artifact/patches/037-set-ReadOnlyRootFilesystem-to-virt-launcher.patch
@@ -31,10 +31,10 @@ index de90ed3cbc..992a449bcc 100644
  		emptyDirVolume("public"),
  		emptyDirVolume("sockets"),
 diff --git a/pkg/virt-controller/services/rendervolumes_test.go b/pkg/virt-controller/services/rendervolumes_test.go
-index e112967eec..ecb929829c 100644
+index e112967eec..4781a313d7 100644
 --- a/pkg/virt-controller/services/rendervolumes_test.go
 +++ b/pkg/virt-controller/services/rendervolumes_test.go
-@@ -342,6 +342,30 @@ func vmiDiskPath(volumeName string) string {
+@@ -342,6 +342,34 @@ func vmiDiskPath(volumeName string) string {
  
  func defaultVolumes() []k8sv1.Volume {
  	return []k8sv1.Volume{
@@ -62,10 +62,14 @@ index e112967eec..ecb929829c 100644
 +			Name:         tmpVolumeName,
 +			VolumeSource: k8sv1.VolumeSource{EmptyDir: &k8sv1.EmptyDirVolumeSource{}},
 +		},
++		{
++			Name:         varLibSWTPMLocalCAVolumeName,
++			VolumeSource: k8sv1.VolumeSource{EmptyDir: &k8sv1.EmptyDirVolumeSource{}},
++		},
  		{
  			Name:         "private",
  			VolumeSource: k8sv1.VolumeSource{EmptyDir: &k8sv1.EmptyDirVolumeSource{}},
-@@ -371,6 +395,12 @@ func defaultVolumeMounts() []k8sv1.VolumeMount {
+@@ -371,6 +399,13 @@ func defaultVolumeMounts() []k8sv1.VolumeMount {
  	hostToContainerPropagation := k8sv1.MountPropagationHostToContainer
  
  	return []k8sv1.VolumeMount{
@@ -75,6 +79,7 @@ index e112967eec..ecb929829c 100644
 +		{Name: varLibLibvirtVolumeName, MountPath: varLibLibvirt},
 +		{Name: varCacheLibvirtVolumeName, MountPath: varCacheLibvirt},
 +		{Name: tmpVolumeName, MountPath: tmp},
++		{Name: varLibSWTPMLocalCAVolumeName, MountPath: varLibSWTPMLocalCA},
  		{Name: "private", MountPath: "/var/run/kubevirt-private"},
  		{Name: "public", MountPath: "/var/run/kubevirt"},
  		{Name: "ephemeral-disks", MountPath: "disk1"},
@@ -192,7 +197,7 @@ index f607c24786..5f0956dad8 100644
  	var opts []NodeSelectorRendererOption
  	if vmi.IsCPUDedicated() {
 diff --git a/pkg/virt-controller/services/template_test.go b/pkg/virt-controller/services/template_test.go
-index c6a7f66a54..99376b4752 100644
+index c6a7f66a54..16c1e102bf 100644
 --- a/pkg/virt-controller/services/template_test.go
 +++ b/pkg/virt-controller/services/template_test.go
 @@ -458,7 +458,7 @@ var _ = Describe("Template", func() {
@@ -218,7 +223,7 @@ index c6a7f66a54..99376b4752 100644
  				Expect(hugepagesLimit.ToDec().ScaledValue(resource.Mega)).To(Equal(int64(64)))
  
 -				Expect(pod.Spec.Volumes).To(HaveLen(9))
-+				Expect(pod.Spec.Volumes).To(HaveLen(15))
++				Expect(pod.Spec.Volumes).To(HaveLen(16))
  				Expect(pod.Spec.Volumes).To(
  					ContainElements(
  						k8sv1.Volume{
@@ -227,7 +232,7 @@ index c6a7f66a54..99376b4752 100644
  							}}))
  
 -				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(8))
-+				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(14))
++				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(15))
  				Expect(pod.Spec.Containers[0].VolumeMounts).To(
  					ContainElements(
  						k8sv1.VolumeMount{
@@ -236,7 +241,7 @@ index c6a7f66a54..99376b4752 100644
  				Expect(hugepagesLimit.ToDec().ScaledValue(resource.Mega)).To(Equal(int64(64)))
  
 -				Expect(pod.Spec.Volumes).To(HaveLen(9))
-+				Expect(pod.Spec.Volumes).To(HaveLen(15))
++				Expect(pod.Spec.Volumes).To(HaveLen(16))
  				Expect(pod.Spec.Volumes).To(
  					ContainElements(
  						k8sv1.Volume{
@@ -245,7 +250,7 @@ index c6a7f66a54..99376b4752 100644
  							}}))
  
 -				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(8))
-+				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(14))
++				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(15))
  				Expect(pod.Spec.Containers[0].VolumeMounts).To(
  					ContainElements(
  						k8sv1.VolumeMount{
@@ -255,12 +260,12 @@ index c6a7f66a54..99376b4752 100644
  				Expect(pod.Spec.Containers[0].VolumeMounts).ToNot(BeEmpty(), "Some mounts in manifest for 1st container")
 -				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(7), "7 mounts in manifest for 1st container")
 -				Expect(pod.Spec.Containers[0].VolumeMounts[6].Name).To(Equal(volumeName), "1st mount in manifest for 1st container has correct name")
-+				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(13), "13 mounts in manifest for 1st container")
-+				Expect(pod.Spec.Containers[0].VolumeMounts[12].Name).To(Equal(volumeName), "1st mount in manifest for 1st container has correct name")
++				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(14), "14 mounts in manifest for 1st container")
++				Expect(pod.Spec.Containers[0].VolumeMounts[13].Name).To(Equal(volumeName), "1st mount in manifest for 1st container has correct name")
  
  				Expect(pod.Spec.Volumes).ToNot(BeEmpty(), "Found some volumes in manifest")
 -				Expect(pod.Spec.Volumes).To(HaveLen(8), "Found 8 volumes in manifest")
-+				Expect(pod.Spec.Volumes).To(HaveLen(14), "Found 14 volumes in manifest")
++				Expect(pod.Spec.Volumes).To(HaveLen(15), "Found 15 volumes in manifest")
  				Expect(pod.Spec.Volumes).To(
  					ContainElement(
  						k8sv1.Volume{
@@ -269,11 +274,11 @@ index c6a7f66a54..99376b4752 100644
  
  				Expect(pod.Spec.Containers[0].VolumeMounts).ToNot(BeEmpty(), "Found some mounts in manifest for 1st container")
 -				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(6), "Found 6 mounts in manifest for 1st container")
-+				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(12), "Found 11 mounts in manifest for 1st container")
++				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(13), "Found 13 mounts in manifest for 1st container")
  
  				Expect(pod.Spec.Volumes).ToNot(BeEmpty(), "Found some volumes in manifest")
 -				Expect(pod.Spec.Volumes).To(HaveLen(9), "Found 9 volumes in manifest")
-+				Expect(pod.Spec.Volumes).To(HaveLen(15), "Found 14 volumes in manifest")
++				Expect(pod.Spec.Volumes).To(HaveLen(16), "Found 16 volumes in manifest")
  				Expect(pod.Spec.Volumes).To(
  					ContainElement(
  						k8sv1.Volume{
@@ -282,7 +287,7 @@ index c6a7f66a54..99376b4752 100644
  				Expect(err).ToNot(HaveOccurred())
  				Expect(pod.Spec.Volumes).ToNot(BeEmpty())
 -				Expect(pod.Spec.Volumes).To(HaveLen(8))
-+				Expect(pod.Spec.Volumes).To(HaveLen(14))
++				Expect(pod.Spec.Volumes).To(HaveLen(15))
  
  				oneMB := resource.MustParse("1Mi")
  				Expect(pod.Spec.Volumes).To(ContainElement(
@@ -291,7 +296,7 @@ index c6a7f66a54..99376b4752 100644
  					}))
  
 -				Expect(pod.Spec.Containers[0].VolumeMounts[6].MountPath).To(Equal(k6tconfig.DownwardMetricDisksDir))
-+				Expect(pod.Spec.Containers[0].VolumeMounts[12].MountPath).To(Equal(k6tconfig.DownwardMetricDisksDir))
++				Expect(pod.Spec.Containers[0].VolumeMounts[13].MountPath).To(Equal(k6tconfig.DownwardMetricDisksDir))
  			})
  
  			It("Should add 1Mi memory overhead", func() {
@@ -300,7 +305,7 @@ index c6a7f66a54..99376b4752 100644
  
  				Expect(pod.Spec.Volumes).ToNot(BeEmpty())
 -				Expect(pod.Spec.Volumes).To(HaveLen(8))
-+				Expect(pod.Spec.Volumes).To(HaveLen(14))
++				Expect(pod.Spec.Volumes).To(HaveLen(15))
  				Expect(pod.Spec.Volumes).To(ContainElement(k8sv1.Volume{
  					Name: "configmap-volume",
  					VolumeSource: k8sv1.VolumeSource{
@@ -309,7 +314,7 @@ index c6a7f66a54..99376b4752 100644
  
  					Expect(pod.Spec.Volumes).ToNot(BeEmpty())
 -					Expect(pod.Spec.Volumes).To(HaveLen(9))
-+					Expect(pod.Spec.Volumes).To(HaveLen(15))
++					Expect(pod.Spec.Volumes).To(HaveLen(16))
  					Expect(pod.Spec.Volumes).To(ContainElement(k8sv1.Volume{
  						Name: "sysprep-configmap-volume",
  						VolumeSource: k8sv1.VolumeSource{
@@ -318,7 +323,7 @@ index c6a7f66a54..99376b4752 100644
  
  					Expect(pod.Spec.Volumes).ToNot(BeEmpty())
 -					Expect(pod.Spec.Volumes).To(HaveLen(9))
-+					Expect(pod.Spec.Volumes).To(HaveLen(15))
++					Expect(pod.Spec.Volumes).To(HaveLen(16))
  
  					Expect(pod.Spec.Volumes).To(ContainElement(k8sv1.Volume{
  						Name: "sysprep-configmap-volume",
@@ -327,7 +332,7 @@ index c6a7f66a54..99376b4752 100644
  
  				Expect(pod.Spec.Volumes).ToNot(BeEmpty())
 -				Expect(pod.Spec.Volumes).To(HaveLen(8))
-+				Expect(pod.Spec.Volumes).To(HaveLen(14))
++				Expect(pod.Spec.Volumes).To(HaveLen(15))
  
  				Expect(pod.Spec.Volumes).To(ContainElement(k8sv1.Volume{
  					Name: "secret-volume",

--- a/images/virt-artifact/patches/037-set-ReadOnlyRootFilesystem-to-virt-launcher.patch
+++ b/images/virt-artifact/patches/037-set-ReadOnlyRootFilesystem-to-virt-launcher.patch
@@ -1,8 +1,8 @@
 diff --git a/pkg/virt-controller/services/rendervolumes.go b/pkg/virt-controller/services/rendervolumes.go
-index de90ed3cbc..798bd2d74e 100644
+index de90ed3cbc..2941b0b8c9 100644
 --- a/pkg/virt-controller/services/rendervolumes.go
 +++ b/pkg/virt-controller/services/rendervolumes.go
-@@ -52,6 +52,11 @@ func NewVolumeRenderer(namespace string, ephemeralDisk string, containerDiskDir
+@@ -52,6 +52,12 @@ func NewVolumeRenderer(namespace string, ephemeralDisk string, containerDiskDir
  
  func (vr *VolumeRenderer) Mounts() []k8sv1.VolumeMount {
  	volumeMounts := []k8sv1.VolumeMount{
@@ -11,10 +11,11 @@ index de90ed3cbc..798bd2d74e 100644
 +		mountPath(etcLibvirtVolumeName, etcLibvirt),
 +		mountPath(varLibLibvirtVolumeName, varLibLibvirt),
 +		mountPath(varCacheLibvirtVolumeName, varCacheLibvirt),
++		mountPath(tmpVolumeName, tmp),
  		mountPath("private", util.VirtPrivateDir),
  		mountPath("public", util.VirtShareDir),
  		mountPath("ephemeral-disks", vr.ephemeralDiskDir),
-@@ -64,6 +69,11 @@ func (vr *VolumeRenderer) Mounts() []k8sv1.VolumeMount {
+@@ -64,6 +70,12 @@ func (vr *VolumeRenderer) Mounts() []k8sv1.VolumeMount {
  
  func (vr *VolumeRenderer) Volumes() []k8sv1.Volume {
  	volumes := []k8sv1.Volume{
@@ -23,14 +24,15 @@ index de90ed3cbc..798bd2d74e 100644
 +		emptyDirVolume(etcLibvirtVolumeName),
 +		emptyDirVolume(varLibLibvirtVolumeName),
 +		emptyDirVolume(varCacheLibvirtVolumeName),
++		emptyDirVolume(tmpVolumeName),
  		emptyDirVolume("private"),
  		emptyDirVolume("public"),
  		emptyDirVolume("sockets"),
 diff --git a/pkg/virt-controller/services/rendervolumes_test.go b/pkg/virt-controller/services/rendervolumes_test.go
-index e112967eec..f954d90d94 100644
+index e112967eec..ecb929829c 100644
 --- a/pkg/virt-controller/services/rendervolumes_test.go
 +++ b/pkg/virt-controller/services/rendervolumes_test.go
-@@ -342,6 +342,26 @@ func vmiDiskPath(volumeName string) string {
+@@ -342,6 +342,30 @@ func vmiDiskPath(volumeName string) string {
  
  func defaultVolumes() []k8sv1.Volume {
  	return []k8sv1.Volume{
@@ -54,10 +56,14 @@ index e112967eec..f954d90d94 100644
 +			Name:         varCacheLibvirtVolumeName,
 +			VolumeSource: k8sv1.VolumeSource{EmptyDir: &k8sv1.EmptyDirVolumeSource{}},
 +		},
++		{
++			Name:         tmpVolumeName,
++			VolumeSource: k8sv1.VolumeSource{EmptyDir: &k8sv1.EmptyDirVolumeSource{}},
++		},
  		{
  			Name:         "private",
  			VolumeSource: k8sv1.VolumeSource{EmptyDir: &k8sv1.EmptyDirVolumeSource{}},
-@@ -371,6 +391,11 @@ func defaultVolumeMounts() []k8sv1.VolumeMount {
+@@ -371,6 +395,12 @@ func defaultVolumeMounts() []k8sv1.VolumeMount {
  	hostToContainerPropagation := k8sv1.MountPropagationHostToContainer
  
  	return []k8sv1.VolumeMount{
@@ -66,14 +72,15 @@ index e112967eec..f954d90d94 100644
 +		{Name: etcLibvirtVolumeName, MountPath: etcLibvirt},
 +		{Name: varLibLibvirtVolumeName, MountPath: varLibLibvirt},
 +		{Name: varCacheLibvirtVolumeName, MountPath: varCacheLibvirt},
++		{Name: tmpVolumeName, MountPath: tmp},
  		{Name: "private", MountPath: "/var/run/kubevirt-private"},
  		{Name: "public", MountPath: "/var/run/kubevirt"},
  		{Name: "ephemeral-disks", MountPath: "disk1"},
 diff --git a/pkg/virt-controller/services/template.go b/pkg/virt-controller/services/template.go
-index f607c24786..c239e9f8bd 100644
+index f607c24786..48906f2dd1 100644
 --- a/pkg/virt-controller/services/template.go
 +++ b/pkg/virt-controller/services/template.go
-@@ -64,15 +64,24 @@ import (
+@@ -64,15 +64,26 @@ import (
  )
  
  const (
@@ -99,15 +106,17 @@ index f607c24786..c239e9f8bd 100644
 +	etcLibvirt                = "/etc/libvirt"
 +	varLibLibvirt             = "/var/lib/libvirt/"
 +	varCacheLibvirt           = "/var/cache/libvirt"
++	tmp                       = "/tmp"
 +	varLogVolumeName          = "var-log"
 +	etcLibvirtVolumeName      = "etc-libvirt"
 +	varLibLibvirtVolumeName   = "var-lib-libvirt"
 +	varCacheLibvirtVolumeName = "var-cache-libvirt"
 +	varRunVolumeName          = "var-run"
++	tmpVolumeName             = "tmp"
  )
  
  const KvmDevice = "devices.virtualization.deckhouse.io/kvm"
-@@ -301,7 +310,6 @@ func generateQemuTimeoutWithJitter(qemuTimeoutBaseSeconds int) string {
+@@ -301,7 +312,6 @@ func generateQemuTimeoutWithJitter(qemuTimeoutBaseSeconds int) string {
  
  func computePodSecurityContext(vmi *v1.VirtualMachineInstance, seccomp *k8sv1.SeccompProfile) *k8sv1.PodSecurityContext {
  	psc := &k8sv1.PodSecurityContext{}
@@ -115,7 +124,7 @@ index f607c24786..c239e9f8bd 100644
  	if util.IsNonRootVMI(vmi) {
  		nonRootUser := int64(util.NonRootUID)
  		psc.RunAsUser = &nonRootUser
-@@ -573,6 +581,21 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
+@@ -573,6 +583,21 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
  		}
  
  	}
@@ -137,7 +146,7 @@ index f607c24786..c239e9f8bd 100644
  	pod := k8sv1.Pod{
  		ObjectMeta: metav1.ObjectMeta{
  			GenerateName: "virt-launcher-" + domain + "-",
-@@ -639,6 +662,40 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
+@@ -639,6 +664,40 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
  	return &pod, nil
  }
  
@@ -179,7 +188,7 @@ index f607c24786..c239e9f8bd 100644
  	var opts []NodeSelectorRendererOption
  	if vmi.IsCPUDedicated() {
 diff --git a/pkg/virt-controller/services/template_test.go b/pkg/virt-controller/services/template_test.go
-index c6a7f66a54..33d1870205 100644
+index c6a7f66a54..99376b4752 100644
 --- a/pkg/virt-controller/services/template_test.go
 +++ b/pkg/virt-controller/services/template_test.go
 @@ -458,7 +458,7 @@ var _ = Describe("Template", func() {
@@ -205,7 +214,7 @@ index c6a7f66a54..33d1870205 100644
  				Expect(hugepagesLimit.ToDec().ScaledValue(resource.Mega)).To(Equal(int64(64)))
  
 -				Expect(pod.Spec.Volumes).To(HaveLen(9))
-+				Expect(pod.Spec.Volumes).To(HaveLen(14))
++				Expect(pod.Spec.Volumes).To(HaveLen(15))
  				Expect(pod.Spec.Volumes).To(
  					ContainElements(
  						k8sv1.Volume{
@@ -214,7 +223,7 @@ index c6a7f66a54..33d1870205 100644
  							}}))
  
 -				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(8))
-+				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(13))
++				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(14))
  				Expect(pod.Spec.Containers[0].VolumeMounts).To(
  					ContainElements(
  						k8sv1.VolumeMount{
@@ -223,7 +232,7 @@ index c6a7f66a54..33d1870205 100644
  				Expect(hugepagesLimit.ToDec().ScaledValue(resource.Mega)).To(Equal(int64(64)))
  
 -				Expect(pod.Spec.Volumes).To(HaveLen(9))
-+				Expect(pod.Spec.Volumes).To(HaveLen(14))
++				Expect(pod.Spec.Volumes).To(HaveLen(15))
  				Expect(pod.Spec.Volumes).To(
  					ContainElements(
  						k8sv1.Volume{
@@ -232,7 +241,7 @@ index c6a7f66a54..33d1870205 100644
  							}}))
  
 -				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(8))
-+				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(13))
++				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(14))
  				Expect(pod.Spec.Containers[0].VolumeMounts).To(
  					ContainElements(
  						k8sv1.VolumeMount{
@@ -242,12 +251,12 @@ index c6a7f66a54..33d1870205 100644
  				Expect(pod.Spec.Containers[0].VolumeMounts).ToNot(BeEmpty(), "Some mounts in manifest for 1st container")
 -				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(7), "7 mounts in manifest for 1st container")
 -				Expect(pod.Spec.Containers[0].VolumeMounts[6].Name).To(Equal(volumeName), "1st mount in manifest for 1st container has correct name")
-+				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(12), "12 mounts in manifest for 1st container")
-+				Expect(pod.Spec.Containers[0].VolumeMounts[11].Name).To(Equal(volumeName), "1st mount in manifest for 1st container has correct name")
++				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(13), "13 mounts in manifest for 1st container")
++				Expect(pod.Spec.Containers[0].VolumeMounts[12].Name).To(Equal(volumeName), "1st mount in manifest for 1st container has correct name")
  
  				Expect(pod.Spec.Volumes).ToNot(BeEmpty(), "Found some volumes in manifest")
 -				Expect(pod.Spec.Volumes).To(HaveLen(8), "Found 8 volumes in manifest")
-+				Expect(pod.Spec.Volumes).To(HaveLen(13), "Found 13 volumes in manifest")
++				Expect(pod.Spec.Volumes).To(HaveLen(14), "Found 14 volumes in manifest")
  				Expect(pod.Spec.Volumes).To(
  					ContainElement(
  						k8sv1.Volume{
@@ -256,11 +265,11 @@ index c6a7f66a54..33d1870205 100644
  
  				Expect(pod.Spec.Containers[0].VolumeMounts).ToNot(BeEmpty(), "Found some mounts in manifest for 1st container")
 -				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(6), "Found 6 mounts in manifest for 1st container")
-+				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(11), "Found 11 mounts in manifest for 1st container")
++				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(12), "Found 11 mounts in manifest for 1st container")
  
  				Expect(pod.Spec.Volumes).ToNot(BeEmpty(), "Found some volumes in manifest")
 -				Expect(pod.Spec.Volumes).To(HaveLen(9), "Found 9 volumes in manifest")
-+				Expect(pod.Spec.Volumes).To(HaveLen(14), "Found 14 volumes in manifest")
++				Expect(pod.Spec.Volumes).To(HaveLen(15), "Found 14 volumes in manifest")
  				Expect(pod.Spec.Volumes).To(
  					ContainElement(
  						k8sv1.Volume{
@@ -269,7 +278,7 @@ index c6a7f66a54..33d1870205 100644
  				Expect(err).ToNot(HaveOccurred())
  				Expect(pod.Spec.Volumes).ToNot(BeEmpty())
 -				Expect(pod.Spec.Volumes).To(HaveLen(8))
-+				Expect(pod.Spec.Volumes).To(HaveLen(13))
++				Expect(pod.Spec.Volumes).To(HaveLen(14))
  
  				oneMB := resource.MustParse("1Mi")
  				Expect(pod.Spec.Volumes).To(ContainElement(
@@ -278,7 +287,7 @@ index c6a7f66a54..33d1870205 100644
  					}))
  
 -				Expect(pod.Spec.Containers[0].VolumeMounts[6].MountPath).To(Equal(k6tconfig.DownwardMetricDisksDir))
-+				Expect(pod.Spec.Containers[0].VolumeMounts[11].MountPath).To(Equal(k6tconfig.DownwardMetricDisksDir))
++				Expect(pod.Spec.Containers[0].VolumeMounts[12].MountPath).To(Equal(k6tconfig.DownwardMetricDisksDir))
  			})
  
  			It("Should add 1Mi memory overhead", func() {
@@ -287,7 +296,7 @@ index c6a7f66a54..33d1870205 100644
  
  				Expect(pod.Spec.Volumes).ToNot(BeEmpty())
 -				Expect(pod.Spec.Volumes).To(HaveLen(8))
-+				Expect(pod.Spec.Volumes).To(HaveLen(13))
++				Expect(pod.Spec.Volumes).To(HaveLen(14))
  				Expect(pod.Spec.Volumes).To(ContainElement(k8sv1.Volume{
  					Name: "configmap-volume",
  					VolumeSource: k8sv1.VolumeSource{
@@ -296,7 +305,7 @@ index c6a7f66a54..33d1870205 100644
  
  					Expect(pod.Spec.Volumes).ToNot(BeEmpty())
 -					Expect(pod.Spec.Volumes).To(HaveLen(9))
-+					Expect(pod.Spec.Volumes).To(HaveLen(14))
++					Expect(pod.Spec.Volumes).To(HaveLen(15))
  					Expect(pod.Spec.Volumes).To(ContainElement(k8sv1.Volume{
  						Name: "sysprep-configmap-volume",
  						VolumeSource: k8sv1.VolumeSource{
@@ -305,7 +314,7 @@ index c6a7f66a54..33d1870205 100644
  
  					Expect(pod.Spec.Volumes).ToNot(BeEmpty())
 -					Expect(pod.Spec.Volumes).To(HaveLen(9))
-+					Expect(pod.Spec.Volumes).To(HaveLen(14))
++					Expect(pod.Spec.Volumes).To(HaveLen(15))
  
  					Expect(pod.Spec.Volumes).To(ContainElement(k8sv1.Volume{
  						Name: "sysprep-configmap-volume",
@@ -314,7 +323,7 @@ index c6a7f66a54..33d1870205 100644
  
  				Expect(pod.Spec.Volumes).ToNot(BeEmpty())
 -				Expect(pod.Spec.Volumes).To(HaveLen(8))
-+				Expect(pod.Spec.Volumes).To(HaveLen(13))
++				Expect(pod.Spec.Volumes).To(HaveLen(14))
  
  				Expect(pod.Spec.Volumes).To(ContainElement(k8sv1.Volume{
  					Name: "secret-volume",

--- a/images/virt-artifact/patches/037-set-ReadOnlyRootFilesystem-to-virt-launcher.patch
+++ b/images/virt-artifact/patches/037-set-ReadOnlyRootFilesystem-to-virt-launcher.patch
@@ -1,8 +1,8 @@
 diff --git a/pkg/virt-controller/services/rendervolumes.go b/pkg/virt-controller/services/rendervolumes.go
-index de90ed3cbc..2941b0b8c9 100644
+index de90ed3cbc..992a449bcc 100644
 --- a/pkg/virt-controller/services/rendervolumes.go
 +++ b/pkg/virt-controller/services/rendervolumes.go
-@@ -52,6 +52,12 @@ func NewVolumeRenderer(namespace string, ephemeralDisk string, containerDiskDir
+@@ -52,6 +52,13 @@ func NewVolumeRenderer(namespace string, ephemeralDisk string, containerDiskDir
  
  func (vr *VolumeRenderer) Mounts() []k8sv1.VolumeMount {
  	volumeMounts := []k8sv1.VolumeMount{
@@ -12,10 +12,11 @@ index de90ed3cbc..2941b0b8c9 100644
 +		mountPath(varLibLibvirtVolumeName, varLibLibvirt),
 +		mountPath(varCacheLibvirtVolumeName, varCacheLibvirt),
 +		mountPath(tmpVolumeName, tmp),
++		mountPath(varLibSWTPMLocalCAVolumeName, varLibSWTPMLocalCA),
  		mountPath("private", util.VirtPrivateDir),
  		mountPath("public", util.VirtShareDir),
  		mountPath("ephemeral-disks", vr.ephemeralDiskDir),
-@@ -64,6 +70,12 @@ func (vr *VolumeRenderer) Mounts() []k8sv1.VolumeMount {
+@@ -64,6 +71,13 @@ func (vr *VolumeRenderer) Mounts() []k8sv1.VolumeMount {
  
  func (vr *VolumeRenderer) Volumes() []k8sv1.Volume {
  	volumes := []k8sv1.Volume{
@@ -25,6 +26,7 @@ index de90ed3cbc..2941b0b8c9 100644
 +		emptyDirVolume(varLibLibvirtVolumeName),
 +		emptyDirVolume(varCacheLibvirtVolumeName),
 +		emptyDirVolume(tmpVolumeName),
++		emptyDirVolume(varLibSWTPMLocalCAVolumeName),
  		emptyDirVolume("private"),
  		emptyDirVolume("public"),
  		emptyDirVolume("sockets"),
@@ -77,10 +79,10 @@ index e112967eec..ecb929829c 100644
  		{Name: "public", MountPath: "/var/run/kubevirt"},
  		{Name: "ephemeral-disks", MountPath: "disk1"},
 diff --git a/pkg/virt-controller/services/template.go b/pkg/virt-controller/services/template.go
-index f607c24786..48906f2dd1 100644
+index f607c24786..5f0956dad8 100644
 --- a/pkg/virt-controller/services/template.go
 +++ b/pkg/virt-controller/services/template.go
-@@ -64,15 +64,26 @@ import (
+@@ -64,15 +64,28 @@ import (
  )
  
  const (
@@ -93,30 +95,32 @@ index f607c24786..48906f2dd1 100644
 -	virtExporter          = "virt-exporter"
 -	hotplugContainerDisks = "hotplug-container-disks"
 -	HotplugContainerDisk  = "hotplug-container-disk-"
-+	containerDisks            = "container-disks"
-+	hotplugDisks              = "hotplug-disks"
-+	hookSidecarSocks          = "hook-sidecar-sockets"
-+	varRun                    = "/var/run"
-+	virtBinDir                = "virt-bin-share-dir"
-+	hotplugDisk               = "hotplug-disk"
-+	virtExporter              = "virt-exporter"
-+	hotplugContainerDisks     = "hotplug-container-disks"
-+	HotplugContainerDisk      = "hotplug-container-disk-"
-+	varLog                    = "/var/log"
-+	etcLibvirt                = "/etc/libvirt"
-+	varLibLibvirt             = "/var/lib/libvirt/"
-+	varCacheLibvirt           = "/var/cache/libvirt"
-+	tmp                       = "/tmp"
-+	varLogVolumeName          = "var-log"
-+	etcLibvirtVolumeName      = "etc-libvirt"
-+	varLibLibvirtVolumeName   = "var-lib-libvirt"
-+	varCacheLibvirtVolumeName = "var-cache-libvirt"
-+	varRunVolumeName          = "var-run"
-+	tmpVolumeName             = "tmp"
++	containerDisks               = "container-disks"
++	hotplugDisks                 = "hotplug-disks"
++	hookSidecarSocks             = "hook-sidecar-sockets"
++	varRun                       = "/var/run"
++	virtBinDir                   = "virt-bin-share-dir"
++	hotplugDisk                  = "hotplug-disk"
++	virtExporter                 = "virt-exporter"
++	hotplugContainerDisks        = "hotplug-container-disks"
++	HotplugContainerDisk         = "hotplug-container-disk-"
++	varLog                       = "/var/log"
++	etcLibvirt                   = "/etc/libvirt"
++	varLibLibvirt                = "/var/lib/libvirt/"
++	varCacheLibvirt              = "/var/cache/libvirt"
++	tmp                          = "/tmp"
++	varLibSWTPMLocalCA           = "/var/lib/swtpm-localca"
++	varLogVolumeName             = "var-log"
++	etcLibvirtVolumeName         = "etc-libvirt"
++	varLibLibvirtVolumeName      = "var-lib-libvirt"
++	varCacheLibvirtVolumeName    = "var-cache-libvirt"
++	varRunVolumeName             = "var-run"
++	tmpVolumeName                = "tmp"
++	varLibSWTPMLocalCAVolumeName = "var-lib-swtpm-localca"
  )
  
  const KvmDevice = "devices.virtualization.deckhouse.io/kvm"
-@@ -301,7 +312,6 @@ func generateQemuTimeoutWithJitter(qemuTimeoutBaseSeconds int) string {
+@@ -301,7 +314,6 @@ func generateQemuTimeoutWithJitter(qemuTimeoutBaseSeconds int) string {
  
  func computePodSecurityContext(vmi *v1.VirtualMachineInstance, seccomp *k8sv1.SeccompProfile) *k8sv1.PodSecurityContext {
  	psc := &k8sv1.PodSecurityContext{}
@@ -124,7 +128,7 @@ index f607c24786..48906f2dd1 100644
  	if util.IsNonRootVMI(vmi) {
  		nonRootUser := int64(util.NonRootUID)
  		psc.RunAsUser = &nonRootUser
-@@ -573,6 +583,21 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
+@@ -573,6 +585,21 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
  		}
  
  	}
@@ -146,7 +150,7 @@ index f607c24786..48906f2dd1 100644
  	pod := k8sv1.Pod{
  		ObjectMeta: metav1.ObjectMeta{
  			GenerateName: "virt-launcher-" + domain + "-",
-@@ -639,6 +664,40 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
+@@ -639,6 +666,40 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
  	return &pod, nil
  }
  

--- a/images/virt-artifact/patches/README.md
+++ b/images/virt-artifact/patches/README.md
@@ -235,5 +235,6 @@ Since libvirt and QEMU require writable directories, five emptyDir volumes are a
 - /etc/libvirt
 - /var/lib/libvirt/
 - /var/cache/libvirt
+- /tmp
 
 This ensures compatibility while maintaining a read-only root filesystem for improved isolation and security.

--- a/images/virt-artifact/patches/README.md
+++ b/images/virt-artifact/patches/README.md
@@ -235,6 +235,7 @@ Since libvirt and QEMU require writable directories, five emptyDir volumes are a
 - /etc/libvirt
 - /var/lib/libvirt/
 - /var/cache/libvirt
+- /var/lib/swtpm-localca
 - /tmp
 
 This ensures compatibility while maintaining a read-only root filesystem for improved isolation and security.


### PR DESCRIPTION
## Description
Add new emptydirs mounted to `/tmp` and  `/var/lib/swtpm-localca` for virt-launcher 
```bash
[root@vm-win11-1 /]# cat /var/log/swtpm/libvirt/qemu/dprytkov_vm-win11-1-swtpm.log
Starting vTPM manufacturing as tss:tss @ Thu 27 Feb 2025 09:59:05 AM UTC
Could not create temporary directory for certs: Failed to create file “/tmp/swtpm_setup.certs.JGNM22”: Read-only file system
```


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [X] The code is covered by unit tests.
- [X] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: core
type: fix
summary: Add new emptydirs mounted to `/tmp` and  `/var/lib/swtpm-localca` for virt-launcher 
impact_level: low

```
