### PR TITLE
test(vm): disable test 'Verify that the virtual machines are restarti…

### DIFF
--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -407,35 +407,35 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 			})
 		})
 
-		Context("Verify that the virtual machines are restarting by ssh", func() {
-			It("reboot VMs by ssh", func() {
-				res := kubectl.List(kc.ResourceVM, kc.GetOptions{
-					Labels:    testCaseLabel,
-					Namespace: conf.Namespace,
-					Output:    "jsonpath='{.items[*].metadata.name}'",
-				})
-				Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
-
-				vms := strings.Split(res.StdOut(), " ")
-
-				RebootVirtualMachinesBySSH(vms...)
-			})
-
-			It("checks VMs phases", func() {
-				By("Virtual machine should be stopped")
-				WaitPhaseByLabel(kc.ResourceVM, string(virtv2.MachineStopped), kc.WaitOptions{
-					Labels:    testCaseLabel,
-					Namespace: conf.Namespace,
-					Timeout:   MaxWaitTimeout,
-				})
-				By("Virtual machine agents should be ready")
-				WaitVmAgentReady(kc.WaitOptions{
-					Labels:    testCaseLabel,
-					Namespace: conf.Namespace,
-					Timeout:   MaxWaitTimeout,
-				})
-			})
-		})
+		//Context("Verify that the virtual machines are restarting by ssh", func() {
+		//	It("reboot VMs by ssh", func() {
+		//		res := kubectl.List(kc.ResourceVM, kc.GetOptions{
+		//			Labels:    testCaseLabel,
+		//			Namespace: conf.Namespace,
+		//			Output:    "jsonpath='{.items[*].metadata.name}'",
+		//		})
+		//		Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
+		//
+		//		vms := strings.Split(res.StdOut(), " ")
+		//
+		//		RebootVirtualMachinesBySSH(vms...)
+		//	})
+		//
+		//	It("checks VMs phases", func() {
+		//		By("Virtual machine should be stopped")
+		//		WaitPhaseByLabel(kc.ResourceVM, string(virtv2.MachineStopped), kc.WaitOptions{
+		//			Labels:    testCaseLabel,
+		//			Namespace: conf.Namespace,
+		//			Timeout:   MaxWaitTimeout,
+		//		})
+		//		By("Virtual machine agents should be ready")
+		//		WaitVmAgentReady(kc.WaitOptions{
+		//			Labels:    testCaseLabel,
+		//			Namespace: conf.Namespace,
+		//			Timeout:   MaxWaitTimeout,
+		//		})
+		//	})
+		//})
 
 		Context("Verify that the virtual machines are restarting after deleting pods", func() {
 			It("reboot VMs by delete pods", func() {


### PR DESCRIPTION
…ng by ssh'

## Description
<!---
  Describe your changes with technical details.
-->
This PR disable broken test "Verify that the virtual machines are restarting by ssh"

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: test
type: vm 
summary: disable test broken "Verify that the virtual machines are restarti..." 
```
