### PR TITLE
feat(core): disable unnecessary libvirt servers

### DIFF
--- a/images/libvirt/patches/001-disable-ro-and-admin-servers.patch
+++ b/images/libvirt/patches/001-disable-ro-and-admin-servers.patch
@@ -1,0 +1,220 @@
+diff --git a/src/logging/log_daemon.c b/src/logging/log_daemon.c
+index daf7ef4b2f..7877ab03f7 100644
+--- a/src/logging/log_daemon.c
++++ b/src/logging/log_daemon.c
+@@ -550,6 +550,7 @@ virLogDaemonUsage(const char *argv0, bool privileged)
+               "  -f | --config <file>   Configuration file.\n"
+               "  -V | --version         Display version information.\n"
+               "  -p | --pid-file <file> Change name of PID file.\n"
++              "  -A | --no-admin-srv    Disable admin server startup.\n"
+               "\n"
+               "libvirt log management daemon:\n"), argv0);
+ 
+@@ -610,6 +611,8 @@ int main(int argc, char **argv) {
+     virLogDaemonConfig *config = NULL;
+     int rv;
+ 
++    bool no_admin_srv = false;
++
+     struct option opts[] = {
+         { "verbose", no_argument, &verbose, 'v' },
+         { "daemon", no_argument, &godaemon, 'd' },
+@@ -618,6 +621,7 @@ int main(int argc, char **argv) {
+         { "pid-file", required_argument, NULL, 'p' },
+         { "version", no_argument, NULL, 'V' },
+         { "help", no_argument, NULL, 'h' },
++        { "no-admin-srv", no_argument, NULL,'A' },
+         { 0, 0, 0, 0 },
+     };
+ 
+@@ -634,7 +638,7 @@ int main(int argc, char **argv) {
+         int c;
+         char *tmp;
+ 
+-        c = getopt_long(argc, argv, "df:p:t:vVh", opts, &optidx);
++        c = getopt_long(argc, argv, "df:p:t:vVhA", opts, &optidx);
+ 
+         if (c == -1)
+             break;
+@@ -678,6 +682,10 @@ int main(int argc, char **argv) {
+             virLogDaemonUsage(argv[0], privileged);
+             exit(EXIT_SUCCESS);
+ 
++        case 'A':
++            no_admin_srv = true;
++            break;
++            
+         case '?':
+         default:
+             virLogDaemonUsage(argv[0], privileged);
+@@ -732,16 +740,18 @@ int main(int argc, char **argv) {
+     VIR_DEBUG("Decided on pid file path '%s'", NULLSTR(pid_file));
+ 
+     if (virDaemonUnixSocketPaths("virtlogd",
+-                                 privileged,
+-                                 NULL,
+-                                 &sock_file,
+-                                 NULL,
+-                                 &admin_sock_file) < 0) {
++                                privileged,
++                                NULL,
++                                &sock_file,
++                                NULL,
++                                no_admin_srv ? NULL : &admin_sock_file) < 0) {
+         VIR_ERROR(_("Can't determine socket paths"));
+         exit(EXIT_FAILURE);
+     }
+-    VIR_DEBUG("Decided on socket paths '%s' and '%s'",
+-              sock_file, admin_sock_file);
++    VIR_DEBUG("Decided on socket path '%s'", sock_file);
++    if (!no_admin_srv) {
++        VIR_DEBUG("Decided on socket path '%s'", admin_sock_file);
++    }
+ 
+     if (virLogDaemonExecRestartStatePath(privileged,
+                                          &state_file) < 0) {
+@@ -819,7 +829,6 @@ int main(int argc, char **argv) {
+         }
+ 
+         logSrv = virNetDaemonGetServer(logDaemon->dmn, "virtlogd");
+-        adminSrv = virNetDaemonGetServer(logDaemon->dmn, "admin");
+ 
+         if (virNetServerAddServiceUNIX(logSrv,
+                                        act, "virtlogd.socket",
+@@ -829,13 +838,16 @@ int main(int argc, char **argv) {
+             ret = VIR_DAEMON_ERR_NETWORK;
+             goto cleanup;
+         }
+-        if (virNetServerAddServiceUNIX(adminSrv,
+-                                       act, "virtlogd-admin.socket",
+-                                       admin_sock_file, 0700, 0, 0,
+-                                       NULL,
+-                                       false, 0, 1) < 0) {
+-            ret = VIR_DAEMON_ERR_NETWORK;
+-            goto cleanup;
++        if (!no_admin_srv) {
++            adminSrv = virNetDaemonGetServer(logDaemon->dmn, "admin");
++            if (virNetServerAddServiceUNIX(adminSrv,
++                                        act, "virtlogd-admin.socket",
++                                        admin_sock_file, 0700, 0, 0,
++                                        NULL,
++                                        false, 0, 1) < 0) {
++                ret = VIR_DAEMON_ERR_NETWORK;
++                goto cleanup;
++            }
+         }
+ 
+         if (act &&
+@@ -847,7 +859,7 @@ int main(int argc, char **argv) {
+         logSrv = virNetDaemonGetServer(logDaemon->dmn, "virtlogd");
+         /* If exec-restarting from old virtlogd, we won't have an
+          * admin server present */
+-        if (virNetDaemonHasServer(logDaemon->dmn, "admin"))
++        if (!no_admin_srv && virNetDaemonHasServer(logDaemon->dmn, "admin"))
+             adminSrv = virNetDaemonGetServer(logDaemon->dmn, "admin");
+     }
+ 
+@@ -873,7 +885,7 @@ int main(int argc, char **argv) {
+         goto cleanup;
+     }
+ 
+-    if (adminSrv != NULL) {
++    if (!no_admin_srv && adminSrv != NULL) {
+         if (!(adminProgram = virNetServerProgramNew(ADMIN_PROGRAM,
+                                                     ADMIN_PROTOCOL_VERSION,
+                                                     adminProcs,
+diff --git a/src/remote/remote_daemon.c b/src/remote/remote_daemon.c
+index 9e82132654..522aad2177 100644
+--- a/src/remote/remote_daemon.c
++++ b/src/remote/remote_daemon.c
+@@ -722,6 +722,8 @@ daemonUsage(const char *argv0, bool privileged)
+         { "-f | --config <file>", N_("Configuration file") },
+         { "-V | --version", N_("Display version information") },
+         { "-p | --pid-file <file>", N_("Change name of PID file") },
++        { "-A | --no-admin-srv", N_("Disable admin server startup")},
++        { "-R | --no-ro-srv", N_("Disable read-only server startup")},
+     };
+ 
+     fprintf(stderr, "\n");
+@@ -806,6 +808,9 @@ int main(int argc, char **argv) {
+     bool implicit_conf = false;
+     char *run_dir = NULL;
+     mode_t old_umask;
++    
++    bool no_admin_srv = false;
++    bool no_ro_srv = false;
+ 
+     struct option opts[] = {
+         { "verbose", no_argument, &verbose, 'v' },
+@@ -818,6 +823,8 @@ int main(int argc, char **argv) {
+         { "pid-file", required_argument, NULL, 'p' },
+         { "version", no_argument, NULL, 'V' },
+         { "help", no_argument, NULL, 'h' },
++        {"no-admin-srv", no_argument, NULL, 'A'},
++        {"no-ro-srv", no_argument, NULL, 'R'},
+         { 0, 0, 0, 0 },
+     };
+ 
+@@ -834,9 +841,9 @@ int main(int argc, char **argv) {
+         int c;
+         char *tmp;
+ #if defined(WITH_IP) && defined(LIBVIRTD)
+-        const char *optstr = "ldf:p:t:vVh";
++        const char *optstr = "ldf:p:t:vVhAR";
+ #else /* !(WITH_IP && LIBVIRTD) */
+-        const char *optstr = "df:p:t:vVh";
++        const char *optstr = "df:p:t:vVhAR";
+ #endif /* !(WITH_IP && LIBVIRTD) */
+ 
+         c = getopt_long(argc, argv, optstr, opts, &optidx);
+@@ -889,6 +896,14 @@ int main(int argc, char **argv) {
+             daemonUsage(argv[0], privileged);
+             exit(EXIT_SUCCESS);
+ 
++        case 'A':
++            no_admin_srv = true;
++            break;
++
++        case 'R':
++            no_ro_srv = true;
++            break;
++            
+         case '?':
+         default:
+             daemonUsage(argv[0], privileged);
+@@ -966,15 +981,18 @@ int main(int argc, char **argv) {
+                                  privileged,
+                                  config->unix_sock_dir,
+                                  &sock_file,
+-                                 &sock_file_ro,
+-                                 &sock_file_adm) < 0) {
++                                 no_ro_srv ? NULL : &sock_file_ro,
++                                 no_admin_srv ? NULL : &sock_file_adm) < 0) {
+         VIR_ERROR(_("Can't determine socket paths"));
+         exit(EXIT_FAILURE);
+     }
+-    VIR_DEBUG("Decided on socket paths '%s', '%s' and '%s'",
+-              sock_file,
+-              NULLSTR(sock_file_ro),
+-              NULLSTR(sock_file_adm));
++    VIR_DEBUG("Decided on socket path '%s'", sock_file);
++    if (!no_ro_srv) {
++        VIR_DEBUG("Decided on socket path '%s'", NULLSTR(sock_file_ro));
++    }
++    if (!no_admin_srv) {
++        VIR_DEBUG("Decided on socket path '%s'", NULLSTR(sock_file_adm));
++    }          
+ 
+     if (godaemon) {
+         if (chdir("/") < 0) {
+@@ -1172,8 +1190,8 @@ int main(int argc, char **argv) {
+                               privileged,
+ #endif /* !WITH_IP */
+                               sock_file,
+-                              sock_file_ro,
+-                              sock_file_adm) < 0) {
++                              no_ro_srv ? NULL : sock_file_ro,
++                              no_admin_srv ? NULL : sock_file_adm) < 0) {
+         ret = VIR_DAEMON_ERR_NETWORK;
+         goto cleanup;
+     }

--- a/images/libvirt/patches/README.md
+++ b/images/libvirt/patches/README.md
@@ -1,0 +1,17 @@
+# Patches
+
+## `001-disable-ro-and-admin-servers.patch`
+
+This patch introduces new flags to enhance the security and control of QEMU services:
+
+- Adds `--no-admin-srv` and `--no-ro-srv` flags to `virtqemud`.
+- Adds `--no-admin-srv` flag to `virtlogd`.
+
+These flags allow disabling the read-only and admin servers for `virtqemud` and the admin server for `virtlogd`, respectively, providing better control over the services and reducing potential attack surfaces.
+
+### Affected Sockets
+
+When all flags are set, the following sockets will be disabled:
+- `/var/run/libvirt/virtlogd-admin-sock`
+- `/var/run/libvirt/virtqemud-admin-sock`
+- `/var/run/libvirt/virtqemud-sock-ro`

--- a/images/libvirt/werf.inc.yaml
+++ b/images/libvirt/werf.inc.yaml
@@ -11,12 +11,17 @@ git:
   to: /
   includePaths:
   - install-libvirt.sh
+  - patches
+  excludePaths:
+    - patches/README.md
   stageDependencies:
+    install:
+      - '**/*'
     setup:
       - install-libvirt.sh
 shell:
   beforeInstall:
-  - | 
+  - |
     apt-get update && apt-get install --yes \
     binutils \
     dmidecode \
@@ -108,7 +113,7 @@ shell:
     ln -s /usr/bin/ccache /usr/libexec/ccache-wrappers/cc
     ln -s /usr/bin/ccache /usr/libexec/ccache-wrappers/clang
     ln -s /usr/bin/ccache /usr/libexec/ccache-wrappers/gcc
-  
+
     pip3 install black
 
   install:
@@ -124,6 +129,12 @@ shell:
     git clone --depth=1 --branch v{{ $version }} {{ $gitRepoUrl }} {{ $gitRepoName }}-{{ $version }}
 
     cd {{ $gitRepoName }}-{{ $version }}
+
+
+    for p in /patches/*.patch ; do
+      echo -n "Apply ${p} ... "
+      git apply  --ignore-space-change --ignore-whitespace ${p} && echo OK || (echo FAIL ; exit 1)
+    done
 
     CFLAGS="-Wframe-larger-than=262144" meson setup build \
       -Dinit_script=systemd \
@@ -174,7 +185,7 @@ shell:
       ninja -C build -j$(nproc)
 
   setup:
-  - |    
+  - |
     /install-libvirt.sh --version-num "{{ $version }}" \
                         -s /{{ $gitRepoName }}-{{ $version }} \
                         -d /BINS \

--- a/images/virt-artifact/patches/038-disable-unnecessary-libvirt-sockets.patch
+++ b/images/virt-artifact/patches/038-disable-unnecessary-libvirt-sockets.patch
@@ -1,0 +1,22 @@
+diff --git a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+index b342c034f7..2c442ca60c 100644
+--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
++++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+@@ -218,7 +218,7 @@ func (l LibvirtWrapper) StartVirtquemud(stopChan chan struct{}) {
+ 	go func() {
+ 		for {
+ 			exitChan := make(chan struct{})
+-			args := []string{"-f", "/var/run/libvirt/virtqemud.conf"}
++			args := []string{"-f", "/var/run/libvirt/virtqemud.conf", "--no-admin-srv", "--no-ro-srv"}
+ 			cmd := exec.Command("/usr/sbin/virtqemud", args...)
+ 			if l.user != 0 {
+ 				cmd.SysProcAttr = &syscall.SysProcAttr{
+@@ -273,7 +273,7 @@ func (l LibvirtWrapper) StartVirtquemud(stopChan chan struct{}) {
+ 
+ func startVirtlogdLogging(stopChan chan struct{}, domainName string, nonRoot bool) {
+ 	for {
+-		cmd := exec.Command("/usr/sbin/virtlogd", "-f", "/etc/libvirt/virtlogd.conf")
++		cmd := exec.Command("/usr/sbin/virtlogd", "-f", "/etc/libvirt/virtlogd.conf", "--no-admin-srv")
+ 
+ 		exitChan := make(chan struct{})
+ 

--- a/images/virt-artifact/patches/README.md
+++ b/images/virt-artifact/patches/README.md
@@ -235,6 +235,25 @@ Since libvirt and QEMU require writable directories, five emptyDir volumes are a
 
 This ensures compatibility while maintaining a read-only root filesystem for improved isolation and security.
 
+#### `038-disable-unnecessary-libvirt-sockets.patch`
+
+This patch disables unnecessary libvirt sockets by running `virtqemud` and `virtlogd` with additional flags to prevent their creation. Specifically, we disable the admin and read-only servers:
+
+- `--no-admin-srv` and `--no-ro-srv` flags for `virtqemud`.
+- `--no-admin-srv` flag for `virtlogd`.
+
+By using these flags, the following sockets are not created in the first place:
+
+- `/var/run/libvirt/virtlogd-admin-sock`
+- `/var/run/libvirt/virtqemud-admin-sock`
+- `/var/run/libvirt/virtqemud-sock-ro`
+
+This ensures a cleaner runtime environment, reducing unnecessary components and preventing unintended interactions, without affecting libvirt's core functionality.
+
+##### Dependency
+
+This patch depends on the [001-disable-ro-and-admin-servers.patch](../../libvirt/patches/001-disable-ro-and-admin-servers.patch) for proper flag application to disable the relevant servers and prevent the creation of their associated sockets.
+
 #### `039-get-applied-checksum.patch`
 
 This patch introduces the GetAppliedChecksum() method in virt-launcher.


### PR DESCRIPTION
## Description
Disable unnecessary libvirt servers

### Add patch `001-disable-ro-and-admin-servers.patch` to `libvirt`

This patch introduces new flags to enhance the security and control of QEMU services:

- Adds `--no-admin-srv` and `--no-ro-srv` flags to `virtqemud`.
- Adds `--no-admin-srv` flag to `virtlogd`.

These flags allow disabling the read-only and admin servers for `virtqemud` and the admin server for `virtlogd`, respectively, providing better control over the services and reducing potential attack surfaces.

#### Affected Sockets

When all flags are set, the following sockets will be disabled:
- `/var/run/libvirt/virtlogd-admin-sock`
- `/var/run/libvirt/virtqemud-admin-sock`
- `/var/run/libvirt/virtqemud-sock-ro`

### Add patch `038-disable-unnecessary-libvirt-sockets.patch` to `kubevirt`

This patch disables unnecessary libvirt sockets by running `virtqemud` and `virtlogd` with additional flags to prevent their creation. Specifically, we disable the admin and read-only servers:

- `--no-admin-srv` and `--no-ro-srv` flags for `virtqemud`.
- `--no-admin-srv` flag for `virtlogd`.

By using these flags, the following sockets are not created in the first place:

- `/var/run/libvirt/virtlogd-admin-sock`
- `/var/run/libvirt/virtqemud-admin-sock`
- `/var/run/libvirt/virtqemud-sock-ro`

This ensures a cleaner runtime environment, reducing unnecessary components and preventing unintended interactions, without affecting libvirt's core functionality.

#### Dependency

This patch depends on the [001-disable-ro-and-admin-servers.patch](../../libvirt/patches/001-disable-ro-and-admin-servers.patch) for proper flag application to disable the relevant servers and prevent the creation of their associated sockets.


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: core
type: feat
summary: Disable unnecessary libvirt servers.
```
