### PR TITLE
fix(module): fix OS Windows mountpoint promql

### DIFF
--- a/monitoring/grafana-dashboards/main/virtual-machine.json
+++ b/monitoring/grafana-dashboards/main/virtual-machine.json
@@ -24,6 +24,7 @@
   "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
+  "id": 47,
   "links": [],
   "panels": [
     {
@@ -1473,7 +1474,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -1609,7 +1611,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -2316,7 +2319,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2389,7 +2393,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 28
+            "y": 24
           },
           "id": 75,
           "options": {
@@ -2486,7 +2490,7 @@
                 "axisPlacement": "auto",
                 "barAlignment": 0,
                 "drawStyle": "line",
-                "fillOpacity": 30,
+                "fillOpacity": 0,
                 "gradientMode": "none",
                 "hideFrom": {
                   "legend": false,
@@ -2516,7 +2520,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2567,7 +2572,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 28
+            "y": 24
           },
           "id": 42,
           "options": {
@@ -2669,7 +2674,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               }
@@ -2680,7 +2686,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 36
+            "y": 32
           },
           "id": 31,
           "options": {
@@ -2780,7 +2786,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2796,7 +2803,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 36
+            "y": 32
           },
           "id": 32,
           "options": {
@@ -2910,7 +2917,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2965,7 +2973,7 @@
             "h": 14,
             "w": 12,
             "x": 0,
-            "y": 29
+            "y": 25
           },
           "id": 44,
           "maxPerRow": 2,
@@ -2995,13 +3003,17 @@
                 "type": "prometheus",
                 "uid": "${ds_prometheus}"
               },
-              "editorMode": "code",
+              "disableTextWrap": false,
+              "editorMode": "builder",
               "exemplar": false,
-              "expr": "sum by (mount_point) (\n        d8_virtualization_virtualmachine_filesystem_capacity_bytes{namespace=\"$namespace\", name=\"$name\", type!=\"cloudinit\", mount_point=\"$mount_point\"}\n)\n",
+              "expr": "sum by(mount_point) (d8_virtualization_virtualmachine_filesystem_capacity_bytes{namespace=\"$namespace\", name=\"$name\", type!=\"cloudinit\", mount_point=~\"$mount_point\"})",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
               "instant": false,
               "legendFormat": "Capacity",
               "range": true,
-              "refId": "A"
+              "refId": "A",
+              "useBackend": false
             },
             {
               "datasource": {
@@ -3010,7 +3022,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum by (mount_point) (d8_virtualization_virtualmachine_filesystem_used_bytes{namespace=\"$namespace\", name=\"$name\", type!=\"cloudinit\", mount_point=\"$mount_point\"})",
+              "expr": "sum by (mount_point) (d8_virtualization_virtualmachine_filesystem_used_bytes{namespace=\"$namespace\", name=\"$name\", type!=\"cloudinit\", mount_point=~\"$mount_point\"})",
               "hide": false,
               "instant": false,
               "legendFormat": "Used",
@@ -4285,8 +4297,8 @@
       {
         "current": {
           "selected": false,
-          "text": "demo-app",
-          "value": "demo-app"
+          "text": "default",
+          "value": "default"
         },
         "datasource": {
           "type": "prometheus",
@@ -4313,8 +4325,8 @@
       {
         "current": {
           "selected": false,
-          "text": "backend-a",
-          "value": "backend-a"
+          "text": "default",
+          "value": "default"
         },
         "datasource": {
           "type": "prometheus",
@@ -4402,7 +4414,7 @@
   "timepicker": {},
   "timezone": "browser",
   "title": "Namespace / Virtual Machine",
-  "uid": "bdw6dw2izvpxcx",
+  "uid": "bdw6dw2izvpxcb",
   "version": 1,
   "weekStart": ""
 }


### PR DESCRIPTION
## Description
fix OS Windows mountpoint promql

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: module
type: fix
summary: fix OS Windows mountpoint promql
impact_level: low
```
