### PR TITLE
fix(vm): fix errors with power state operations

### DIFF
--- a/images/virtualization-artifact/pkg/controller/powerstate/kvvm_request.go
+++ b/images/virtualization-artifact/pkg/controller/powerstate/kvvm_request.go
@@ -18,6 +18,7 @@ package powerstate
 
 import (
 	"errors"
+	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	kvv1 "kubevirt.io/api/core/v1"
@@ -25,10 +26,7 @@ import (
 	"github.com/deckhouse/virtualization-controller/pkg/common/patch"
 )
 
-var (
-	ErrChangesAlreadyExists    = errors.New("changes already exist in the current status")
-	ErrUnableToCompleteRequest = errors.New("unable to complete request: stop/start already underway")
-)
+var ErrChangesAlreadyExist = errors.New("changes already exist in the current status")
 
 // BuildPatch creates a patch to request VM state changing via updating KVVM status.
 //
@@ -55,11 +53,11 @@ func BuildPatch(vm *kvv1.VirtualMachine, changes ...kvv1.VirtualMachineStateChan
 		}
 		if len(vm.Status.StateChangeRequests) != 0 {
 			if equality.Semantic.DeepEqual(vm.Status.StateChangeRequests, changes) {
-				return nil, ErrChangesAlreadyExists
+				return nil, ErrChangesAlreadyExist
 			}
 
 			if failOnConflict {
-				return nil, ErrUnableToCompleteRequest
+				return nil, fmt.Errorf("unable to complete request: stop/start already underway")
 			} else {
 				verb = patch.PatchReplaceOp
 			}

--- a/images/virtualization-artifact/pkg/controller/powerstate/operations.go
+++ b/images/virtualization-artifact/pkg/controller/powerstate/operations.go
@@ -37,7 +37,7 @@ func StartVM(ctx context.Context, cl client.Client, kvvm *kvv1.VirtualMachine) e
 	jp, err := BuildPatch(kvvm,
 		kvv1.VirtualMachineStateChangeRequest{Action: kvv1.StartRequest})
 	if err != nil {
-		if errors.Is(err, ErrChangesAlreadyExists) {
+		if errors.Is(err, ErrChangesAlreadyExist) {
 			return nil
 		}
 		return err
@@ -74,7 +74,7 @@ func RestartVM(ctx context.Context, cl client.Client, kvvm *kvv1.VirtualMachine,
 		kvv1.VirtualMachineStateChangeRequest{Action: kvv1.StopRequest, UID: &kvvmi.UID},
 		kvv1.VirtualMachineStateChangeRequest{Action: kvv1.StartRequest})
 	if err != nil {
-		if errors.Is(err, ErrChangesAlreadyExists) {
+		if errors.Is(err, ErrChangesAlreadyExist) {
 			return nil
 		}
 		return err

--- a/images/virtualization-artifact/pkg/controller/powerstate/operations.go
+++ b/images/virtualization-artifact/pkg/controller/powerstate/operations.go
@@ -18,6 +18,7 @@ package powerstate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -36,6 +37,9 @@ func StartVM(ctx context.Context, cl client.Client, kvvm *kvv1.VirtualMachine) e
 	jp, err := BuildPatch(kvvm,
 		kvv1.VirtualMachineStateChangeRequest{Action: kvv1.StartRequest})
 	if err != nil {
+		if errors.Is(err, ErrChangesAlreadyExists) {
+			return nil
+		}
 		return err
 	}
 	return cl.Status().Patch(ctx, kvvm, client.RawPatch(types.JSONPatchType, jp), &client.SubResourcePatchOptions{})
@@ -70,6 +74,9 @@ func RestartVM(ctx context.Context, cl client.Client, kvvm *kvv1.VirtualMachine,
 		kvv1.VirtualMachineStateChangeRequest{Action: kvv1.StopRequest, UID: &kvvmi.UID},
 		kvv1.VirtualMachineStateChangeRequest{Action: kvv1.StartRequest})
 	if err != nil {
+		if errors.Is(err, ErrChangesAlreadyExists) {
+			return nil
+		}
 		return err
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_power_state.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_power_state.go
@@ -70,6 +70,9 @@ func (h *SyncPowerStateHandler) Handle(ctx context.Context, s state.VirtualMachi
 	}
 
 	changed := s.VirtualMachine().Changed()
+	if isDeletion(changed) {
+		return reconcile.Result{}, nil
+	}
 
 	kvvm, err := s.KVVM(ctx)
 	if err != nil {

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_power_state.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_power_state.go
@@ -212,7 +212,7 @@ func (h *SyncPowerStateHandler) handleManualPolicy(
 	return Nothing
 }
 
-func (h *SyncPowerStateHandler) isRestartVM(kvvm *virtv1.VirtualMachine) bool {
+func (h *SyncPowerStateHandler) isVMRestarting(kvvm *virtv1.VirtualMachine) bool {
 	if kvvm != nil &&
 		len(kvvm.Status.StateChangeRequests) == 2 &&
 		kvvm.Status.StateChangeRequests[0].Action == virtv1.StopRequest &&
@@ -232,7 +232,7 @@ func (h *SyncPowerStateHandler) handleAlwaysOnPolicy(
 	shutdownInfo powerstate.ShutdownInfo,
 ) (VMAction, error) {
 	if kvvmi == nil {
-		if h.isRestartVM(kvvm) {
+		if h.isVMRestarting(kvvm) {
 			return Nothing, nil
 		}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
- Add checks for current restarts when attempting to start a VM with AlwaysOn.
- In the sync_powerstate.go handler, add a check for the deletion of the current VM.
- Add a check for the current status of StateChangeRequests when creating a new request.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->

This PR fix errors with power state operations. For example: 
```
[
  {
    "controller": "vm-controller",
    "name": "head-ec22cb89-vm-automatic-conf",
    "namespace": "head-ec22cb89-testcases-vm-configuration",
    "msg": "failed to sync powerstate: failed to start VM: unable to complete request: stop/start already underway",
    "err": null,
    "source": "usr/local/go/src/virtualization-controller/pkg/controller/vm/internal/sync_power_state.go:82"
  },
  {
    "controller": "vm-controller",
    "name": "head-ec22cb89-vm-manual-conf",
    "namespace": "head-ec22cb89-testcases-vm-configuration",
    "msg": "failed to sync powerstate: add annotation to KVVM: internalvirtualizationvirtualmachines.internal.virtualization.deckhouse.io \"head-ec22cb89-vm-manual-conf\" not found",
    "err": null,
    "source": "usr/local/go/src/virtualization-controller/pkg/controller/vm/internal/sync_power_state.go:82"
  }
]
```


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: vm
type: fix
summary: fix errors with power state operations
```
