### PR TITLE
chore(test): dump resources on error

### DIFF
--- a/.github/workflows/nightly_e2e_tests_main.yaml
+++ b/.github/workflows/nightly_e2e_tests_main.yaml
@@ -74,6 +74,12 @@ jobs:
         run: |
           task run:ci -v
 
+      - uses: actions/upload-artifact@v4
+        with:
+          name: resources_from_failed_tests
+          path: |
+            /tmp/e2e_failed__*
+
       - name: Send results to Loop
         working-directory: ./tests/e2e/
         if: always()

--- a/.github/workflows/nightly_e2e_tests_main.yaml
+++ b/.github/workflows/nightly_e2e_tests_main.yaml
@@ -75,6 +75,7 @@ jobs:
           task run:ci -v
 
       - uses: actions/upload-artifact@v4
+        if: always() && steps.e2e-tests.outcome == 'failed'
         with:
           name: resources_from_failed_tests
           path: /tmp/e2e_failed__*

--- a/.github/workflows/nightly_e2e_tests_main.yaml
+++ b/.github/workflows/nightly_e2e_tests_main.yaml
@@ -77,8 +77,8 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: resources_from_failed_tests
-          path: |
-            /tmp/e2e_failed__*
+          path: /tmp/e2e_failed__*
+          if-no-files-found: ignore
 
       - name: Send results to Loop
         working-directory: ./tests/e2e/

--- a/.github/workflows/nightly_e2e_tests_main.yaml
+++ b/.github/workflows/nightly_e2e_tests_main.yaml
@@ -75,7 +75,7 @@ jobs:
           task run:ci -v
 
       - uses: actions/upload-artifact@v4
-        if: always() && steps.e2e-tests.outcome == 'failed'
+        if: always()
         with:
           name: resources_from_failed_tests
           path: /tmp/e2e_failed__*

--- a/tests/e2e/affinity_toleration_test.go
+++ b/tests/e2e/affinity_toleration_test.go
@@ -189,6 +189,8 @@ var _ = Describe("Virtual machine affinity and toleration", ginkgoutil.CommonE2E
 		masterNodeLabel                = map[string]string{"node.deckhouse.io/group": "master"}
 	)
 
