### PR TITLE
chore(ci): add QoL-features to automatic e2e tests

### DIFF
--- a/.github/workflows/dev_module_build.yml
+++ b/.github/workflows/dev_module_build.yml
@@ -532,43 +532,12 @@ jobs:
         run: |
           task run -v
 
-      - name: Remove label
-        if: ${{ always() }}
-        id: remove-label
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{secrets.RELEASE_PLEASE_TOKEN}}
-          script: |
-            const issueNumber = context.issue.number;
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const labelToRemove = 'e2e/run';
-
-            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
-              owner,
-              repo,
-              issue_number: issueNumber,
-            });
-
-            if (labels.some(label => label.name === labelToRemove)) {
-              await github.rest.issues.removeLabel({
-                owner,
-                repo,
-                issue_number: issueNumber,
-                name: labelToRemove,
-              });
-              console.log(`Removed label '${labelToRemove}' from PR #${issueNumber}`);
-            } else {
-              console.log(`Label '${labelToRemove}' not found on PR #${issueNumber}`);
-            }
-
       - name: Cleanup E2E resources on cancel
         if: always() && steps.e2e-tests.outcome == 'cancelled'
-        timeout-minutes: 3
+        timeout-minutes: 60
         id: e2e-tests-cleanup
         working-directory: ./tests/e2e/
         run: |
-          sleep 300
           task cleanup
 
   update_comment_on_finish:
@@ -593,3 +562,36 @@ jobs:
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             await e2eStatus.setStatusAfterE2eRun({github, context, core});
+  
+  remove_label:
+    name: Remove label
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    steps:
+      - name: Remove label
+        id: remove-label
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{secrets.RELEASE_PLEASE_TOKEN}}
+          script: |
+            const issueNumber = context.issue.number; const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const labelToRemove = 'e2e/run';
+
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner,
+              repo,
+              issue_number: issueNumber,
+            });
+
+            if (labels.some(label => label.name === labelToRemove)) {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                name: labelToRemove,
+              });
+              console.log(`Removed label '${labelToRemove}' from PR #${issueNumber}`);
+            } else {
+              console.log(`Label '${labelToRemove}' not found on PR #${issueNumber}`);
+            }

--- a/.github/workflows/dev_module_build.yml
+++ b/.github/workflows/dev_module_build.yml
@@ -562,11 +562,17 @@ jobs:
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             await e2eStatus.setStatusAfterE2eRun({github, context, core});
-  
+
   remove_label:
     name: Remove label
     runs-on: ubuntu-latest
+    # run the job at the end
     if: ${{ always() }}
+    needs:
+      - dev_setup_build
+      - set_e2e_requirement_status
+      - set_vars
+      - run_e2e
     steps:
       - name: Remove label
         id: remove-label

--- a/.github/workflows/dev_module_build.yml
+++ b/.github/workflows/dev_module_build.yml
@@ -564,10 +564,11 @@ jobs:
 
       - name: Cleanup E2E resources on cancel
         if: always() && steps.e2e-tests.outcome == 'cancelled'
-        timeout-minutes: 60
+        timeout-minutes: 3
         id: e2e-tests-cleanup
         working-directory: ./tests/e2e/
         run: |
+          sleep 300
           task cleanup
 
   update_comment_on_finish:

--- a/.github/workflows/dev_module_build.yml
+++ b/.github/workflows/dev_module_build.yml
@@ -564,6 +564,7 @@ jobs:
 
       - name: Cleanup E2E resources on cancel
         if: always() && steps.e2e-tests.outcome == 'cancelled'
+        timeout-minutes: 60
         id: e2e-tests-cleanup
         working-directory: ./tests/e2e/
         run: |

--- a/tests/e2e/Taskfile.yaml
+++ b/tests/e2e/Taskfile.yaml
@@ -117,7 +117,12 @@ tasks:
       - d8
     cmds:
       - |
-        E2E_PREFIX="head-$(git rev-parse --short HEAD)"
+        if [ -z "$E2E_PREFIX" ]; then
+          E2E_PREFIX="head-$(git rev-parse --short HEAD)"
+          echo "E2E_PREFIX not set. Setting E2E_PREFIX to $E2E_PREFIX"
+        else
+          echo "Using existing E2E_PREFIX: $E2E_PREFIX"
+        fi
 
         delete_resources_with_prefix() {
             local RESOURCE_TYPE=$1

--- a/tests/e2e/Taskfile.yaml
+++ b/tests/e2e/Taskfile.yaml
@@ -127,9 +127,10 @@ tasks:
         delete_resources_with_prefix() {
             local RESOURCE_TYPE=$1
             local RESOURCES=$(kubectl get "$RESOURCE_TYPE" --no-headers 2>/dev/null | awk "/$E2E_PREFIX/ {print \$1}")
-            
             if [[ -n "$RESOURCES" ]]; then
-                echo "$RESOURCES" | xargs -r kubectl delete "$RESOURCE_TYPE"
+              echo "Deleting $RESOURCE_TYPE:"
+              echo "$RESOURCES" | awk '{print "  - " $1}'
+              echo "$RESOURCES" | xargs -r kubectl delete "$RESOURCE_TYPE"
             else
                 echo "No $RESOURCE_TYPE found with prefix $E2E_PREFIX"
             fi


### PR DESCRIPTION
Signed-off-by: Maksim Fedotov <maksim.fedotov@flant.com>

## Description
<!---
  Describe your changes with technical details.
-->
Add following QoL features to e2e:
- add `cleanup` task to automatically remove all resources created by e2e tests.
- add timeout for cleanup job
- move label removal to separate job to fix issues with `e2e/run` label not being removed if the job is cancelled before the start of e2e tests

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: ci
type: chore
summary: add QoL-features to automatic e2e tests
```
