### PR TITLE
fix(core): rename ValidatingAdmissionPolicy to not conflict with original kubevirt

### DIFF
--- a/hooks/migrate_delete_renamed_validation_admission_policy.py
+++ b/hooks/migrate_delete_renamed_validation_admission_policy.py
@@ -41,7 +41,7 @@ class MigrateDeleteRenamedVAPResources(Hook):
             "afterHelm": 5,
             "kubernetes": [
                 {
-                    "name": self.SNAPSHOT_NAME,
+                    "name": self.POLICY_SNAPSHOT_NAME,
                     "apiVersion": "admissionregistration.k8s.io/v1",
                     "kind": "ValidatingAdmissionPolicy",
                     "nameSelector": {
@@ -52,7 +52,7 @@ class MigrateDeleteRenamedVAPResources(Hook):
                             "matchNames": [self.namespace]
                         }
                     },
-                    "includeSnapshotsFrom": [self.SNAPSHOT_NAME],
+                    "group": "all",
                     "jqFilter": '{"name": .metadata.name, "kind": .kind, "labels": .metadata.labels}',
                     "queue": f"/modules/{self.module_name}/vap-resources",
                     "keepFullObjectsInMemory": False,
@@ -60,7 +60,7 @@ class MigrateDeleteRenamedVAPResources(Hook):
                     "executeHookOnEvent": []
                 },
                 {
-                    "name": self.SNAPSHOT_NAME,
+                    "name": self.BINDING_SNAPSHOT_NAME,
                     "apiVersion": "admissionregistration.k8s.io/v1",
                     "kind": "ValidatingAdmissionPolicyBinding",
                     "nameSelector": {
@@ -71,7 +71,7 @@ class MigrateDeleteRenamedVAPResources(Hook):
                             "matchNames": [self.namespace]
                         }
                     },
-                    "includeSnapshotsFrom": [self.SNAPSHOT_NAME],
+                    "group": "all",
                     "jqFilter": '{"name": .metadata.name, "kind": .kind, "labels": .metadata.labels}',
                     "queue": f"/modules/{self.module_name}/vap-resources",
                     "keepFullObjectsInMemory": False,

--- a/hooks/migrate_delete_renamed_validation_admission_policy.py
+++ b/hooks/migrate_delete_renamed_validation_admission_policy.py
@@ -29,7 +29,6 @@ class MigrateDeleteRenamedVAPResources(Hook):
 
     def __init__(self, module_name: str):
         self.module_name = module_name
-        self.namespace = common.NAMESPACE
         self.vapolicy_name = "kubevirt-node-restriction-policy"
         self.vapolicy_binding_name = "kubevirt-node-restriction-binding"
         self.managed_by_label = "app.kubernetes.io/managed-by"
@@ -47,11 +46,6 @@ class MigrateDeleteRenamedVAPResources(Hook):
                     "nameSelector": {
                         "matchNames": [self.vapolicy_name]
                     },
-                    "namespace": {
-                        "nameSelector": {
-                            "matchNames": [self.namespace]
-                        }
-                    },
                     "group": "all",
                     "jqFilter": '{"name": .metadata.name, "kind": .kind, "labels": .metadata.labels}',
                     "queue": f"/modules/{self.module_name}/vap-resources",
@@ -65,11 +59,6 @@ class MigrateDeleteRenamedVAPResources(Hook):
                     "kind": "ValidatingAdmissionPolicyBinding",
                     "nameSelector": {
                         "matchNames": [self.vapolicy_binding_name]
-                    },
-                    "namespace": {
-                        "nameSelector": {
-                            "matchNames": [self.namespace]
-                        }
                     },
                     "group": "all",
                     "jqFilter": '{"name": .metadata.name, "kind": .kind, "labels": .metadata.labels}',
@@ -94,9 +83,8 @@ class MigrateDeleteRenamedVAPResources(Hook):
                         # Delete
                         name = s["filterResult"]["name"]
                         kind = s["filterResult"]["kind"]
-                        print(f"Delete deprecated {kind} {self.namespace}/{name}.")
+                        print(f"Delete deprecated {kind} {name}.")
                         ctx.kubernetes.delete(kind=kind,
-                                          namespace=self.namespace,
                                           name=name)
             if found_deprecated == 0:
                 print("No deprecated resources found, migration not required.")

