### PR TITLE
fix(vi,vd): fix default storage class usage

### DIFF
--- a/api/core/v1alpha2/events.go
+++ b/api/core/v1alpha2/events.go
@@ -82,6 +82,9 @@ const (
 	// ReasonVDResizingNotAvailable is event reason that VD Resizing is not available.
 	ReasonVDResizingNotAvailable = "VirtualDiskResizingNotAvailable"
 
+	// ReasonVIStorageClassNotFound is event reason that VIStorageClass not found.
+	ReasonVIStorageClassNotFound = "VirtualImageStorageClassNotFound"
+
 	// ReasonDataSourceSyncStarted is event reason that DataSource sync is started.
 	ReasonDataSourceSyncStarted = "DataSourceImportStarted"
 	// ReasonDataSourceSyncInProgress is event reason that DataSource sync is in progress.

--- a/api/core/v1alpha2/vicondition/condition.go
+++ b/api/core/v1alpha2/vicondition/condition.go
@@ -79,8 +79,6 @@ const (
 	ProvisioningNotStarted ReadyReason = "ProvisioningNotStarted"
 	// ProvisioningFailed indicates that the provisioning process has failed.
 	ProvisioningFailed ReadyReason = "ProvisioningFailed"
-	// StorageClassNotReady indicates that the provisioning process pending because `StorageClass` not ready.
-	StorageClassNotReady ReadyReason = "StorageClassNotReady"
 	// Ready indicates that the import process is complete and the `VirtualImage` is ready for use.
 	Ready ReadyReason = "Ready"
 	// QuotaExceeded indicates that the VirtualImage is reached project quotas and can not be provisioned.
@@ -93,6 +91,8 @@ const (
 
 	// StorageClassReady indicates that the chosen StorageClass exists.
 	StorageClassReady StorageClassReadyReason = "StorageClassReady"
+	// StorageClassNotReady indicates that the provisioning process pending because `StorageClass` not ready.
+	StorageClassNotReady ReadyReason = "StorageClassNotReady"
 	// StorageClassNotFound indicates that the chosen StorageClass not found.
 	StorageClassNotFound StorageClassReadyReason = "StorageClassNotFound"
 	// DVCRTypeUsed indicates that the DVCR provisioning chosen.

--- a/api/core/v1alpha2/vicondition/condition.go
+++ b/api/core/v1alpha2/vicondition/condition.go
@@ -79,6 +79,8 @@ const (
 	ProvisioningNotStarted ReadyReason = "ProvisioningNotStarted"
 	// ProvisioningFailed indicates that the provisioning process has failed.
 	ProvisioningFailed ReadyReason = "ProvisioningFailed"
+	// StorageClassNotReady indicates that the provisioning process pending because `StorageClass` not ready.
+	StorageClassNotReady ReadyReason = "StorageClassNotReady"
 	// Ready indicates that the import process is complete and the `VirtualImage` is ready for use.
 	Ready ReadyReason = "Ready"
 	// QuotaExceeded indicates that the VirtualImage is reached project quotas and can not be provisioned.
@@ -91,8 +93,6 @@ const (
 
 	// StorageClassReady indicates that the chosen StorageClass exists.
 	StorageClassReady StorageClassReadyReason = "StorageClassReady"
-	// StorageClassNotReady indicates that the provisioning process pending because `StorageClass` not ready.
-	StorageClassNotReady ReadyReason = "StorageClassNotReady"
 	// StorageClassNotFound indicates that the chosen StorageClass not found.
 	StorageClassNotFound StorageClassReadyReason = "StorageClassNotFound"
 	// DVCRTypeUsed indicates that the DVCR provisioning chosen.

--- a/images/virtualization-artifact/pkg/controller/service/vi_storage_class_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/vi_storage_class_service.go
@@ -39,7 +39,7 @@ func NewVirtualImageStorageClassService(settings config.VirtualImageStorageClass
 	}
 }
 
-// GetStorageClass determines the storage class for VI from global settings and resource spec.
+// GetValidatedStorageClass determines the storage class for VI from global settings and resource spec.
 //
 // Global settings contain a default storage class and an array of allowed storageClasses from the ModuleConfig.
 // Storage class is allowed if contained in the "allowed" array.

--- a/images/virtualization-artifact/pkg/controller/service/vi_storage_class_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/vi_storage_class_service.go
@@ -17,20 +17,25 @@ limitations under the License.
 package service
 
 import (
+	"context"
 	"slices"
 
+	corev1 "k8s.io/api/core/v1"
 	storev1 "k8s.io/api/storage/v1"
 
 	"github.com/deckhouse/virtualization-controller/pkg/config"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/supplements"
 )
 
 type VirtualImageStorageClassService struct {
 	storageClassSettings config.VirtualImageStorageClassSettings
+	scGetter             StorageClassGetter
 }
 
-func NewVirtualImageStorageClassService(settings config.VirtualImageStorageClassSettings) *VirtualImageStorageClassService {
+func NewVirtualImageStorageClassService(settings config.VirtualImageStorageClassSettings, scGetter StorageClassGetter) *VirtualImageStorageClassService {
 	return &VirtualImageStorageClassService{
 		storageClassSettings: settings,
+		scGetter:             scGetter,
 	}
 }
 
@@ -47,7 +52,7 @@ func NewVirtualImageStorageClassService(settings config.VirtualImageStorageClass
 // Errors:
 // 1. Return error if no storage class is specified.
 // 2. Return error if specified non-empty class is not allowed.
-func (svc *VirtualImageStorageClassService) GetStorageClass(storageClassFromSpec *string, clusterDefaultStorageClass *storev1.StorageClass) (*string, error) {
+func (svc *VirtualImageStorageClassService) GetValidatedStorageClass(storageClassFromSpec *string, clusterDefaultStorageClass *storev1.StorageClass) (*string, error) {
 	if svc.storageClassSettings.DefaultStorageClassName == "" && len(svc.storageClassSettings.AllowedStorageClassNames) == 0 {
 		if svc.storageClassSettings.StorageClassName == "" {
 			return storageClassFromSpec, nil
@@ -85,4 +90,36 @@ func (svc *VirtualImageStorageClassService) GetStorageClass(storageClassFromSpec
 	}
 
 	return nil, ErrStorageClassNotFound
+}
+
+func (svc *VirtualImageStorageClassService) IsStorageClassAllowed(scName string) bool {
+	if svc.storageClassSettings.DefaultStorageClassName == "" && len(svc.storageClassSettings.AllowedStorageClassNames) == 0 {
+		return true
+	}
+
+	if slices.Contains(svc.storageClassSettings.AllowedStorageClassNames, scName) {
+		return true
+	}
+
+	if svc.storageClassSettings.DefaultStorageClassName != "" && svc.storageClassSettings.DefaultStorageClassName == scName {
+		return true
+	}
+
+	return false
+}
+
+func (svc *VirtualImageStorageClassService) GetModuleStorageClass(ctx context.Context) (*storev1.StorageClass, error) {
+	return svc.GetStorageClass(ctx, svc.storageClassSettings.DefaultStorageClassName)
+}
+
+func (svc *VirtualImageStorageClassService) GetPersistentVolumeClaim(ctx context.Context, sup *supplements.Generator) (*corev1.PersistentVolumeClaim, error) {
+	return svc.scGetter.GetPersistentVolumeClaim(ctx, sup)
+}
+
+func (svc *VirtualImageStorageClassService) GetStorageClass(ctx context.Context, scName string) (*storev1.StorageClass, error) {
+	return svc.scGetter.GetStorageClass(ctx, &scName)
+}
+
+func (svc *VirtualImageStorageClassService) GetDefaultStorageClass(ctx context.Context) (*storev1.StorageClass, error) {
+	return svc.scGetter.GetDefaultStorageClass(ctx)
 }

--- a/images/virtualization-artifact/pkg/controller/service/vi_storage_class_service_test.go
+++ b/images/virtualization-artifact/pkg/controller/service/vi_storage_class_service_test.go
@@ -40,9 +40,9 @@ var _ = Describe("VirtualImageStorageClassService", func() {
 	Context("when settings are empty", func() {
 		It("returns the storageClassFromSpec", func() {
 			storageClassSettings = config.VirtualImageStorageClassSettings{}
-			service = NewVirtualImageStorageClassService(storageClassSettings)
+			service = NewVirtualImageStorageClassService(storageClassSettings, nil)
 			sc := ptr.To("requested-storage-class")
-			storageClass, err := service.GetStorageClass(sc, clusterDefaultStorageClass)
+			storageClass, err := service.GetValidatedStorageClass(sc, clusterDefaultStorageClass)
 
 			Expect(err).To(BeNil())
 			Expect(storageClass).To(Equal(sc))
@@ -52,9 +52,9 @@ var _ = Describe("VirtualImageStorageClassService", func() {
 	Context("when settings are empty and storageClassFromSpec is empty", func() {
 		It("returns the storageClassFromSpec", func() {
 			storageClassSettings = config.VirtualImageStorageClassSettings{}
-			service = NewVirtualImageStorageClassService(storageClassSettings)
+			service = NewVirtualImageStorageClassService(storageClassSettings, nil)
 
-			storageClass, err := service.GetStorageClass(nil, clusterDefaultStorageClass)
+			storageClass, err := service.GetValidatedStorageClass(nil, clusterDefaultStorageClass)
 
 			Expect(err).To(BeNil())
 			Expect(storageClass).To(BeNil())
@@ -64,9 +64,9 @@ var _ = Describe("VirtualImageStorageClassService", func() {
 	Context("when settings and clusterDefaultStorageClass are empty", func() {
 		It("returns the storageClassFromSpec", func() {
 			storageClassSettings = config.VirtualImageStorageClassSettings{}
-			service = NewVirtualImageStorageClassService(storageClassSettings)
+			service = NewVirtualImageStorageClassService(storageClassSettings, nil)
 			sc := ptr.To("requested-storage-class")
-			storageClass, err := service.GetStorageClass(sc, nil)
+			storageClass, err := service.GetValidatedStorageClass(sc, nil)
 
 			Expect(err).To(BeNil())
 			Expect(storageClass).To(Equal(sc))
@@ -78,24 +78,24 @@ var _ = Describe("VirtualImageStorageClassService", func() {
 			storageClassSettings = config.VirtualImageStorageClassSettings{
 				StorageClassName: "storage-class-name",
 			}
-			service = NewVirtualImageStorageClassService(storageClassSettings)
+			service = NewVirtualImageStorageClassService(storageClassSettings, nil)
 		})
 
 		It("return the StorageClassName if storageClassFromSpec is empty", func() {
-			storageClass, err := service.GetStorageClass(nil, nil)
+			storageClass, err := service.GetValidatedStorageClass(nil, nil)
 			Expect(err).To(BeNil())
 			Expect(storageClass).To(Equal(&storageClassSettings.StorageClassName))
 		})
 
 		It("return the StorageClassName if storageClassFromSpec equal StorageClassName", func() {
-			storageClass, err := service.GetStorageClass(&storageClassSettings.StorageClassName, nil)
+			storageClass, err := service.GetValidatedStorageClass(&storageClassSettings.StorageClassName, nil)
 			Expect(err).To(BeNil())
 			Expect(storageClass).To(Equal(&storageClassSettings.StorageClassName))
 		})
 
 		It("return the err if storageClassFromSpec not equal StorageClassName", func() {
 			sc := ptr.To("requested-storage-class")
-			_, err := service.GetStorageClass(sc, nil)
+			_, err := service.GetValidatedStorageClass(sc, nil)
 			Expect(err).To(Equal(ErrStorageClassNotAllowed))
 		})
 	})
@@ -106,25 +106,25 @@ var _ = Describe("VirtualImageStorageClassService", func() {
 				AllowedStorageClassNames: []string{"allowed-storage-class"},
 				DefaultStorageClassName:  "",
 			}
-			service = NewVirtualImageStorageClassService(storageClassSettings)
+			service = NewVirtualImageStorageClassService(storageClassSettings, nil)
 		})
 
 		It("returns the requested storage class if it's in the allowed list", func() {
 			sc := ptr.To("allowed-storage-class")
-			storageClass, err := service.GetStorageClass(sc, clusterDefaultStorageClass)
+			storageClass, err := service.GetValidatedStorageClass(sc, clusterDefaultStorageClass)
 
 			Expect(err).To(BeNil())
 			Expect(storageClass).To(Equal(sc))
 		})
 
 		It("returns an error if the requested storage class is not in the allowed list", func() {
-			_, err := service.GetStorageClass(ptr.To("not-allowed-storage-class"), clusterDefaultStorageClass)
+			_, err := service.GetValidatedStorageClass(ptr.To("not-allowed-storage-class"), clusterDefaultStorageClass)
 
 			Expect(err).To(Equal(ErrStorageClassNotAllowed))
 		})
 
 		It("returns an error if storageClassFromSpec is empty", func() {
-			_, err := service.GetStorageClass(nil, clusterDefaultStorageClass)
+			_, err := service.GetValidatedStorageClass(nil, clusterDefaultStorageClass)
 
 			Expect(err).To(Equal(ErrStorageClassNotAllowed))
 		})
@@ -136,11 +136,11 @@ var _ = Describe("VirtualImageStorageClassService", func() {
 				AllowedStorageClassNames: []string{},
 				DefaultStorageClassName:  "default-storage-class",
 			}
-			service = NewVirtualImageStorageClassService(storageClassSettings)
+			service = NewVirtualImageStorageClassService(storageClassSettings, nil)
 		})
 
 		It("returns the default storage class if storageClassFromSpec is empty", func() {
-			storageClass, err := service.GetStorageClass(nil, clusterDefaultStorageClass)
+			storageClass, err := service.GetValidatedStorageClass(nil, clusterDefaultStorageClass)
 
 			Expect(err).To(BeNil())
 			Expect(storageClass).To(Equal(ptr.To("default-storage-class")))
@@ -148,14 +148,14 @@ var _ = Describe("VirtualImageStorageClassService", func() {
 
 		It("returns the requested storage class if it matches the default storage class", func() {
 			sc := ptr.To("default-storage-class")
-			storageClass, err := service.GetStorageClass(sc, clusterDefaultStorageClass)
+			storageClass, err := service.GetValidatedStorageClass(sc, clusterDefaultStorageClass)
 
 			Expect(err).To(BeNil())
 			Expect(storageClass).To(Equal(sc))
 		})
 
 		It("returns an error if the requested storage class does not match the default", func() {
-			_, err := service.GetStorageClass(ptr.To("different-storage-class"), clusterDefaultStorageClass)
+			_, err := service.GetValidatedStorageClass(ptr.To("different-storage-class"), clusterDefaultStorageClass)
 
 			Expect(err).To(Equal(ErrStorageClassNotAllowed))
 		})
@@ -167,11 +167,11 @@ var _ = Describe("VirtualImageStorageClassService", func() {
 				AllowedStorageClassNames: []string{"allowed-storage-class"},
 				DefaultStorageClassName:  "default-storage-class",
 			}
-			service = NewVirtualImageStorageClassService(storageClassSettings)
+			service = NewVirtualImageStorageClassService(storageClassSettings, nil)
 		})
 
 		It("returns the default storage class if storageClassFromSpec is empty", func() {
-			storageClass, err := service.GetStorageClass(nil, clusterDefaultStorageClass)
+			storageClass, err := service.GetValidatedStorageClass(nil, clusterDefaultStorageClass)
 
 			Expect(err).To(BeNil())
 			Expect(storageClass).To(Equal(ptr.To("default-storage-class")))
@@ -179,14 +179,14 @@ var _ = Describe("VirtualImageStorageClassService", func() {
 
 		It("returns the requested storage class if it's in the allowed list", func() {
 			sc := ptr.To("allowed-storage-class")
-			storageClass, err := service.GetStorageClass(sc, clusterDefaultStorageClass)
+			storageClass, err := service.GetValidatedStorageClass(sc, clusterDefaultStorageClass)
 
 			Expect(err).To(BeNil())
 			Expect(storageClass).To(Equal(sc))
 		})
 
 		It("returns an error if the requested storage class is not in the allowed list", func() {
-			_, err := service.GetStorageClass(ptr.To("not-allowed-storage-class"), clusterDefaultStorageClass)
+			_, err := service.GetValidatedStorageClass(ptr.To("not-allowed-storage-class"), clusterDefaultStorageClass)
 
 			Expect(err).To(Equal(ErrStorageClassNotAllowed))
 		})

--- a/images/virtualization-artifact/pkg/controller/vd/internal/storageclass_ready.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/storageclass_ready.go
@@ -18,6 +18,7 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -27,6 +28,7 @@ import (
 
 	"github.com/deckhouse/virtualization-controller/pkg/common/annotations"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/supplements"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
@@ -76,7 +78,7 @@ func (h StorageClassReadyHandler) Handle(ctx context.Context, vd *virtv2.Virtual
 
 	// 3. Try to use default storage class from the module settings.
 	moduleStorageClass, err := h.svc.GetModuleStorageClass(ctx)
-	if err != nil {
+	if err != nil && !errors.Is(err, service.ErrDefaultStorageClassNotFound) {
 		return reconcile.Result{}, fmt.Errorf("get module storage class: %w", err)
 	}
 
@@ -87,7 +89,7 @@ func (h StorageClassReadyHandler) Handle(ctx context.Context, vd *virtv2.Virtual
 
 	// 4. Try to use default storage class from the cluster.
 	defaultStorageClass, err := h.svc.GetDefaultStorageClass(ctx)
-	if err != nil {
+	if err != nil && !errors.Is(err, service.ErrDefaultStorageClassNotFound) {
 		return reconcile.Result{}, fmt.Errorf("get default storage class: %w", err)
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vi/internal/interfaces.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/interfaces.go
@@ -20,14 +20,14 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
-	storev1 "k8s.io/api/storage/v1"
+	storagev1 "k8s.io/api/storage/v1"
 
 	"github.com/deckhouse/virtualization-controller/pkg/controller/supplements"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vi/internal/source"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
-//go:generate moq -rm -out mock.go . DiskService Sources
+//go:generate moq -rm -out mock.go . DiskService Sources StorageClassService
 
 type Sources interface {
 	Changed(ctx context.Context, vi *virtv2.VirtualImage) bool
@@ -36,6 +36,14 @@ type Sources interface {
 }
 
 type DiskService interface {
-	GetStorageClass(ctx context.Context, storageClassName *string) (*storev1.StorageClass, error)
+	GetStorageClass(ctx context.Context, storageClassName *string) (*storagev1.StorageClass, error)
+	GetPersistentVolumeClaim(ctx context.Context, sup *supplements.Generator) (*corev1.PersistentVolumeClaim, error)
+}
+
+type StorageClassService interface {
+	IsStorageClassAllowed(sc string) bool
+	GetModuleStorageClass(ctx context.Context) (*storagev1.StorageClass, error)
+	GetDefaultStorageClass(ctx context.Context) (*storagev1.StorageClass, error)
+	GetStorageClass(ctx context.Context, sc string) (*storagev1.StorageClass, error)
 	GetPersistentVolumeClaim(ctx context.Context, sup *supplements.Generator) (*corev1.PersistentVolumeClaim, error)
 }

--- a/images/virtualization-artifact/pkg/controller/vi/internal/mock.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/mock.go
@@ -9,7 +9,7 @@ import (
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vi/internal/source"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
-	storev1 "k8s.io/api/storage/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"sync"
 )
 
@@ -26,7 +26,7 @@ var _ DiskService = &DiskServiceMock{}
 //			GetPersistentVolumeClaimFunc: func(ctx context.Context, sup *supplements.Generator) (*corev1.PersistentVolumeClaim, error) {
 //				panic("mock out the GetPersistentVolumeClaim method")
 //			},
-//			GetStorageClassFunc: func(ctx context.Context, storageClassName *string) (*storev1.StorageClass, error) {
+//			GetStorageClassFunc: func(ctx context.Context, storageClassName *string) (*storagev1.StorageClass, error) {
 //				panic("mock out the GetStorageClass method")
 //			},
 //		}
@@ -40,7 +40,7 @@ type DiskServiceMock struct {
 	GetPersistentVolumeClaimFunc func(ctx context.Context, sup *supplements.Generator) (*corev1.PersistentVolumeClaim, error)
 
 	// GetStorageClassFunc mocks the GetStorageClass method.
-	GetStorageClassFunc func(ctx context.Context, storageClassName *string) (*storev1.StorageClass, error)
+	GetStorageClassFunc func(ctx context.Context, storageClassName *string) (*storagev1.StorageClass, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -100,7 +100,7 @@ func (mock *DiskServiceMock) GetPersistentVolumeClaimCalls() []struct {
 }
 
 // GetStorageClass calls GetStorageClassFunc.
-func (mock *DiskServiceMock) GetStorageClass(ctx context.Context, storageClassName *string) (*storev1.StorageClass, error) {
+func (mock *DiskServiceMock) GetStorageClass(ctx context.Context, storageClassName *string) (*storagev1.StorageClass, error) {
 	if mock.GetStorageClassFunc == nil {
 		panic("DiskServiceMock.GetStorageClassFunc: method is nil but DiskService.GetStorageClass was just called")
 	}
@@ -298,5 +298,259 @@ func (mock *SourcesMock) ForCalls() []struct {
 	mock.lockFor.RLock()
 	calls = mock.calls.For
 	mock.lockFor.RUnlock()
+	return calls
+}
+
+// Ensure, that StorageClassServiceMock does implement StorageClassService.
+// If this is not the case, regenerate this file with moq.
+var _ StorageClassService = &StorageClassServiceMock{}
+
+// StorageClassServiceMock is a mock implementation of StorageClassService.
+//
+//	func TestSomethingThatUsesStorageClassService(t *testing.T) {
+//
+//		// make and configure a mocked StorageClassService
+//		mockedStorageClassService := &StorageClassServiceMock{
+//			GetDefaultStorageClassFunc: func(ctx context.Context) (*storagev1.StorageClass, error) {
+//				panic("mock out the GetDefaultStorageClass method")
+//			},
+//			GetModuleStorageClassFunc: func(ctx context.Context) (*storagev1.StorageClass, error) {
+//				panic("mock out the GetModuleStorageClass method")
+//			},
+//			GetPersistentVolumeClaimFunc: func(ctx context.Context, sup *supplements.Generator) (*corev1.PersistentVolumeClaim, error) {
+//				panic("mock out the GetPersistentVolumeClaim method")
+//			},
+//			GetStorageClassFunc: func(ctx context.Context, sc string) (*storagev1.StorageClass, error) {
+//				panic("mock out the GetStorageClass method")
+//			},
+//			IsStorageClassAllowedFunc: func(sc string) bool {
+//				panic("mock out the IsStorageClassAllowed method")
+//			},
+//		}
+//
+//		// use mockedStorageClassService in code that requires StorageClassService
+//		// and then make assertions.
+//
+//	}
+type StorageClassServiceMock struct {
+	// GetDefaultStorageClassFunc mocks the GetDefaultStorageClass method.
+	GetDefaultStorageClassFunc func(ctx context.Context) (*storagev1.StorageClass, error)
+
+	// GetModuleStorageClassFunc mocks the GetModuleStorageClass method.
+	GetModuleStorageClassFunc func(ctx context.Context) (*storagev1.StorageClass, error)
+
+	// GetPersistentVolumeClaimFunc mocks the GetPersistentVolumeClaim method.
+	GetPersistentVolumeClaimFunc func(ctx context.Context, sup *supplements.Generator) (*corev1.PersistentVolumeClaim, error)
+
+	// GetStorageClassFunc mocks the GetStorageClass method.
+	GetStorageClassFunc func(ctx context.Context, sc string) (*storagev1.StorageClass, error)
+
+	// IsStorageClassAllowedFunc mocks the IsStorageClassAllowed method.
+	IsStorageClassAllowedFunc func(sc string) bool
+
+	// calls tracks calls to the methods.
+	calls struct {
+		// GetDefaultStorageClass holds details about calls to the GetDefaultStorageClass method.
+		GetDefaultStorageClass []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+		}
+		// GetModuleStorageClass holds details about calls to the GetModuleStorageClass method.
+		GetModuleStorageClass []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+		}
+		// GetPersistentVolumeClaim holds details about calls to the GetPersistentVolumeClaim method.
+		GetPersistentVolumeClaim []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Sup is the sup argument value.
+			Sup *supplements.Generator
+		}
+		// GetStorageClass holds details about calls to the GetStorageClass method.
+		GetStorageClass []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Sc is the sc argument value.
+			Sc string
+		}
+		// IsStorageClassAllowed holds details about calls to the IsStorageClassAllowed method.
+		IsStorageClassAllowed []struct {
+			// Sc is the sc argument value.
+			Sc string
+		}
+	}
+	lockGetDefaultStorageClass   sync.RWMutex
+	lockGetModuleStorageClass    sync.RWMutex
+	lockGetPersistentVolumeClaim sync.RWMutex
+	lockGetStorageClass          sync.RWMutex
+	lockIsStorageClassAllowed    sync.RWMutex
+}
+
+// GetDefaultStorageClass calls GetDefaultStorageClassFunc.
+func (mock *StorageClassServiceMock) GetDefaultStorageClass(ctx context.Context) (*storagev1.StorageClass, error) {
+	if mock.GetDefaultStorageClassFunc == nil {
+		panic("StorageClassServiceMock.GetDefaultStorageClassFunc: method is nil but StorageClassService.GetDefaultStorageClass was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+	}{
+		Ctx: ctx,
+	}
+	mock.lockGetDefaultStorageClass.Lock()
+	mock.calls.GetDefaultStorageClass = append(mock.calls.GetDefaultStorageClass, callInfo)
+	mock.lockGetDefaultStorageClass.Unlock()
+	return mock.GetDefaultStorageClassFunc(ctx)
+}
+
+// GetDefaultStorageClassCalls gets all the calls that were made to GetDefaultStorageClass.
+// Check the length with:
+//
+//	len(mockedStorageClassService.GetDefaultStorageClassCalls())
+func (mock *StorageClassServiceMock) GetDefaultStorageClassCalls() []struct {
+	Ctx context.Context
+} {
+	var calls []struct {
+		Ctx context.Context
+	}
+	mock.lockGetDefaultStorageClass.RLock()
+	calls = mock.calls.GetDefaultStorageClass
+	mock.lockGetDefaultStorageClass.RUnlock()
+	return calls
+}
+
+// GetModuleStorageClass calls GetModuleStorageClassFunc.
+func (mock *StorageClassServiceMock) GetModuleStorageClass(ctx context.Context) (*storagev1.StorageClass, error) {
+	if mock.GetModuleStorageClassFunc == nil {
+		panic("StorageClassServiceMock.GetModuleStorageClassFunc: method is nil but StorageClassService.GetModuleStorageClass was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+	}{
+		Ctx: ctx,
+	}
+	mock.lockGetModuleStorageClass.Lock()
+	mock.calls.GetModuleStorageClass = append(mock.calls.GetModuleStorageClass, callInfo)
+	mock.lockGetModuleStorageClass.Unlock()
+	return mock.GetModuleStorageClassFunc(ctx)
+}
+
+// GetModuleStorageClassCalls gets all the calls that were made to GetModuleStorageClass.
+// Check the length with:
+//
+//	len(mockedStorageClassService.GetModuleStorageClassCalls())
+func (mock *StorageClassServiceMock) GetModuleStorageClassCalls() []struct {
+	Ctx context.Context
+} {
+	var calls []struct {
+		Ctx context.Context
+	}
+	mock.lockGetModuleStorageClass.RLock()
+	calls = mock.calls.GetModuleStorageClass
+	mock.lockGetModuleStorageClass.RUnlock()
+	return calls
+}
+
+// GetPersistentVolumeClaim calls GetPersistentVolumeClaimFunc.
+func (mock *StorageClassServiceMock) GetPersistentVolumeClaim(ctx context.Context, sup *supplements.Generator) (*corev1.PersistentVolumeClaim, error) {
+	if mock.GetPersistentVolumeClaimFunc == nil {
+		panic("StorageClassServiceMock.GetPersistentVolumeClaimFunc: method is nil but StorageClassService.GetPersistentVolumeClaim was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+		Sup *supplements.Generator
+	}{
+		Ctx: ctx,
+		Sup: sup,
+	}
+	mock.lockGetPersistentVolumeClaim.Lock()
+	mock.calls.GetPersistentVolumeClaim = append(mock.calls.GetPersistentVolumeClaim, callInfo)
+	mock.lockGetPersistentVolumeClaim.Unlock()
+	return mock.GetPersistentVolumeClaimFunc(ctx, sup)
+}
+
+// GetPersistentVolumeClaimCalls gets all the calls that were made to GetPersistentVolumeClaim.
+// Check the length with:
+//
+//	len(mockedStorageClassService.GetPersistentVolumeClaimCalls())
+func (mock *StorageClassServiceMock) GetPersistentVolumeClaimCalls() []struct {
+	Ctx context.Context
+	Sup *supplements.Generator
+} {
+	var calls []struct {
+		Ctx context.Context
+		Sup *supplements.Generator
+	}
+	mock.lockGetPersistentVolumeClaim.RLock()
+	calls = mock.calls.GetPersistentVolumeClaim
+	mock.lockGetPersistentVolumeClaim.RUnlock()
+	return calls
+}
+
+// GetStorageClass calls GetStorageClassFunc.
+func (mock *StorageClassServiceMock) GetStorageClass(ctx context.Context, sc string) (*storagev1.StorageClass, error) {
+	if mock.GetStorageClassFunc == nil {
+		panic("StorageClassServiceMock.GetStorageClassFunc: method is nil but StorageClassService.GetStorageClass was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+		Sc  string
+	}{
+		Ctx: ctx,
+		Sc:  sc,
+	}
+	mock.lockGetStorageClass.Lock()
+	mock.calls.GetStorageClass = append(mock.calls.GetStorageClass, callInfo)
+	mock.lockGetStorageClass.Unlock()
+	return mock.GetStorageClassFunc(ctx, sc)
+}
+
+// GetStorageClassCalls gets all the calls that were made to GetStorageClass.
+// Check the length with:
+//
+//	len(mockedStorageClassService.GetStorageClassCalls())
+func (mock *StorageClassServiceMock) GetStorageClassCalls() []struct {
+	Ctx context.Context
+	Sc  string
+} {
+	var calls []struct {
+		Ctx context.Context
+		Sc  string
+	}
+	mock.lockGetStorageClass.RLock()
+	calls = mock.calls.GetStorageClass
+	mock.lockGetStorageClass.RUnlock()
+	return calls
+}
+
+// IsStorageClassAllowed calls IsStorageClassAllowedFunc.
+func (mock *StorageClassServiceMock) IsStorageClassAllowed(sc string) bool {
+	if mock.IsStorageClassAllowedFunc == nil {
+		panic("StorageClassServiceMock.IsStorageClassAllowedFunc: method is nil but StorageClassService.IsStorageClassAllowed was just called")
+	}
+	callInfo := struct {
+		Sc string
+	}{
+		Sc: sc,
+	}
+	mock.lockIsStorageClassAllowed.Lock()
+	mock.calls.IsStorageClassAllowed = append(mock.calls.IsStorageClassAllowed, callInfo)
+	mock.lockIsStorageClassAllowed.Unlock()
+	return mock.IsStorageClassAllowedFunc(sc)
+}
+
+// IsStorageClassAllowedCalls gets all the calls that were made to IsStorageClassAllowed.
+// Check the length with:
+//
+//	len(mockedStorageClassService.IsStorageClassAllowedCalls())
+func (mock *StorageClassServiceMock) IsStorageClassAllowedCalls() []struct {
+	Sc string
+} {
+	var calls []struct {
+		Sc string
+	}
+	mock.lockIsStorageClassAllowed.RLock()
+	calls = mock.calls.IsStorageClassAllowed
+	mock.lockIsStorageClassAllowed.RUnlock()
 	return calls
 }

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/http.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/http.go
@@ -211,7 +211,7 @@ func (ds HTTPDataSource) StoreToPVC(ctx context.Context, vi *virtv2.VirtualImage
 	}
 
 	clusterDefaultSC, _ := ds.diskService.GetDefaultStorageClass(ctx)
-	sc, err := ds.storageClassService.GetStorageClass(vi.Spec.PersistentVolumeClaim.StorageClass, clusterDefaultSC)
+	sc, err := ds.storageClassService.GetValidatedStorageClass(vi.Spec.PersistentVolumeClaim.StorageClass, clusterDefaultSC)
 	if updated, err := setConditionFromStorageClassError(err, cb); err != nil || updated {
 		return reconcile.Result{}, err
 	}

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref.go
@@ -103,7 +103,7 @@ func (ds ObjectRefDataSource) StoreToPVC(ctx context.Context, vi *virtv2.Virtual
 	defer func() { conditions.SetCondition(cb, &vi.Status.Conditions) }()
 
 	clusterDefaultSC, _ := ds.diskService.GetDefaultStorageClass(ctx)
-	sc, err := ds.storageClassService.GetStorageClass(vi.Spec.PersistentVolumeClaim.StorageClass, clusterDefaultSC)
+	sc, err := ds.storageClassService.GetValidatedStorageClass(vi.Spec.PersistentVolumeClaim.StorageClass, clusterDefaultSC)
 	if updated, err := setConditionFromStorageClassError(err, cb); err != nil || updated {
 		return reconcile.Result{}, err
 	}

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vd.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vd.go
@@ -229,7 +229,7 @@ func (ds ObjectRefVirtualDisk) StoreToPVC(ctx context.Context, vi *virtv2.Virtua
 	}
 
 	clusterDefaultSC, _ := ds.diskService.GetDefaultStorageClass(ctx)
-	sc, err := ds.storageClassService.GetStorageClass(vi.Spec.PersistentVolumeClaim.StorageClass, clusterDefaultSC)
+	sc, err := ds.storageClassService.GetValidatedStorageClass(vi.Spec.PersistentVolumeClaim.StorageClass, clusterDefaultSC)
 	if updated, err := setConditionFromStorageClassError(err, cb); err != nil || updated {
 		return reconcile.Result{}, err
 	}

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vi_on_pvc.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vi_on_pvc.go
@@ -206,7 +206,7 @@ func (ds ObjectRefDataVirtualImageOnPVC) StoreToPVC(ctx context.Context, vi, viR
 	}
 
 	clusterDefaultSC, _ := ds.diskService.GetDefaultStorageClass(ctx)
-	sc, err := ds.storageClassService.GetStorageClass(vi.Spec.PersistentVolumeClaim.StorageClass, clusterDefaultSC)
+	sc, err := ds.storageClassService.GetValidatedStorageClass(vi.Spec.PersistentVolumeClaim.StorageClass, clusterDefaultSC)
 	if updated, err := setConditionFromStorageClassError(err, cb); err != nil || updated {
 		return reconcile.Result{}, err
 	}

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/registry.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/registry.go
@@ -99,7 +99,7 @@ func (ds RegistryDataSource) StoreToPVC(ctx context.Context, vi *virtv2.VirtualI
 	}
 
 	clusterDefaultSC, _ := ds.diskService.GetDefaultStorageClass(ctx)
-	sc, err := ds.storageClassService.GetStorageClass(vi.Spec.PersistentVolumeClaim.StorageClass, clusterDefaultSC)
+	sc, err := ds.storageClassService.GetValidatedStorageClass(vi.Spec.PersistentVolumeClaim.StorageClass, clusterDefaultSC)
 	if updated, err := setConditionFromStorageClassError(err, cb); err != nil || updated {
 		return reconcile.Result{}, err
 	}

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/upload.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/upload.go
@@ -102,7 +102,7 @@ func (ds UploadDataSource) StoreToPVC(ctx context.Context, vi *virtv2.VirtualIma
 	}
 
 	clusterDefaultSC, _ := ds.diskService.GetDefaultStorageClass(ctx)
-	sc, err := ds.storageClassService.GetStorageClass(vi.Spec.PersistentVolumeClaim.StorageClass, clusterDefaultSC)
+	sc, err := ds.storageClassService.GetValidatedStorageClass(vi.Spec.PersistentVolumeClaim.StorageClass, clusterDefaultSC)
 	if updated, err := setConditionFromStorageClassError(err, cb); err != nil || updated {
 		return reconcile.Result{}, err
 	}

--- a/images/virtualization-artifact/pkg/controller/vi/internal/storageclass_ready.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/storageclass_ready.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -35,7 +36,7 @@ import (
 )
 
 type StorageClassReadyHandler struct {
-	service  DiskService
+	svc      StorageClassService
 	recorder eventrecord.EventRecorderLogger
 }
 
@@ -43,9 +44,9 @@ func (h StorageClassReadyHandler) Name() string {
 	return "StorageClassReadyHandler"
 }
 
-func NewStorageClassReadyHandler(recorder eventrecord.EventRecorderLogger, diskService DiskService) *StorageClassReadyHandler {
+func NewStorageClassReadyHandler(recorder eventrecord.EventRecorderLogger, svc StorageClassService) *StorageClassReadyHandler {
 	return &StorageClassReadyHandler{
-		service:  diskService,
+		svc:      svc,
 		recorder: recorder,
 	}
 }
@@ -71,58 +72,162 @@ func (h StorageClassReadyHandler) Handle(ctx context.Context, vi *virtv2.Virtual
 	}
 
 	supgen := supplements.NewGenerator(annotations.VIShortName, vi.Name, vi.Namespace, vi.UID)
-	pvc, err := h.service.GetPersistentVolumeClaim(ctx, supgen)
+	pvc, err := h.svc.GetPersistentVolumeClaim(ctx, supgen)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	hasNoStorageClassInSpec := vi.Spec.PersistentVolumeClaim.StorageClass == nil || *vi.Spec.PersistentVolumeClaim.StorageClass == ""
-	hasStorageClassInStatus := vi.Status.StorageClassName != ""
-	var storageClassName *string
+	// Reset storage class every time.
+	vi.Status.StorageClassName = ""
 
-	sc, err := h.service.GetStorageClass(ctx, storageClassName)
-	if err != nil && !errors.Is(err, service.ErrDefaultStorageClassNotFound) && !errors.Is(err, service.ErrStorageClassNotFound) {
-		return reconcile.Result{}, err
+	// 1. PVC already exists: used storage class is known.
+	if pvc != nil {
+		return reconcile.Result{}, h.setFromExistingPVC(ctx, vi, pvc, cb)
 	}
 
-	switch {
-	case pvc != nil && pvc.Spec.StorageClassName != nil && *pvc.Spec.StorageClassName != "":
-		vi.Status.StorageClassName = *pvc.Spec.StorageClassName
-	case vi.Spec.PersistentVolumeClaim.StorageClass != nil && *vi.Spec.PersistentVolumeClaim.StorageClass != "":
-		vi.Status.StorageClassName = *vi.Spec.PersistentVolumeClaim.StorageClass
-	case !hasStorageClassInStatus && sc != nil:
-		vi.Status.StorageClassName = sc.Name
+	// 2. VirtualImage has storage class in the spec.
+	if vi.Spec.PersistentVolumeClaim.StorageClass != nil && *vi.Spec.PersistentVolumeClaim.StorageClass != "" {
+		return reconcile.Result{}, h.setFromSpec(ctx, vi, cb)
 	}
 
-	switch {
-	case sc != nil:
+	// 3. Try to use default storage class from the module settings.
+	moduleStorageClass, err := h.svc.GetModuleStorageClass(ctx)
+	if err != nil && !errors.Is(err, service.ErrDefaultStorageClassNotFound) {
+		return reconcile.Result{}, fmt.Errorf("get module storage class: %w", err)
+	}
+
+	if moduleStorageClass != nil {
+		h.setFromModuleSettings(vi, moduleStorageClass, cb)
+		return reconcile.Result{}, nil
+	}
+
+	// 4. Try to use default storage class from the cluster.
+	defaultStorageClass, err := h.svc.GetDefaultStorageClass(ctx)
+	if err != nil && !errors.Is(err, service.ErrDefaultStorageClassNotFound) {
+		return reconcile.Result{}, fmt.Errorf("get default storage class: %w", err)
+	}
+
+	if defaultStorageClass != nil {
+		h.setFromDefault(vi, defaultStorageClass, cb)
+		return reconcile.Result{}, nil
+	}
+
+	msg := "The default StorageClass was not found in either the cluster or the module settings. Please specify a StorageClass name explicitly in the spec."
+	h.recorder.Event(
+		vi,
+		corev1.EventTypeWarning,
+		virtv2.ReasonVIStorageClassNotFound,
+		msg,
+	)
+	cb.
+		Status(metav1.ConditionFalse).
+		Reason(vicondition.StorageClassNotFound).
+		Message(msg)
+	return reconcile.Result{}, nil
+}
+
+func (h StorageClassReadyHandler) setFromSpec(ctx context.Context, vi *virtv2.VirtualImage, cb *conditions.ConditionBuilder) error {
+	vi.Status.StorageClassName = *vi.Spec.PersistentVolumeClaim.StorageClass
+
+	if !h.svc.IsStorageClassAllowed(*vi.Spec.PersistentVolumeClaim.StorageClass) {
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(vicondition.StorageClassNotReady).
+			Message(fmt.Sprintf("The specified StorageClass %q is not allowed. Please check the module settings.", vi.Status.StorageClassName))
+		return nil
+	}
+
+	sc, err := h.svc.GetStorageClass(ctx, *vi.Spec.PersistentVolumeClaim.StorageClass)
+	if err != nil {
+		return fmt.Errorf("get storage class specified in spec: %w", err)
+	}
+
+	if sc == nil {
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(vicondition.StorageClassNotFound).
+			Message(fmt.Sprintf("The specified StorageClass %q was not found.", vi.Status.StorageClassName))
+		return nil
+	}
+
+	if !sc.DeletionTimestamp.IsZero() {
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(vicondition.StorageClassNotReady).
+			Message(fmt.Sprintf("The specified StorageClass %q is terminating and cannot be used.", vi.Status.StorageClassName))
+		return nil
+	}
+
+	cb.
+		Status(metav1.ConditionTrue).
+		Reason(vicondition.StorageClassReady).
+		Message("")
+	return nil
+}
+
+func (h StorageClassReadyHandler) setFromExistingPVC(ctx context.Context, vi *virtv2.VirtualImage, pvc *corev1.PersistentVolumeClaim, cb *conditions.ConditionBuilder) error {
+	if pvc.Spec.StorageClassName == nil || *pvc.Spec.StorageClassName == "" {
+		return fmt.Errorf("pvc does not have storage class")
+	}
+
+	vi.Status.StorageClassName = *pvc.Spec.StorageClassName
+
+	sc, err := h.svc.GetStorageClass(ctx, *pvc.Spec.StorageClassName)
+	if err != nil {
+		return fmt.Errorf("get storage class used by pvc: %w", err)
+	}
+
+	if sc == nil {
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(vicondition.StorageClassNotFound).
+			Message(fmt.Sprintf("The StorageClass %q used by the underlying PersistentVolumeClaim was not found.", vi.Status.StorageClassName))
+		return nil
+	}
+
+	if sc.DeletionTimestamp != nil {
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(vicondition.StorageClassNotReady).
+			Message(fmt.Sprintf("The StorageClass %q used by the underlying PersistentVolumeClaim is terminating and cannot be used.", vi.Status.StorageClassName))
+		return nil
+	}
+
+	cb.
+		Status(metav1.ConditionTrue).
+		Reason(vicondition.StorageClassReady).
+		Message("")
+	return nil
+}
+
+func (h StorageClassReadyHandler) setFromModuleSettings(vi *virtv2.VirtualImage, moduleStorageClass *storagev1.StorageClass, cb *conditions.ConditionBuilder) {
+	vi.Status.StorageClassName = moduleStorageClass.Name
+
+	if moduleStorageClass.DeletionTimestamp.IsZero() {
 		cb.
 			Status(metav1.ConditionTrue).
 			Reason(vicondition.StorageClassReady).
 			Message("")
-	case hasNoStorageClassInSpec:
-		h.recorder.Event(
-			vi,
-			corev1.EventTypeNormal,
-			virtv2.ReasonVDStorageClassNotFound,
-			"The default storage class was not found in cluster. Please specify the storage class name in the virtual disk specification.",
-		)
+	} else {
 		cb.
 			Status(metav1.ConditionFalse).
-			Reason(vicondition.StorageClassNotFound).
-			Message("The default storage class was not found in cluster. Please specify the storage class name in the virtual image or virtualization module config specification.")
-	default:
-		h.recorder.Eventf(
-			vi,
-			corev1.EventTypeNormal,
-			virtv2.ReasonVDStorageClassNotFound,
-			"Storage class %q not found", *vi.Spec.PersistentVolumeClaim.StorageClass,
-		)
-		cb.
-			Status(metav1.ConditionFalse).
-			Reason(vicondition.StorageClassNotFound).
-			Message(fmt.Sprintf("Storage class %q not found", *vi.Spec.PersistentVolumeClaim.StorageClass))
+			Reason(vicondition.StorageClassNotReady).
+			Message(fmt.Sprintf("The default StorageClass %q, defined in the module settings, is terminating and cannot be used.", vi.Status.StorageClassName))
 	}
+}
 
-	return reconcile.Result{}, nil
+func (h StorageClassReadyHandler) setFromDefault(vi *virtv2.VirtualImage, defaultStorageClass *storagev1.StorageClass, cb *conditions.ConditionBuilder) {
+	vi.Status.StorageClassName = defaultStorageClass.Name
+
+	if defaultStorageClass.DeletionTimestamp.IsZero() {
+		cb.
+			Status(metav1.ConditionTrue).
+			Reason(vicondition.StorageClassReady).
+			Message("")
+	} else {
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(vicondition.StorageClassNotReady).
+			Message(fmt.Sprintf("The default StorageClass %q is terminating and cannot be used.", vi.Status.StorageClassName))
+	}
 }

--- a/images/virtualization-artifact/pkg/controller/vi/vi_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vi/vi_controller.go
@@ -65,7 +65,7 @@ func NewController(
 	uploader := service.NewUploaderService(dvcr, mgr.GetClient(), uploaderImage, requirements, PodPullPolicy, PodVerbose, ControllerName, protection)
 	bounder := service.NewBounderPodService(dvcr, mgr.GetClient(), bounderImage, requirements, PodPullPolicy, PodVerbose, ControllerName, protection)
 	disk := service.NewDiskService(mgr.GetClient(), dvcr, protection, ControllerName)
-	scService := service.NewVirtualImageStorageClassService(storageClassSettings)
+	scService := service.NewVirtualImageStorageClassService(storageClassSettings, disk)
 	recorder := eventrecord.NewEventRecorderLogger(mgr, ControllerName)
 
 	sources := source.NewSources()
@@ -76,7 +76,7 @@ func NewController(
 
 	reconciler := NewReconciler(
 		mgr.GetClient(),
-		internal.NewStorageClassReadyHandler(recorder, disk),
+		internal.NewStorageClassReadyHandler(recorder, scService),
 		internal.NewDatasourceReadyHandler(sources),
 		internal.NewLifeCycleHandler(sources, mgr.GetClient()),
 		internal.NewDeletionHandler(sources),


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
- handle default storage class from the module config
- fix `StorageClassReady` condition

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
When a VirtualImage is created without the StorageClass field in its specification and the default storage class is absent from the ModuleConfig, it is not handled after updating the default storage class in the ModuleConfig.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
The default storage class field works properly in the reconciliation loop of the VirtualImage resource.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: vi,vd 
type: fix
summary: "The `VirtualImageDefaultStorageClass` from the `ModuleConfig` is handled correctly now." 
```
