### PR TITLE
docs: fix external link on Installation page

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -131,7 +131,14 @@ Virtual machines use `PersistentVolume` resources. To manage these resources and
 
 2. To store virtual machine data (virtual disks and images), you must enable one or more supported [storage](#supported-storage-systems).
 
-3. [Set](https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/) default `StorageClass`.
+3. Set default `StorageClass`.
+
+   ```shell
+   # Specify the name of your StorageClass object.
+   DEFAULT_STORAGE_CLASS=replicated-storage-class
+   sudo -i d8 k patch mc global --type='json' -p='[{"op": "replace", "path": "/spec/settings/defaultClusterStorageClass", "value": "'"$DEFAULT_STORAGE_CLASS"'"}]'
+   ```
+
 4. Turn on the [console](https://deckhouse.io/modules/console/stable/) module, which will allow you to manage virtualization components through via UI (This feature is available only to users of the EE edition).
 
 5. Enable the `virtualization` module:

--- a/docs/INSTALL_RU.md
+++ b/docs/INSTALL_RU.md
@@ -135,7 +135,13 @@ weight: 15
 
 2. Для хранения данных виртуальных машин (виртуальные диски и образы) необходимо включить один или несколько поддерживаемых [хранилищ](#поддерживаемые-хранилища).
 
-3. [Установите](https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/) `StorageClass` по умолчанию.
+3. Установите `StorageClass` по умолчанию.
+
+   ```shell
+   # Укажите имя своего объекта StorageClass.
+   DEFAULT_STORAGE_CLASS=replicated-storage-class
+   sudo -i d8 k patch mc global --type='json' -p='[{"op": "replace", "path": "/spec/settings/defaultClusterStorageClass", "value": "'"$DEFAULT_STORAGE_CLASS"'"}]'
+   ```
 
 4. Включите модуль [console](https://deckhouse.ru/modules/console/stable/), который позволит управлять компонентами виртуализации через графический интерфейс (данная возможность доступна только пользователям EE-редакции).
 


### PR DESCRIPTION
## Description

Fix external link on the Installation page.
Change link from code example. 


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: docs
type: chore
summary: Change external link from code example on the Installation page. 
```
