### PR TITLE
refactor(core): virt-launcher

### DIFF
--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -326,10 +326,10 @@ shell:
   setup:
   - |
     ./relocate_binaries.sh -i "{{ $virtLauncherDependencies.binaries | join " " }}" -o /relocate
-    
-    # Copy additional config swtpm
+
+    echo "Copy additional config swtpm"
     cp -a /etc/{swtpm_setup.conf,swtpm-localca.conf,swtpm-localca.options} /relocate/etc/
-    # Copy xattr config
+    echo "Copy xattr config"
     cp -a /etc/xattr.conf /relocate/etc
 
     # glibc-gconv-modules
@@ -397,12 +397,13 @@ shell:
     cp /relocate/scripts/virt-launcher-monitor-wrapper.sh /relocate/usr/bin/virt-launcher-monitor
     chmod +x /relocate/usr/bin/virt-launcher-monitor
   - |
+    cd /relocate
+    
     echo "Create symlinks for container-disk"
     mkdir -p /relocate/init/usr/bin
-    cd /relocate
     ln -s usr/bin/container-disk ./init/usr/bin/container-disk
-  - |
-    cd /relocate
+    
+    echo "Create symlink for run -> var/run "
     ln -s var/run run
 
   # /etc/libvirt-init will be copied back into /etc/libvirt at runtime. This is necessary because we configure libvirt to mount /etc/libvirt and set readOnlyRootFilesystem for other directories.


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Improved code readability virt-launcher build

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: core
type: refactor
summary: improve code readability virt-launcher image build
```
