### PR TITLE
fix(kubevirt):  fix RBAC: Add Patch Permissions for DS virt-handler on VMI

### DIFF
--- a/images/virt-artifact/patches/039-get-applied-checksum.patch
+++ b/images/virt-artifact/patches/039-get-applied-checksum.patch
@@ -876,7 +876,7 @@ index d0d1ea0378..68213c6456 100644
 +	return "", errors.New("error getting the checksum")
 +}
 diff --git a/pkg/virt-handler/vm.go b/pkg/virt-handler/vm.go
-index 1ff0209578..2d36473623 100644
+index ce689368a8..0e8825cfd2 100644
 --- a/pkg/virt-handler/vm.go
 +++ b/pkg/virt-handler/vm.go
 @@ -37,6 +37,7 @@ import (
@@ -1187,6 +1187,19 @@ index cddee4f199..6744cb2913 100644
 +func (l *LibvirtDomainManager) GetAppliedVMIChecksum() string {
 +	return l.checksum.Get()
 +}
+diff --git a/pkg/virt-operator/resource/generate/rbac/handler.go b/pkg/virt-operator/resource/generate/rbac/handler.go
+index 2640f61826..5d9a7b6279 100644
+--- a/pkg/virt-operator/resource/generate/rbac/handler.go
++++ b/pkg/virt-operator/resource/generate/rbac/handler.go
+@@ -78,7 +78,7 @@ func newHandlerClusterRole() *rbacv1.ClusterRole {
+ 					"virtualmachineinstances",
+ 				},
+ 				Verbs: []string{
+-					"update", "list", "watch",
++					"update", "list", "watch", "patch",
+ 				},
+ 			},
+ 			{
 diff --git a/pkg/vsock/system/v1/system.pb.go b/pkg/vsock/system/v1/system.pb.go
 index 6f743628c7..2c47c64162 100644
 --- a/pkg/vsock/system/v1/system.pb.go


### PR DESCRIPTION
## Description
fix RBAC: Add Patch Permissions for DS virt-handler on VMI


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: kubevirt 
type: fix
summary: Add Patch Permissions for DS virt-handler on VMI
impact_level: low
```
