### PR TITLE
chore(ci): increase the duration to detect prs that are stuck

### DIFF
--- a/.github/scripts/prs_notifier.mjs
+++ b/.github/scripts/prs_notifier.mjs
@@ -212,7 +212,7 @@ function getPullRequestGroup(reviews, requestedReviewers) {
     }
 
     const submittedAt = new Date(review.submitted_at)
-    submittedAt.setDate(submittedAt.getDate() + 1);
+    submittedAt.setTime(submittedAt.getTime() + 1.5 * 24 * 60 * 60 * 1000); // submittedAt + 1.5 days.
     if (now.getDay() !== 1 && submittedAt < now) {
       return STUCK;
     }


### PR DESCRIPTION
## Description

Increase the duration to detect prs that are stuck


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


```changes
section: ci
type: chore
summary: increase the duration to detect prs that are stuck
```
