### PR TITLE
fix(vm): ensure detachment happened

### DIFF
--- a/images/virtualization-artifact/.golangci.yaml
+++ b/images/virtualization-artifact/.golangci.yaml
@@ -25,7 +25,7 @@ linters-settings:
   goimports:
     local-prefixes: github.com/deckhouse/
   errcheck:
-    ignore: fmt:.*,[rR]ead|[wW]rite|[cC]lose,io:Copy
+    exclude-functions: fmt:.*,[rR]ead|[wW]rite|[cC]lose,io:Copy
   revive:
     rules:
       - name: dot-imports
@@ -41,7 +41,7 @@ linters:
     - errcheck
     - errname
     - errorlint
-    - exportloopref
+    - copyloopvar
     - gci
     - gocritic
     - gofmt

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
@@ -52,17 +52,17 @@ func GenerateCVMIDiskName(name string) string {
 	return CVMIDiskPrefix + name
 }
 
-func GetOriginalDiskName(prefixedName string) (string, bool) {
+func GetOriginalDiskName(prefixedName string) (string, virtv2.BlockDeviceKind) {
 	switch {
 	case strings.HasPrefix(prefixedName, VMDDiskPrefix):
-		return strings.TrimPrefix(prefixedName, VMDDiskPrefix), true
+		return strings.TrimPrefix(prefixedName, VMDDiskPrefix), virtv2.DiskDevice
 	case strings.HasPrefix(prefixedName, VMIDiskPrefix):
-		return strings.TrimPrefix(prefixedName, VMIDiskPrefix), true
+		return strings.TrimPrefix(prefixedName, VMIDiskPrefix), virtv2.ImageDevice
 	case strings.HasPrefix(prefixedName, CVMIDiskPrefix):
-		return strings.TrimPrefix(prefixedName, CVMIDiskPrefix), true
+		return strings.TrimPrefix(prefixedName, CVMIDiskPrefix), virtv2.ClusterImageDevice
 	}
 
-	return prefixedName, false
+	return prefixedName, ""
 }
 
 func GenerateSerialFromObject(obj metav1.Object) string {

--- a/images/virtualization-artifact/pkg/controller/service/attachment_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/attachment_service.go
@@ -149,14 +149,14 @@ func (s AttachmentService) HotPlugDisk(ctx context.Context, ad *AttachmentDisk, 
 	})
 }
 
