### PR TITLE
fix(core): add swtpm configs and gnutls-utils to virt-launcher image

### DIFF
--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -318,7 +318,10 @@ shell:
   - |
     ./relocate_binaries.sh -i "{{ $virtLauncherDependencies.binaries | join " " }}" -o /relocate
 
-    mkdir -p /relocate/{etc,root,var/run}
+    mkdir -p /relocate/{etc,root,var/run,var/log/swtpm/libvirt/qemu}
+    
+    # Copy additional config swtpm
+    cp -a /etc/{swtpm_setup.conf,swtpm-localca.conf,swtpm-localca.options} /relocate/etc/
 
     # glibc-gconv-modules
     cp -a /usr/lib64/gconv /relocate/usr/lib64

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -129,6 +129,7 @@ packages:
   - ethtool
   - fdisk
   - glibc-gconv-modules
+  - gnutls-utils
   - hwclock
   - iptables
   - libffi8
@@ -157,6 +158,12 @@ binaries:
   - /usr/bin/cut
   - /usr/bin/grep
   - /usr/bin/sync
+  # Gnu utils (requared for swtpm)
+  - /usr/bin/certtool
+  - /usr/bin/gnutls-cli
+  - /usr/bin/ocsptool
+  - /usr/bin/p11tool
+  - /usr/bin/psktool
   # Utilities for mount
   - /usr/bin/mount
   - /usr/bin/umount
@@ -294,7 +301,9 @@ shell:
 
     apt-get clean
 
-    mkdir -p /VBINS/var/{log/libvirt/qemu,run/libvirt/qemu,lib/libvirt/qemu}
+    echo "Create folder hierarchy in VBINS"
+    mkdir -p /VBINS/{etc,root}
+    mkdir -p /VBINS/var/{log/libvirt/qemu,log/swtpm/libvirt/qemu,lib/libvirt/qemu,run/libvirt/qemu}
 
     echo "=====Copy libvirt binaries to temp folder======"
     cp -a /libvirt-bins/. /VBINS/
@@ -317,15 +326,14 @@ shell:
   setup:
   - |
     ./relocate_binaries.sh -i "{{ $virtLauncherDependencies.binaries | join " " }}" -o /relocate
-
-    mkdir -p /relocate/{etc,root,var/run,var/log/swtpm/libvirt/qemu}
     
     # Copy additional config swtpm
     cp -a /etc/{swtpm_setup.conf,swtpm-localca.conf,swtpm-localca.options} /relocate/etc/
+    # Copy xattr config
+    cp -a /etc/xattr.conf /relocate/etc
 
     # glibc-gconv-modules
     cp -a /usr/lib64/gconv /relocate/usr/lib64
-    cp /etc/xattr.conf /relocate/etc
 
     echo "root:x:0:0:root:/root:/bin/bash" >> /relocate/etc/passwd
     echo "root:x:0:" >> /relocate/etc/group


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Swtpm configs and gnutls-utils was added to virt-laucher, for correct launch windows vm and vm with UEFI


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
Without these components, the vm with UEFI will not migrate

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: core
type: fix
summary:  add swtpm configs and gnutls-utils to virt-launcher image
```
