### PR TITLE
refactor(kubevirt): Remove init container `etc-libvirt-init` and handle setup in virt-launcher

### DIFF
--- a/images/virt-artifact/patches/037-set-ReadOnlyRootFilesystem-to-virt-launcher.patch
+++ b/images/virt-artifact/patches/037-set-ReadOnlyRootFilesystem-to-virt-launcher.patch
@@ -84,7 +84,7 @@ index e112967eec..4781a313d7 100644
  		{Name: "public", MountPath: "/var/run/kubevirt"},
  		{Name: "ephemeral-disks", MountPath: "disk1"},
 diff --git a/pkg/virt-controller/services/template.go b/pkg/virt-controller/services/template.go
-index f607c24786..5f0956dad8 100644
+index f607c24786..1221448946 100644
 --- a/pkg/virt-controller/services/template.go
 +++ b/pkg/virt-controller/services/template.go
 @@ -64,15 +64,28 @@ import (
@@ -111,7 +111,7 @@ index f607c24786..5f0956dad8 100644
 +	HotplugContainerDisk         = "hotplug-container-disk-"
 +	varLog                       = "/var/log"
 +	etcLibvirt                   = "/etc/libvirt"
-+	varLibLibvirt                = "/var/lib/libvirt/"
++	varLibLibvirt                = "/var/lib/libvirt"
 +	varCacheLibvirt              = "/var/cache/libvirt"
 +	tmp                          = "/tmp"
 +	varLibSWTPMLocalCA           = "/var/lib/swtpm-localca"
@@ -133,11 +133,10 @@ index f607c24786..5f0956dad8 100644
  	if util.IsNonRootVMI(vmi) {
  		nonRootUser := int64(util.NonRootUID)
  		psc.RunAsUser = &nonRootUser
-@@ -573,6 +585,21 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
+@@ -573,6 +585,20 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
  		}
  
  	}
