### PR TITLE
fix(api): avoid requeue rate limiter

### DIFF
--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref.go
@@ -35,7 +35,6 @@ import (
 	"github.com/deckhouse/virtualization-controller/pkg/controller"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/importer"
-	"github.com/deckhouse/virtualization-controller/pkg/controller/reconciler"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/supplements"
 	"github.com/deckhouse/virtualization-controller/pkg/dvcr"
@@ -160,7 +159,12 @@ func (ds ObjectRefDataSource) Sync(ctx context.Context, cvi *virtv2.ClusterVirtu
 			return reconcile.Result{}, err
 		}
 
-		return CleanUp(ctx, cvi, ds)
+		_, err = CleanUp(ctx, cvi, ds)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		return reconcile.Result{}, nil
 	case object.IsTerminating(pod):
 		cvi.Status.Phase = virtv2.ImagePending
 
@@ -289,25 +293,25 @@ func (ds ObjectRefDataSource) Sync(ctx context.Context, cvi *virtv2.ClusterVirtu
 	return reconcile.Result{Requeue: true}, nil
 }
 
-func (ds ObjectRefDataSource) CleanUp(ctx context.Context, cvi *virtv2.ClusterVirtualImage) (reconcile.Result, error) {
+func (ds ObjectRefDataSource) CleanUp(ctx context.Context, cvi *virtv2.ClusterVirtualImage) (bool, error) {
 	viRefResult, err := ds.viOnPvcSyncer.CleanUp(ctx, cvi)
 	if err != nil {
-		return reconcile.Result{}, err
+		return false, err
 	}
 
 	vdRefResult, err := ds.vdSyncer.CleanUp(ctx, cvi)
 	if err != nil {
-		return reconcile.Result{}, err
+		return false, err
 	}
 
 	supgen := supplements.NewGenerator(annotations.CVIShortName, cvi.Name, ds.controllerNamespace, cvi.UID)
 
 	objRefRequeue, err := ds.importerService.CleanUp(ctx, supgen)
 	if err != nil {
-		return reconcile.Result{}, err
+		return false, err
 	}
 
-	return reconciler.MergeResults(viRefResult, vdRefResult, reconcile.Result{Requeue: objRefRequeue}), nil
+	return viRefResult || vdRefResult || objRefRequeue, nil
 }
 
 func (ds ObjectRefDataSource) Validate(ctx context.Context, cvi *virtv2.ClusterVirtualImage) error {

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref_vd.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref_vd.go
@@ -90,7 +90,12 @@ func (ds ObjectRefVirtualDisk) Sync(ctx context.Context, cvi *virtv2.ClusterVirt
 			return reconcile.Result{}, err
 		}
 
-		return CleanUp(ctx, cvi, ds)
+		_, err = CleanUp(ctx, cvi, ds)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		return reconcile.Result{}, nil
 	case object.IsTerminating(pod):
 		cvi.Status.Phase = virtv2.ImagePending
 
@@ -205,13 +210,8 @@ func (ds ObjectRefVirtualDisk) Sync(ctx context.Context, cvi *virtv2.ClusterVirt
 	return reconcile.Result{Requeue: true}, nil
 }
 
-func (ds ObjectRefVirtualDisk) CleanUp(ctx context.Context, cvi *virtv2.ClusterVirtualImage) (reconcile.Result, error) {
-	importerRequeue, err := ds.importerService.DeletePod(ctx, cvi, controllerName)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
-	return reconcile.Result{Requeue: importerRequeue}, nil
+func (ds ObjectRefVirtualDisk) CleanUp(ctx context.Context, cvi *virtv2.ClusterVirtualImage) (bool, error) {
+	return ds.importerService.DeletePod(ctx, cvi, controllerName)
 }
 
 func (ds ObjectRefVirtualDisk) getEnvSettings(cvi *virtv2.ClusterVirtualImage, sup *supplements.Generator) *importer.Settings {

--- a/images/virtualization-artifact/pkg/controller/vd/internal/deletion.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/deletion.go
@@ -18,6 +18,7 @@ package internal
 
 import (
 	"context"
+	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -49,7 +50,7 @@ func (h DeletionHandler) Handle(ctx context.Context, vd *virtv2.VirtualDisk) (re
 		}
 
 		if requeue {
-			return reconcile.Result{Requeue: true}, nil
+			return reconcile.Result{RequeueAfter: time.Second}, nil
 		}
 
 		log.Info("Deletion observed: remove cleanup finalizer from VirtualDisk")

--- a/images/virtualization-artifact/pkg/controller/vi/internal/deletion.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/deletion.go
@@ -18,6 +18,7 @@ package internal
 
 import (
 	"context"
+	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -49,7 +50,7 @@ func (h DeletionHandler) Handle(ctx context.Context, vi *virtv2.VirtualImage) (r
 		}
 
 		if requeue {
-			return reconcile.Result{Requeue: true}, nil
+			return reconcile.Result{RequeueAfter: time.Second}, nil
 		}
 
 		log.Info("Deletion observed: remove cleanup finalizer from VirtualImage")


### PR DESCRIPTION
## Description

1. Requeuing with a 0-second delay triggers the rate limiter, which could cause some required requeues to be delayed, leading to block devices getting stuck in the Terminating phase. Overall, requeuing with a 0-second delay is a bad practice that should be avoided

2. cvi CleanUp now also returns `(bool, error)`, just like vd and vi. It's consistent now.


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries

```changes
section: api
type: fix
summary: fix the issue of block devices getting stuck in the Terminating phase.
```
