### PR TITLE
feat(audit): add webhook rules

### DIFF
--- a/templates/virtualization-audit/validation-webhook.yaml
+++ b/templates/virtualization-audit/validation-webhook.yaml
@@ -36,6 +36,8 @@ webhooks:
         port: 443
       caBundle: |
         {{ .Values.virtualization.internal.audit.cert.ca | b64enc }}
+    admissionReviewVersions: [ "v1" ]
+    sideEffects: None
   - name: "vmop.virtualization-audit.validate.d8-virtualization"
     rules:
       - apiGroups: [ "virtualization.deckhouse.io" ]
@@ -51,6 +53,8 @@ webhooks:
         port: 443
       caBundle: |
         {{ .Values.virtualization.internal.audit.cert.ca | b64enc }}
+    admissionReviewVersions: [ "v1" ]
+    sideEffects: None
   - name: "vmstate.virtualization-audit.validate.d8-virtualization"
     objectSelector:
       matchExpressions:
@@ -72,5 +76,41 @@ webhooks:
         {{ .Values.virtualization.internal.audit.cert.ca | b64enc }}
     admissionReviewVersions: [ "v1" ]
     sideEffects: None
+  - name: "component-deletion.virtualization-audit.validate.d8-virtualization"
+    objectSelector:
+      namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: d8-virtualization
+    rules:
+      - apiGroups: [ "" ]
+        apiVersions: [ "v1" ]
+        operations: [ "CREATE", "DELETE" ]
+        resources: [ "pods" ]
+        scope: "Namespaced"
+    clientConfig:
+      service:
+        namespace: d8-{{ .Chart.Name }}
+        name: virtualization-audit
+        path: /component-deletion
+        port: 443
+      caBundle: |
+        {{ .Values.virtualization.internal.audit.cert.ca | b64enc }}
+    admissionReviewVersions: [ "v1" ]
+    sideEffects: None
+  - name: "mc.virtualization-audit.validate.d8-virtualization"
+    rules:
+      - apiGroups: [ "deckhouse.io" ]
+        apiVersions: [ "v1alpha1" ]
+        operations: [ "CREATE", "UPDATE", "DELETE" ]
+        resources: [ "moduleconfigs" ]
+        scope: "Cluster"
+    clientConfig:
+      service:
+        namespace: d8-{{ .Chart.Name }}
+        name: virtualization-audit
+        path: /moduleconfig
+        port: 443
+      caBundle: |
+        {{ .Values.virtualization.internal.audit.cert.ca | b64enc }}
     admissionReviewVersions: [ "v1" ]
     sideEffects: None

--- a/templates/virtualization-audit/validation-webhook.yaml
+++ b/templates/virtualization-audit/validation-webhook.yaml
@@ -8,7 +8,7 @@ webhooks:
     rules:
       - apiGroups:   ["virtualization.deckhouse.io"]
         apiVersions: ["v1alpha2"]
-        operations:  ["CREATE", "UPDATE"]
+        operations:  ["CREATE", "UPDATE", "DELETE"]
         resources:   ["virtualmachines"]
         scope:       "Namespaced"
     clientConfig:
@@ -36,5 +36,41 @@ webhooks:
         port: 443
       caBundle: |
         {{ .Values.virtualization.internal.audit.cert.ca | b64enc }}
+  - name: "vmop.virtualization-audit.validate.d8-virtualization"
+    rules:
+      - apiGroups: [ "virtualization.deckhouse.io" ]
+        apiVersions: [ "v1alpha2" ]
+        operations: [ "CREATE" ]
+        resources: [ "virtualmachineoperations" ]
+        scope: "Namespaced"
+    clientConfig:
+      service:
+        namespace: d8-{{ .Chart.Name }}
+        name: virtualization-audit
+        path: /virtualmachineoperation
+        port: 443
+      caBundle: |
+        {{ .Values.virtualization.internal.audit.cert.ca | b64enc }}
+  - name: "vmstate.virtualization-audit.validate.d8-virtualization"
+    objectSelector:
+      matchExpressions:
+        - key: "vm.kubevirt.internal.virtualization.deckhouse.io/name" 
+          operator: Exists
+    rules:
+      - apiGroups: [ "" ]
+        apiVersions: [ "v1" ]
+        operations: [ "CREATE" ]
+        resources: [ "pods" ]
+        scope: "Namespaced"
+    clientConfig:
+      service:
+        namespace: d8-{{ .Chart.Name }}
+        name: virtualization-audit
+        path: /virtualmachinestate
+        port: 443
+      caBundle: |
+        {{ .Values.virtualization.internal.audit.cert.ca | b64enc }}
+    admissionReviewVersions: [ "v1" ]
+    sideEffects: None
     admissionReviewVersions: [ "v1" ]
     sideEffects: None

--- a/templates/virtualization-audit/validation-webhook.yaml
+++ b/templates/virtualization-audit/validation-webhook.yaml
@@ -21,6 +21,23 @@ webhooks:
         {{ .Values.virtualization.internal.audit.cert.ca | b64enc }}
     admissionReviewVersions: ["v1"]
     sideEffects: None
+  - name: "portforward.virtualization-audit.validate.d8-virtualization"
+    rules:
+      - apiGroups:   ["virtualization.deckhouse.io"]
+        apiVersions: ["v1alpha2"]
+        operations:  ["UPDATE"]
+        resources:   ["virtualmachines/portforward"]
+        scope:       "Namespaced"
+    clientConfig:
+      service:
+        namespace: d8-{{ .Chart.Name }}
+        name: virtualization-audit
+        path: /portforward
+        port: 443
+      caBundle: |
+        {{ .Values.virtualization.internal.audit.cert.ca | b64enc }}
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
   - name: "vi.virtualization-audit.validate.d8-virtualization"
     rules:
       - apiGroups: [ "virtualization.deckhouse.io" ]

--- a/templates/virtualization-audit/validation-webhook.yaml
+++ b/templates/virtualization-audit/validation-webhook.yaml
@@ -94,10 +94,9 @@ webhooks:
     admissionReviewVersions: [ "v1" ]
     sideEffects: None
   - name: "component-deletion.virtualization-audit.validate.d8-virtualization"
-    objectSelector:
-      namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: d8-virtualization
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: d8-virtualization
     rules:
       - apiGroups: [ "" ]
         apiVersions: [ "v1" ]


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Add rules for ValidatingWebhookConfiguration

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: 
type: 
summary: 
```