-func (s AttachmentService) NeedUnplug(vm *virtv2.VirtualMachine, objectRef virtv2.VMBDAObjectRef) bool {
+func (s AttachmentService) IsAttached(vm *virtv2.VirtualMachine, vmbda *virtv2.VirtualMachineBlockDeviceAttachment) bool {
 	if vm == nil {
 		return false
 	}
 
 	for _, bdRef := range vm.Status.BlockDeviceRefs {
-		if bdRef.Kind == virtv2.BlockDeviceKind(objectRef.Kind) && bdRef.Name == objectRef.Name {
-			return bdRef.Hotplugged
+		if bdRef.Kind == virtv2.BlockDeviceKind(vmbda.Spec.BlockDeviceRef.Kind) && bdRef.Name == vmbda.Spec.BlockDeviceRef.Name {
+			return bdRef.Hotplugged && bdRef.VirtualMachineBlockDeviceAttachmentName == vmbda.Name
 		}
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vm/internal/block_device.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/block_device.go
@@ -18,6 +18,7 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -114,36 +115,21 @@ func (h *BlockDeviceHandler) Handle(ctx context.Context, s state.VirtualMachineS
 		return reconcile.Result{}, nil
 	}
 
-	// Get hot plugged BlockDeviceRefs from vmbdas.
-	vmbdaStatusRefs, err := h.getBlockDeviceStatusRefsFromVMBDA(ctx, s)
+	// Fill BlockDeviceRefs every time without knowledge of previously kept BlockDeviceRefs.
+	changed.Status.BlockDeviceRefs, err = h.getBlockDeviceStatusRefs(ctx, s)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to get block device status refs: %w", err)
+	}
+
+	// There is no need to set block device refs acquired here to the status now,
+	// as they will be set to the status by the new method `getBlockDeviceStatusRefs` above.
+	// It hasn't been refactored now because a new PR, which will completely refactor this handler, will be merged soon.
+	vmbdaRefs, err := h.getBlockDeviceStatusRefsFromVMBDA(ctx, s)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to get hotplugged block devices: %w", err)
 	}
 
-	// Get BlockDeviceRefs from spec.
-	bdStatusRefs, conflictWarning := h.getBlockDeviceStatusRefsFromSpec(current, bdState, vmbdaStatusRefs)
-
-	// Fill BlockDeviceRefs every time without knowledge of previously kept BlockDeviceRefs.
-	changed.Status.BlockDeviceRefs = bdStatusRefs
-	changed.Status.BlockDeviceRefs = append(changed.Status.BlockDeviceRefs, vmbdaStatusRefs...)
-
-	kvvmi, err := s.KVVMI(ctx)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
-	// Sync BlockDeviceRefs in the status with KVVMI volumes.
-	if kvvmi != nil {
-		for i, bdStatusRef := range changed.Status.BlockDeviceRefs {
-			vs := h.findVolumeStatus(GenerateDiskName(bdStatusRef.Kind, bdStatusRef.Name), kvvmi)
-			if vs == nil || (vs.Phase != "" && vs.Phase != virtv1.VolumeReady) {
-				continue
-			}
-
-			changed.Status.BlockDeviceRefs[i].Target = vs.Target
-			changed.Status.BlockDeviceRefs[i].Attached = true
-		}
-	}
+	conflictWarning := h.getBlockDeviceWarnings(current, bdState, vmbdaRefs)
 
 	// Update the BlockDevicesReady condition if there are conflicted virtual disks.
 	if conflictWarning != "" {
@@ -222,14 +208,13 @@ func (h *BlockDeviceHandler) Name() string {
 	return nameBlockDeviceHandler
 }
 
-func (h *BlockDeviceHandler) getBlockDeviceStatusRefsFromSpec(vm *virtv2.VirtualMachine, bdState BlockDevicesState, hotplugs []virtv2.BlockDeviceStatusRef) ([]virtv2.BlockDeviceStatusRef, string) {
+func (h *BlockDeviceHandler) getBlockDeviceWarnings(vm *virtv2.VirtualMachine, bdState BlockDevicesState, hotplugs []virtv2.BlockDeviceStatusRef) string {
 	hotplugsByName := make(map[string]struct{}, len(hotplugs))
 	for _, hotplug := range hotplugs {
 		hotplugsByName[hotplug.Name] = struct{}{}
 	}
 
 	var conflictedRefs []string
-	var refs []virtv2.BlockDeviceStatusRef
 
 	for _, bdSpecRef := range vm.Spec.BlockDeviceRefs {
 		// It is a precaution to not apply changes in spec.blockDeviceRefs if disk is already
@@ -258,11 +243,6 @@ func (h *BlockDeviceHandler) getBlockDeviceStatusRefsFromSpec(vm *virtv2.Virtual
 				continue
 			}
 		}
-
-		bdStatusRef := h.getDiskStatusRef(bdSpecRef.Kind, bdSpecRef.Name)
-		bdStatusRef.Size = h.getBlockDeviceSize(&bdStatusRef, bdState)
-
-		refs = append(refs, bdStatusRef)
 	}
 
 	var warning string
@@ -270,78 +250,184 @@ func (h *BlockDeviceHandler) getBlockDeviceStatusRefsFromSpec(vm *virtv2.Virtual
 		warning = fmt.Sprintf("spec.blockDeviceRefs field contains hotplugged disks (%s): unplug or remove them from spec to continue.", strings.Join(conflictedRefs, ", "))
 	}
 
-	return refs, warning
+	return warning
 }
 
-func (h *BlockDeviceHandler) getBlockDeviceStatusRefsFromVMBDA(ctx context.Context, s state.VirtualMachineState) ([]virtv2.BlockDeviceStatusRef, error) {
-	vmbdas, err := s.VMBDAList(ctx)
+type nameKindKey struct {
+	kind virtv2.BlockDeviceKind
+	name string
+}
+
+// getBlockDeviceStatusRefs returns block device refs to populate .status.blockDeviceRefs of the virtual machine.
+// If kvvm is present, this method will reflect all volumes with prefixes (vi,vd, or cvi) into the slice of `BlockDeviceStatusRef`.
+// Block devices from the virtual machine specification will be added to the resulting slice if they have not been included in the previous step.
+func (h *BlockDeviceHandler) getBlockDeviceStatusRefs(ctx context.Context, s state.VirtualMachineState) ([]virtv2.BlockDeviceStatusRef, error) {
+	kvvm, err := s.KVVM(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	var refs []virtv2.BlockDeviceStatusRef
 
-	for _, vmbda := range vmbdas {
-		switch vmbda.Status.Phase {
-		case virtv2.BlockDeviceAttachmentPhaseInProgress,
-			virtv2.BlockDeviceAttachmentPhaseAttached:
-		default:
+	// 1. There is no kvvm yet: populate block device refs with the spec.
+	if kvvm == nil {
+		for _, specBlockDeviceRef := range s.VirtualMachine().Current().Spec.BlockDeviceRefs {
+			ref := h.getBlockDeviceStatusRef(specBlockDeviceRef.Kind, specBlockDeviceRef.Name)
+			ref.Size, err = h.getBlockDeviceRefSize(ctx, ref, s)
+			if err != nil {
+				return nil, err
+			}
+			refs = append(refs, ref)
+		}
+
+		return refs, nil
+	}
+
+	if kvvm.Spec.Template == nil {
+		return nil, errors.New("there is no spec template")
+	}
+
+	kvvmi, err := s.KVVMI(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var kvvmiVolumeStatusByName map[string]virtv1.VolumeStatus
+	if kvvmi != nil {
+		kvvmiVolumeStatusByName = make(map[string]virtv1.VolumeStatus)
+		for _, vs := range kvvmi.Status.VolumeStatus {
+			kvvmiVolumeStatusByName[vs.Name] = vs
+		}
+	}
+
+	attachedBlockDeviceRefs := make(map[nameKindKey]struct{})
+
+	// 2. The kvvm already exists: populate block device refs with the kvvm volumes.
+	for _, volume := range kvvm.Spec.Template.Spec.Volumes {
+		bdName, kind := kvbuilder.GetOriginalDiskName(volume.Name)
+		if kind == "" {
+			// Reflect only vi, vd, or cvi block devices in status.
+			// This is neither of them, so skip.
 			continue
 		}
 
-		var (
-			cvi         *virtv2.ClusterVirtualImage
-			vi          *virtv2.VirtualImage
-			vd          *virtv2.VirtualDisk
-			bdStatusRef virtv2.BlockDeviceStatusRef
-		)
-
-		switch vmbda.Spec.BlockDeviceRef.Kind {
-		case virtv2.VMBDAObjectRefKindVirtualDisk:
-			vd, err = s.VirtualDisk(ctx, vmbda.Spec.BlockDeviceRef.Name)
+		ref := h.getBlockDeviceStatusRef(kind, bdName)
+		ref.Target, ref.Attached = h.getBlockDeviceTarget(volume, kvvmiVolumeStatusByName)
+		ref.Size, err = h.getBlockDeviceRefSize(ctx, ref, s)
+		if err != nil {
+			return nil, err
+		}
+		ref.Hotplugged, err = h.isHotplugged(ctx, volume, kvvmiVolumeStatusByName, s)
+		if err != nil {
+			return nil, err
+		}
+		if ref.Hotplugged {
+			ref.VirtualMachineBlockDeviceAttachmentName, err = h.getBlockDeviceAttachmentName(ctx, kind, bdName, s)
 			if err != nil {
 				return nil, err
 			}
-
-			if vd == nil {
-				continue
-			}
-
-			bdStatusRef = h.getDiskStatusRef(virtv2.DiskDevice, vmbda.Spec.BlockDeviceRef.Name)
-			bdStatusRef.Size = vd.Status.Capacity
-		case virtv2.VMBDAObjectRefKindVirtualImage:
-			vi, err = s.VirtualImage(ctx, vmbda.Spec.BlockDeviceRef.Name)
-			if err != nil {
-				return nil, err
-			}
-
-			if vi == nil {
-				continue
-			}
-
-			bdStatusRef = h.getDiskStatusRef(virtv2.ImageDevice, vmbda.Spec.BlockDeviceRef.Name)
-			bdStatusRef.Size = vi.Status.Size.Unpacked
-
-		case virtv2.VMBDAObjectRefKindClusterVirtualImage:
-			cvi, err = s.ClusterVirtualImage(ctx, vmbda.Spec.BlockDeviceRef.Name)
-			if err != nil {
-				return nil, err
-			}
-
-			if cvi == nil {
-				continue
-			}
-
-			bdStatusRef = h.getDiskStatusRef(virtv2.ClusterImageDevice, vmbda.Spec.BlockDeviceRef.Name)
-			bdStatusRef.Size = cvi.Status.Size.Unpacked
-		default:
-			return nil, fmt.Errorf("unacceptable `Kind` of `BlockDeviceRef`: %s", vmbda.Spec.BlockDeviceRef.Kind)
 		}
 
-		bdStatusRef.Hotplugged = true
-		bdStatusRef.VirtualMachineBlockDeviceAttachmentName = vmbda.Name
+		refs = append(refs, ref)
+		attachedBlockDeviceRefs[nameKindKey{
+			kind: ref.Kind,
+			name: ref.Name,
+		}] = struct{}{}
+	}
 
-		refs = append(refs, bdStatusRef)
+	// 3. The kvvm may be missing some block devices from the spec; they need to be added as well.
+	for _, specBlockDeviceRef := range s.VirtualMachine().Current().Spec.BlockDeviceRefs {
+		_, ok := attachedBlockDeviceRefs[nameKindKey{
+			kind: specBlockDeviceRef.Kind,
+			name: specBlockDeviceRef.Name,
+		}]
+		if ok {
+			continue
+		}
+
+		ref := h.getBlockDeviceStatusRef(specBlockDeviceRef.Kind, specBlockDeviceRef.Name)
+		ref.Size, err = h.getBlockDeviceRefSize(ctx, ref, s)
+		if err != nil {
+			return nil, err
+		}
+		refs = append(refs, ref)
+	}
+
+	return refs, nil
+}
+
+// Deprecated. It will be removed soon.
+func (h *BlockDeviceHandler) getBlockDeviceStatusRefsFromVMBDA(ctx context.Context, s state.VirtualMachineState) ([]virtv2.BlockDeviceStatusRef, error) {
+	vmbdasByBlockDevice, err := s.VirtualMachineBlockDeviceAttachments(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var refs []virtv2.BlockDeviceStatusRef
+
+	for _, vmbdas := range vmbdasByBlockDevice {
+		for _, vmbda := range vmbdas {
+			switch vmbda.Status.Phase {
+			case virtv2.BlockDeviceAttachmentPhaseInProgress,
+				virtv2.BlockDeviceAttachmentPhaseAttached:
+			default:
+				continue
+			}
+
+			var (
+				cvi         *virtv2.ClusterVirtualImage
+				vi          *virtv2.VirtualImage
+				vd          *virtv2.VirtualDisk
+				bdStatusRef virtv2.BlockDeviceStatusRef
+			)
+
+			switch vmbda.Spec.BlockDeviceRef.Kind {
+			case virtv2.VMBDAObjectRefKindVirtualDisk:
+				vd, err = s.VirtualDisk(ctx, vmbda.Spec.BlockDeviceRef.Name)
+				if err != nil {
+					return nil, err
+				}
+
+				if vd == nil {
+					continue
+				}
+
+				bdStatusRef = h.getBlockDeviceStatusRef(virtv2.DiskDevice, vmbda.Spec.BlockDeviceRef.Name)
+				bdStatusRef.Size = vd.Status.Capacity
+			case virtv2.VMBDAObjectRefKindVirtualImage:
+				vi, err = s.VirtualImage(ctx, vmbda.Spec.BlockDeviceRef.Name)
+				if err != nil {
+					return nil, err
+				}
+
+				if vi == nil {
+					continue
+				}
+
+				bdStatusRef = h.getBlockDeviceStatusRef(virtv2.ImageDevice, vmbda.Spec.BlockDeviceRef.Name)
+				bdStatusRef.Size = vi.Status.Size.Unpacked
+
+			case virtv2.VMBDAObjectRefKindClusterVirtualImage:
+				cvi, err = s.ClusterVirtualImage(ctx, vmbda.Spec.BlockDeviceRef.Name)
+				if err != nil {
+					return nil, err
+				}
+
+				if cvi == nil {
+					continue
+				}
+
+				bdStatusRef = h.getBlockDeviceStatusRef(virtv2.ClusterImageDevice, vmbda.Spec.BlockDeviceRef.Name)
+				bdStatusRef.Size = cvi.Status.Size.Unpacked
+			default:
+				return nil, fmt.Errorf("unacceptable `Kind` of `BlockDeviceRef`: %s", vmbda.Spec.BlockDeviceRef.Kind)
+			}
+
+			bdStatusRef.Hotplugged = true
+			bdStatusRef.VirtualMachineBlockDeviceAttachmentName = vmbda.Name
+
+			refs = append(refs, bdStatusRef)
+		}
 	}
 
 	return refs, nil
@@ -461,54 +547,137 @@ func (h *BlockDeviceHandler) updateFinalizers(ctx context.Context, vm *virtv2.Vi
 	return nil
 }
 
-func (h *BlockDeviceHandler) getDiskStatusRef(kind virtv2.BlockDeviceKind, name string) virtv2.BlockDeviceStatusRef {
+func (h *BlockDeviceHandler) getBlockDeviceStatusRef(kind virtv2.BlockDeviceKind, name string) virtv2.BlockDeviceStatusRef {
 	return virtv2.BlockDeviceStatusRef{
 		Kind: kind,
 		Name: name,
 	}
 }
 
-func (h *BlockDeviceHandler) getBlockDeviceSize(ref *virtv2.BlockDeviceStatusRef, state BlockDevicesState) string {
-	switch ref.Kind {
-	case virtv2.ImageDevice:
-		vi, hasVI := state.VIByName[ref.Name]
-		if !hasVI {
-			return ""
-		}
-
-		return vi.Status.Size.Unpacked
-	case virtv2.DiskDevice:
-		vd, hasVI := state.VDByName[ref.Name]
-		if !hasVI {
-			return ""
-		}
-
-		return vd.Status.Capacity
-	case virtv2.ClusterImageDevice:
-		cvi, hasCvi := state.CVIByName[ref.Name]
-		if !hasCvi {
-			return ""
-		}
-
-		return cvi.Status.Size.Unpacked
-	}
-
-	return ""
+type BlockDeviceGetter interface {
+	VirtualDisk(ctx context.Context, name string) (*virtv2.VirtualDisk, error)
+	VirtualImage(ctx context.Context, name string) (*virtv2.VirtualImage, error)
+	ClusterVirtualImage(ctx context.Context, name string) (*virtv2.ClusterVirtualImage, error)
 }
 
-func (h *BlockDeviceHandler) findVolumeStatus(name string, kvvmi *virtv1.VirtualMachineInstance) *virtv1.VolumeStatus {
-	if kvvmi == nil {
-		return nil
+func (h *BlockDeviceHandler) getBlockDeviceRefSize(ctx context.Context, ref virtv2.BlockDeviceStatusRef, getter BlockDeviceGetter) (string, error) {
+	switch ref.Kind {
+	case virtv2.ImageDevice:
+		vi, err := getter.VirtualImage(ctx, ref.Name)
+		if err != nil {
+			return "", err
+		}
+
+		if vi == nil {
+			return "", nil
+		}
+
+		return vi.Status.Size.Unpacked, nil
+	case virtv2.DiskDevice:
+		vd, err := getter.VirtualDisk(ctx, ref.Name)
+		if err != nil {
+			return "", err
+		}
+
+		if vd == nil {
+			return "", nil
+		}
+
+		return vd.Status.Capacity, nil
+	case virtv2.ClusterImageDevice:
+		cvi, err := getter.ClusterVirtualImage(ctx, ref.Name)
+		if err != nil {
+			return "", err
+		}
+
+		if cvi == nil {
+			return "", nil
+		}
+
+		return cvi.Status.Size.Unpacked, nil
 	}
 
-	for i := range kvvmi.Status.VolumeStatus {
-		vs := kvvmi.Status.VolumeStatus[i]
-		if vs.Name == name {
-			return &vs
+	return "", nil
+}
+
+func (h *BlockDeviceHandler) getBlockDeviceTarget(volume virtv1.Volume, kvvmiVolumeStatusByName map[string]virtv1.VolumeStatus) (string, bool) {
+	vs, ok := kvvmiVolumeStatusByName[volume.Name]
+	if !ok {
+		return "", false
+	}
+
+	return vs.Target, true
+}
+
+func (h *BlockDeviceHandler) isHotplugged(ctx context.Context, volume virtv1.Volume, kvvmiVolumeStatusByName map[string]virtv1.VolumeStatus, s state.VirtualMachineState) (bool, error) {
+	switch {
+	// 1. If kvvmi has volume status with hotplugVolume reference then it's 100% hot-plugged volume.
+	case kvvmiVolumeStatusByName[volume.Name].HotplugVolume != nil:
+		return true, nil
+
+	// 2. If kvvm has volume with hot-pluggable pvc reference then it's 100% hot-plugged volume.
+	case volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.Hotpluggable:
+		return true, nil
+
+	// 3. We cannot check volume.ContainerDisk.Hotpluggable, as this field was added in our patches and is not reflected in the api version of virtv1 used by us.
+	// Until we have a 3rd-party repository to import the modified virtv1, we have to make decisions based on indirect signs.
+	// If there was a previously hot-plugged block device and the VMBDA is still alive, then it's a hot-plugged block device.
+	// TODO: Use volume.ContainerDisk.Hotpluggable for decision-making when the 3rd-party repository is available.
+	case volume.ContainerDisk != nil:
+		bdName, kind := kvbuilder.GetOriginalDiskName(volume.Name)
+		if h.canBeHotPlugged(s.VirtualMachine().Current(), kind, bdName) {
+			vmbdaName, err := h.getBlockDeviceAttachmentName(ctx, kind, bdName, s)
+			if err != nil {
+				return false, err
+			}
+			return vmbdaName != "", nil
 		}
 	}
 
-	return nil
+	// 4. Is not hot-plugged.
+	return false, nil
+}
+
+func (h *BlockDeviceHandler) getBlockDeviceAttachmentName(ctx context.Context, kind virtv2.BlockDeviceKind, bdName string, s state.VirtualMachineState) (string, error) {
+	log := logger.FromContext(ctx).With(logger.SlogHandler(nameBlockDeviceHandler))
+
+	vmbdasByRef, err := s.VirtualMachineBlockDeviceAttachments(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	vmbdas := vmbdasByRef[virtv2.VMBDAObjectRef{
+		Kind: virtv2.VMBDAObjectRefKind(kind),
+		Name: bdName,
+	}]
+
+	switch len(vmbdas) {
+	case 0:
+		log.Error("No one vmbda was found for hot-plugged block device")
+		return "", nil
+	case 1:
+		// OK.
+	default:
+		log.Error("Only one vmbda should be found for hot-plugged block device")
+	}
+
+	return vmbdas[0].Name, nil
+}
+
+func (h *BlockDeviceHandler) canBeHotPlugged(vm *virtv2.VirtualMachine, kind virtv2.BlockDeviceKind, bdName string) bool {
+	for _, bdRef := range vm.Status.BlockDeviceRefs {
+		if bdRef.Kind == kind && bdRef.Name == bdName {
+			return bdRef.Hotplugged
+		}
+	}
+
+	for _, bdRef := range vm.Spec.BlockDeviceRefs {
+		if bdRef.Kind == kind && bdRef.Name == bdName {
+			return false
+		}
+	}
+
+	return true
 }
 
 func NewBlockDeviceState(s state.VirtualMachineState) BlockDevicesState {
@@ -543,18 +712,6 @@ func (s *BlockDevicesState) Reload(ctx context.Context) error {
 	s.VIByName = viByName
 	s.CVIByName = ciByName
 	s.VDByName = vdByName
-	return nil
-}
 
-func GenerateDiskName(kind virtv2.BlockDeviceKind, name string) string {
-	switch kind {
-	case virtv2.ImageDevice:
-		return kvbuilder.GenerateVMIDiskName(name)
-	case virtv2.ClusterImageDevice:
-		return kvbuilder.GenerateCVMIDiskName(name)
-	case virtv2.DiskDevice:
-		return kvbuilder.GenerateVMDDiskName(name)
-	default:
-		return ""
-	}
+	return nil
 }

--- a/images/virtualization-artifact/pkg/controller/vm/internal/state/state.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/state/state.go
@@ -42,13 +42,13 @@ type VirtualMachineState interface {
 	KVVMI(ctx context.Context) (*virtv1.VirtualMachineInstance, error)
 	Pods(ctx context.Context) (*corev1.PodList, error)
 	Pod(ctx context.Context) (*corev1.Pod, error)
-	VMBDAList(ctx context.Context) ([]virtv2.VirtualMachineBlockDeviceAttachment, error)
 	VirtualDisk(ctx context.Context, name string) (*virtv2.VirtualDisk, error)
 	VirtualImage(ctx context.Context, name string) (*virtv2.VirtualImage, error)
 	ClusterVirtualImage(ctx context.Context, name string) (*virtv2.ClusterVirtualImage, error)
 	VirtualDisksByName(ctx context.Context) (map[string]*virtv2.VirtualDisk, error)
 	VirtualImagesByName(ctx context.Context) (map[string]*virtv2.VirtualImage, error)
 	ClusterVirtualImagesByName(ctx context.Context) (map[string]*virtv2.ClusterVirtualImage, error)
+	VirtualMachineBlockDeviceAttachments(ctx context.Context) (map[virtv2.VMBDAObjectRef][]*virtv2.VirtualMachineBlockDeviceAttachment, error)
 	IPAddress(ctx context.Context) (*virtv2.VirtualMachineIPAddress, error)
 	Class(ctx context.Context) (*virtv2.VirtualMachineClass, error)
 	Shared(fn func(s *Shared))
@@ -59,19 +59,20 @@ func New(c client.Client, vm *service.Resource[*virtv2.VirtualMachine, virtv2.Vi
 }
 
 type state struct {
-	client    client.Client
-	mu        sync.RWMutex
-	vm        *service.Resource[*virtv2.VirtualMachine, virtv2.VirtualMachineStatus]
-	kvvm      *virtv1.VirtualMachine
-	kvvmi     *virtv1.VirtualMachineInstance
-	pods      *corev1.PodList
-	pod       *corev1.Pod
-	vdByName  map[string]*virtv2.VirtualDisk
-	viByName  map[string]*virtv2.VirtualImage
-	cviByName map[string]*virtv2.ClusterVirtualImage
-	ipAddress *virtv2.VirtualMachineIPAddress
-	vmClass   *virtv2.VirtualMachineClass
-	shared    Shared
+	client      client.Client
+	mu          sync.RWMutex
+	vm          *service.Resource[*virtv2.VirtualMachine, virtv2.VirtualMachineStatus]
+	kvvm        *virtv1.VirtualMachine
+	kvvmi       *virtv1.VirtualMachineInstance
+	pods        *corev1.PodList
+	pod         *corev1.Pod
+	vdByName    map[string]*virtv2.VirtualDisk
+	viByName    map[string]*virtv2.VirtualImage
+	cviByName   map[string]*virtv2.ClusterVirtualImage
+	vmbdasByRef map[virtv2.VMBDAObjectRef][]*virtv2.VirtualMachineBlockDeviceAttachment
+	ipAddress   *virtv2.VirtualMachineIPAddress
+	vmClass     *virtv2.VirtualMachineClass
+	shared      Shared
 }
 
 type Shared struct {
@@ -169,23 +170,40 @@ func (s *state) Pod(ctx context.Context) (*corev1.Pod, error) {
 	return pod, nil
 }
 
-func (s *state) VMBDAList(ctx context.Context) ([]virtv2.VirtualMachineBlockDeviceAttachment, error) {
-	var list virtv2.VirtualMachineBlockDeviceAttachmentList
-	err := s.client.List(ctx, &list, &client.ListOptions{
+func (s *state) VirtualMachineBlockDeviceAttachments(ctx context.Context) (map[virtv2.VMBDAObjectRef][]*virtv2.VirtualMachineBlockDeviceAttachment, error) {
+	if s.vm == nil {
+		return nil, nil
+	}
+	if len(s.vmbdasByRef) > 0 {
+		return s.vmbdasByRef, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var vmbdas virtv2.VirtualMachineBlockDeviceAttachmentList
+	err := s.client.List(ctx, &vmbdas, &client.ListOptions{
 		Namespace: s.vm.Name().Namespace,
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	var vmbdas []virtv2.VirtualMachineBlockDeviceAttachment
-	for _, vmbda := range list.Items {
-		if vmbda.Spec.VirtualMachineName == s.vm.Name().Name {
-			vmbdas = append(vmbdas, vmbda)
+	vmbdasByRef := make(map[virtv2.VMBDAObjectRef][]*virtv2.VirtualMachineBlockDeviceAttachment)
+	for _, vmbda := range vmbdas.Items {
+		if vmbda.Spec.VirtualMachineName != s.vm.Name().Name {
+			continue
 		}
+
+		key := virtv2.VMBDAObjectRef{
+			Kind: vmbda.Spec.BlockDeviceRef.Kind,
+			Name: vmbda.Spec.BlockDeviceRef.Name,
+		}
+
+		vmbdasByRef[key] = append(vmbdasByRef[key], &vmbda)
 	}
 
-	return vmbdas, nil
+	s.vmbdasByRef = vmbdasByRef
+	return vmbdasByRef, nil
 }
 
 func (s *state) VirtualDisk(ctx context.Context, name string) (*virtv2.VirtualDisk, error) {

--- a/images/virtualization-artifact/pkg/controller/vm/vm_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/vm/vm_reconciler.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	virtv1 "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -336,35 +337,44 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	log.Debug("Start reconcile VM")
 
 	var result reconcile.Result
-	var handlerErr error
+	var errs error
 
 	for _, h := range r.handlers {
 		log.Debug("Run handler", logger.SlogHandler(h.Name()))
 
 		var res reconcile.Result
 		res, err = h.Handle(ctx, s)
-		if err != nil {
+		switch {
+		case err == nil: // OK.
+		case k8serrors.IsConflict(err):
+			log.Debug("The handler failed with an error", logger.SlogHandler(h.Name()), logger.SlogErr(err))
+			result.Requeue = true
+		default:
 			log.Error("The handler failed with an error", logger.SlogHandler(h.Name()), logger.SlogErr(err))
-			handlerErr = errors.Join(handlerErr, err)
+			errs = errors.Join(errs, err)
 		}
+
 		result = service.MergeResults(result, res)
 	}
 
-	if handlerErr != nil {
-		err = r.updateVM(ctx, vm)
-		if err != nil {
-			log.Error("Failed to update VirtualMachine")
-		}
-		return reconcile.Result{}, handlerErr
+	err = r.updateVM(ctx, vm)
+	switch {
+	case err == nil: // OK.
+	case k8serrors.IsConflict(err):
+		log.Debug("Failed to update VirtualMachine", logger.SlogErr(err))
+		result.Requeue = true
+	default:
+		log.Error("Failed to update VirtualMachine", logger.SlogErr(err))
+		errs = errors.Join(errs, err)
 	}
 
-	err = r.updateVM(ctx, vm)
-	if err != nil {
-		log.Error("Failed to update VirtualMachine")
-		return reconcile.Result{}, err
+	if errs != nil {
+		log.Error("Reconciling has been finished with error", logger.SlogErr(errs))
+		return reconcile.Result{}, errs
 	}
 
 	log.Debug("Finished reconcile VM")
+
 	return result, nil
 }
 

--- a/images/virtualization-artifact/pkg/controller/vmbda/internal/errors.go
+++ b/images/virtualization-artifact/pkg/controller/vmbda/internal/errors.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import "strings"
+
+func IsOutdatedRequestError(err error) bool {
+	return strings.Contains(err.Error(), "the server rejected our request due to an error in our request")
+}
+
+func IsDoesNotExistError(err error) bool {
+	return strings.Contains(err.Error(), "does not exist")
+}

--- a/images/virtualization-artifact/pkg/controller/vmbda/internal/watcher/kvvmi_watcher.go
+++ b/images/virtualization-artifact/pkg/controller/vmbda/internal/watcher/kvvmi_watcher.go
@@ -120,9 +120,8 @@ func (eh KVVMIEventHandler) getHotPluggedVolumeStatuses(obj client.Object) map[s
 
 	for _, vs := range kvvmi.Status.VolumeStatus {
 		if vs.HotplugVolume != nil {
-			var name string
-			name, ok = kvbuilder.GetOriginalDiskName(vs.Name)
-			if !ok {
+			name, kind := kvbuilder.GetOriginalDiskName(vs.Name)
+			if kind == "" {
 				slog.Default().Warn("VolumeStatus is not a Disk", "vsName", vs.Name, "name", kvvmi.Name, "ns", kvvmi.Namespace)
 				continue
 			}


### PR DESCRIPTION
## Description

1. BlockDeviceHandler was violating the contract regarding the setting of `.status.blockDeviceRefs`.
BlockDeviceHandler was populating `.status.blockDeviceRefs` based on what was in `.spec` and from the existing vmbda in the cluster, which led to problems. 

`.status.blockDeviceRefs` should reflect not only the block devices expected to be attached as per the spec but also those that are present in kvvm (these two sets of block devices may not match). Fixed this.

2. The log level of conflict error (“the object has been modified; please apply your changes to the latest version and try again”) for virtual machines is now set to debug, not error.

3. The vmbda will no longer be deleted until detaching is completed.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


```changes
section: vm
type: fix
summary: add missed but attached block device references to the status of the virtual machine
```