--- a/hooks/migrate_delete_renamed_validation_admission_policy.py
+++ b/hooks/migrate_delete_renamed_validation_admission_policy.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+#
+# Copyright 2023 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Callable
+from deckhouse import hook
+from lib.hooks.hook import Hook
+import common
+
+
+# MigrateDeleteRenamedVAPResources deletes orphan resources after renaming them in Kubevirt.
+# Deletion is required to not conflict with the original Kubevirt installation.
+# AfterHelm binding is used to minimize risk of resources recreating by the old version of the virt-operator.
+class MigrateDeleteRenamedVAPResources(Hook):
+    BINDING_SNAPSHOT_NAME = "validating_admission_policy"
+    POLICY_SNAPSHOT_NAME = "validating_admission_policy_binding"
+
+    def __init__(self, module_name: str):
+        self.module_name = module_name
+        self.namespace = common.NAMESPACE
+        self.vapolicy_name = "kubevirt-node-restriction-policy"
+        self.vapolicy_binding_name = "kubevirt-node-restriction-binding"
+        self.managed_by_label = "app.kubernetes.io/managed-by"
+        self.managed_by_label_value = "virt-operator-internal-virtualization"
+
+    def generate_config(self) -> dict:
+        return {
+            "configVersion": "v1",
+            "afterHelm": 5,
+            "kubernetes": [
+                {
+                    "name": self.SNAPSHOT_NAME,
+                    "apiVersion": "admissionregistration.k8s.io/v1",
+                    "kind": "ValidatingAdmissionPolicy",
+                    "nameSelector": {
+                        "matchNames": [self.vapolicy_name]
+                    },
+                    "namespace": {
+                        "nameSelector": {
+                            "matchNames": [self.namespace]
+                        }
+                    },
+                    "includeSnapshotsFrom": [self.SNAPSHOT_NAME],
+                    "jqFilter": '{"name": .metadata.name, "kind": .kind, "labels": .metadata.labels}',
+                    "queue": f"/modules/{self.module_name}/vap-resources",
+                    "keepFullObjectsInMemory": False,
+                    "executeHookOnSynchronization": False,
+                    "executeHookOnEvent": []
+                },
+                {
+                    "name": self.SNAPSHOT_NAME,
+                    "apiVersion": "admissionregistration.k8s.io/v1",
+                    "kind": "ValidatingAdmissionPolicyBinding",
+                    "nameSelector": {
+                        "matchNames": [self.vapolicy_binding_name]
+                    },
+                    "namespace": {
+                        "nameSelector": {
+                            "matchNames": [self.namespace]
+                        }
+                    },
+                    "includeSnapshotsFrom": [self.SNAPSHOT_NAME],
+                    "jqFilter": '{"name": .metadata.name, "kind": .kind, "labels": .metadata.labels}',
+                    "queue": f"/modules/{self.module_name}/vap-resources",
+                    "keepFullObjectsInMemory": False,
+                    "executeHookOnSynchronization": False,
+                    "executeHookOnEvent": []
+                },
+            ]
+        }
+
+    def reconcile(self) -> Callable[[hook.Context], None]:
+        def r(ctx: hook.Context):
+            found_deprecated = 0
+            for snapshot_name in [self.POLICY_SNAPSHOT_NAME, self.BINDING_SNAPSHOT_NAME]:
+                for s in ctx.snapshots.get(snapshot_name, []):
+                    labels = s["filterResult"]["labels"]
+                    if not self.managed_by_label in labels:
+                        continue
+                    if labels[self.managed_by_label] == self.managed_by_label_value:
+                        ++found_deprecated
+                        # Delete
+                        name = s["filterResult"]["name"]
+                        kind = s["filterResult"]["kind"]
+                        print(f"Delete deprecated {kind} {self.namespace}/{name}.")
+                        ctx.kubernetes.delete(kind=kind,
+                                          namespace=self.namespace,
+                                          name=name)
+            if found_deprecated == 0:
+                print("No deprecated resources found, migration not required.")
+        return r
+
+
+if __name__ == "__main__":
+    h = MigrateDeleteRenamedVAPResources(common.MODULE_NAME)
+    h.run()

--- a/images/virt-artifact/patches/015-rename-core-resources.patch
+++ b/images/virt-artifact/patches/015-rename-core-resources.patch
@@ -1,8 +1,8 @@
 diff --git a/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget.go b/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget.go
-index 228518871..55ce72b6c 100644
+index d510bbb57c..914f9a1034 100644
 --- a/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget.go
 +++ b/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget.go
