### PR TITLE
test: more logs for virt-api

### DIFF
--- a/images/virt-artifact/patches/040-test.patch
+++ b/images/virt-artifact/patches/040-test.patch
@@ -1,0 +1,43 @@
+diff --git a/pkg/service/service.go b/pkg/service/service.go
+index 2929c48395..cefbabc704 100644
+--- a/pkg/service/service.go
++++ b/pkg/service/service.go
+@@ -81,7 +81,7 @@ func Setup(service Service) {
+ 	service.AddFlags()
+ 
+ 	// set new default verbosity, was set to 0 by glog
+-	flag.Set("v", "2")
++	// flag.Set("v", "2")
+ 
+ 	flag.Parse()
+ }
+diff --git a/pkg/virt-api/api.go b/pkg/virt-api/api.go
+index 9202809911..9d2a61853a 100644
+--- a/pkg/virt-api/api.go
++++ b/pkg/virt-api/api.go
+@@ -1064,6 +1064,12 @@ func (app *virtAPIApp) startTLS(informerFactory controller.KubeInformerFactory)
+ }
+ 
+ func (app *virtAPIApp) Run() {
++	log.Log.Info("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAa")
++	log.Log.Info("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAa")
++	log.Log.Info("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAa")
++	log.Log.Info("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAa")
++	log.Log.Info("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAa")
++
+ 	host, err := os.Hostname()
+ 	if err != nil {
+ 		panic(fmt.Errorf("unable to get hostname: %v", err))
+diff --git a/pkg/virt-api/rest/subresource.go b/pkg/virt-api/rest/subresource.go
+index 6a3e2b4143..cc60ed7b91 100644
+--- a/pkg/virt-api/rest/subresource.go
++++ b/pkg/virt-api/rest/subresource.go
+@@ -1255,7 +1255,7 @@ func (app *SubresourceAPIApp) vmVolumePatchStatus(name, namespace string, volume
+ 	dryRunOption := app.getDryRunOption(volumeRequest)
+ 	log.Log.Object(vm).V(4).Infof(patchingVMFmt, string(patchBytes))
+ 	if err := app.statusUpdater.PatchStatus(vm, types.JSONPatchType, patchBytes, &k8smetav1.PatchOptions{DryRun: dryRunOption}); err != nil {
+-		log.Log.Object(vm).Errorf("unable to patch vm status: %v", err)
++		log.Log.Object(vm).With("patch", string(patchBytes)).With("remove", volumeRequest.RemoveVolumeOptions.Name).Errorf("unable to patch vm status: %v", err)
+ 		if errors.IsInvalid(err) {
+ 			if statErr, ok := err.(*errors.StatusError); ok {
+ 				return statErr


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: 
type: 
summary: 
```
