### PR TITLE
fix(cvi, vi): fix some panics in upload import service

### DIFF
--- a/images/virtualization-artifact/pkg/common/network_policy/network_policy.go
+++ b/images/virtualization-artifact/pkg/common/network_policy/network_policy.go
@@ -63,6 +63,6 @@ func GetNetworkPolicy(ctx context.Context, client client.Client, name types.Name
 	return object.FetchObject(ctx, name, client, &netv1.NetworkPolicy{})
 }
 
-func GetNetworkPolicyFromObject(ctx context.Context, client client.Client, obj metav1.Object) (*netv1.NetworkPolicy, error) {
+func GetNetworkPolicyFromObject(ctx context.Context, client client.Client, obj client.Object) (*netv1.NetworkPolicy, error) {
 	return object.FetchObject(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, client, &netv1.NetworkPolicy{})
 }

--- a/images/virtualization-artifact/pkg/controller/service/uploader_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/uploader_service.go
@@ -191,7 +191,7 @@ func (s UploaderService) Protect(ctx context.Context, pod *corev1.Pod, svc *core
 			return fmt.Errorf("failed to get networkPolicy for removing importer's supplements protection: %w", err)
 		}
 	}
-	err = s.protection.AddProtection(ctx, pod, svc, ing, networkPolicy)
+	err = s.protection.AddProtection(ctx, networkPolicy, pod, svc, ing)
 	if err != nil {
 		return fmt.Errorf("failed to add protection for uploader's supplements: %w", err)
 	}
@@ -208,7 +208,7 @@ func (s UploaderService) Unprotect(ctx context.Context, pod *corev1.Pod, svc *co
 			return fmt.Errorf("failed to get networkPolicy for removing importer's supplements protection: %w", err)
 		}
 	}
-	err = s.protection.RemoveProtection(ctx, pod, svc, ing, networkPolicy)
+	err = s.protection.RemoveProtection(ctx, networkPolicy, pod, svc, ing)
 	if err != nil {
 		return fmt.Errorf("failed to remove protection for uploader's supplements: %w", err)
 	}

--- a/images/virtualization-artifact/pkg/controller/service/uploader_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/uploader_service.go
@@ -90,8 +90,8 @@ func (s UploaderService) Start(
 		}
 	}
 
-	pod, err := uploader.NewPod(podSettings, settings).Create(ctx, s.client)
-	if err != nil && !k8serrors.IsAlreadyExists(err) {
+	pod, err := uploader.NewPod(podSettings, settings).GetOrCreate(ctx, s.client)
+	if err != nil {
 		return err
 	}
 
@@ -182,47 +182,35 @@ func (s UploaderService) CleanUpSupplements(ctx context.Context, sup *supplement
 	return haveDeleted, nil
 }
 
-func (s UploaderService) Protect(ctx context.Context, pod *corev1.Pod, svc *corev1.Service, ing *netv1.Ingress) error {
-	err := s.protection.AddProtection(ctx, pod, svc, ing)
-	if err != nil {
-		return fmt.Errorf("failed to add protection for uploader's supplements: %w", err)
-	}
+func (s UploaderService) Protect(ctx context.Context, pod *corev1.Pod, svc *corev1.Service, ing *netv1.Ingress) (err error) {
+	var networkPolicy *netv1.NetworkPolicy
 
 	if pod != nil {
-		networkPolicy, err := networkpolicy.GetNetworkPolicyFromObject(ctx, s.client, pod)
+		networkPolicy, err = networkpolicy.GetNetworkPolicyFromObject(ctx, s.client, pod)
 		if err != nil {
 			return fmt.Errorf("failed to get networkPolicy for removing importer's supplements protection: %w", err)
 		}
-
-		if networkPolicy != nil {
-			err = s.protection.RemoveProtection(ctx, networkPolicy)
-			if err != nil {
-				return fmt.Errorf("failed to remove protection for importer's supplements: %w", err)
-			}
-		}
+	}
+	err = s.protection.AddProtection(ctx, pod, svc, ing, networkPolicy)
+	if err != nil {
+		return fmt.Errorf("failed to add protection for uploader's supplements: %w", err)
 	}
 
 	return nil
 }
 
-func (s UploaderService) Unprotect(ctx context.Context, pod *corev1.Pod, svc *corev1.Service, ing *netv1.Ingress) error {
-	err := s.protection.RemoveProtection(ctx, pod, svc, ing)
-	if err != nil {
-		return fmt.Errorf("failed to remove protection for uploader's supplements: %w", err)
-	}
+func (s UploaderService) Unprotect(ctx context.Context, pod *corev1.Pod, svc *corev1.Service, ing *netv1.Ingress) (err error) {
+	var networkPolicy *netv1.NetworkPolicy
 
 	if pod != nil {
-		networkPolicy, err := networkpolicy.GetNetworkPolicyFromObject(ctx, s.client, pod)
+		networkPolicy, err = networkpolicy.GetNetworkPolicyFromObject(ctx, s.client, pod)
 		if err != nil {
 			return fmt.Errorf("failed to get networkPolicy for removing importer's supplements protection: %w", err)
 		}
-
-		if networkPolicy != nil {
-			err = s.protection.RemoveProtection(ctx, networkPolicy)
-			if err != nil {
-				return fmt.Errorf("failed to remove protection for importer's supplements: %w", err)
-			}
-		}
+	}
+	err = s.protection.RemoveProtection(ctx, pod, svc, ing, networkPolicy)
+	if err != nil {
+		return fmt.Errorf("failed to remove protection for uploader's supplements: %w", err)
 	}
 
 	return nil

--- a/images/virtualization-artifact/pkg/controller/uploader/uploader_pod.go
+++ b/images/virtualization-artifact/pkg/controller/uploader/uploader_pod.go
@@ -22,6 +22,7 @@ import (
 	"path"
 
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -68,20 +69,23 @@ type PodSettings struct {
 	NodePlacement        *provisioner.NodePlacement
 }
 
-// Create creates and returns a pointer to a pod which is created based on the passed-in endpoint, secret
+// GetOrCreate creates and returns a pointer to a pod which is created based on the passed-in endpoint, secret
 // name, etc. A nil secret means the endpoint credentials are not passed to the uploader pod.
-func (p *Pod) Create(ctx context.Context, client client.Client) (*corev1.Pod, error) {
+func (p *Pod) GetOrCreate(ctx context.Context, c client.Client) (*corev1.Pod, error) {
 	pod, err := p.makeSpec()
 	if err != nil {
 		return nil, err
 	}
 
-	err = client.Create(ctx, pod)
-	if err != nil {
-		return nil, err
+	err = c.Create(ctx, pod)
+	if err == nil {
+		return pod, nil
 	}
-
-	return pod, nil
+	if k8serrors.IsAlreadyExists(err) {
+		err = c.Get(ctx, client.ObjectKeyFromObject(pod), pod)
+		return pod, err
+	}
+	return nil, err
 }
 
 func (p *Pod) makeSpec() (*corev1.Pod, error) {


### PR DESCRIPTION
## Description
fix some panics in upload import service


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: cvi
type: fix
summary: fix some panics in upload service
impact_level: low
```