+	AfterEach(func() { OnFailureSaveTestResources(testCaseLabel) })
+
 	Context("When the virtualization resources are applied:", func() {
 		It("result should be succeeded", func() {
 			res := kubectl.Apply(kc.ApplyOptions{

--- a/tests/e2e/affinity_toleration_test.go
+++ b/tests/e2e/affinity_toleration_test.go
@@ -189,7 +189,11 @@ var _ = Describe("Virtual machine affinity and toleration", ginkgoutil.CommonE2E
 		masterNodeLabel                = map[string]string{"node.deckhouse.io/group": "master"}
 	)
 
-	AfterEach(func() { OnFailureSaveTestResources(testCaseLabel) })
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			SaveTestResources(testCaseLabel)
+		}
+	})
 
 	Context("When the virtualization resources are applied:", func() {
 		It("result should be succeeded", func() {

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -69,7 +69,11 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 		notAlwaysOnLabel   = map[string]string{"notAlwaysOn": "complex-test"}
 	)
 
-	AfterEach(func() { OnFailureSaveTestResources(testCaseLabel) })
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			SaveTestResources(testCaseLabel)
+		}
+	})
 
 	Context("Preparing the environment", func() {
 		It("sets the namespace", func() {

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -69,6 +69,8 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 		notAlwaysOnLabel   = map[string]string{"notAlwaysOn": "complex-test"}
 	)
 
+	AfterEach(func() { OnFailureSaveTestResources(testCaseLabel) })
+
 	Context("Preparing the environment", func() {
 		It("sets the namespace", func() {
 			kustomization := fmt.Sprintf("%s/%s", conf.TestData.ComplexTest, "kustomization.yaml")

--- a/tests/e2e/image_hotplug_test.go
+++ b/tests/e2e/image_hotplug_test.go
@@ -143,7 +143,11 @@ var _ = Describe("Image hotplug", ginkgoutil.CommonE2ETestDecorators(), func() {
 		testCaseLabel = map[string]string{"testcase": "image-hotplug"}
 	)
 
-	AfterEach(func() { OnFailureSaveTestResources(testCaseLabel) })
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			SaveTestResources(testCaseLabel)
+		}
+	})
 
 	BeforeAll(func() {
 		kustomization := fmt.Sprintf("%s/%s", conf.TestData.ImageHotplug, "kustomization.yaml")

--- a/tests/e2e/image_hotplug_test.go
+++ b/tests/e2e/image_hotplug_test.go
@@ -143,6 +143,8 @@ var _ = Describe("Image hotplug", ginkgoutil.CommonE2ETestDecorators(), func() {
 		testCaseLabel = map[string]string{"testcase": "image-hotplug"}
 	)
 
+	AfterEach(func() { OnFailureSaveTestResources(testCaseLabel) })
+
 	BeforeAll(func() {
 		kustomization := fmt.Sprintf("%s/%s", conf.TestData.ImageHotplug, "kustomization.yaml")
 		ns, err := kustomize.GetNamespace(kustomization)

--- a/tests/e2e/images_creation_test.go
+++ b/tests/e2e/images_creation_test.go
@@ -43,6 +43,8 @@ var _ = Describe("Virtual images creation", ginkgoutil.CommonE2ETestDecorators()
 		}
 	})
 
+	AfterEach(func() { OnFailureSaveTestResources(testCaseLabel) })
+
 	Context("Preparing the environment", func() {
 		It("sets the namespace", func() {
 			kustomization := fmt.Sprintf("%s/%s", conf.TestData.ImagesCreation, "kustomization.yaml")

--- a/tests/e2e/images_creation_test.go
+++ b/tests/e2e/images_creation_test.go
@@ -43,7 +43,11 @@ var _ = Describe("Virtual images creation", ginkgoutil.CommonE2ETestDecorators()
 		}
 	})
 
-	AfterEach(func() { OnFailureSaveTestResources(testCaseLabel) })
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			SaveTestResources(testCaseLabel)
+		}
+	})
 
 	Context("Preparing the environment", func() {
 		It("sets the namespace", func() {

--- a/tests/e2e/importer_network_policy_test.go
+++ b/tests/e2e/importer_network_policy_test.go
@@ -42,7 +42,11 @@ var _ = Describe("Importer network policy", ginkgoutil.CommonE2ETestDecorators()
 		}
 	})
 
-	AfterEach(func() { OnFailureSaveTestResources(testCaseLabel) })
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			SaveTestResources(testCaseLabel)
+		}
+	})
 
 	Context("Preparing the environment", func() {
 		It("sets the namespace", func() {

--- a/tests/e2e/importer_network_policy_test.go
+++ b/tests/e2e/importer_network_policy_test.go
@@ -29,6 +29,8 @@ import (
 )
 
 var _ = Describe("Importer network policy", ginkgoutil.CommonE2ETestDecorators(), func() {
+	testCaseLabel := map[string]string{"testcase": "importer-network-policy"}
+
 	AfterAll(func() {
 		By("Delete manifests")
 		DeleteTestCaseResources(ResourcesToDelete{KustomizationDir: conf.TestData.ImporterNetworkPolicy})
@@ -40,7 +42,7 @@ var _ = Describe("Importer network policy", ginkgoutil.CommonE2ETestDecorators()
 		}
 	})
 
-	testCaseLabel := map[string]string{"testcase": "importer-network-policy"}
+	AfterEach(func() { OnFailureSaveTestResources(testCaseLabel) })
 
 	Context("Preparing the environment", func() {
 		It("sets the namespace", func() {

--- a/tests/e2e/kubectl/kubectl.go
+++ b/tests/e2e/kubectl/kubectl.go
@@ -48,7 +48,7 @@ type Kubectl interface {
 	Apply(opts ApplyOptions) *executor.CMDResult
 	Create(filepath string, opts CreateOptions) *executor.CMDResult
 	CreateResource(resource Resource, name string, opts CreateOptions) *executor.CMDResult
-	Get(filepath string, opts GetOptions) *executor.CMDResult
+	Get(resource string, opts GetOptions) *executor.CMDResult
 	GetResource(resource Resource, name string, opts GetOptions) *executor.CMDResult
 	Delete(opts DeleteOptions) *executor.CMDResult
 	List(resource Resource, opts GetOptions) *executor.CMDResult
@@ -197,8 +197,8 @@ func (k KubectlCMD) CreateResource(resource Resource, name string, opts CreateOp
 	return k.ExecContext(ctx, cmd)
 }
 
-func (k KubectlCMD) Get(filepath string, opts GetOptions) *executor.CMDResult {
-	cmd := fmt.Sprintf("%s get -f %s", k.cmd, filepath)
+func (k KubectlCMD) Get(resource string, opts GetOptions) *executor.CMDResult {
+	cmd := fmt.Sprintf("%s get %s", k.cmd, resource)
 	cmd = k.getOptions(cmd, opts)
 	ctx, cancel := context.WithTimeout(context.Background(), MediumTimeout)
 	defer cancel()

--- a/tests/e2e/sizing_policy_test.go
+++ b/tests/e2e/sizing_policy_test.go
@@ -86,6 +86,8 @@ var _ = Describe("Sizing policy", ginkgoutil.CommonE2ETestDecorators(), func() {
 		testCaseLabel                  = map[string]string{"testcase": "sizing-policy"}
 	)
 
+	AfterEach(func() { OnFailureSaveTestResources(testCaseLabel) })
+
 	Context("Preparing the environment", func() {
 		vmNotValidSizingPolicyChanging = fmt.Sprintf("%s-vm-%s", namePrefix, notExistingVmClassChanging["vm"])
 		vmNotValidSizingPolicyCreating = fmt.Sprintf("%s-vm-%s", namePrefix, notExistingVmClassCreating["vm"])

--- a/tests/e2e/sizing_policy_test.go
+++ b/tests/e2e/sizing_policy_test.go
@@ -86,7 +86,11 @@ var _ = Describe("Sizing policy", ginkgoutil.CommonE2ETestDecorators(), func() {
 		testCaseLabel                  = map[string]string{"testcase": "sizing-policy"}
 	)
 
-	AfterEach(func() { OnFailureSaveTestResources(testCaseLabel) })
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			SaveTestResources(testCaseLabel)
+		}
+	})
 
 	Context("Preparing the environment", func() {
 		vmNotValidSizingPolicyChanging = fmt.Sprintf("%s-vm-%s", namePrefix, notExistingVmClassChanging["vm"])

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -654,10 +654,8 @@ func IsContainerRestarted(podName, containerName, namespace string, startedAt v1
 	return false, fmt.Errorf("failed to compare the `startedAt` field before and after the tests ran: %s", podName)
 }
 
-func OnFailureSaveTestResources(labels map[string]string) {
-	if CurrentSpecReport().Failed() {
-		cmdr := kubectl.Get("virtualization -A", kc.GetOptions{Output: "yaml", Labels: labels})
-		err := os.WriteFile("/tmp/e2e_failed__"+labels["testcase"]+".yaml", cmdr.StdOutBytes(), 0644)
-		Expect(err).NotTo(HaveOccurred())
-	}
+func SaveTestResources(labels map[string]string) {
+	cmdr := kubectl.Get("virtualization -A", kc.GetOptions{Output: "yaml", Labels: labels})
+	err := os.WriteFile("/tmp/e2e_failed__"+labels["testcase"]+".yaml", cmdr.StdOutBytes(), 0644)
+	Expect(err).NotTo(HaveOccurred())
 }

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -653,3 +653,11 @@ func IsContainerRestarted(podName, containerName, namespace string, startedAt v1
 	}
 	return false, fmt.Errorf("failed to compare the `startedAt` field before and after the tests ran: %s", podName)
 }
+
+func OnFailureSaveTestResources(labels map[string]string) {
+	if CurrentSpecReport().Failed() {
+		cmdr := kubectl.Get("virtualization -A", kc.GetOptions{Output: "yaml", Labels: labels})
+		err := os.WriteFile("/tmp/e2e_failed__"+labels["testcase"]+".yaml", cmdr.StdOutBytes(), 0644)
+		Expect(err).NotTo(HaveOccurred())
+	}
+}

--- a/tests/e2e/vd_snapshots_test.go
+++ b/tests/e2e/vd_snapshots_test.go
@@ -237,7 +237,11 @@ var _ = Describe("Virtual disk snapshots", ginkgoutil.CommonE2ETestDecorators(),
 		vmAutomaticWithHotplug         = map[string]string{"vm": "automatic-with-hotplug"}
 	)
 
-	AfterEach(func() { OnFailureSaveTestResources(testCaseLabel) })
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			SaveTestResources(testCaseLabel)
+		}
+	})
 
 	Context("Preparing the environment", func() {
 		It("sets the namespace", func() {

--- a/tests/e2e/vd_snapshots_test.go
+++ b/tests/e2e/vd_snapshots_test.go
@@ -237,6 +237,8 @@ var _ = Describe("Virtual disk snapshots", ginkgoutil.CommonE2ETestDecorators(),
 		vmAutomaticWithHotplug         = map[string]string{"vm": "automatic-with-hotplug"}
 	)
 
+	AfterEach(func() { OnFailureSaveTestResources(testCaseLabel) })
+
 	Context("Preparing the environment", func() {
 		It("sets the namespace", func() {
 			kustomization := fmt.Sprintf("%s/%s", conf.TestData.VdSnapshots, "kustomization.yaml")

--- a/tests/e2e/vm_configuration_test.go
+++ b/tests/e2e/vm_configuration_test.go
@@ -126,7 +126,11 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 		manualLabel    = map[string]string{"vm": "manual-conf"}
 	)
 
-	AfterEach(func() { OnFailureSaveTestResources(testCaseLabel) })
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			SaveTestResources(testCaseLabel)
+		}
+	})
 
 	Context("Preparing the environment", func() {
 		It("sets the namespace", func() {

--- a/tests/e2e/vm_configuration_test.go
+++ b/tests/e2e/vm_configuration_test.go
@@ -126,6 +126,8 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 		manualLabel    = map[string]string{"vm": "manual-conf"}
 	)
 
+	AfterEach(func() { OnFailureSaveTestResources(testCaseLabel) })
+
 	Context("Preparing the environment", func() {
 		It("sets the namespace", func() {
 			kustomization := fmt.Sprintf("%s/%s", conf.TestData.VmConfiguration, "kustomization.yaml")

--- a/tests/e2e/vm_connectivity_test.go
+++ b/tests/e2e/vm_connectivity_test.go
@@ -106,6 +106,8 @@ var _ = Describe("VM connectivity", ginkgoutil.CommonE2ETestDecorators(), func()
 		selectorB string
 	)
 
+	AfterEach(func() { OnFailureSaveTestResources(testCaseLabel) })
+
 	Context("Preparing the environment", func() {
 		It("sets the namespace", func() {
 			kustomization := fmt.Sprintf("%s/%s", conf.TestData.Connectivity, "kustomization.yaml")

--- a/tests/e2e/vm_connectivity_test.go
+++ b/tests/e2e/vm_connectivity_test.go
@@ -106,7 +106,11 @@ var _ = Describe("VM connectivity", ginkgoutil.CommonE2ETestDecorators(), func()
 		selectorB string
 	)
 
-	AfterEach(func() { OnFailureSaveTestResources(testCaseLabel) })
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			SaveTestResources(testCaseLabel)
+		}
+	})
 
 	Context("Preparing the environment", func() {
 		It("sets the namespace", func() {

--- a/tests/e2e/vm_disk_attachment_test.go
+++ b/tests/e2e/vm_disk_attachment_test.go
@@ -126,6 +126,8 @@ var _ = Describe("Virtual disk attachment", ginkgoutil.CommonE2ETestDecorators()
 		vmName             string
 	)
 
+	AfterEach(func() { OnFailureSaveTestResources(testCaseLabel) })
+
 	Context("Preparing the environment", func() {
 		vdAttach = fmt.Sprintf("%s-vd-attach-%s", namePrefix, nameSuffix)
 		vmName = fmt.Sprintf("%s-vm-%s", namePrefix, nameSuffix)

--- a/tests/e2e/vm_disk_attachment_test.go
+++ b/tests/e2e/vm_disk_attachment_test.go
@@ -126,7 +126,11 @@ var _ = Describe("Virtual disk attachment", ginkgoutil.CommonE2ETestDecorators()
 		vmName             string
 	)
 
-	AfterEach(func() { OnFailureSaveTestResources(testCaseLabel) })
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			SaveTestResources(testCaseLabel)
+		}
+	})
 
 	Context("Preparing the environment", func() {
 		vdAttach = fmt.Sprintf("%s-vd-attach-%s", namePrefix, nameSuffix)

--- a/tests/e2e/vm_disk_resizing_test.go
+++ b/tests/e2e/vm_disk_resizing_test.go
@@ -203,7 +203,11 @@ var _ = Describe("Virtual disk resizing", ginkgoutil.CommonE2ETestDecorators(), 
 		conf.SetNamespace(ns)
 	})
 
-	AfterEach(func() { OnFailureSaveTestResources(testCaseLabel) })
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			SaveTestResources(testCaseLabel)
+		}
+	})
 
 	Context("When the resources are applied", func() {
 		It("result should be succeeded", func() {

--- a/tests/e2e/vm_disk_resizing_test.go
+++ b/tests/e2e/vm_disk_resizing_test.go
@@ -203,6 +203,8 @@ var _ = Describe("Virtual disk resizing", ginkgoutil.CommonE2ETestDecorators(), 
 		conf.SetNamespace(ns)
 	})
 
+	AfterEach(func() { OnFailureSaveTestResources(testCaseLabel) })
+
 	Context("When the resources are applied", func() {
 		It("result should be succeeded", func() {
 			res := kubectl.Apply(kc.ApplyOptions{

--- a/tests/e2e/vm_label_annotation_test.go
+++ b/tests/e2e/vm_label_annotation_test.go
@@ -113,7 +113,11 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 	testCaseLabel := map[string]string{"testcase": "vm-label-annotation"}
 	specialKeyValue := map[string]string{specialKey: specialValue}
 
-	AfterEach(func() { OnFailureSaveTestResources(testCaseLabel) })
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			SaveTestResources(testCaseLabel)
+		}
+	})
 
 	Context("Preparing the environment", func() {
 		It("sets the namespace", func() {

--- a/tests/e2e/vm_label_annotation_test.go
+++ b/tests/e2e/vm_label_annotation_test.go
@@ -113,6 +113,8 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 	testCaseLabel := map[string]string{"testcase": "vm-label-annotation"}
 	specialKeyValue := map[string]string{specialKey: specialValue}
 
+	AfterEach(func() { OnFailureSaveTestResources(testCaseLabel) })
+
 	Context("Preparing the environment", func() {
 		It("sets the namespace", func() {
 			kustomization := fmt.Sprintf("%s/%s", conf.TestData.VmLabelAnnotation, "kustomization.yaml")

--- a/tests/e2e/vm_migration_test.go
+++ b/tests/e2e/vm_migration_test.go
@@ -42,7 +42,11 @@ func MigrateVirtualMachines(label map[string]string, templatePath string, virtua
 var _ = Describe("Virtual machine migration", ginkgoutil.CommonE2ETestDecorators(), func() {
 	testCaseLabel := map[string]string{"testcase": "vm-migration"}
 
-	AfterEach(func() { OnFailureSaveTestResources(testCaseLabel) })
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			SaveTestResources(testCaseLabel)
+		}
+	})
 
 	Context("Preparing the environment", func() {
 		It("sets the namespace", func() {

--- a/tests/e2e/vm_migration_test.go
+++ b/tests/e2e/vm_migration_test.go
@@ -42,6 +42,8 @@ func MigrateVirtualMachines(label map[string]string, templatePath string, virtua
 var _ = Describe("Virtual machine migration", ginkgoutil.CommonE2ETestDecorators(), func() {
 	testCaseLabel := map[string]string{"testcase": "vm-migration"}
 
+	AfterEach(func() { OnFailureSaveTestResources(testCaseLabel) })
+
 	Context("Preparing the environment", func() {
 		It("sets the namespace", func() {
 			kustomization := fmt.Sprintf("%s/%s", conf.TestData.VmMigration, "kustomization.yaml")

--- a/tests/e2e/vm_version_test.go
+++ b/tests/e2e/vm_version_test.go
@@ -38,7 +38,11 @@ var _ = Describe("Virtual machine versions", ginkgoutil.CommonE2ETestDecorators(
 
 	testCaseLabel := map[string]string{"testcase": "vm-versions"}
 
-	AfterEach(func() { OnFailureSaveTestResources(testCaseLabel) })
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			SaveTestResources(testCaseLabel)
+		}
+	})
 
 	Context("Preparing the environment", func() {
 		It("sets the namespace", func() {

--- a/tests/e2e/vm_version_test.go
+++ b/tests/e2e/vm_version_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/deckhouse/virtualization/tests/e2e/config"
 	"github.com/deckhouse/virtualization/tests/e2e/ginkgoutil"
 
-	// . "github.com/deckhouse/virtualization/tests/e2e/helper"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 	kc "github.com/deckhouse/virtualization/tests/e2e/kubectl"
 )
@@ -38,6 +37,8 @@ var _ = Describe("Virtual machine versions", ginkgoutil.CommonE2ETestDecorators(
 	})
 
 	testCaseLabel := map[string]string{"testcase": "vm-versions"}
+
+	AfterEach(func() { OnFailureSaveTestResources(testCaseLabel) })
 
 	Context("Preparing the environment", func() {
 		It("sets the namespace", func() {


### PR DESCRIPTION
## Description
This PR introduces a mechanism to automatically dump all test-related resources into a single YAML file whenever a test fails. This enhancement provides a comprehensive snapshot of the test environment at the time of failure, enabling faster debugging and more efficient issue resolution.

## Why do we need it, and what problem does it solve?
When tests fail, diagnosing the root cause often requires inspecting the state of various resources (e.g., deployments, pods, services, config maps, secrets) in the test environment. However:

Manually gathering these resources is time-consuming and error-prone.
Resource states may change or be deleted before they can be inspected.
Lack of a unified view makes it difficult to reproduce and analyze failures.
This PR addresses these challenges by automating the collection of all relevant resources into a single YAML file when a test fails.


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: ci
type: chore
summary: automate dumping of test resources to a single YAML file on failure for faster debugging and reproducibility.
```
