### PR TITLE
fix(vi): handle vi default storage class from module config

### DIFF
--- a/images/virtualization-artifact/pkg/controller/indexer/indexer.go
+++ b/images/virtualization-artifact/pkg/controller/indexer/indexer.go
@@ -41,8 +41,9 @@ const (
 	IndexFieldVIByVDSnapshot  = "vi,spec.DataSource.ObjectRef.Name,.Kind=VirtualDiskSnapshot"
 	IndexFieldCVIByVDSnapshot = "cvi,spec.DataSource.ObjectRef.Name,.Kind=VirtualDiskSnapshot"
 
-	IndexFieldVDByStorageClass = "vd.spec.PersistentVolumeClaim.StorageClass"
-	IndexFieldVIByStorageClass = "vi.spec.PersistentVolumeClaim.StorageClass"
+	IndexFieldVDByStorageClass         = "vd.spec.PersistentVolumeClaim.StorageClass"
+	IndexFieldVIByStorageClass         = "vi.spec.PersistentVolumeClaim.StorageClass"
+	IndexFieldVIByNotReadyStorageClass = "vi,status.conditions[].type,StorageClassReady"
 
 	IndexFieldVMSnapshotByVM         = "spec.virtualMachineName"
 	IndexFieldVMSnapshotByVDSnapshot = "status.virtualDiskSnapshotNames"
@@ -72,6 +73,7 @@ func IndexALL(ctx context.Context, mgr manager.Manager) error {
 		IndexVDByStorageClass,
 		IndexVIByVDSnapshot,
 		IndexVIByStorageClass,
+		IndexVIByNotReadyStorageClass,
 		IndexCVIByVDSnapshot,
 		IndexVMIPByAddress,
 		IndexVMBDAByVM,

--- a/images/virtualization-artifact/pkg/controller/vi/internal/watcher/moduleconfig_watcher.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/watcher/moduleconfig_watcher.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watcher
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/deckhouse/virtualization-controller/pkg/controller/indexer"
+	mcapi "github.com/deckhouse/virtualization-controller/pkg/controller/moduleconfig/api"
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vicondition"
+)
+
+type ModuleConfigWatcher struct {
+	client client.Client
+	logger *slog.Logger
+}
+
+func NewModuleConfigWatcher(client client.Client) *StorageClassWatcher {
+	return &StorageClassWatcher{
+		client: client,
+		logger: slog.Default().With("watcher", "moduleconfig"),
+	}
+}
+
+func (w ModuleConfigWatcher) Watch(mgr manager.Manager, ctr controller.Controller) error {
+	return ctr.Watch(
+		source.Kind(mgr.GetCache(), &mcapi.ModuleConfig{}),
+		handler.EnqueueRequestsFromMapFunc(w.enqueueRequests),
+		predicate.Funcs{
+			CreateFunc: func(event event.CreateEvent) bool { return true },
+			DeleteFunc: func(event event.DeleteEvent) bool { return true },
+			UpdateFunc: func(event event.UpdateEvent) bool {
+				oldMc, oldOk := event.ObjectOld.(*mcapi.ModuleConfig)
+				newMc, newOk := event.ObjectNew.(*mcapi.ModuleConfig)
+				if !oldOk || !newOk {
+					return false
+				}
+				var (
+					oldViDefaultSc string
+					newViDefaultSc string
+				)
+				if virtualImages, ok := oldMc.Spec.Settings["virtualImages"].(map[string]interface{}); ok {
+					if defaultClass, ok := virtualImages["defaultStorageClassName"].(string); ok {
+						oldViDefaultSc = defaultClass
+					}
+				}
+				if virtualImages, ok := newMc.Spec.Settings["virtualImages"].(map[string]interface{}); ok {
+					if defaultClass, ok := virtualImages["defaultStorageClassName"].(string); ok {
+						oldViDefaultSc = defaultClass
+					}
+				}
+				return oldViDefaultSc != newViDefaultSc
+			},
+		},
+	)
+}
+
+func (w ModuleConfigWatcher) enqueueRequests(ctx context.Context, object client.Object) []reconcile.Request {
+	var vis virtv2.VirtualImageList
+	err := w.client.List(ctx, &vis, &client.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector(indexer.IndexFieldVIByNotReadyStorageClass, string(vicondition.StorageClassReadyType)),
+	})
+	if err != nil {
+		w.logger.Error(fmt.Sprintf("failed to list virtual images: %s", err))
+		return []reconcile.Request{}
+	}
+
+	var requests []reconcile.Request
+	for _, vi := range vis.Items {
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      vi.Name,
+				Namespace: vi.Namespace,
+			},
+		})
+	}
+
+	return requests
+}

--- a/images/virtualization-artifact/pkg/controller/vi/vi_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/vi/vi_reconciler.go
@@ -225,6 +225,7 @@ func (r *Reconciler) SetupController(_ context.Context, mgr manager.Manager, ctr
 		watcher.NewStorageClassWatcher(mgr.GetClient()),
 		watcher.NewVirtualMachineWatcher(mgr.GetClient()),
 		watcher.NewVirtualDiskSnapshotWatcher(mgr.GetClient()),
+		watcher.NewModuleConfigWatcher(mgr.GetClient()),
 	} {
 		err := w.Watch(mgr, ctr)
 		if err != nil {

--- a/templates/virtualization-controller/rbac-for-us.yaml
+++ b/templates/virtualization-controller/rbac-for-us.yaml
@@ -225,6 +225,14 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - moduleconfigs
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
When a `VirtualImage` is created without the `StorageClass` field in its specification and the default storage class is absent from the `ModuleConfig`, it is not handled after updating the default storage class in the `ModuleConfig`.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
The default storage class field works properly in the reconciliation loop of the `VirtualImage` resource.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: vi 
type: fix
summary: "The `VirtualImageDefaultStorageClass` from the `ModuleConfig` is handled correctly now." 
```
