### PR TITLE
fix(test): fix e2e panic

### DIFF
--- a/tests/e2e/sizing_policy_test.go
+++ b/tests/e2e/sizing_policy_test.go
@@ -182,7 +182,7 @@ var _ = Describe("Sizing policy", ginkgoutil.CommonE2ETestDecorators(), func() {
 			It("changes VMClassName in VM specification with existing VMClass", func() {
 				mergePatch := fmt.Sprintf("{\"spec\":{\"virtualMachineClassName\":%q}}", vmClassDiscovery)
 				err := MergePatchResource(kc.ResourceVM, vmNotValidSizingPolicyChanging, mergePatch)
-				Expect(err).NotTo(HaveOccurred(), err)
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("checks VM phase and condition status after changing", func() {
@@ -206,13 +206,13 @@ var _ = Describe("Sizing policy", ginkgoutil.CommonE2ETestDecorators(), func() {
 			It("changes VMClassName in VM specification with not existing VMClass which have correct prefix for creating", func() {
 				mergePatch := fmt.Sprintf("{\"spec\":{\"virtualMachineClassName\":%q}}", vmClassDiscoveryCopy)
 				err := MergePatchResource(kc.ResourceVM, vmNotValidSizingPolicyCreating, mergePatch)
-				Expect(err).NotTo(HaveOccurred(), err)
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("creates new `VirtualMachineClass`", func() {
 				vmClass := virtv2.VirtualMachineClass{}
 				err := GetObject(kc.ResourceVMClass, vmClassDiscovery, &vmClass, kc.GetOptions{})
-				Expect(err).NotTo(HaveOccurred(), err)
+				Expect(err).NotTo(HaveOccurred())
 				vmClass.Name = vmClassDiscoveryCopy
 				vmClass.Labels = map[string]string{"id": namePrefix}
 				writeErr := WriteYamlObject(newVmClassFilePath, &vmClass)
@@ -249,13 +249,13 @@ var _ = Describe("Sizing policy", ginkgoutil.CommonE2ETestDecorators(), func() {
 			vms := strings.Split(res.StdOut(), " ")
 			vmClass := virtv2.VirtualMachineClass{}
 			err := GetObject(kc.ResourceVMClass, vmClassDiscovery, &vmClass, kc.GetOptions{})
-			Expect(err).NotTo(HaveOccurred(), err)
+			Expect(err).NotTo(HaveOccurred())
 
 			for _, vm := range vms {
 				By(fmt.Sprintf("Check virtual machine: %s", vm))
 				vmObj := virtv2.VirtualMachine{}
 				err := GetObject(kc.ResourceVM, vm, &vmObj, kc.GetOptions{Namespace: conf.Namespace})
-				Expect(err).NotTo(HaveOccurred(), err)
+				Expect(err).NotTo(HaveOccurred())
 				ValidateVirtualMachineByClass(&vmClass, &vmObj)
 			}
 		})

--- a/tests/e2e/vm_configuration_test.go
+++ b/tests/e2e/vm_configuration_test.go
@@ -207,7 +207,7 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 
 				vmResource := virtv2.VirtualMachine{}
 				err := GetObject(kc.ResourceVM, vms[0], &vmResource, kc.GetOptions{Namespace: conf.Namespace})
-				Expect(err).NotTo(HaveOccurred(), err)
+				Expect(err).NotTo(HaveOccurred())
 
 				oldCpuCores = vmResource.Spec.CPU.Cores
 				newCPUCores = 1 + (vmResource.Spec.CPU.Cores & 1)

--- a/tests/e2e/vm_connectivity_test.go
+++ b/tests/e2e/vm_connectivity_test.go
@@ -179,7 +179,7 @@ var _ = Describe("VM connectivity", ginkgoutil.CommonE2ETestDecorators(), func()
 				Command: "sleep",
 				Args:    []string{"10000"},
 			})
-			Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
+			Expect(res.Error()).NotTo(HaveOccurred())
 			WaitResource(kc.ResourcePod, CurlPod, waitFor, ShortWaitDuration)
 		})
 	})
@@ -190,23 +190,23 @@ var _ = Describe("VM connectivity", ginkgoutil.CommonE2ETestDecorators(), func()
 			err = GetObject(kc.ResourceVM, aObjName, &vmA, kc.GetOptions{
 				Namespace: conf.Namespace,
 			})
-			Expect(err).NotTo(HaveOccurred(), err)
+			Expect(err).NotTo(HaveOccurred())
 			vmB = virtv2.VirtualMachine{}
 			err = GetObject(kc.ResourceVM, bObjName, &vmB, kc.GetOptions{
 				Namespace: conf.Namespace,
 			})
-			Expect(err).NotTo(HaveOccurred(), err)
+			Expect(err).NotTo(HaveOccurred())
 
 			svcA = corev1.Service{}
 			err = GetObject(kc.ResourceService, aObjName, &svcA, kc.GetOptions{
 				Namespace: conf.Namespace,
 			})
-			Expect(err).NotTo(HaveOccurred(), err)
+			Expect(err).NotTo(HaveOccurred())
 			svcB = corev1.Service{}
 			err = GetObject(kc.ResourceService, bObjName, &svcB, kc.GetOptions{
 				Namespace: conf.Namespace,
 			})
-			Expect(err).NotTo(HaveOccurred(), err)
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("check ssh connection via `d8 v` to VMs", func() {

--- a/tests/e2e/vm_disk_resizing_test.go
+++ b/tests/e2e/vm_disk_resizing_test.go
@@ -287,7 +287,7 @@ var _ = Describe("Virtual disk resizing", ginkgoutil.CommonE2ETestDecorators(), 
 
 			It("obtains the disks metadata before resizing", func() {
 				vmDisksBefore, err = GetVirtualMachineDisks(vmObj.Name, conf)
-				Expect(err).NotTo(HaveOccurred(), err)
+				Expect(err).NotTo(HaveOccurred())
 				Expect(vmDisksBefore).Should(HaveLen(diskCount))
 			})
 

--- a/tests/e2e/vm_label_annotation_test.go
+++ b/tests/e2e/vm_label_annotation_test.go
@@ -176,7 +176,7 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 
 			vms := strings.Split(res.StdOut(), " ")
 			err := AddLabel(kc.ResourceVM, specialKeyValue, vms...)
-			Expect(err).NotTo(HaveOccurred(), err)
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("checks VMs and pods labels after VMs labeling", func() {
@@ -221,7 +221,7 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 
 			vms := strings.Split(res.StdOut(), " ")
 			err := RemoveLabel(kc.ResourceVM, specialKeyValue, vms...)
-			Expect(err).NotTo(HaveOccurred(), err)
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("checks VMs and pods labels after VMs unlabeling", func() {
@@ -268,7 +268,7 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 
 			vms := strings.Split(res.StdOut(), " ")
 			err := AddAnnotation(kc.ResourceVM, specialKeyValue, vms...)
-			Expect(err).NotTo(HaveOccurred(), err)
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("checks VMs and pods annotations after VMs annotating", func() {
@@ -313,7 +313,7 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 
 			vms := strings.Split(res.StdOut(), " ")
 			err := RemoveAnnotation(kc.ResourceVM, specialKeyValue, vms...)
-			Expect(err).NotTo(HaveOccurred(), err)
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("checks VMs and pods annotations after VMs unannotating", func() {


### PR DESCRIPTION
## Description
Fix e2e panic caused wrong assertation.


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: api
type: fix
summary: "fix e2e panic caused wrong assertation"
impact_level: low
```
