### PR TITLE
fix(vm): fix start vm after change run policy from AlwaysOff 

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_power_state.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_power_state.go
@@ -132,7 +132,10 @@ func (h *SyncPowerStateHandler) syncPowerState(
 	case virtv2.AlwaysOffPolicy:
 		vmAction = h.handleAlwaysOffPolicy(ctx, s, kvvmi)
 	case virtv2.AlwaysOnPolicy:
-		vmAction = h.handleAlwaysOnPolicy(ctx, s, kvvm, kvvmi, isConfigurationApplied, shutdownInfo)
+		vmAction, err = h.handleAlwaysOnPolicy(ctx, s, kvvm, kvvmi, isConfigurationApplied, shutdownInfo)
+		if err != nil {
+			return err
+		}
 	case virtv2.AlwaysOnUnlessStoppedManually:
 		vmAction, err = h.handleAlwaysOnUnlessStoppedManuallyPolicy(ctx, s, kvvm, kvvmi, isConfigurationApplied, shutdownInfo)
 		if err != nil {
@@ -212,28 +215,33 @@ func (h *SyncPowerStateHandler) handleAlwaysOnPolicy(
 	kvvmi *virtv1.VirtualMachineInstance,
 	isConfigurationApplied bool,
 	shutdownInfo powerstate.ShutdownInfo,
-) VMAction {
+) (VMAction, error) {
 	if kvvmi == nil {
 		if isConfigurationApplied {
 			h.recordStartEventf(ctx, s.VirtualMachine().Current(), "Start initiated "+
 				"by controller for AlwaysOn policy")
-			return Start
+			return Start, nil
 		}
 
-		return Nothing
+		err := kvvmutil.AddStartAnnotation(ctx, h.client, kvvm)
+		if err != nil {
+			return Nothing, fmt.Errorf("add annotation to KVVM: %w", err)
+		}
+
+		return Nothing, nil
 	}
 
 	if kvvmi.DeletionTimestamp != nil {
 		if h.checkNeedStartVM(ctx, s, kvvm, isConfigurationApplied, virtv2.AlwaysOnPolicy) {
-			return Start
+			return Start, nil
 		}
-		return Nothing
+		return Nothing, nil
 	}
 
 	if kvvm.Annotations[annotations.AnnVmRestartRequested] == "true" && kvvmi.Status.Phase == virtv1.Running {
 		h.recordRestartEventf(ctx, s.VirtualMachine().Current(), "Restart initiated "+
 			"by VirtualMachineOparation for AlwaysOn runPolicy")
-		return Restart
+		return Restart, nil
 	}
 
 	if kvvmi.Status.Phase == virtv1.Succeeded || kvvmi.Status.Phase == virtv1.Failed {
@@ -241,15 +249,15 @@ func (h *SyncPowerStateHandler) handleAlwaysOnPolicy(
 			if shutdownInfo.Reason == powerstate.GuestResetReason {
 				h.recordRestartEventf(ctx, s.VirtualMachine().Current(), "Restart initiated by inside "+
 					"the guest VirtualMachine for AlwaysOn runPolicy")
-				return Restart
+				return Restart, nil
 			}
 		}
 		h.recordRestartEventf(ctx, s.VirtualMachine().Current(), "Restart initiated by controller "+
 			"after stopping from inside the guest VirtualMachine for AlwaysOn runPolicy")
-		return Restart
+		return Restart, nil
 	}
 
-	return Nothing
+	return Nothing, nil
 }
 
 func (h *SyncPowerStateHandler) handleAlwaysOnUnlessStoppedManuallyPolicy(

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_power_state.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_power_state.go
@@ -280,7 +280,7 @@ func (h *SyncPowerStateHandler) handleAlwaysOnUnlessStoppedManuallyPolicy(
 				return Nothing, fmt.Errorf("load last applied spec: %w", err)
 			}
 
-			if lastAppliedSpec != nil && lastAppliedSpec.RunPolicy == virtv2.AlwaysOffPolicy && s.VirtualMachine().Current().Spec.RunPolicy == virtv2.AlwaysOnUnlessStoppedManually {
+			if lastAppliedSpec != nil && lastAppliedSpec.RunPolicy == virtv2.AlwaysOffPolicy {
 				err = kvvmutil.AddStartAnnotation(ctx, h.client, kvvm)
 				if err != nil {
 					return Nothing, fmt.Errorf("add annotation to KVVM: %w", err)

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_power_state_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_power_state_test.go
@@ -255,7 +255,7 @@ var _ = Describe("Test action getters for different run policy", func() {
 	})
 
 	Context("handleAlwaysOnPolicy", func() {
-		It("should return start action when kvvmi is nil and configureation not applied", func() {
+		It("should return start action when kvvmi is nil and configuration not applied", func() {
 			kvvm.Annotations["initFoo"] = "initBar"
 			err := fakeClient.Update(context.TODO(), kvvm)
 			Expect(err).NotTo(HaveOccurred())
@@ -268,7 +268,7 @@ var _ = Describe("Test action getters for different run policy", func() {
 			Expect(kvvm.Annotations[annotations.AnnVmStartRequested]).To(Equal("true"))
 		})
 
-		It("should return start action when kvvmi is nil and configureation applied", func() {
+		It("should return start action when kvvmi is nil and configuration applied", func() {
 			action, err := handler.handleAlwaysOnPolicy(
 				ctx, vmState, kvvm, nil, true, powerstate.ShutdownInfo{},
 			)


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
This pull request addresses issues related to starting virtual machines after changes in their power settings. Specifically, it fixes the following scenarios:

- AlwaysOff to AlwaysOn: Resolves the problem that prevented virtual machines from starting automatically when their setting is changed from "AlwaysOff" to "AlwaysOn".
- AlwaysOff to AlwaysOnUnlessStoppedManually: Corrects the issue that hindered the automatic start of virtual machines when transitioning from "AlwaysOff" to "AlwaysOnUnlessStoppedManually".


## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: vm
type: fix
summary: fix start VM after change run policy from AlwaysOff
impact_level: low
```
