### PR TITLE
test(vm): reboot using nohup

### DIFF
--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -597,7 +597,7 @@ func GenerateVMOPWithSuffix(vmName, suffix string, labels map[string]string, vmo
 func StopVirtualMachinesBySSH(virtualMachines ...string) {
 	GinkgoHelper()
 
-	cmd := "sudo poweroff -f"
+	cmd := "sudo nohup poweroff -f > /dev/null 2>&1 &"
 
 	for _, vm := range virtualMachines {
 		ExecSshCommand(vm, cmd)
@@ -607,7 +607,7 @@ func StopVirtualMachinesBySSH(virtualMachines ...string) {
 func RebootVirtualMachinesBySSH(virtualMachines ...string) {
 	GinkgoHelper()
 
-	cmd := "sudo reboot -f"
+	cmd := "sudo nohup reboot -f > /dev/null 2>&1 &"
 
 	for _, vm := range virtualMachines {
 		ExecSshCommand(vm, cmd)

--- a/tests/e2e/vm_configuration_test.go
+++ b/tests/e2e/vm_configuration_test.go
@@ -242,7 +242,7 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 
 				vms := strings.Split(res.StdOut(), " ")
 				for _, vm := range vms {
-					cmd := "sudo reboot -f"
+					cmd := "sudo nohup reboot -f > /dev/null 2>&1 &"
 					ExecSshCommand(vm, cmd)
 				}
 				WaitVmAgentReady(kc.WaitOptions{


### PR DESCRIPTION
## Description

We had tests failing because the command ssh `reboot -f` was not executing completely. More precisely, the reboot request was sent, and the virtual machine rebooted successfully, but the SSH session remained active throughout the reboot process and eventually disconnected with a timeout error:

> Error: websocket: close 1006 (abnormal closure): unexpected EOF 

This caused the test to fail. The `-f` flag was causing this behavior. Without it, everything worked fine. I resolved it by rebooting with `nohup reboot -f`.


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries

```changes
section: vm
type: chore
summary: reboot using nohup
impact_level: low
```
