### PR TITLE
test(vm): refactor affinity and toleration test case

### DIFF
--- a/tests/e2e/affinity_toleration_test.go
+++ b/tests/e2e/affinity_toleration_test.go
@@ -34,7 +34,7 @@ import (
 	kc "github.com/deckhouse/virtualization/tests/e2e/kubectl"
 )
 
-func IsVmMigratable(vmObj *virtv2.VirtualMachine) {
+func ExpectVirtualMachineIsMigratable(vmObj *virtv2.VirtualMachine) {
 	GinkgoHelper()
 	for _, c := range vmObj.Status.Conditions {
 		if c.Type == string(vmcondition.TypeMigratable) {
@@ -264,7 +264,7 @@ var _ = Describe("Virtual machine affinity and toleration", ginkgoutil.CommonE2E
 			By("Change affinity to anti-affinity when the `VirtualMachines` are runnning: `vm-a` and `vm-c` should be running on the different nodes", func() {
 				wg := &sync.WaitGroup{}
 
-				IsVmMigratable(vmObjC)
+				ExpectVirtualMachineIsMigratable(vmObjC)
 				p, err := GenerateVirtualMachineAndPodAntiAffinityPatch(vmKey, nodeLabelKey, metav1.LabelSelectorOpIn, []string{vmA[vmKey]})
 				Expect(err).NotTo(HaveOccurred(), "failed to generate the `VirtualMachineAndPodAntiAffinity` patch")
 				jsonPatchAdd := &kc.JsonPatch{
@@ -326,7 +326,7 @@ var _ = Describe("Virtual machine affinity and toleration", ginkgoutil.CommonE2E
 					Namespace: conf.Namespace,
 				})
 
-				IsVmMigratable(updatedVmObjC)
+				ExpectVirtualMachineIsMigratable(updatedVmObjC)
 				p, err := GenerateVirtualMachineAndPodAffinityPatch(vmKey, nodeLabelKey, metav1.LabelSelectorOpIn, []string{vmA[vmKey]})
 				Expect(err).NotTo(HaveOccurred(), "failed to generate the `VirtualMachineAndPodAffinity` patch")
 				jsonPatchAdd := &kc.JsonPatch{
@@ -394,9 +394,9 @@ var _ = Describe("Virtual machine affinity and toleration", ginkgoutil.CommonE2E
 			By("Sets the `spec.nodeSelector` with the `status.nodeSelector` value", func() {
 				vmObj, err = GetVirtualMachineObjByLabel(conf.Namespace, vmNodeSelector)
 				Expect(err).NotTo(HaveOccurred(), "failed to obtain the %q `VirtualMachine` object", vmNodeSelector)
-				IsVmMigratable(vmObj)
+				ExpectVirtualMachineIsMigratable(vmObj)
 				sourceNode = vmObj.Status.Node
-				Expect(sourceNode).ShouldNot(Equal(""), "the `vm.status.nodeName` should have a value")
+				Expect(sourceNode).ShouldNot(BeEmpty(), "the `vm.status.nodeName` should have a value")
 				mergePatch := fmt.Sprintf(`{"spec":{"nodeSelector":{%q:%q}}}`, nodeLabelKey, sourceNode)
 				err = MergePatchResource(kc.ResourceVM, vmObj.Name, mergePatch)
 				Expect(err).NotTo(HaveOccurred(), "failed to patch the %q `VirtualMachine`", vmNodeSelector)
@@ -427,7 +427,7 @@ var _ = Describe("Virtual machine affinity and toleration", ginkgoutil.CommonE2E
 				Expect(updatedVmObj.Status.MigrationState).Should(BeNil())
 
 				sourceNode := updatedVmObj.Status.Node
-				Expect(sourceNode).ShouldNot(Equal(""), "the `vm.status.nodeName` should have a value")
+				Expect(sourceNode).ShouldNot(BeEmpty(), "the `vm.status.nodeName` should have a value")
 
 				targetNode, err = DefineTargetNode(sourceNode, workerNodeLabel)
 				Expect(err).NotTo(HaveOccurred())
@@ -483,9 +483,9 @@ var _ = Describe("Virtual machine affinity and toleration", ginkgoutil.CommonE2E
 			By("Sets the `spec.affinity.nodeAffinity` with the `status.nodeSelector` value", func() {
 				vmObj, err = GetVirtualMachineObjByLabel(conf.Namespace, vmNodeAffinity)
 				Expect(err).NotTo(HaveOccurred())
-				IsVmMigratable(vmObj)
+				ExpectVirtualMachineIsMigratable(vmObj)
 				sourceNode = vmObj.Status.Node
-				Expect(sourceNode).ShouldNot(Equal(""), "the `vm.status.nodeName` should have a value")
+				Expect(sourceNode).ShouldNot(BeEmpty(), "the `vm.status.nodeName` should have a value")
 
 				p, err := GenerateNodeAffinityPatch(nodeLabelKey, corev1.NodeSelectorOpIn, []string{sourceNode})
 				Expect(err).NotTo(HaveOccurred())
@@ -519,7 +519,7 @@ var _ = Describe("Virtual machine affinity and toleration", ginkgoutil.CommonE2E
 				Expect(updatedVmObj.Status.MigrationState).Should(BeNil())
 
 				sourceNode = updatedVmObj.Status.Node
-				Expect(sourceNode).ShouldNot(Equal(""), "the `vm.status.nodeName` should have a value")
+				Expect(sourceNode).ShouldNot(BeEmpty(), "the `vm.status.nodeName` should have a value")
 
 				targetNode, err = DefineTargetNode(sourceNode, workerNodeLabel)
 				Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/affinity_toleration_test.go
+++ b/tests/e2e/affinity_toleration_test.go
@@ -397,7 +397,7 @@ var _ = Describe("Virtual machine affinity and toleration", ginkgoutil.CommonE2E
 				IsVmMigratable(vmObj)
 				sourceNode = vmObj.Status.Node
 				Expect(sourceNode).ShouldNot(Equal(""), "the `vm.status.nodeName` should have a value")
-				mergePatch := fmt.Sprintf("{\"spec\":{\"nodeSelector\":{\"%s\":\"%s\"}}}", nodeLabelKey, sourceNode)
+				mergePatch := fmt.Sprintf(`{"spec":{"nodeSelector":{%q:%q}}}`, nodeLabelKey, sourceNode)
 				err = MergePatchResource(kc.ResourceVM, vmObj.Name, mergePatch)
 				Expect(err).NotTo(HaveOccurred(), "failed to patch the %q `VirtualMachine`", vmNodeSelector)
 			})
@@ -449,7 +449,7 @@ var _ = Describe("Virtual machine affinity and toleration", ginkgoutil.CommonE2E
 						return nil
 					}).WithTimeout(Timeout).WithPolling(migratingStatusPollingInterval).Should(Succeed())
 				}()
-				mergePatch := fmt.Sprintf("{\"spec\":{\"nodeSelector\":{\"%s\":\"%s\"}}}", nodeLabelKey, targetNode)
+				mergePatch := fmt.Sprintf(`{"spec":{"nodeSelector":{%q:%q}}}`, nodeLabelKey, targetNode)
 				err = MergePatchResource(kc.ResourceVM, vmObj.Name, mergePatch)
 				Expect(err).NotTo(HaveOccurred(), "failed to patch the %q `VirtualMachine`", vmNodeSelector)
 				wg.Wait()
@@ -489,7 +489,7 @@ var _ = Describe("Virtual machine affinity and toleration", ginkgoutil.CommonE2E
 
 				p, err := GenerateNodeAffinityPatch(nodeLabelKey, corev1.NodeSelectorOpIn, []string{sourceNode})
 				Expect(err).NotTo(HaveOccurred())
-				mergePatch := fmt.Sprintf("{\"spec\":{\"affinity\":%s}}", p)
+				mergePatch := fmt.Sprintf(`{"spec":{"affinity":%s}}`, p)
 				err = MergePatchResource(kc.ResourceVM, vmObj.Name, mergePatch)
 				Expect(err).NotTo(HaveOccurred(), "failed to patch the %q `VirtualMachine`", vmNodeAffinity)
 			})
@@ -544,7 +544,7 @@ var _ = Describe("Virtual machine affinity and toleration", ginkgoutil.CommonE2E
 						return nil
 					}).WithTimeout(Timeout).WithPolling(migratingStatusPollingInterval).Should(Succeed())
 				}()
-				mergePatch := fmt.Sprintf("{\"spec\":{\"affinity\":%s}}", p)
+				mergePatch := fmt.Sprintf(`{"spec":{"affinity":%s}}`, p)
 				err = MergePatchResource(kc.ResourceVM, vmObj.Name, mergePatch)
 				Expect(err).NotTo(HaveOccurred(), "failed to patch the %q `VirtualMachine`", vmNodeAffinity)
 				wg.Wait()

--- a/tests/e2e/affinity_toleration_test.go
+++ b/tests/e2e/affinity_toleration_test.go
@@ -17,132 +17,553 @@ limitations under the License.
 package e2e
 
 import (
+	"encoding/json"
 	"fmt"
+	"sync"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmcondition"
 	"github.com/deckhouse/virtualization/tests/e2e/config"
 	"github.com/deckhouse/virtualization/tests/e2e/ginkgoutil"
 	kc "github.com/deckhouse/virtualization/tests/e2e/kubectl"
 )
 
+func IsVmMigratable(vmObj *virtv2.VirtualMachine) {
+	GinkgoHelper()
+	for _, c := range vmObj.Status.Conditions {
+		if c.Type == string(vmcondition.TypeMigratable) {
+			Expect(c.Status).Should(Equal(metav1.ConditionTrue),
+				"the `VirtualMachine` %s should be %q",
+				vmObj.Name,
+				vmcondition.TypeMigratable,
+			)
+		}
+	}
+}
+
+func DefineTargetNode(sourceNode string, targetLabel map[string]string) (string, error) {
+	nodes := &corev1.NodeList{}
+	err := GetObjects(kc.ResourceNode, nodes, kc.GetOptions{
+		Labels: targetLabel,
+	})
+	if err != nil {
+		return "", err
+	}
+	for _, n := range nodes.Items {
+		if n.Name != sourceNode {
+			for _, c := range n.Status.Conditions {
+				if c.Type == corev1.NodeReady && c.Status == corev1.ConditionTrue {
+					return n.Name, nil
+				}
+			}
+		}
+	}
+	return "", fmt.Errorf("failed to define a target node")
+}
+
+func GetVirtualMachineObjByLabel(namespace string, label map[string]string) (*virtv2.VirtualMachine, error) {
+	vmObjects := virtv2.VirtualMachineList{}
+	err := GetObjects(kc.ResourceVM, &vmObjects, kc.GetOptions{
+		Labels:    label,
+		Namespace: namespace,
+	})
+	if len(vmObjects.Items) != 1 {
+		return nil, fmt.Errorf("there is only one `VirtualMachine` with the %q label in this case", label)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to obtain the %q `VirtualMachine`", label)
+	}
+	return &vmObjects.Items[0], nil
+}
+
+func GenerateNodeAffinityPatch(key string, operator corev1.NodeSelectorOperator, values []string) ([]byte, error) {
+	vmAffinity := &virtv2.VMAffinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{
+								Key:      key,
+								Operator: operator,
+								Values:   values,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	b, err := json.Marshal(vmAffinity)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func GenerateVirtualMachineAndPodAntiAffinityPatch(key, topologyKey string, operator metav1.LabelSelectorOperator, values []string) ([]byte, error) {
+	vmAndPodAntiAffinity := &virtv2.VirtualMachineAndPodAntiAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: []virtv2.VirtualMachineAndPodAffinityTerm{
+			{
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      key,
+							Operator: operator,
+							Values:   values,
+						},
+					},
+				},
+				TopologyKey: topologyKey,
+			},
+		},
+	}
+
+	b, err := json.Marshal(vmAndPodAntiAffinity)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func GenerateVirtualMachineAndPodAffinityPatch(key, topologyKey string, operator metav1.LabelSelectorOperator, values []string) ([]byte, error) {
+	vmAndPodAffinity := &virtv2.VirtualMachineAndPodAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: []virtv2.VirtualMachineAndPodAffinityTerm{
+			{
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      key,
+							Operator: operator,
+							Values:   values,
+						},
+					},
+				},
+				TopologyKey: topologyKey,
+			},
+		},
+	}
+
+	b, err := json.Marshal(vmAndPodAffinity)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
 var _ = Describe("Virtual machine affinity and toleration", ginkgoutil.CommonE2ETestDecorators(), func() {
-	BeforeEach(func() {
+	BeforeAll(func() {
 		if config.IsReusable() {
 			Skip("Test not available in REUSABLE mode: not supported yet.")
 		}
+
+		kustomization := fmt.Sprintf("%s/%s", conf.TestData.AffinityToleration, "kustomization.yaml")
+		ns, err := kustomize.GetNamespace(kustomization)
+		Expect(err).NotTo(HaveOccurred(), "%w", err)
+		conf.SetNamespace(ns)
 	})
 
-	var (
-		testCaseLabel = map[string]string{"testcase": "affinity-toleration"}
-		vmA           = map[string]string{"vm": "vm-a"}
-		vmB           = map[string]string{"vm": "vm-b"}
-		vmC           = map[string]string{"vm": "vm-c"}
-		vmD           = map[string]string{"vm": "vm-d"}
+	const (
+		nodeLabelKey   = "kubernetes.io/hostname"
+		masterLabelKey = "node.deckhouse.io/group"
+		vmKey          = "vm"
 	)
 
-	Context("Preparing the environment", func() {
-		It("sets the namespace", func() {
-			kustomization := fmt.Sprintf("%s/%s", conf.TestData.AffinityToleration, "kustomization.yaml")
-			ns, err := kustomize.GetNamespace(kustomization)
-			Expect(err).NotTo(HaveOccurred(), "%w", err)
-			conf.SetNamespace(ns)
-		})
-	})
+	var (
+		migratingStatusPollingInterval = 1 * time.Second
+		testCaseLabel                  = map[string]string{"testcase": "affinity-toleration"}
+		vmA                            = map[string]string{"vm": "vm-a"}
+		vmB                            = map[string]string{"vm": "vm-b"}
+		vmC                            = map[string]string{"vm": "vm-c"}
+		vmD                            = map[string]string{"vm": "vm-d"}
+		vmNodeSelector                 = map[string]string{"vm": "vm-node-selector"}
+		vmNodeAffinity                 = map[string]string{"vm": "vm-node-affinity"}
+		workerNodeLabel                = map[string]string{"node.deckhouse.io/group": "worker"}
+		masterNodeLabel                = map[string]string{"node.deckhouse.io/group": "master"}
+	)
 
-	Context("When virtualization resources are applied:", func() {
+	Context("When the virtualization resources are applied:", func() {
 		It("result should be succeeded", func() {
 			res := kubectl.Apply(kc.ApplyOptions{
 				Filename:       []string{conf.TestData.AffinityToleration},
 				FilenameOption: kc.Kustomize,
 			})
-			Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
+			Expect(res.Error()).NotTo(HaveOccurred(), "failed to apply the test case resources")
 		})
-	})
 
-	Context("When virtual images are applied:", func() {
-		It("checks VIs phases", func() {
-			By(fmt.Sprintf("VIs should be in %s phases", PhaseReady))
-			WaitPhaseByLabel(kc.ResourceVI, PhaseReady, kc.WaitOptions{
-				Labels:    testCaseLabel,
-				Namespace: conf.Namespace,
-				Timeout:   MaxWaitTimeout,
+		It("checks the resources phase", func() {
+			By(fmt.Sprintf("`VirtualImages` should be in the %q phase", virtv2.ImageReady), func() {
+				WaitPhaseByLabel(kc.ResourceVI, PhaseReady, kc.WaitOptions{
+					Labels:    testCaseLabel,
+					Namespace: conf.Namespace,
+					Timeout:   MaxWaitTimeout,
+				})
 			})
-		})
-	})
-
-	Context("When virtual machine classes are applied:", func() {
-		It("checks VMClasses phases", func() {
-			By(fmt.Sprintf("VMClasses should be in %s phases", PhaseReady))
-			WaitPhaseByLabel(kc.ResourceVMClass, PhaseReady, kc.WaitOptions{
-				Labels:    testCaseLabel,
-				Namespace: conf.Namespace,
-				Timeout:   MaxWaitTimeout,
+			By(fmt.Sprintf("`VirtualMachineClasses` should be in %s phases", virtv2.ClassPhaseReady), func() {
+				WaitPhaseByLabel(kc.ResourceVMClass, PhaseReady, kc.WaitOptions{
+					Labels:    testCaseLabel,
+					Namespace: conf.Namespace,
+					Timeout:   MaxWaitTimeout,
+				})
 			})
-		})
-	})
-
-	Context("When virtual disks are applied:", func() {
-		It("checks VDs phases", func() {
-			By(fmt.Sprintf("VDs should be in %s phases", PhaseReady))
-			WaitPhaseByLabel(kc.ResourceVD, PhaseReady, kc.WaitOptions{
-				Labels:    testCaseLabel,
-				Namespace: conf.Namespace,
-				Timeout:   MaxWaitTimeout,
+			By(fmt.Sprintf("`VirtualDisks` should be in the %q phase", virtv2.DiskReady), func() {
+				WaitPhaseByLabel(kc.ResourceVD, PhaseReady, kc.WaitOptions{
+					Labels:    testCaseLabel,
+					Namespace: conf.Namespace,
+					Timeout:   MaxWaitTimeout,
+				})
 			})
-		})
-	})
-
-	Context("When virtual machines are applied:", func() {
-		It("checks VMs phases", func() {
-			By("Virtual machine agents should be ready")
-			WaitVmAgentReady(kc.WaitOptions{
-				Labels:    testCaseLabel,
-				Namespace: conf.Namespace,
-				Timeout:   MaxWaitTimeout,
+			By("`VirtualMachines` agents should be ready", func() {
+				WaitVmAgentReady(kc.WaitOptions{
+					Labels:    testCaseLabel,
+					Namespace: conf.Namespace,
+					Timeout:   MaxWaitTimeout,
+				})
 			})
 		})
 	})
 
-	Context("When virtual machine agents are ready", func() {
-		It("checks VMs `status.nodeName`", func() {
-			vmObjects := virtv2.VirtualMachineList{}
-			err := GetObjects(kc.ResourceVM, &vmObjects, kc.GetOptions{
-				Labels:    vmA,
-				Namespace: conf.Namespace,
+	Context("When the virtual machines agents are ready", func() {
+		It("checks the `status.nodeName` field of the `VirtualMachines`", func() {
+			var (
+				vmObjA = &virtv2.VirtualMachine{}
+				vmObjB = &virtv2.VirtualMachine{}
+				vmObjC = &virtv2.VirtualMachine{}
+				vmObjD = &virtv2.VirtualMachine{}
+				err    error
+			)
+			By("Obtain the `VirtualMachine` objects", func() {
+				vmObjA, err = GetVirtualMachineObjByLabel(conf.Namespace, vmA)
+				Expect(err).NotTo(HaveOccurred(), "failed to obtain the %q `VirtualMachine`", vmA)
+				vmObjB, err = GetVirtualMachineObjByLabel(conf.Namespace, vmB)
+				Expect(err).NotTo(HaveOccurred(), "failed to obtain the %q `VirtualMachine`", vmB)
+				vmObjC, err = GetVirtualMachineObjByLabel(conf.Namespace, vmC)
+				Expect(err).NotTo(HaveOccurred(), "failed to obtain the %q `VirtualMachine`", vmC)
+				vmObjD, err = GetVirtualMachineObjByLabel(conf.Namespace, vmD)
+				Expect(err).NotTo(HaveOccurred(), "failed to obtain the %q `VirtualMachine`", vmD)
 			})
-			Expect(err).NotTo(HaveOccurred(), "error: cannot get virtual machines with label %s\nstderr: %s", vmA, err)
-			vmANodeName := vmObjects.Items[0].Status.Node
-			err = GetObjects(kc.ResourceVM, &vmObjects, kc.GetOptions{
-				Labels:    vmC,
-				Namespace: conf.Namespace,
+			By("Set affinity when creating the `VirtualMachines`.`: `vm-a` and `vm-c` should be running on the same node", func() {
+				Expect(vmObjA.Status.Node).Should(Equal(vmObjC.Status.Node), "%q and %q `VirtualMachines` should be running on the same node", vmA, vmC)
 			})
-			Expect(err).NotTo(HaveOccurred(), "error: cannot get virtual machines with label %s\nstderr: %s", vmC, err)
-			vmCNodeName := vmObjects.Items[0].Status.Node
-			By("Affinity: `vm-a` and `vm-c` should be running on the same node")
-			Expect(vmANodeName).Should(Equal(vmCNodeName), "error: vm-a and vm-c should be running on the same node")
-			err = GetObjects(kc.ResourceVM, &vmObjects, kc.GetOptions{
-				Labels:    vmB,
-				Namespace: conf.Namespace,
+			By("Set anti-affinity when creating the `VirtualMachines`: `vm-a` and `vm-b` should be running on the different nodes", func() {
+				Expect(vmObjA.Status.Node).ShouldNot(Equal(vmObjB.Status.Node), "%q and %q `VirtualMachines` should be running on the different nodes", vmA, vmB)
 			})
-			Expect(err).NotTo(HaveOccurred(), "error: cannot get virtual machines with label %s\nstderr: %s", vmB, err)
-			vmBNodeName := vmObjects.Items[0].Status.Node
-			By("AntiAffinity: `vm-a` and `vm-b` should be running on different nodes")
-			Expect(vmANodeName).ShouldNot(Equal(vmBNodeName), "error: vm-a and vm-b should be running on different nodes")
-			err = GetObjects(kc.ResourceVM, &vmObjects, kc.GetOptions{
-				Labels:    vmD,
-				Namespace: conf.Namespace,
+			By("Set toleration when creating the `VirtualMachines`: `vm-d` should be running on a master node", func() {
+				nodeObj := corev1.Node{}
+				err := GetObject(kc.ResourceNode, vmObjD.Status.Node, &nodeObj, kc.GetOptions{})
+				Expect(err).NotTo(HaveOccurred(), "failed to obtain the %q node", vmObjD.Status.Node)
+				Expect(nodeObj.Labels).Should(HaveKeyWithValue(masterLabelKey, masterNodeLabel[masterLabelKey]), "%q `VirtualMachine` should be running on a master node", vmD)
 			})
-			Expect(err).NotTo(HaveOccurred(), "error: cannot get virtual machines with label %s\nstderr: %s", vmD, err)
-			vmDNodeName := vmObjects.Items[0].Status.Node
-			nodeObj := v1.Node{}
-			err = GetObject(kc.ResourceNode, vmDNodeName, &nodeObj, kc.GetOptions{})
-			Expect(err).NotTo(HaveOccurred(), "error: cannot get node %s:\nstderr: %s", vmDNodeName, err)
-			By("Toleration: `vm-d` should be running on a master node")
-			Expect(nodeObj.Labels).Should(HaveKeyWithValue("node.deckhouse.io/group", "master"))
+			By("Change affinity to anti-affinity when the `VirtualMachines` are runnning: `vm-a` and `vm-c` should be running on the different nodes", func() {
+				wg := &sync.WaitGroup{}
+
+				IsVmMigratable(vmObjC)
+				p, err := GenerateVirtualMachineAndPodAntiAffinityPatch(vmKey, nodeLabelKey, metav1.LabelSelectorOpIn, []string{vmA[vmKey]})
+				Expect(err).NotTo(HaveOccurred(), "failed to generate the `VirtualMachineAndPodAntiAffinity` patch")
+				jsonPatchAdd := &kc.JsonPatch{
+					Op:    "add",
+					Path:  "/spec/affinity/virtualMachineAndPodAntiAffinity",
+					Value: string(p),
+				}
+				jsonPatchRemove := &kc.JsonPatch{
+					Op:   "remove",
+					Path: "/spec/affinity/virtualMachineAndPodAffinity",
+				}
+				wg.Add(1)
+				go func() {
+					defer GinkgoRecover()
+					defer wg.Done()
+					Eventually(func() error {
+						updatedVmObjC := &virtv2.VirtualMachine{}
+						err := GetObject(virtv2.VirtualMachineResource, vmObjC.Name, updatedVmObjC, kc.GetOptions{
+							Namespace: conf.Namespace,
+						})
+						if err != nil {
+							return err
+						}
+						if updatedVmObjC.Status.Phase != virtv2.MachineMigrating {
+							return fmt.Errorf("the `VirtualMachine` should be %s", virtv2.MachineMigrating)
+						}
+						return nil
+					}).WithTimeout(Timeout).WithPolling(migratingStatusPollingInterval).Should(Succeed())
+				}()
+				res := kubectl.PatchResource(kc.ResourceVM, vmObjC.Name, kc.PatchOptions{
+					JsonPatch: []*kc.JsonPatch{
+						jsonPatchAdd,
+						jsonPatchRemove,
+					},
+					Namespace: conf.Namespace,
+				})
+				Expect(res.Error()).NotTo(HaveOccurred(), "failed to patch the %q `VirtualMachine`", vmC)
+				wg.Wait()
+
+				WaitVmAgentReady(kc.WaitOptions{
+					Labels:    vmC,
+					Namespace: conf.Namespace,
+					Timeout:   MaxWaitTimeout,
+				})
+				updatedVmObjC := &virtv2.VirtualMachine{}
+				err = GetObject(virtv2.VirtualMachineResource, vmObjC.Name, updatedVmObjC, kc.GetOptions{
+					Namespace: conf.Namespace,
+				})
+				Expect(err).NotTo(HaveOccurred(), "failed to obtain the %q `VirtualMachine` object", vmC)
+				Expect(updatedVmObjC.Status.MigrationState.Source.Node).Should(Equal(vmObjC.Status.Node))
+				Expect(updatedVmObjC.Status.MigrationState.Target.Node).ShouldNot(Equal(vmObjA.Status.Node))
+				Expect(updatedVmObjC.Status.Node).ShouldNot(Equal(vmObjA.Status.Node))
+			})
+			By("Change anti-affinity to affinity when the `VirtualMachines` are runnning: `vm-a` and `vm-c` should be running on the same node", func() {
+				wg := &sync.WaitGroup{}
+
+				updatedVmObjC := &virtv2.VirtualMachine{}
+				err = GetObject(virtv2.VirtualMachineResource, vmObjC.Name, updatedVmObjC, kc.GetOptions{
+					Namespace: conf.Namespace,
+				})
+
+				IsVmMigratable(updatedVmObjC)
+				p, err := GenerateVirtualMachineAndPodAffinityPatch(vmKey, nodeLabelKey, metav1.LabelSelectorOpIn, []string{vmA[vmKey]})
+				Expect(err).NotTo(HaveOccurred(), "failed to generate the `VirtualMachineAndPodAffinity` patch")
+				jsonPatchAdd := &kc.JsonPatch{
+					Op:    "add",
+					Path:  "/spec/affinity/virtualMachineAndPodAffinity",
+					Value: string(p),
+				}
+				jsonPatchRemove := &kc.JsonPatch{
+					Op:   "remove",
+					Path: "/spec/affinity/virtualMachineAndPodAntiAffinity",
+				}
+				wg.Add(1)
+				go func() {
+					defer GinkgoRecover()
+					defer wg.Done()
+					Eventually(func() error {
+						updatedVmObjC := &virtv2.VirtualMachine{}
+						err := GetObject(virtv2.VirtualMachineResource, vmObjC.Name, updatedVmObjC, kc.GetOptions{
+							Namespace: conf.Namespace,
+						})
+						if err != nil {
+							return err
+						}
+						if updatedVmObjC.Status.Phase != virtv2.MachineMigrating {
+							return fmt.Errorf("the `VirtualMachine` should be %s", virtv2.MachineMigrating)
+						}
+						return nil
+					}).WithTimeout(Timeout).WithPolling(migratingStatusPollingInterval).Should(Succeed())
+				}()
+				res := kubectl.PatchResource(kc.ResourceVM, vmObjC.Name, kc.PatchOptions{
+					JsonPatch: []*kc.JsonPatch{
+						jsonPatchAdd,
+						jsonPatchRemove,
+					},
+					Namespace: conf.Namespace,
+				})
+				Expect(res.Error()).NotTo(HaveOccurred(), "failed to patch the %q `VirtualMachine`", vmC)
+				wg.Wait()
+
+				WaitVmAgentReady(kc.WaitOptions{
+					Labels:    vmC,
+					Namespace: conf.Namespace,
+					Timeout:   MaxWaitTimeout,
+				})
+				updatedVmObjC = &virtv2.VirtualMachine{}
+				err = GetObject(virtv2.VirtualMachineResource, vmObjC.Name, updatedVmObjC, kc.GetOptions{
+					Namespace: conf.Namespace,
+				})
+				Expect(err).NotTo(HaveOccurred(), "failed to obtain the %q `VirtualMachine` object", vmC)
+				Expect(updatedVmObjC.Status.MigrationState.Source.Node).ShouldNot(Equal(vmObjA.Status.Node))
+				Expect(updatedVmObjC.Status.MigrationState.Target.Node).Should(Equal(vmObjA.Status.Node))
+				Expect(updatedVmObjC.Status.Node).Should(Equal(vmObjA.Status.Node))
+			})
+		})
+	})
+
+	Context("When the virtual machine `node-selector` agent is ready", func() {
+		It("sets the `spec.nodeSelector` field", func() {
+			var (
+				sourceNode string
+				targetNode string
+				err        error
+			)
+			vmObj := &virtv2.VirtualMachine{}
+			By("Sets the `spec.nodeSelector` with the `status.nodeSelector` value", func() {
+				vmObj, err = GetVirtualMachineObjByLabel(conf.Namespace, vmNodeSelector)
+				Expect(err).NotTo(HaveOccurred(), "failed to obtain the %q `VirtualMachine` object", vmNodeSelector)
+				IsVmMigratable(vmObj)
+				sourceNode = vmObj.Status.Node
+				Expect(sourceNode).ShouldNot(Equal(""), "the `vm.status.nodeName` should have a value")
+				mergePatch := fmt.Sprintf("{\"spec\":{\"nodeSelector\":{\"%s\":\"%s\"}}}", nodeLabelKey, sourceNode)
+				err = MergePatchResource(kc.ResourceVM, vmObj.Name, mergePatch)
+				Expect(err).NotTo(HaveOccurred(), "failed to patch the %q `VirtualMachine`", vmNodeSelector)
+			})
+			By("The `VirtualMachine` should not be migrated", func() {
+				time.Sleep(20 * time.Second)
+				updatedVmObj := &virtv2.VirtualMachine{}
+				err := GetObject(virtv2.VirtualMachineResource, vmObj.Name, updatedVmObj, kc.GetOptions{
+					Namespace: conf.Namespace,
+				})
+				Expect(err).NotTo(HaveOccurred(), "failed to obtain the %q `VirtualMachine` object", vmNodeSelector)
+				for _, c := range updatedVmObj.Status.Conditions {
+					if c.Type == string(vmcondition.TypeMigrating) {
+						Expect(c.Status).Should(Equal(metav1.ConditionFalse))
+					}
+				}
+				Expect(updatedVmObj.Status.MigrationState).Should(BeNil())
+				Expect(updatedVmObj.Status.Node).Should(Equal(sourceNode))
+			})
+			By("Sets the `spec.nodeSelector` with `another node` value", func() {
+				wg := &sync.WaitGroup{}
+
+				updatedVmObj := &virtv2.VirtualMachine{}
+				err := GetObject(virtv2.VirtualMachineResource, vmObj.Name, updatedVmObj, kc.GetOptions{
+					Namespace: conf.Namespace,
+				})
+				Expect(err).NotTo(HaveOccurred(), "failed to obtain the %q `VirtualMachine` object", vmNodeSelector)
+				Expect(updatedVmObj.Status.MigrationState).Should(BeNil())
+
+				sourceNode := updatedVmObj.Status.Node
+				Expect(sourceNode).ShouldNot(Equal(""), "the `vm.status.nodeName` should have a value")
+
+				targetNode, err = DefineTargetNode(sourceNode, workerNodeLabel)
+				Expect(err).NotTo(HaveOccurred())
+				wg.Add(1)
+				go func() {
+					defer GinkgoRecover()
+					defer wg.Done()
+					Eventually(func() error {
+						updatedVmObj := &virtv2.VirtualMachine{}
+						err := GetObject(virtv2.VirtualMachineResource, vmObj.Name, updatedVmObj, kc.GetOptions{
+							Namespace: conf.Namespace,
+						})
+						if err != nil {
+							return err
+						}
+						if updatedVmObj.Status.Phase != virtv2.MachineMigrating {
+							return fmt.Errorf("the `VirtualMachine` should be %s", virtv2.MachineMigrating)
+						}
+						return nil
+					}).WithTimeout(Timeout).WithPolling(migratingStatusPollingInterval).Should(Succeed())
+				}()
+				mergePatch := fmt.Sprintf("{\"spec\":{\"nodeSelector\":{\"%s\":\"%s\"}}}", nodeLabelKey, targetNode)
+				err = MergePatchResource(kc.ResourceVM, vmObj.Name, mergePatch)
+				Expect(err).NotTo(HaveOccurred(), "failed to patch the %q `VirtualMachine`", vmNodeSelector)
+				wg.Wait()
+			})
+			By("The `VirtualMachine` should be migrated", func() {
+				WaitVmAgentReady(kc.WaitOptions{
+					Labels:    vmNodeSelector,
+					Namespace: conf.Namespace,
+					Timeout:   MaxWaitTimeout,
+				})
+				updatedVmObj := &virtv2.VirtualMachine{}
+				err := GetObject(virtv2.VirtualMachineResource, vmObj.Name, updatedVmObj, kc.GetOptions{
+					Namespace: conf.Namespace,
+				})
+				Expect(err).NotTo(HaveOccurred(), "failed to obtain the %q `VirtualMachine` object", vmNodeSelector)
+				Expect(updatedVmObj.Status.MigrationState.Source.Node).Should(Equal(sourceNode))
+				Expect(updatedVmObj.Status.MigrationState.Target.Node).Should(Equal(targetNode))
+				Expect(updatedVmObj.Status.Node).Should(Equal(targetNode))
+			})
+		})
+	})
+
+	Context("When the virtual machine `node-affinity` agent is ready", func() {
+		It("sets the `spec.affinity.nodeAffinity` field", func() {
+			var (
+				sourceNode string
+				targetNode string
+				err        error
+			)
+			vmObj := &virtv2.VirtualMachine{}
+			By("Sets the `spec.affinity.nodeAffinity` with the `status.nodeSelector` value", func() {
+				vmObj, err = GetVirtualMachineObjByLabel(conf.Namespace, vmNodeAffinity)
+				Expect(err).NotTo(HaveOccurred())
+				IsVmMigratable(vmObj)
+				sourceNode = vmObj.Status.Node
+				Expect(sourceNode).ShouldNot(Equal(""), "the `vm.status.nodeName` should have a value")
+
+				p, err := GenerateNodeAffinityPatch(nodeLabelKey, corev1.NodeSelectorOpIn, []string{sourceNode})
+				Expect(err).NotTo(HaveOccurred())
+				mergePatch := fmt.Sprintf("{\"spec\":{\"affinity\":%s}}", p)
+				err = MergePatchResource(kc.ResourceVM, vmObj.Name, mergePatch)
+				Expect(err).NotTo(HaveOccurred(), "failed to patch the %q `VirtualMachine`", vmNodeAffinity)
+			})
+			By("The `VirtualMachine` should not be migrated", func() {
+				time.Sleep(20 * time.Second)
+				updatedVmObj := &virtv2.VirtualMachine{}
+				err := GetObject(virtv2.VirtualMachineResource, vmObj.Name, updatedVmObj, kc.GetOptions{
+					Namespace: conf.Namespace,
+				})
+				Expect(err).NotTo(HaveOccurred(), "failed to obtain the %q `VirtualMachine` object", vmNodeAffinity)
+				for _, c := range updatedVmObj.Status.Conditions {
+					if c.Type == string(vmcondition.TypeMigrating) {
+						Expect(c.Status).Should(Equal(metav1.ConditionFalse))
+					}
+				}
+				Expect(updatedVmObj.Status.MigrationState).Should(BeNil())
+				Expect(updatedVmObj.Status.Node).Should(Equal(sourceNode))
+			})
+			By("Sets the `spec.affinity.nodeAffinity` with `another node` value", func() {
+				wg := &sync.WaitGroup{}
+
+				updatedVmObj := &virtv2.VirtualMachine{}
+				err := GetObject(virtv2.VirtualMachineResource, vmObj.Name, updatedVmObj, kc.GetOptions{
+					Namespace: conf.Namespace,
+				})
+				Expect(err).NotTo(HaveOccurred(), "failed to obtain the %q `VirtualMachine` object", vmNodeAffinity)
+				Expect(updatedVmObj.Status.MigrationState).Should(BeNil())
+
+				sourceNode = updatedVmObj.Status.Node
+				Expect(sourceNode).ShouldNot(Equal(""), "the `vm.status.nodeName` should have a value")
+
+				targetNode, err = DefineTargetNode(sourceNode, workerNodeLabel)
+				Expect(err).NotTo(HaveOccurred())
+
+				p, err := GenerateNodeAffinityPatch(nodeLabelKey, corev1.NodeSelectorOpIn, []string{targetNode})
+				Expect(err).NotTo(HaveOccurred(), "failed to generate the `NodeAffinity` patch")
+				wg.Add(1)
+				go func() {
+					defer GinkgoRecover()
+					defer wg.Done()
+					Eventually(func() error {
+						updatedVmObj := &virtv2.VirtualMachine{}
+						err := GetObject(virtv2.VirtualMachineResource, vmObj.Name, updatedVmObj, kc.GetOptions{
+							Namespace: conf.Namespace,
+						})
+						if err != nil {
+							return err
+						}
+						if updatedVmObj.Status.Phase != virtv2.MachineMigrating {
+							return fmt.Errorf("the `VirtualMachine` should be %s", virtv2.MachineMigrating)
+						}
+						return nil
+					}).WithTimeout(Timeout).WithPolling(migratingStatusPollingInterval).Should(Succeed())
+				}()
+				mergePatch := fmt.Sprintf("{\"spec\":{\"affinity\":%s}}", p)
+				err = MergePatchResource(kc.ResourceVM, vmObj.Name, mergePatch)
+				Expect(err).NotTo(HaveOccurred(), "failed to patch the %q `VirtualMachine`", vmNodeAffinity)
+				wg.Wait()
+			})
+			By("The `VirtualMachine` should be migrated", func() {
+				WaitVmAgentReady(kc.WaitOptions{
+					Labels:    vmNodeAffinity,
+					Namespace: conf.Namespace,
+					Timeout:   MaxWaitTimeout,
+				})
+				updatedVmObj := &virtv2.VirtualMachine{}
+				err := GetObject(virtv2.VirtualMachineResource, vmObj.Name, updatedVmObj, kc.GetOptions{
+					Namespace: conf.Namespace,
+				})
+				Expect(err).NotTo(HaveOccurred(), "failed to obtain the %q `VirtualMachine` object", vmNodeAffinity)
+				Expect(updatedVmObj.Status.MigrationState.Source.Node).Should(Equal(sourceNode))
+				Expect(updatedVmObj.Status.MigrationState.Target.Node).Should(Equal(targetNode))
+				Expect(updatedVmObj.Status.Node).Should(Equal(targetNode))
+			})
 		})
 	})
 

--- a/tests/e2e/kubectl/kubectl.go
+++ b/tests/e2e/kubectl/kubectl.go
@@ -109,7 +109,7 @@ type PatchOptions struct {
 	Type       string
 	PatchFile  string
 	MergePatch string
-	JsonPatch  *JsonPatch
+	JsonPatch  []*JsonPatch
 }
 
 type JsonPatch struct {
@@ -127,7 +127,7 @@ func (p JsonPatch) String() string {
 	} else {
 		value = fmt.Sprintf("\"%s\"", p.Value)
 	}
-	return fmt.Sprintf("[{\"op\": \"%s\", \"path\": \"%s\", \"value\":%s}]", p.Op, p.Path, value)
+	return fmt.Sprintf("{\"op\": \"%s\", \"path\": \"%s\", \"value\":%s}", p.Op, p.Path, value)
 }
 
 type KubectlConf struct {
@@ -378,7 +378,12 @@ func (k KubectlCMD) patchOptions(cmd string, opts PatchOptions) string {
 		cmd = fmt.Sprintf("%s --patch-file=%s", cmd, opts.PatchFile)
 	}
 	if opts.JsonPatch != nil {
-		cmd = fmt.Sprintf("%s --type=json --patch='%s'", cmd, opts.JsonPatch.String())
+		patches := make([]string, len(opts.JsonPatch))
+		for i, p := range opts.JsonPatch {
+			patches[i] = p.String()
+		}
+		rawPatches := strings.Join(patches, ",")
+		cmd = fmt.Sprintf("%s --type=json --patch='[%s]'", cmd, rawPatches)
 	}
 	if opts.MergePatch != "" {
 		cmd = fmt.Sprintf("%s --type=merge --patch='%s'", cmd, opts.MergePatch)

--- a/tests/e2e/kubectl/kubectl.go
+++ b/tests/e2e/kubectl/kubectl.go
@@ -125,9 +125,9 @@ func (p JsonPatch) String() string {
 		strings.HasPrefix(p.Value, "{") {
 		value = p.Value
 	} else {
-		value = fmt.Sprintf("\"%s\"", p.Value)
+		value = fmt.Sprintf("%q", p.Value)
 	}
-	return fmt.Sprintf("{\"op\": \"%s\", \"path\": \"%s\", \"value\":%s}", p.Op, p.Path, value)
+	return fmt.Sprintf(`{"op": %q, "path": %q, "value":%s}`, p.Op, p.Path, value)
 }
 
 type KubectlConf struct {

--- a/tests/e2e/testdata/affinity-toleration/vm/base/vm.yaml
+++ b/tests/e2e/testdata/affinity-toleration/vm/base/vm.yaml
@@ -3,7 +3,7 @@ kind: VirtualMachine
 metadata:
   name: vm
 spec:
-  virtualMachineClassName: generic
+  virtualMachineClassName: affinity-discovery
   cpu:
     cores: 1
     coreFraction: 5%

--- a/tests/e2e/testdata/affinity-toleration/vm/kustomization.yaml
+++ b/tests/e2e/testdata/affinity-toleration/vm/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
   - overlays/vm-b-not-a
   - overlays/vm-c-and-a
   - overlays/vm-d
+  - overlays/vm-node-affinity
+  - overlays/vm-node-selector

--- a/tests/e2e/testdata/affinity-toleration/vm/overlays/vm-a-not-b/vm.vmclass.patch.yaml
+++ b/tests/e2e/testdata/affinity-toleration/vm/overlays/vm-a-not-b/vm.vmclass.patch.yaml
@@ -1,6 +1,0 @@
-apiVersion: virtualization.deckhouse.io/v1alpha2
-kind: VirtualMachine
-metadata:
-  name: vm
-spec:
-  virtualMachineClassName: affinity-discovery

--- a/tests/e2e/testdata/affinity-toleration/vm/overlays/vm-b-not-a/kustomization.yaml
+++ b/tests/e2e/testdata/affinity-toleration/vm/overlays/vm-b-not-a/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
 patches:
   - path: vm.affinity.patch.yaml
   - path: vm.tolerations.patch.yaml
-  - path: vm.vmclass.patch.yaml
 labels:
   - includeSelectors: true
     pairs:

--- a/tests/e2e/testdata/affinity-toleration/vm/overlays/vm-b-not-a/vm.vmclass.patch.yaml
+++ b/tests/e2e/testdata/affinity-toleration/vm/overlays/vm-b-not-a/vm.vmclass.patch.yaml
@@ -1,6 +1,0 @@
-apiVersion: virtualization.deckhouse.io/v1alpha2
-kind: VirtualMachine
-metadata:
-  name: vm
-spec:
-  virtualMachineClassName: affinity-discovery

--- a/tests/e2e/testdata/affinity-toleration/vm/overlays/vm-c-and-a/kustomization.yaml
+++ b/tests/e2e/testdata/affinity-toleration/vm/overlays/vm-c-and-a/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
 patches:
   - path: vm.affinity.patch.yaml
   - path: vm.tolerations.patch.yaml
-  - path: vm.vmclass.patch.yaml
 labels:
   - includeSelectors: true
     pairs:

--- a/tests/e2e/testdata/affinity-toleration/vm/overlays/vm-c-and-a/vm.vmclass.patch.yaml
+++ b/tests/e2e/testdata/affinity-toleration/vm/overlays/vm-c-and-a/vm.vmclass.patch.yaml
@@ -1,6 +1,0 @@
-apiVersion: virtualization.deckhouse.io/v1alpha2
-kind: VirtualMachine
-metadata:
-  name: vm
-spec:
-  virtualMachineClassName: affinity-discovery

--- a/tests/e2e/testdata/affinity-toleration/vm/overlays/vm-d/kustomization.yaml
+++ b/tests/e2e/testdata/affinity-toleration/vm/overlays/vm-d/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
 patches:
   - path: vm.affinity.patch.yaml
   - path: vm.tolerations.patch.yaml
-  - path: vm.vmclass.patch.yaml
 labels:
   - includeSelectors: true
     pairs:

--- a/tests/e2e/testdata/affinity-toleration/vm/overlays/vm-d/vm.vmclass.patch.yaml
+++ b/tests/e2e/testdata/affinity-toleration/vm/overlays/vm-d/vm.vmclass.patch.yaml
@@ -1,6 +1,0 @@
-apiVersion: virtualization.deckhouse.io/v1alpha2
-kind: VirtualMachine
-metadata:
-  name: vm
-spec:
-  virtualMachineClassName: affinity-discovery

--- a/tests/e2e/testdata/affinity-toleration/vm/overlays/vm-node-affinity/kustomization.yaml
+++ b/tests/e2e/testdata/affinity-toleration/vm/overlays/vm-node-affinity/kustomization.yaml
@@ -1,12 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-nameSuffix: -a-not-b
+nameSuffix: -node-affinity
 resources:
   - ../../base
-patches:
-  - path: vm.affinity.patch.yaml
-  - path: vm.tolerations.patch.yaml
 labels:
   - includeSelectors: true
     pairs:
-      vm: vm-a
+      vm: vm-node-affinity

--- a/tests/e2e/testdata/affinity-toleration/vm/overlays/vm-node-selector/kustomization.yaml
+++ b/tests/e2e/testdata/affinity-toleration/vm/overlays/vm-node-selector/kustomization.yaml
@@ -1,12 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-nameSuffix: -a-not-b
+nameSuffix: -node-selector
 resources:
   - ../../base
-patches:
-  - path: vm.affinity.patch.yaml
-  - path: vm.tolerations.patch.yaml
 labels:
   - includeSelectors: true
     pairs:
-      vm: vm-a
+      vm: vm-node-selector

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -147,7 +147,7 @@ func WaitResource(resource kc.Resource, name, waitFor string, timeout time.Durat
 	Expect(res.Error()).NotTo(HaveOccurred(), "wait failed %s %s/%s.\n%s", resource, conf.Namespace, name, res.StdErr())
 }
 
-func PatchResource(resource kc.Resource, name string, patch *kc.JsonPatch) {
+func PatchResource(resource kc.Resource, name string, patch []*kc.JsonPatch) {
 	GinkgoHelper()
 	res := kubectl.PatchResource(resource, name, kc.PatchOptions{
 		Namespace: conf.Namespace,

--- a/tests/e2e/vm_connectivity_test.go
+++ b/tests/e2e/vm_connectivity_test.go
@@ -255,10 +255,12 @@ var _ = Describe("VM connectivity", ginkgoutil.CommonE2ETestDecorators(), func()
 			selectorA = svcA.Spec.Selector["service"]
 			selectorB = svcB.Spec.Selector["service"]
 
-			PatchResource(kc.ResourceService, svcA.Name, &kc.JsonPatch{
-				Op:    "replace",
-				Path:  "/spec/selector/service",
-				Value: selectorB,
+			PatchResource(kc.ResourceService, svcA.Name, []*kc.JsonPatch{
+				{
+					Op:    "replace",
+					Path:  "/spec/selector/service",
+					Value: selectorB,
+				},
 			})
 		})
 
@@ -281,10 +283,12 @@ var _ = Describe("VM connectivity", ginkgoutil.CommonE2ETestDecorators(), func()
 		})
 
 		It(fmt.Sprintf("changes back selector in service %s", aObjName), func() {
-			PatchResource(kc.ResourceService, svcA.Name, &kc.JsonPatch{
-				Op:    "replace",
-				Path:  "/spec/selector/service",
-				Value: selectorA,
+			PatchResource(kc.ResourceService, svcA.Name, []*kc.JsonPatch{
+				{
+					Op:    "replace",
+					Path:  "/spec/selector/service",
+					Value: selectorA,
+				},
 			})
 		})
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
- Improve Ginkgo contexts
- Add node selector configuration case
- Add node affinity configuration case
- Add virtual machine and pod affinity configuration case
- Add virtual machine and pod anti-affinity configuration case

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
This extends the affinity and toleration test cases.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: vm
type: test
summary: "This extends the affinity and toleration test cases."
impact_level: low
```
