### PR TITLE
feat: add yes flag to dvcr-cleaner

### DIFF
--- a/images/dvcr-artifact/cmd/dvcr-cleaner/cmd/delete.go
+++ b/images/dvcr-artifact/cmd/dvcr-cleaner/cmd/delete.go
@@ -81,12 +81,14 @@ func DeleteImage(imageType, imgsDir string, cmd *cobra.Command, args []string) e
 		return errors.New("flag `all` cannot be used with `imageName`")
 	}
 
-	confirm, err := Confirm()
-	if err != nil {
-		return fmt.Errorf("confirm is failed: %w", err)
-	}
-	if !confirm {
-		return nil
+	if !YesFlag {
+		confirm, err := Confirm()
+		if err != nil {
+			return fmt.Errorf("confirm is failed: %w", err)
+		}
+		if !confirm {
+			return nil
+		}
 	}
 
 	if len(args) != 0 {
@@ -145,5 +147,8 @@ func init() {
 	DeleteCmd.AddCommand(deleteCviCmd, deleteViCmd)
 	deleteViCmd.Flags().StringVarP(&NamespaceFlag, "namespace", "n", "default", "a namespace of VirtualImages")
 	deleteViCmd.Flags().BoolVar(&AllImagesFlag, "all", false, "delete all VirtualImages")
+	deleteViCmd.Flags().BoolVarP(&YesFlag, "yes", "y", false, "Auto confirm delete VirtualImages")
+
 	deleteCviCmd.Flags().BoolVar(&AllImagesFlag, "all", false, "delete all ClusterVirtualImages")
+	deleteCviCmd.Flags().BoolVarP(&YesFlag, "yes", "y", false, "Auto confirm delete ClusterVirtualImages")
 }

--- a/images/dvcr-artifact/cmd/dvcr-cleaner/cmd/ls.go
+++ b/images/dvcr-artifact/cmd/dvcr-cleaner/cmd/ls.go
@@ -28,6 +28,7 @@ import (
 
 var (
 	NamespaceFlag     string
+	YesFlag           bool
 	AllImagesFlag     bool
 	AllNamespacesFlag bool
 	RepoDir           = "/var/lib/registry/docker/registry/v2/repositories"


### PR DESCRIPTION
## Description
add yes flag to dvcr-cleaner


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: dvcr
type: feat
summary: add yes flag to dvcr-cleaner
impact_level: low
```
