### PR TITLE
fix(vm): correct CPU core validation logic for range checks

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm/internal/validators/cpu_count_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/validators/cpu_count_validator.go
@@ -45,11 +45,11 @@ func (v *CpuCountValidator) Validate(vm *v1alpha2.VirtualMachine) (admission.War
 	switch {
 	case cores <= 16:
 		return nil, nil
-	case cores <= 32 && cores%2 != 0:
+	case cores > 16 && cores <= 32 && cores%2 != 0:
 		return nil, fmt.Errorf("the requested number of cores must be a multiple of 2")
-	case cores <= 64 && cores%4 != 0:
+	case cores > 32 && cores <= 64 && cores%4 != 0:
 		return nil, fmt.Errorf("the requested number of cores must be a multiple of 4")
-	case cores%8 != 0:
+	case cores > 64 && cores%8 != 0:
 		return nil, fmt.Errorf("the requested number of cores must be a multiple of 8")
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vm/internal/validators/cpu_count_validator_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/validators/cpu_count_validator_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validators
+
+import (
+	"testing"
+
+	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+)
+
+func TestCpuCountValidate(t *testing.T) {
+	tests := []struct {
+		desiredCores int
+		valid        bool
+	}{
+		{1, true},
+		{2, true},
+		{3, true},
+		{4, true},
+		{5, true},
+		{15, true},
+		{16, true},
+
+		{18, true},
+		{19, false},
+		{20, true},
+		{31, false},
+		{32, true},
+
+		{36, true},
+		{37, false},
+		{40, true},
+		{60, true},
+		{63, false},
+		{64, true},
+
+		{72, true},
+		{76, false},
+		{80, true},
+		{248, true},
+		{256, true},
+		{252, false},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			vm := &v1alpha2.VirtualMachine{Spec: v1alpha2.VirtualMachineSpec{CPU: v1alpha2.CPUSpec{Cores: test.desiredCores}}}
+			cpuCountValidator := NewCpuCountValidator()
+
+			_, err := cpuCountValidator.Validate(vm)
+
+			if test.valid && err != nil {
+				t.Errorf("For %d cores, expected valid, but validation failed", test.desiredCores)
+			}
+
+			if !test.valid && err == nil {
+				t.Errorf("For %d cores, expected not valid, but validation succeeded", test.desiredCores)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
Fix bug that is triggered by the absence of the escape in the positive case and failing to continue on switch case

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: vm
type: fix
summary: correct CPU core validation logic for range checks
```
