### PR TITLE
fix(core): fix symlinks and add missing binaries virt-launcher

### DIFF
--- a/images/libvirt/install-libvirt.sh
+++ b/images/libvirt/install-libvirt.sh
@@ -141,7 +141,7 @@ $SRC_BUILD/src/libvirt_storage_file_fs.so to /usr/lib64/libvirt/storage-file
 # $SRC_BUILD/src/libvirt_driver_ch.so to /usr/lib64/libvirt/connection-driver
 $SRC_BUILD/src/libvirt_driver_qemu.so to /usr/lib64/libvirt/connection-driver
 # $SRC_BUILD/src/libvirt_driver_vbox.so to /usr/lib64/libvirt/connection-driver
-# $SRC_BUILD/src/libvirtd to /usr/sbin
+$SRC_BUILD/src/libvirtd to /usr/sbin
 $SRC_BUILD/src/virtproxyd to /usr/sbin
 $SRC_BUILD/src/virtinterfaced to /usr/sbin
 $SRC_BUILD/src/virtlockd to /usr/sbin

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -334,8 +334,10 @@ shell:
     echo "Create symlinks for OVMF"
     mkdir -p /relocate/usr/share/OVMF
 
+    cd /relocate/usr/share/edk2/ovmf
+    ln -sf OVMF_CODE.fd   OVMF_CODE.cc.fd
+
     cd /relocate
-    ln -sf usr/share/edk2/ovmf/OVMF_CODE.fd   usr/share/edk2/ovmf/OVMF_CODE.cc.fd
     ln -sf ../edk2/ovmf/OVMF_CODE.cc.fd       usr/share/OVMF/OVMF_CODE.cc.fd
     
     ln -s ../edk2/ovmf/OVMF_CODE.secboot.fd   usr/share/OVMF

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -176,7 +176,7 @@ binaries:
   # Ethtool
   - /usr/sbin/ethlist /usr/sbin/ethtool /usr/sbin/iptables /usr/sbin/ip /usr/sbin/bridge /usr/sbin/nft
   # Procps utils
-  - /usr/sbin/sysctl /usr/bin/pgrep /usr/bin/pidwait /usr/bin/pkill /usr/bin/pmap /usr/bin/pwdx
+  - /usr/sbin/sysctl
   # Passt (User-mode networking daemons for virtual machines and namespaces)
   - /usr/bin/passt /usr/bin/passt.avx2 /usr/bin/pasta /usr/bin/pasta.avx2 /usr/bin/qrap
   # Swtpm
@@ -319,7 +319,7 @@ shell:
   - |
     ./relocate_binaries.sh -i "{{ $virtLauncherDependencies.binaries | join " " }}" -o /relocate
 
-    mkdir -p /relocate/{etc,root}
+    mkdir -p /relocate/{etc,root,var/run}
 
     # glibc-gconv-modules
     cp -a /usr/lib64/gconv /relocate/usr/lib64
@@ -391,6 +391,9 @@ shell:
     mkdir -p /relocate/init/usr/bin
     cd /relocate
     ln -s usr/bin/container-disk ./init/usr/bin/container-disk
+  - |
+    cd /relocate
+    ln -s var/run run
 
 ---
 image: {{ $.ImageName }}-liboverride-builder

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -157,22 +157,26 @@ binaries:
   - /usr/bin/mv
   - /usr/bin/cut
   - /usr/bin/grep
+  - /usr/bin/sync
   # Utilities for mount
   - /usr/bin/mount
   - /usr/bin/umount
+  - /usr/bin/findmnt
   # Blk utilites
   - /usr/sbin/blkid
   - /usr/sbin/blockdev
   # Openssl
   - /usr/bin/openssl
   # Acl utils
-  - /usr/bin/chacl /usr/bin/getfacl /usr/bin/setfacl /usr/bin/chmod
+  - /usr/bin/chacl /usr/bin/getfacl /usr/bin/setfacl /usr/bin/chmod /usr/bin/chown
   # Fs utils
   - /usr/sbin/fstrim /usr/sbin/fuser /usr/sbin/findfs
   # Xorriso (Creates an image of an ISO9660 filesystem)
   - /usr/bin/xorriso-dd-target /usr/bin/xorrisofs
   # Ethtool
   - /usr/sbin/ethlist /usr/sbin/ethtool /usr/sbin/iptables /usr/sbin/ip /usr/sbin/bridge /usr/sbin/nft
+  # Procps utils
+  - /usr/sbin/sysctl /usr/bin/pgrep /usr/bin/pidwait /usr/bin/pkill /usr/bin/pmap /usr/bin/pwdx
   # Passt (User-mode networking daemons for virtual machines and namespaces)
   - /usr/bin/passt /usr/bin/passt.avx2 /usr/bin/pasta /usr/bin/pasta.avx2 /usr/bin/qrap
   # Swtpm

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -172,7 +172,7 @@ binaries:
   # Xorriso (Creates an image of an ISO9660 filesystem)
   - /usr/bin/xorriso-dd-target /usr/bin/xorrisofs
   # Ethtool
-  - /usr/sbin/ethlist /usr/sbin/ethtool /usr/sbin/iptables /usr/sbin/ip /usr/sbin/bridge
+  - /usr/sbin/ethlist /usr/sbin/ethtool /usr/sbin/iptables /usr/sbin/ip /usr/sbin/bridge /usr/sbin/nft
   # Passt (User-mode networking daemons for virtual machines and namespaces)
   - /usr/bin/passt /usr/bin/passt.avx2 /usr/bin/pasta /usr/bin/pasta.avx2 /usr/bin/qrap
   # Swtpm
@@ -291,7 +291,7 @@ shell:
 
     apt-get clean
 
-    mkdir -p /VBINS/var/{log/libvirt/qemu,run,lib/libvirt/qemu}
+    mkdir -p /VBINS/var/{log/libvirt/qemu,run/libvirt/qemu,lib/libvirt/qemu}
 
     echo "=====Copy libvirt binaries to temp folder======"
     cp -a /libvirt-bins/. /VBINS/


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Added `findmnt` and `nft` to libvirtd dependencies – These tools are necessary for proper functionality and compatibility with libvirtd.
Created a symlink `ln -s var/run run` – This ensures compatibility and resolves potential issues with paths expecting /run to exist as a symlink to /var/run.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
Some virtual machines can't start, error in logs like: `Still missing PID for vm /run/libvirt/qemu/vm.pid no such file or directory`

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: core
type: fix
summary: fix symlinks and add missing binaries virt-launcher
```
