### PR TITLE
test(vdsnapshot): disable consistency check

### DIFF
--- a/tests/e2e/vd_snapshots_test.go
+++ b/tests/e2e/vd_snapshots_test.go
@@ -30,6 +30,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	sdsrepvolv1 "github.com/deckhouse/sds-replicated-volume/api/v1alpha1"
+
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmcondition"
 	"github.com/deckhouse/virtualization/tests/e2e/config"
@@ -368,15 +369,16 @@ var _ = Describe("Virtual disk snapshots", ginkgoutil.CommonE2ETestDecorators(),
 				Namespace: conf.Namespace,
 				Timeout:   MaxWaitTimeout,
 			})
-			By("Snapshots should be consistent", func() {
-				vdSnapshots := virtv2.VirtualDiskSnapshotList{}
-				err := GetObjects(kc.ResourceVDSnapshot, &vdSnapshots, kc.GetOptions{Namespace: conf.Namespace, Labels: hasNoConsumerLabel})
-				Expect(err).NotTo(HaveOccurred(), "cannot get `vdSnapshots`\nstderr: %s", err)
-
-				for _, snapshot := range vdSnapshots.Items {
-					Expect(*snapshot.Status.Consistent).To(BeTrue(), "consistent field should be `true`: %s", snapshot.Name)
-				}
-			})
+			// TODO: It is a known issue that disk snapshots are not always created consistently. To prevent this error from causing noise during testing, we disabled this check. It will need to be re-enabled once the consistency issue is fixed.
+			// By("Snapshots should be consistent", func() {
+			// 	vdSnapshots := virtv2.VirtualDiskSnapshotList{}
+			// 	err := GetObjects(kc.ResourceVDSnapshot, &vdSnapshots, kc.GetOptions{Namespace: conf.Namespace, Labels: hasNoConsumerLabel})
+			// 	Expect(err).NotTo(HaveOccurred(), "cannot get `vdSnapshots`\nstderr: %s", err)
+			//
+			// 	for _, snapshot := range vdSnapshots.Items {
+			// 		Expect(*snapshot.Status.Consistent).To(BeTrue(), "consistent field should be `true`: %s", snapshot.Name)
+			// 	}
+			// })
 		})
 	})
 
@@ -488,28 +490,29 @@ var _ = Describe("Virtual disk snapshots", ginkgoutil.CommonE2ETestDecorators(),
 			}
 		})
 
-		It("checks snapshots of attached VDs", func() {
-			By(fmt.Sprintf("Snapshots should be in %s phase", PhaseReady))
-			WaitPhaseByLabel(kc.ResourceVDSnapshot, PhaseReady, kc.WaitOptions{
-				Labels:    attachedVirtualDiskLabel,
-				Namespace: conf.Namespace,
-				Timeout:   MaxWaitTimeout,
-			})
-			By("Snapshots should be consistent", func() {
-				vdSnapshots := virtv2.VirtualDiskSnapshotList{}
-				err := GetObjects(kc.ResourceVDSnapshot, &vdSnapshots, kc.GetOptions{
-					ExcludedLabels: []string{"hasNoConsumer"},
-					Namespace:      conf.Namespace,
-					Labels:         attachedVirtualDiskLabel,
-				})
-				Expect(err).NotTo(HaveOccurred(), "cannot get `vdSnapshots`\nstderr: %s", err)
-
-				for _, snapshot := range vdSnapshots.Items {
-					Expect(snapshot.Status.Consistent).ToNot(BeNil())
-					Expect(*snapshot.Status.Consistent).To(BeTrue(), "consistent field should be `true`: %s", snapshot.Name)
-				}
-			})
-		})
+		// TODO: It is a known issue that disk snapshots are not always created consistently. To prevent this error from causing noise during testing, we disabled this check. It will need to be re-enabled once the consistency issue is fixed.
+		// It("checks snapshots of attached VDs", func() {
+		// 	By(fmt.Sprintf("Snapshots should be in %s phase", PhaseReady))
+		// 	WaitPhaseByLabel(kc.ResourceVDSnapshot, PhaseReady, kc.WaitOptions{
+		// 		Labels:    attachedVirtualDiskLabel,
+		// 		Namespace: conf.Namespace,
+		// 		Timeout:   MaxWaitTimeout,
+		// 	})
+		// 	By("Snapshots should be consistent", func() {
+		// 		vdSnapshots := virtv2.VirtualDiskSnapshotList{}
+		// 		err := GetObjects(kc.ResourceVDSnapshot, &vdSnapshots, kc.GetOptions{
+		// 			ExcludedLabels: []string{"hasNoConsumer"},
+		// 			Namespace:      conf.Namespace,
+		// 			Labels:         attachedVirtualDiskLabel,
+		// 		})
+		// 		Expect(err).NotTo(HaveOccurred(), "cannot get `vdSnapshots`\nstderr: %s", err)
+		//
+		// 		for _, snapshot := range vdSnapshots.Items {
+		// 			Expect(snapshot.Status.Consistent).ToNot(BeNil())
+		// 			Expect(*snapshot.Status.Consistent).To(BeTrue(), "consistent field should be `true`: %s", snapshot.Name)
+		// 		}
+		// 	})
+		// })
 
 		It("checks `FileSystemFrozen` status of VMs", func() {
 			By("Status should not be `Frozen`")


### PR DESCRIPTION
## Description

It is a known issue that disk snapshots are not always created consistently. 
To prevent this error from causing noise during testing, we disabled this check. 
It will need to be re-enabled once the consistency issue is fixed.


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries

```changes
section: vdsnapshot
type: chore
summary: disable consistency check
impact_level: low
```
