### PR TITLE
fix(vm): suppressed the output of "internal virtual machine error" when a pod is unschedulable

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm/internal/util.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/util.go
@@ -238,7 +238,6 @@ func isInternalVirtualMachineError(phase virtv1.VirtualMachinePrintableStatus) b
 		virtv1.VirtualMachineStatusDataVolumeError,
 		virtv1.VirtualMachineStatusPvcNotFound,
 		virtv1.VirtualMachineStatusCrashLoopBackOff,
-		virtv1.VirtualMachineStatusUnschedulable,
 		virtv1.VirtualMachineStatusUnknown,
 	}, phase)
 }

--- a/tests/e2e/default_config.yaml
+++ b/tests/e2e/default_config.yaml
@@ -37,7 +37,6 @@ testData:
 logFilter:
   - "pattern to exclude"
   - "Server rejected event (will not retry!)" # Msg.
-  - "Internal virtual machine error" # Msg.
   - "validation failed for data source objectref" # Err.
   - "error patching metadata: virtualdisks" # Err.
   - "error patching metadata: virtualmachineclasses" # Err.


### PR DESCRIPTION
## Description
Suppressed the output of "internal virtual machine error" when a pod is unschedulable.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: vm
type: fix
summary: Suppressed the output of internal virtual machine error when a pod is unschedulable.
impact_level: low
```
