### PR TITLE
chore(test): add additional error dump info

### DIFF
--- a/tests/e2e/affinity_toleration_test.go
+++ b/tests/e2e/affinity_toleration_test.go
@@ -191,7 +191,7 @@ var _ = Describe("Virtual machine affinity and toleration", ginkgoutil.CommonE2E
 
 	AfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			SaveTestResources(testCaseLabel)
+			SaveTestResources(testCaseLabel, CurrentSpecReport().LeafNodeText)
 		}
 	})
 

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 
 	AfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			SaveTestResources(testCaseLabel)
+			SaveTestResources(testCaseLabel, CurrentSpecReport().LeafNodeText)
 		}
 	})
 

--- a/tests/e2e/image_hotplug_test.go
+++ b/tests/e2e/image_hotplug_test.go
@@ -145,7 +145,7 @@ var _ = Describe("Image hotplug", ginkgoutil.CommonE2ETestDecorators(), func() {
 
 	AfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			SaveTestResources(testCaseLabel)
+			SaveTestResources(testCaseLabel, CurrentSpecReport().LeafNodeText)
 		}
 	})
 

--- a/tests/e2e/images_creation_test.go
+++ b/tests/e2e/images_creation_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Virtual images creation", ginkgoutil.CommonE2ETestDecorators()
 
 	AfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			SaveTestResources(testCaseLabel)
+			SaveTestResources(testCaseLabel, CurrentSpecReport().LeafNodeText)
 		}
 	})
 

--- a/tests/e2e/importer_network_policy_test.go
+++ b/tests/e2e/importer_network_policy_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Importer network policy", ginkgoutil.CommonE2ETestDecorators()
 
 	AfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			SaveTestResources(testCaseLabel)
+			SaveTestResources(testCaseLabel, CurrentSpecReport().LeafNodeText)
 		}
 	})
 

--- a/tests/e2e/sizing_policy_test.go
+++ b/tests/e2e/sizing_policy_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Sizing policy", ginkgoutil.CommonE2ETestDecorators(), func() {
 
 	AfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			SaveTestResources(testCaseLabel)
+			SaveTestResources(testCaseLabel, CurrentSpecReport().LeafNodeText)
 		}
 	})
 

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -656,6 +656,7 @@ func IsContainerRestarted(podName, containerName, namespace string, startedAt v1
 
 func SaveTestResources(labels map[string]string, additional string) {
 	cmdr := kubectl.Get("virtualization -A", kc.GetOptions{Output: "yaml", Labels: labels})
+	Expect(cmdr.Error()).NotTo(HaveOccurred(), "cmd: %s\nstderr: %s", cmdr.GetCmd(), cmdr.StdErr())
 
 	additional = strings.ToLower(additional)
 	additional = strings.ReplaceAll(strings.ToLower(additional), " ", "_")

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -654,8 +654,13 @@ func IsContainerRestarted(podName, containerName, namespace string, startedAt v1
 	return false, fmt.Errorf("failed to compare the `startedAt` field before and after the tests ran: %s", podName)
 }
 
-func SaveTestResources(labels map[string]string) {
+func SaveTestResources(labels map[string]string, additional string) {
 	cmdr := kubectl.Get("virtualization -A", kc.GetOptions{Output: "yaml", Labels: labels})
-	err := os.WriteFile("/tmp/e2e_failed__"+labels["testcase"]+".yaml", cmdr.StdOutBytes(), 0644)
+
+	additional = strings.ToLower(additional)
+	additional = strings.ReplaceAll(strings.ToLower(additional), " ", "_")
+	str := fmt.Sprintf("/tmp/e2e_failed__%s__%s.yaml", labels["testcase"], additional)
+
+	err := os.WriteFile(str, cmdr.StdOutBytes(), 0644)
 	Expect(err).NotTo(HaveOccurred())
 }

--- a/tests/e2e/vd_snapshots_test.go
+++ b/tests/e2e/vd_snapshots_test.go
@@ -239,7 +239,7 @@ var _ = Describe("Virtual disk snapshots", ginkgoutil.CommonE2ETestDecorators(),
 
 	AfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			SaveTestResources(testCaseLabel)
+			SaveTestResources(testCaseLabel, CurrentSpecReport().LeafNodeText)
 		}
 	})
 

--- a/tests/e2e/vm_configuration_test.go
+++ b/tests/e2e/vm_configuration_test.go
@@ -128,7 +128,7 @@ var _ = Describe("Virtual machine configuration", ginkgoutil.CommonE2ETestDecora
 
 	AfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			SaveTestResources(testCaseLabel)
+			SaveTestResources(testCaseLabel, CurrentSpecReport().LeafNodeText)
 		}
 	})
 

--- a/tests/e2e/vm_connectivity_test.go
+++ b/tests/e2e/vm_connectivity_test.go
@@ -108,7 +108,7 @@ var _ = Describe("VM connectivity", ginkgoutil.CommonE2ETestDecorators(), func()
 
 	AfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			SaveTestResources(testCaseLabel)
+			SaveTestResources(testCaseLabel, CurrentSpecReport().LeafNodeText)
 		}
 	})
 

--- a/tests/e2e/vm_disk_attachment_test.go
+++ b/tests/e2e/vm_disk_attachment_test.go
@@ -128,7 +128,7 @@ var _ = Describe("Virtual disk attachment", ginkgoutil.CommonE2ETestDecorators()
 
 	AfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			SaveTestResources(testCaseLabel)
+			SaveTestResources(testCaseLabel, CurrentSpecReport().LeafNodeText)
 		}
 	})
 

--- a/tests/e2e/vm_disk_resizing_test.go
+++ b/tests/e2e/vm_disk_resizing_test.go
@@ -205,7 +205,7 @@ var _ = Describe("Virtual disk resizing", ginkgoutil.CommonE2ETestDecorators(), 
 
 	AfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			SaveTestResources(testCaseLabel)
+			SaveTestResources(testCaseLabel, CurrentSpecReport().LeafNodeText)
 		}
 	})
 

--- a/tests/e2e/vm_label_annotation_test.go
+++ b/tests/e2e/vm_label_annotation_test.go
@@ -115,7 +115,7 @@ var _ = Describe("Virtual machine label and annotation", ginkgoutil.CommonE2ETes
 
 	AfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			SaveTestResources(testCaseLabel)
+			SaveTestResources(testCaseLabel, CurrentSpecReport().LeafNodeText)
 		}
 	})
 

--- a/tests/e2e/vm_migration_test.go
+++ b/tests/e2e/vm_migration_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Virtual machine migration", ginkgoutil.CommonE2ETestDecorators
 
 	AfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			SaveTestResources(testCaseLabel)
+			SaveTestResources(testCaseLabel, CurrentSpecReport().LeafNodeText)
 		}
 	})
 

--- a/tests/e2e/vm_version_test.go
+++ b/tests/e2e/vm_version_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Virtual machine versions", ginkgoutil.CommonE2ETestDecorators(
 
 	AfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			SaveTestResources(testCaseLabel)
+			SaveTestResources(testCaseLabel, CurrentSpecReport().LeafNodeText)
 		}
 	})
 


### PR DESCRIPTION
## Description
Clarification of the file name for dumps on test failures, now the file name includes the specific case in which the test crashed.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: ci
type: chore
summary: improve failed test dump
```
