### PR TITLE
fix(core): use v1beta1 version for ValidatingAdmissionPolicy

### DIFF
--- a/hooks/migrate_delete_renamed_validation_admission_policy.py
+++ b/hooks/migrate_delete_renamed_validation_admission_policy.py
@@ -35,8 +35,6 @@ class MigrateDeleteRenamedVAPResources(Hook):
         self.managed_by_label_value = "virt-operator-internal-virtualization"
 
     def generate_config(self) -> dict:
-        kubernetesVersion = "1.30"
-
         return {
             "configVersion": "v1",
             "afterHelm": 5,

--- a/hooks/migrate_delete_renamed_validation_admission_policy.py
+++ b/hooks/migrate_delete_renamed_validation_admission_policy.py
@@ -85,6 +85,7 @@ class MigrateDeleteRenamedVAPResources(Hook):
                         kind = s["filterResult"]["kind"]
                         print(f"Delete deprecated {kind} {name}.")
                         ctx.kubernetes.delete(kind=kind,
+                                          namespace='',
                                           name=name)
             if found_deprecated == 0:
                 print("No deprecated resources found, migration not required.")

--- a/hooks/migrate_delete_renamed_validation_admission_policy.py
+++ b/hooks/migrate_delete_renamed_validation_admission_policy.py
@@ -35,13 +35,15 @@ class MigrateDeleteRenamedVAPResources(Hook):
         self.managed_by_label_value = "virt-operator-internal-virtualization"
 
     def generate_config(self) -> dict:
+        kubernetesVersion = "1.30"
+
         return {
             "configVersion": "v1",
             "afterHelm": 5,
             "kubernetes": [
                 {
                     "name": self.POLICY_SNAPSHOT_NAME,
-                    "apiVersion": "admissionregistration.k8s.io/v1",
+                    "apiVersion": "admissionregistration.k8s.io/v1beta1",
                     "kind": "ValidatingAdmissionPolicy",
                     "nameSelector": {
                         "matchNames": [self.vapolicy_name]
@@ -55,7 +57,7 @@ class MigrateDeleteRenamedVAPResources(Hook):
                 },
                 {
                     "name": self.BINDING_SNAPSHOT_NAME,
-                    "apiVersion": "admissionregistration.k8s.io/v1",
+                    "apiVersion": "admissionregistration.k8s.io/v1beta1",
                     "kind": "ValidatingAdmissionPolicyBinding",
                     "nameSelector": {
                         "matchNames": [self.vapolicy_binding_name]


### PR DESCRIPTION
## Description

- Use v1beta1 so migration hook can work in Kubernetes 1.28 and 1.29.

<!---
  Describe your changes with technical details.
-->


## Why do we need it, and what problem does it solve?

Kubernetes subscriptions not support subscribe to nonexistent versions of CRD (yet).  ValidatingAdmissionPolicy/v1 exists in Kubernetes 1.30 and later, so we use v1beta1 for now. We can just delete this hook when v1beta1 will be removed (in 1.36 may be?).

Continuation of #839 

<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?

VAP Migration hook works in Kubernetes 1.28 and 1.29


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: core
type: fix
summary: Fix ValidatingAdmissionPolicy migration hook, it should support Kubernetes 1.28+
impact_level: low
```
