### PR TITLE
feat(observability): add virtual machine agent metric

### DIFF
--- a/images/virtualization-artifact/pkg/monitoring/metrics/virtualmachine/data_metric.go
+++ b/images/virtualization-artifact/pkg/monitoring/metrics/virtualmachine/data_metric.go
@@ -43,6 +43,7 @@ type dataMetric struct {
 	MemoryRuntimeOverhead               float64
 	AwaitingRestartToApplyConfiguration bool
 	ConfigurationApplied                bool
+	AgentReady                          bool
 	RunPolicy                           virtv2.RunPolicy
 	Pods                                []virtv2.VirtualMachinePod
 	Labels                              map[string]string
@@ -61,6 +62,7 @@ func newDataMetric(vm *virtv2.VirtualMachine) *dataMetric {
 	var (
 		awaitingRestartToApplyConfiguration bool
 		configurationApplied                bool
+		agentReady                          bool
 	)
 	if cond, found := conditions.GetCondition(vmcondition.TypeAwaitingRestartToApplyConfiguration,
 		vm.Status.Conditions); found && cond.Status == metav1.ConditionTrue {
@@ -69,6 +71,10 @@ func newDataMetric(vm *virtv2.VirtualMachine) *dataMetric {
 	if cond, found := conditions.GetCondition(vmcondition.TypeConfigurationApplied,
 		vm.Status.Conditions); found && cond.Status == metav1.ConditionTrue {
 		configurationApplied = true
+	}
+	if cond, found := conditions.GetCondition(vmcondition.TypeAgentReady,
+		vm.Status.Conditions); found && cond.Status == metav1.ConditionTrue {
+		agentReady = true
 	}
 	pods := make([]virtv2.VirtualMachinePod, len(vm.Status.VirtualMachinePods))
 	for i, pod := range vm.Status.VirtualMachinePods {
@@ -90,6 +96,7 @@ func newDataMetric(vm *virtv2.VirtualMachine) *dataMetric {
 		MemoryRuntimeOverhead:               float64(res.Memory.RuntimeOverhead.Value()),
 		AwaitingRestartToApplyConfiguration: awaitingRestartToApplyConfiguration,
 		ConfigurationApplied:                configurationApplied,
+		AgentReady:                          agentReady,
 		RunPolicy:                           vm.Spec.RunPolicy,
 		Pods:                                pods,
 		Labels: promutil.WrapPrometheusLabels(vm.GetLabels(), "label", func(key, value string) bool {

--- a/images/virtualization-artifact/pkg/monitoring/metrics/virtualmachine/metrics.go
+++ b/images/virtualization-artifact/pkg/monitoring/metrics/virtualmachine/metrics.go
@@ -34,6 +34,7 @@ const (
 	MetricVirtualMachineAwaitingRestartToApplyConfiguration     = "virtualmachine_awaiting_restart_to_apply_configuration"
 	MetricVirtualMachineConfigurationApplied                    = "virtualmachine_configuration_applied"
 	MetricVirtualMachineConfigurationRunPolicy                  = "virtualmachine_configuration_run_policy"
+	MetricVirtualMachineAgentReady                              = "virtualmachine_agent_ready"
 	MetricVirtualMachinePod                                     = "virtualmachine_pod"
 	MetricVirtualMachineLabels                                  = "virtualmachine_labels"
 	MetricVirtualMachineAnnotations                             = "virtualmachine_annotations"
@@ -152,6 +153,13 @@ var virtualMachineMetrics = map[string]metrics.MetricInfo{
 
 	MetricVirtualMachineAnnotations: metrics.NewMetricInfo(MetricVirtualMachineAnnotations,
 		"Kubernetes annotations converted to Prometheus labels.",
+		prometheus.GaugeValue,
+		WithBaseLabels(),
+		nil,
+	),
+
+	MetricVirtualMachineAgentReady: metrics.NewMetricInfo(MetricVirtualMachineAgentReady,
+		"The virtualmachine agent ready.",
 		prometheus.GaugeValue,
 		WithBaseLabels(),
 		nil,

--- a/images/virtualization-artifact/pkg/monitoring/metrics/virtualmachine/scraper.go
+++ b/images/virtualization-artifact/pkg/monitoring/metrics/virtualmachine/scraper.go
@@ -51,6 +51,7 @@ func (s *scraper) Report(m *dataMetric) {
 	s.updateMetricVirtualMachinePod(m)
 	s.updateMetricVirtualMachineLabels(m)
 	s.updateMetricVirtualMachineAnnotations(m)
+	s.updateMetricVirtualMachineAgentReady(m)
 }
 
 func (s *scraper) updateMetricVirtualMachineStatusPhase(m *dataMetric) {
@@ -121,6 +122,10 @@ func (s *scraper) updateMetricVirtualMachineAwaitingRestartToApplyConfiguration(
 func (s *scraper) updateMetricVirtualMachineConfigurationApplied(m *dataMetric) {
 	s.defaultUpdate(MetricVirtualMachineConfigurationApplied,
 		common.BoolFloat64(m.ConfigurationApplied), m)
+}
+
+func (s *scraper) updateMetricVirtualMachineAgentReady(m *dataMetric) {
+	s.defaultUpdate(MetricVirtualMachineAgentReady, common.BoolFloat64(m.AgentReady), m)
 }
 
 func (s *scraper) updateMetricVirtualMachineConfigurationRunPolicy(m *dataMetric) {


### PR DESCRIPTION
## Description
Added a Prometheus metric indicating the readiness of the virtual machine agent.


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feature
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: observability
type: feature
summary: "Add a Prometheus metric indicating the readiness of the virtual machine agent."
```
