### PR TITLE
chore(docs): remove commit conventions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,37 +47,24 @@ Images, such as build images or images with binary artifacts, should not be incl
 
 ## Conventions
 
-### Commit message
+### Changes Block
 
-Each commit message consists of a **header** and a [**body**](#body). The header has a special format that includes a [**type**](#type), a [**scope**](#scope) and a [**subject**](#subject):
+When submitting a pull request, include a **changes block** to document modifications for the changelog. This block helps automate the release changelog creation, tracks updates, and prepares release notes.
 
+#### Format
+
+The changes block consists of YAML documents, each detailing a specific change. Use the following structure:
+
+````
+```changes
+section: <affected-section>
+type: <feature|fix|chore>
+summary: <Concise description of the change.>
+impact_level: <low|high>  # Optional
+impact: |
+  <Detailed impact description if impact_level is high>
 ```
-<type>(<scope>): <subject>
-<BLANK LINE>
-<body>
-```
-
-**Examples:**
-
-  - _feat(api): bump resource version to v1beta1_
-  - _feat(images): implement ImageLost phase_
-  - _feat(images, vi): add PVC as a storage_
-  - _fix(vm, vmclass): fix unsupported type of class_
-  - _refactor(core): rename 3rd party resources_
-  - _docs(module): describe how to install module_
-  - _chore(core): use alt linux as base image_
-  - _chore: update go dependencies_
-
-#### Type
-
-Must be one of the following:
-
-* **feat**: new features or capabilities that enhance the user's experience.
-* **fix**: bug fixes that enhance the user's experience.
-* **refactor**: a code changes that neither fixes a bug nor adds a feature.
-* **docs**: updates or improvements to documentation.
-* **test**: additions or corrections to tests.
-* **chore**: updates that don't fit into other types.
+````
 
 #### Scope
 
@@ -128,53 +115,6 @@ Supported scopes are the following:
   # Network related changes important for end-user.
   - network  
   ```
-
-#### Subject
-
-The subject contains a succinct description of the change:
-
-  - use the imperative, present tense: "change" not "changed" nor "changes"
-  - don't capitalize the first letter
-  - no dot (.) at the end
-
-#### Body
-
-Just as in the **subject**, use the imperative, present tense: "change" not "changed" nor "changes".
-The body should include the motivation for the change and contrast this with previous behavior.
-
-### Branch name
-
-Each branch name consists of a [**type**](#type), [**scope**](#scope), and a [**short-description**](#short-description):
-
-```
-<type>/<scope>/<short-description>
-```
-
-When naming branches, only the top-level scope should be used. Multiple or nested scopes are not allowed in branch names, ensuring that each branch is clearly associated with a broad area of the project.
-
-**Examples:**
-
-  - _feat/disks/support-new-image-source_
-  - _chore/ci/speed-up-builds_
-
-### Changes Block
-
-When submitting a pull request, include a **changes block** to document modifications for the changelog. This block helps automate the release changelog creation, tracks updates, and prepares release notes.
-
-#### Format
-
-The changes block consists of YAML documents, each detailing a specific change. Use the following structure:
-
-````
-```changes
-section: <affected-section>
-type: <feature|fix|chore>
-summary: <Concise description of the change.>
-impact_level: <low|high>  # Optional
-impact: |
-  <Detailed impact description if impact_level is high>
-```
-````
 
 #### Fields Description
 


### PR DESCRIPTION
Signed-off-by: Maksim Fedotov <maksim.fedotov@flant.com>

## Description
<!---
  Describe your changes with technical details.
-->
Remove commit conventions from CONTRIBUTING.md.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
This repository has successfully moved on to Changelog entries, and changelog is now generated automatically. Because of this, we don't need commit conventions anymore.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: docs
type: chore
summary: remove commit conventions
```
