### PR TITLE
fix(vm): correct maximum CPU sockets assignment in domain specification 

### DIFF
--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
@@ -46,8 +46,6 @@ const (
 
 	// GenericCPUModel specifies the base CPU model for Features and Discovery CPU model types.
 	GenericCPUModel = "kvm64"
-	// MaxCpuSockets defines the maximum number of CPU sockets allowed in the CPU topology
-	MaxCpuSockets = 8
 )
 
 type KVVMOptions struct {
@@ -240,7 +238,7 @@ func (b *KVVM) SetCpu(cores int, coreFraction string) error {
 
 	domainSpec.CPU.Cores = uint32(coresNeeded)
 	domainSpec.CPU.Sockets = uint32(socketsNeeded)
-	domainSpec.CPU.MaxSockets = uint32(MaxCpuSockets)
+	domainSpec.CPU.MaxSockets = uint32(socketsNeeded)
 	return nil
 }
 


### PR DESCRIPTION
## Description
User required sockets count for MaxSockets in VM spec


## Why do we need it, and what problem does it solve?
In some cases with Windows 11 that's cause bugs


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->
```changes
section: vm
type: fix
summary: correct maximum CPU sockets assignment in domain specification 
```
