### PR TITLE
fix(cvi): watch vd snapshot

### DIFF
--- a/api/core/v1alpha2/cvicondition/condition.go
+++ b/api/core/v1alpha2/cvicondition/condition.go
@@ -60,6 +60,8 @@ const (
 	VirtualDiskNotReadyForUse DatasourceReadyReason = "VirtualDiskNotReadyForUse"
 	// VirtualDiskAttachedToVirtualMachine indicates that the `VirtualDisk` attached to `VirtualMachine`.
 	VirtualDiskAttachedToVirtualMachine DatasourceReadyReason = "VirtualDiskAttachedToVirtualMachine"
+	// VirtualDiskSnapshotNotReady indicates that the `VirtualDiskSnapshot` datasource is not ready, which prevents the import process from starting.
+	VirtualDiskSnapshotNotReady DatasourceReadyReason = "VirtualDiskSnapshotNotReady"
 
 	// WaitForUserUpload indicates that the `ClusterVirtualImage` is waiting for the user to upload a datasource for the import process to continue.
 	WaitForUserUpload ReadyReason = "WaitForUserUpload"

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/datasource_ready.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/datasource_ready.go
@@ -101,6 +101,12 @@ func (h DatasourceReadyHandler) Handle(ctx context.Context, cvi *virtv2.ClusterV
 			Reason(cvicondition.VirtualDiskAttachedToVirtualMachine).
 			Message(service.CapitalizeFirstLetter(err.Error() + "."))
 		return reconcile.Result{}, nil
+	case errors.As(err, &source.VirtualDiskSnapshotNotReadyError{}):
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(cvicondition.VirtualDiskSnapshotNotReady).
+			Message(service.CapitalizeFirstLetter(err.Error()))
+		return reconcile.Result{}, nil
 	default:
 		return reconcile.Result{}, err
 	}

--- a/images/virtualization-artifact/pkg/controller/indexer/cvi_indexer.go
+++ b/images/virtualization-artifact/pkg/controller/indexer/cvi_indexer.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package indexer
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+)
+
+func IndexCVIByVDSnapshot(ctx context.Context, mgr manager.Manager) error {
+	return mgr.GetFieldIndexer().IndexField(ctx, &virtv2.ClusterVirtualImage{}, IndexFieldCVIByVDSnapshot, func(object client.Object) []string {
+		cvi, ok := object.(*virtv2.ClusterVirtualImage)
+		if !ok || cvi == nil {
+			return nil
+		}
+
+		if cvi.Spec.DataSource.Type != virtv2.DataSourceTypeObjectRef {
+			return nil
+		}
+
+		if cvi.Spec.DataSource.ObjectRef == nil || cvi.Spec.DataSource.ObjectRef.Kind != virtv2.ClusterVirtualImageObjectRefKindVirtualDiskSnapshot {
+			return nil
+		}
+
+		key := types.NamespacedName{
+			Namespace: cvi.Spec.DataSource.ObjectRef.Namespace,
+			Name:      cvi.Spec.DataSource.ObjectRef.Name,
+		}
+
+		return []string{key.String()}
+	})
+}

--- a/images/virtualization-artifact/pkg/controller/indexer/indexer.go
+++ b/images/virtualization-artifact/pkg/controller/indexer/indexer.go
@@ -37,8 +37,9 @@ const (
 
 	IndexFieldVMIPLeaseByVMIP = "spec.virtualMachineIPAddressRef.Name"
 
-	IndexFieldVDByVDSnapshot = "vd,spec.DataSource.ObjectRef.Name,.Kind=VirtualDiskSnapshot"
-	IndexFieldVIByVDSnapshot = "vi,spec.DataSource.ObjectRef.Name,.Kind=VirtualDiskSnapshot"
+	IndexFieldVDByVDSnapshot  = "vd,spec.DataSource.ObjectRef.Name,.Kind=VirtualDiskSnapshot"
+	IndexFieldVIByVDSnapshot  = "vi,spec.DataSource.ObjectRef.Name,.Kind=VirtualDiskSnapshot"
+	IndexFieldCVIByVDSnapshot = "cvi,spec.DataSource.ObjectRef.Name,.Kind=VirtualDiskSnapshot"
 
 	IndexFieldVDByStorageClass = "vd.spec.PersistentVolumeClaim.StorageClass"
 	IndexFieldVIByStorageClass = "vi.spec.PersistentVolumeClaim.StorageClass"
@@ -71,6 +72,7 @@ func IndexALL(ctx context.Context, mgr manager.Manager) error {
 		IndexVDByStorageClass,
 		IndexVIByVDSnapshot,
 		IndexVIByStorageClass,
+		IndexCVIByVDSnapshot,
 		IndexVMIPByAddress,
 		IndexVMBDAByVM,
 	} {


### PR DESCRIPTION
## Description

1. Add the omitted watcher for vd snapshots
2. Fix the display of the error for the user if the snapshot is not ready yet
3. Improve watcher for virtual machines

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
```changes
section: cvi 
type: fix
summary: add the omitted watcher for vd snapshots
impact_level: low
```
