### PR TITLE
fix(vd): watch pvc creation events

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vd/vd_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/vd/vd_reconciler.go
@@ -178,7 +178,7 @@ func (r *Reconciler) SetupController(_ context.Context, mgr manager.Manager, ctr
 			mgr.GetRESTMapper(),
 			&virtv2.VirtualDisk{},
 		), predicate.Funcs{
-			CreateFunc: func(e event.CreateEvent) bool { return false },
+			CreateFunc: func(e event.CreateEvent) bool { return true },
 			DeleteFunc: func(e event.DeleteEvent) bool { return true },
 			UpdateFunc: func(e event.UpdateEvent) bool {
 				oldPVC, ok := e.ObjectOld.(*corev1.PersistentVolumeClaim)


### PR DESCRIPTION
## Description

Watch events for PVC creation are missed: VD could have gotten stuck in Provisioning instead of WaitForFirstConsumer

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

```changes
section: vd
type: fix
summary: watch pvc creation events
impact_level: low
```