-+	initContainers = append(initContainers, t.newEtcLibvirtCopierInitContainer(vmi, userId))
 +
 +	// Set ReadOnlyRootFilesystem
 +	setReadOnlyRootFilesystem := func(ctrs []k8sv1.Container) {
@@ -155,49 +154,8 @@ index f607c24786..5f0956dad8 100644
  	pod := k8sv1.Pod{
  		ObjectMeta: metav1.ObjectMeta{
  			GenerateName: "virt-launcher-" + domain + "-",
-@@ -639,6 +666,40 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
- 	return &pod, nil
- }
- 
-+func (t *templateService) newEtcLibvirtCopierInitContainer(vmi *v1.VirtualMachineInstance, userID int64) k8sv1.Container {
-+	const (
-+		initPath      = "/init"
-+		containerName = etcLibvirtVolumeName + "-init"
-+	)
-+	command := []string{"sh", "-c", fmt.Sprintf("cp -a %s/. %s", etcLibvirt, initPath+"/")}
-+
-+	cpInitContainerOpts := []Option{
-+		WithVolumeMounts(k8sv1.VolumeMount{
-+			Name:      etcLibvirtVolumeName,
-+			MountPath: initPath,
-+		}),
-+		WithResourceRequirements(k8sv1.ResourceRequirements{
-+			Requests: k8sv1.ResourceList{
-+				k8sv1.ResourceCPU:    resource.MustParse("10m"),
-+				k8sv1.ResourceMemory: resource.MustParse("1M"),
-+			},
-+			Limits: k8sv1.ResourceList{
-+				k8sv1.ResourceCPU:    resource.MustParse("100m"),
-+				k8sv1.ResourceMemory: resource.MustParse("40M"),
-+			},
-+		}),
-+		WithNoCapabilities(),
-+	}
-+	if util.IsNonRootVMI(vmi) {
-+		cpInitContainerOpts = append(cpInitContainerOpts, WithNonRoot(userID))
-+	}
-+	if t.IsPPC64() {
-+		cpInitContainerOpts = append(cpInitContainerOpts, WithPrivileged())
-+	}
-+
-+	return NewContainerSpecRenderer(containerName, t.launcherImage, t.clusterConfig.GetImagePullPolicy(), cpInitContainerOpts...).Render(command)
-+}
-+
- func (t *templateService) newNodeSelectorRenderer(vmi *v1.VirtualMachineInstance) *NodeSelectorRenderer {
- 	var opts []NodeSelectorRendererOption
- 	if vmi.IsCPUDedicated() {
 diff --git a/pkg/virt-controller/services/template_test.go b/pkg/virt-controller/services/template_test.go
-index c6a7f66a54..16c1e102bf 100644
+index c6a7f66a54..80dab4e808 100644
 --- a/pkg/virt-controller/services/template_test.go
 +++ b/pkg/virt-controller/services/template_test.go
 @@ -458,7 +458,7 @@ var _ = Describe("Template", func() {
@@ -205,19 +163,10 @@ index c6a7f66a54..16c1e102bf 100644
  				Expect(pod.Spec.Containers[1].ImagePullPolicy).To(Equal(k8sv1.PullPolicy("IfNotPresent")))
  				Expect(*pod.Spec.TerminationGracePeriodSeconds).To(Equal(int64(60)))
 -				Expect(pod.Spec.InitContainers).To(BeEmpty())
-+				Expect(pod.Spec.InitContainers).To(HaveLen(1))
++				Expect(pod.Spec.InitContainers).To(HaveLen(0))
  				By("setting the right hostname")
  				Expect(pod.Spec.Hostname).To(Equal("testvmi"))
  				Expect(pod.Spec.Subdomain).To(BeEmpty())
-@@ -933,7 +933,7 @@ var _ = Describe("Template", func() {
- 				pod, err := svc.RenderLaunchManifest(&vmi)
- 				Expect(err).ToNot(HaveOccurred())
- 
--				Expect(pod.Spec.InitContainers).To(HaveLen(3))
-+				Expect(pod.Spec.InitContainers).To(HaveLen(4))
- 				Expect(pod.Spec.InitContainers[0].VolumeMounts[0].MountPath).To(Equal("/init/usr/bin"))
- 				Expect(pod.Spec.InitContainers[0].VolumeMounts[0].Name).To(Equal("virt-bin-share-dir"))
- 				Expect(pod.Spec.InitContainers[0].Command).To(Equal([]string{"/usr/bin/cp",
 @@ -2314,7 +2314,7 @@ var _ = Describe("Template", func() {
  				Expect(hugepagesRequest.ToDec().ScaledValue(resource.Mega)).To(Equal(int64(64)))
  				Expect(hugepagesLimit.ToDec().ScaledValue(resource.Mega)).To(Equal(int64(64)))
@@ -336,3 +285,68 @@ index c6a7f66a54..16c1e102bf 100644
  
  				Expect(pod.Spec.Volumes).To(ContainElement(k8sv1.Volume{
  					Name: "secret-volume",
+diff --git a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+index b342c034f7..37630f597f 100644
+--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
++++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+@@ -472,7 +472,60 @@ func copyFile(from, to string) error {
+ 	return err
+ }
+ 
++func copyDir(src, dest string) error {
++	sourceDirInfo, err := os.Stat(src)
++	if err != nil {
++		return err
++	}
++
++	if _, err = os.Stat(dest); err != nil {
++		if os.IsNotExist(err) {
++			err = os.MkdirAll(dest, sourceDirInfo.Mode())
++			if err != nil {
++				return err
++			}
++		} else {
++			return err
++		}
++	}
++
++	entries, err := os.ReadDir(src)
++	if err != nil {
++		return err
++	}
++
++	for _, entry := range entries {
++		srcPath := filepath.Join(src, entry.Name())
++		destPath := filepath.Join(dest, entry.Name())
++
++		if entry.IsDir() {
++			err = copyDir(srcPath, destPath)
++			if err != nil {
++				return err
++			}
++		} else {
++			err = copyFile(srcPath, destPath)
++			if err != nil {
++				return err
++			}
++		}
++	}
++
++	return nil
++}
++
++const (
++	etlLibvirtInit = "/etc/libvirt-init"
++	etcLibvirt     = "/etc/libvirt"
++)
++
+ func (l LibvirtWrapper) SetupLibvirt(customLogFilters *string) (err error) {
++	if _, err = os.Stat(etlLibvirtInit); err == nil {
++		if err = copyDir(etlLibvirtInit, etcLibvirt); err != nil {
++			return fmt.Errorf("failed to copy %q to %q: %w", etlLibvirtInit, etcLibvirt, err)
++		}
++	}
++
+ 	runtimeQemuConfPath := qemuConfPath
+ 	if !l.root() {
+ 		runtimeQemuConfPath = qemuNonRootConfPath

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -394,8 +394,8 @@ shell:
     cd /relocate
     ln -s var/run run
 
-  # /etc/libvirt-init will be copied to /etc/libvirt at runtime. This is necessary because we configure libvirt during runtime and set readOnlyRootFilesystem.
-  # DON'T Move. In node-labeler.sh used /etc/libvirt.
+  # /etc/libvirt-init will be copied back into /etc/libvirt at runtime. This is necessary because we configure libvirt to mount /etc/libvirt and set readOnlyRootFilesystem for other directories.
+  # DO NOT REMOVE. node-labeler.sh uses /etc/libvirt.
   - |
     cp -a etc/libvirt etc/libvirt-init
 

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -11,7 +11,6 @@ git:
     to: /etc
     includePaths:
     - ld.so.preload
-
 ---
 image: {{ $.ImageName }}-prepared
 final: false
@@ -299,7 +298,7 @@ shell:
 
     echo "=====Copy libvirt binaries to temp folder======"
     cp -a /libvirt-bins/. /VBINS/
-    
+
     echo "=====Copy qemu binaries to temp folder======"
     cp -a /qemu-bins/. /VBINS/
 
@@ -311,7 +310,7 @@ shell:
     ./relocate_binaries.sh -i "$LIST" -o /VBINS
 
     cp -a /VBINS/. /relocate
-    
+
     # Cleanup
     rm -rf /{VBINS,qemu-bins,libvirt-bins}
 
@@ -328,12 +327,12 @@ shell:
     echo "root:x:0:0:root:/root:/bin/bash" >> /relocate/etc/passwd
     echo "root:x:0:" >> /relocate/etc/group
     echo "root:x:::::::" >> /relocate/etc/shadow
-    
+
     echo "qemu:x:107:107::/home/qemu:/bin/bash" >> /relocate/etc/passwd
     echo "qemu:x:107:" >> /relocate/etc/group
     mkdir -p /relocate/home/qemu
     chown -R 107:107 /relocate/home/qemu
-  
+
   - |
     echo "Create symlinks for OVMF"
     mkdir -p /relocate/usr/share/OVMF
@@ -343,12 +342,12 @@ shell:
 
     cd /relocate
     ln -sf ../edk2/ovmf/OVMF_CODE.cc.fd       usr/share/OVMF/OVMF_CODE.cc.fd
-    
+
     ln -s ../edk2/ovmf/OVMF_CODE.secboot.fd   usr/share/OVMF
     ln -s ../edk2/ovmf/OVMF_VARS.fd           usr/share/OVMF
     ln -s ../edk2/ovmf/OVMF_VARS.secboot.fd   usr/share/OVMF
     ln -s ../edk2/ovmf/UefiShell.iso          usr/share/OVMF
-    
+
     cd /
 
   - |
@@ -394,6 +393,11 @@ shell:
   - |
     cd /relocate
     ln -s var/run run
+
+  # /etc/libvirt-init will be copied to /etc/libvirt at runtime. This is necessary because we configure libvirt during runtime and set readOnlyRootFilesystem.
+  # DON'T Move. In node-labeler.sh used /etc/libvirt.
+  - |
+    cp -a etc/libvirt etc/libvirt-init
 
 ---
 image: {{ $.ImageName }}-liboverride-builder


### PR DESCRIPTION
## Description  

Previously, an init container was used to copy `/etc/libvirt` to `emptyDir` because the filesystem was mounted with `ReadOnlyRootFilesystem`, but we needed write access.  

With this change:  
- The init container has been removed.  
- During the build process, `/etc/libvirt` is now copied to `/etc/libvirt-init`.  
- A new `setupLibvirt` function has been added to `virt-launcher`, which copies the files back to `/etc/libvirt` if `/etc/libvirt-init` exists.  

This eliminates the need for an extra init container while preserving the required functionality.


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [X] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: kubevirt
type: chore
summary: Remove init container etc-libvirt-init and handle setup in virt-launcher
impact_level: low
-->

```changes
section: kubevirt
type: refactor
summary: Remove init container etc-libvirt-init and handle setup in virt-launcher
impact_level: low

```
