### PR TITLE
test(vm): reboot vms with force

### DIFF
--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -596,7 +596,7 @@ func GenerateVMOPWithSuffix(vmName, suffix string, labels map[string]string, vmo
 func StopVirtualMachinesBySSH(virtualMachines ...string) {
 	GinkgoHelper()
 
-	cmd := "sudo poweroff"
+	cmd := "sudo poweroff -f"
 
 	for _, vm := range virtualMachines {
 		ExecSshCommand(vm, cmd)
@@ -606,7 +606,7 @@ func StopVirtualMachinesBySSH(virtualMachines ...string) {
 func RebootVirtualMachinesBySSH(virtualMachines ...string) {
 	GinkgoHelper()
 
-	cmd := "sudo reboot"
+	cmd := "sudo reboot -f"
 
 	for _, vm := range virtualMachines {
 		ExecSshCommand(vm, cmd)

--- a/tests/e2e/vm_configuration_test.go
+++ b/tests/e2e/vm_configuration_test.go
@@ -242,7 +242,7 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 
 				vms := strings.Split(res.StdOut(), " ")
 				for _, vm := range vms {
-					cmd := "sudo reboot"
+					cmd := "sudo reboot -f"
 					ExecSshCommand(vm, cmd)
 				}
 				WaitVmAgentReady(kc.WaitOptions{


### PR DESCRIPTION
## Description

Reboot vms with force flag


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


```changes
section: vm
type: chore
summary: reboot vms with force flag
impact_level: low
```