-@@ -485,7 +485,10 @@ func (c *DisruptionBudgetController) createPDB(key string, vmi *virtv1.VirtualMa
+@@ -490,7 +490,10 @@ func (c *DisruptionBudgetController) createPDB(key string, vmi *virtv1.VirtualMa
  			OwnerReferences: []v1.OwnerReference{
  				*v1.NewControllerRef(vmi, virtv1.VirtualMachineInstanceGroupVersionKind),
  			},
@@ -15,12 +15,12 @@ index 228518871..55ce72b6c 100644
  		Spec: policyv1.PodDisruptionBudgetSpec{
  			MinAvailable: &minAvailable,
 diff --git a/pkg/virt-operator/resource/generate/components/serviceaccountnames.go b/pkg/virt-operator/resource/generate/components/serviceaccountnames.go
-index 0948629bb..9aca3b3bd 100644
+index 0948629bb5..9aca3b3bd2 100644
 --- a/pkg/virt-operator/resource/generate/components/serviceaccountnames.go
 +++ b/pkg/virt-operator/resource/generate/components/serviceaccountnames.go
 @@ -1,9 +1,9 @@
  package components
-
+ 
  const (
 -	ApiServiceAccountName         = "kubevirt-apiserver"
 -	ControllerServiceAccountName  = "kubevirt-controller"
@@ -32,34 +32,51 @@ index 0948629bb..9aca3b3bd 100644
 +	HandlerServiceAccountName     = "kubevirt-internal-virtualization-handler"
  	OperatorServiceAccountName    = "kubevirt-operator"
  )
+diff --git a/pkg/virt-operator/resource/generate/components/validatingadmissionpolicy.go b/pkg/virt-operator/resource/generate/components/validatingadmissionpolicy.go
+index 5fefec2304..a878bf1856 100644
+--- a/pkg/virt-operator/resource/generate/components/validatingadmissionpolicy.go
++++ b/pkg/virt-operator/resource/generate/components/validatingadmissionpolicy.go
+@@ -31,9 +31,9 @@ import (
+ )
+ 
+ const (
+-	validatingAdmissionPolicyBindingName = "kubevirt-node-restriction-binding"
+-	validatingAdmissionPolicyName        = "kubevirt-node-restriction-policy"
+-	nodeRestrictionAppLabelValue         = "kubevirt-node-restriction"
++	validatingAdmissionPolicyBindingName = "kubevirt-internal-virtualization-node-restriction-binding"
++	validatingAdmissionPolicyName        = "kubevirt-internal-virtualization-node-restriction-policy"
++	nodeRestrictionAppLabelValue         = "kubevirt-internal-virtualization-node-restriction"
+ 
+ 	NodeRestrictionErrModifySpec           = "this user cannot modify spec of node"
+ 	NodeRestrictionErrChangeMetadataFields = "this user can only change allowed metadata fields"
 diff --git a/pkg/virt-operator/resource/generate/components/webhooks.go b/pkg/virt-operator/resource/generate/components/webhooks.go
-index 2600f8f39..620449fa1 100644
+index 1f12d586fc..36cd1e17a3 100644
 --- a/pkg/virt-operator/resource/generate/components/webhooks.go
 +++ b/pkg/virt-operator/resource/generate/components/webhooks.go
-@@ -833,15 +833,15 @@ const VirtHandlerServiceName = "virt-handler"
-
+@@ -859,15 +859,15 @@ const VirtHandlerServiceName = "virt-handler"
+ 
  const VirtExportProxyServiceName = "virt-exportproxy"
-
+ 
 -const VirtAPIValidatingWebhookName = "virt-api-validator"
 +const VirtAPIValidatingWebhookName = "virt-internal-virtualization-api-validator"
-
+ 
  const VirtOperatorServiceName = "kubevirt-operator-webhook"
-
+ 
 -const VirtAPIMutatingWebhookName = "virt-api-mutator"
 +const VirtAPIMutatingWebhookName = "virt-internal-virtualization-api-mutator"
-
+ 
  const KubevirtOperatorWebhookServiceName = "kubevirt-operator-webhook"
-
+ 
 -const KubeVirtOperatorValidatingWebhookName = "virt-operator-validator"
 +const KubeVirtOperatorValidatingWebhookName = "virt-internal-virtualization-operator-validator"
-
+ 
  const VMSnapshotValidatePath = "/virtualmachinesnapshots-validate"
-
+ 
 diff --git a/pkg/virt-operator/resource/generate/rbac/apiserver.go b/pkg/virt-operator/resource/generate/rbac/apiserver.go
-index 932f7391e..76c79d452 100644
+index 99e8fe12dd..1707ba19da 100644
 --- a/pkg/virt-operator/resource/generate/rbac/apiserver.go
 +++ b/pkg/virt-operator/resource/generate/rbac/apiserver.go
-@@ -294,7 +294,7 @@ func newApiServerAuthDelegatorClusterRoleBinding(namespace string) *rbacv1.Clust
+@@ -307,7 +307,7 @@ func newApiServerAuthDelegatorClusterRoleBinding(namespace string) *rbacv1.Clust
  			Kind:       "ClusterRoleBinding",
  		},
  		ObjectMeta: metav1.ObjectMeta{
@@ -74,13 +91,13 @@ index a3c5addcd8..e4eadb48f3 100644
 +++ b/pkg/virt-operator/resource/generate/rbac/cluster.go
 @@ -36,8 +36,8 @@ import (
  )
-
+ 
  const (
 -	defaultClusterRoleName          = "kubevirt.io:default"
 -	instancetypeViewClusterRoleName = "instancetype.kubevirt.io:view"
 +	defaultClusterRoleName          = "kubevirt.internal.virtualization.deckhouse.io:default"
 +	instancetypeViewClusterRoleName = "instancetype.kubevirt.internal.virtualization.deckhouse.io:view"
-
+ 
  	apiVersion            = "version"
  	apiGuestFs            = "guestfs"
 @@ -178,7 +178,7 @@ func newAdminClusterRole() *rbacv1.ClusterRole {
@@ -111,7 +128,7 @@ index a3c5addcd8..e4eadb48f3 100644
  				virtv1.AppLabel: "",
  				"rbac.authorization.k8s.io/aggregate-to-view": "true",
 diff --git a/pkg/virt-operator/resource/generate/rbac/exportproxy.go b/pkg/virt-operator/resource/generate/rbac/exportproxy.go
-index 071ed91f9..ebc9f2adb 100644
+index 071ed91f90..ebc9f2adbd 100644
 --- a/pkg/virt-operator/resource/generate/rbac/exportproxy.go
 +++ b/pkg/virt-operator/resource/generate/rbac/exportproxy.go
 @@ -23,11 +23,12 @@ import (
@@ -119,20 +136,20 @@ index 071ed91f9..ebc9f2adb 100644
  	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
  	"k8s.io/apimachinery/pkg/runtime"
 +	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
-
+ 
  	virtv1 "kubevirt.io/api/core/v1"
  )
-
+ 
 -const ExportProxyServiceAccountName = "kubevirt-exportproxy"
 +const ExportProxyServiceAccountName = components.ExportProxyServiceAccountName
-
+ 
  func GetAllExportProxy(namespace string) []runtime.Object {
  	return []runtime.Object{
 diff --git a/pkg/virt-operator/resource/generate/rbac/operator.go b/pkg/virt-operator/resource/generate/rbac/operator.go
-index 4eca946a4..061135fd9 100644
+index 160083ac5b..c10a42d6f8 100644
 --- a/pkg/virt-operator/resource/generate/rbac/operator.go
 +++ b/pkg/virt-operator/resource/generate/rbac/operator.go
-@@ -435,7 +435,7 @@ func newOperatorRoleBinding(namespace string) *rbacv1.RoleBinding {
+@@ -428,7 +428,7 @@ func newOperatorRoleBinding(namespace string) *rbacv1.RoleBinding {
  			Kind:       "RoleBinding",
  		},
  		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION

## Description

- Rename internal resources: ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding.
- Add afterHelm hook to delete orphan resources.


## Why do we need it, and what problem does it solve?

Kubevirt installs ValidatingAdmissionPolicy in Kubernetes >=1.30.
Rename this ValidatingAdmissionPolicy resource to not conflict with the original Kubevirt installation.

## What is the expected result?

1. Original Kubevirt installs successfully.

2. No VAP with original name after module update:

Before:
```
# kubectl get validatingadmissionpolicybindings.admissionregistration.k8s.io
...
kubevirt-node-restriction-binding                    kubevirt-node-restriction-policy               <unset>    3m24s
```

After:
```
# kubectl get validatingadmissionpolicy
NAME                                                       VALIDATIONS   PARAMKIND   AGE
...
kubevirt-internal-virtualization-node-restriction-policy   6             <unset>     27m
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: core
type: fix
summary: Rename internal resources to not conflict with the original Kubevirt installation.
```
