### PR TITLE
test: increase e2e tests timeout

### DIFF
--- a/.github/workflows/nightly_e2e_tests_main.yaml
+++ b/.github/workflows/nightly_e2e_tests_main.yaml
@@ -17,6 +17,7 @@ name: Nightly E2E tests(main)
 env:
   CI_COMMIT_REF_NAME: ${{ github.ref_name }}
   GO_VERSION: "1.22.7"
+  TIMEOUT: "2h"
 
 on:
   workflow_dispatch:

--- a/tests/e2e/Taskfile.yaml
+++ b/tests/e2e/Taskfile.yaml
@@ -7,7 +7,6 @@ vars:
     # Should hide curly brackets from task templater.
     sh: go list -f '{{`{{.Version}}`}}' -m github.com/onsi/ginkgo/v2
   VERSION: "v1.0.0"
-  TIMEOUT: "2h"
 
 tasks:
   copy:
@@ -104,10 +103,10 @@ tasks:
         ginkgo -v \
           --race \
           {{if .TIMEOUT -}}
-          --timeout={{ .TIMEOUT }}
+          --timeout={{ .TIMEOUT }} \
           {{else -}}
-          --timeout=2h
-          {{end}}
+          --timeout=2h \
+          {{end -}}
           {{if .FOCUS -}}
           --focus "{{ .FOCUS }}"
-          {{end}}
+          {{end -}}

--- a/tests/e2e/Taskfile.yaml
+++ b/tests/e2e/Taskfile.yaml
@@ -7,6 +7,7 @@ vars:
     # Should hide curly brackets from task templater.
     sh: go list -f '{{`{{.Version}}`}}' -m github.com/onsi/ginkgo/v2
   VERSION: "v1.0.0"
+  TIMEOUT: "2h"
 
 tasks:
   copy:
@@ -55,7 +56,7 @@ tasks:
     cmds:
       - |
         bash -c 'GINKGO_RESULT=$(mktemp)
-        ginkgo -v | tee $GINKGO_RESULT
+        ginkgo -v --race --timeout=$TIMEOUT | tee $GINKGO_RESULT
         EXIT_CODE="${PIPESTATUS[0]}"
         RESULT=$(sed -e "s/\x1b\[[0-9;]*m//g" $GINKGO_RESULT | grep --color=never -E "FAIL!|SUCCESS!")
         if [[ $RESULT == FAIL!* || $EXIT_CODE -ne "0" ]]; then
@@ -101,6 +102,12 @@ tasks:
     cmds:
       - |
         ginkgo -v \
+          --race \
+          {{if .TIMEOUT -}}
+          --timeout={{ .TIMEOUT }}
+          {{else -}}
+          --timeout=2h
+          {{end}}
           {{if .FOCUS -}}
           --focus "{{ .FOCUS }}"
           {{end}}


### PR DESCRIPTION
## Description
This change increases the timeout duration for Ginkgo-based end-to-end (e2e) tests.

## Why is this change necessary, and what problem does it address?
As the number of e2e tests has grown significantly, the current timeout of 1 hour is no longer sufficient to complete all test cases. This limitation has resulted in incomplete test runs and potential disruptions to the testing process. By extending the timeout, we ensure that all tests have adequate time to execute, regardless of their increasing complexity and count.

## What is the expected outcome?
The timeout for all e2e tests will be increased to 2 hours . This adjustment will allow the entire test suite to run to completion without premature termination, ensuring reliable and consistent test results.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: ci
type: chore
summary: increase timeout for e2e tests
```
