### PR TITLE
test(vmop): add test vmop migration cancel

### DIFF
--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -509,7 +509,7 @@ var _ = Describe("Complex test", ginkgoutil.CommonE2ETestDecorators(), func() {
 
 				vms := strings.Split(res.StdOut(), " ")
 
-				MigrateVirtualMachines(testCaseLabel, conf.TestData.ComplexTest, vms...)
+				MigrateVirtualMachines(testCaseLabel, vms...)
 			})
 		})
 

--- a/tests/e2e/config/config.go
+++ b/tests/e2e/config/config.go
@@ -148,6 +148,7 @@ type TestData struct {
 	VmConfiguration       string `yaml:"vmConfiguration"`
 	VmLabelAnnotation     string `yaml:"vmLabelAnnotation"`
 	VmMigration           string `yaml:"vmMigration"`
+	VmMigrationCancel     string `yaml:"vmMigrationCancel"`
 	VmDiskAttachment      string `yaml:"vmDiskAttachment"`
 	VmVersions            string `yaml:"vmVersions"`
 	VdSnapshots           string `yaml:"vdSnapshots"`

--- a/tests/e2e/default_config.yaml
+++ b/tests/e2e/default_config.yaml
@@ -30,6 +30,7 @@ testData:
   vmConfiguration: "/tmp/testdata/vm-configuration"
   vmLabelAnnotation: "/tmp/testdata/vm-label-annotation"
   vmMigration: "/tmp/testdata/vm-migration"
+  vmMigrationCancel: "/tmp/testdata/vm-migration-cancel"
   vmDiskAttachment: "/tmp/testdata/vm-disk-attachment"
   vmVersions: "/tmp/testdata/vm-versions"
   vdSnapshots: "/tmp/testdata/vd-snapshots"

--- a/tests/e2e/kubectl/kubectl.go
+++ b/tests/e2e/kubectl/kubectl.go
@@ -86,6 +86,7 @@ type DeleteOptions struct {
 	IgnoreNotFound bool
 	Labels         map[string]string
 	Namespace      string
+	Name           string
 	Recursive      bool
 	Resource       Resource
 }
@@ -386,6 +387,9 @@ func (k KubectlCMD) deleteOptions(cmd string, opts DeleteOptions) string {
 	cmd = k.addNamespace(cmd, opts.Namespace)
 	cmd = k.addLabels(cmd, opts.Labels, opts.ExcludedLabels)
 	cmd = k.addIgnoreNotFound(cmd, opts.IgnoreNotFound)
+	if opts.Name != "" {
+		cmd += fmt.Sprintf(" %s", opts.Name)
+	}
 	return cmd
 }
 

--- a/tests/e2e/sig_test.go
+++ b/tests/e2e/sig_test.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+)
+
+func SIGMigration() Labels {
+	return Label("SIG-Migration")
+}

--- a/tests/e2e/testdata/vm-migration-cancel/kustomization.yaml
+++ b/tests/e2e/testdata/vm-migration-cancel/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: testcases
+namePrefix: pr-number-or-commit-hash-
+resources:
+  - vi
+  - vm
+  - ns.yaml
+configurations:
+  - transformer.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      id: pr-number-or-commit-hash
+      testcase: vm-migration-cancel

--- a/tests/e2e/testdata/vm-migration-cancel/ns.yaml
+++ b/tests/e2e/testdata/vm-migration-cancel/ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default

--- a/tests/e2e/testdata/vm-migration-cancel/transformer.yaml
+++ b/tests/e2e/testdata/vm-migration-cancel/transformer.yaml
@@ -1,0 +1,52 @@
+namespace:
+  - kind: ClusterVirtualImage
+    path: spec/dataSource/objectRef/namespace
+nameReference:
+  - kind: VirtualImage
+    version: v1alpha2 # optional
+    fieldSpecs:
+      - path: spec/dataSource/objectRef/name
+        kind: ClusterVirtualImage
+      - path: spec/dataSource/objectRef/name
+        kind: VirtualImage
+      - path: spec/dataSource/objectRef/name
+        kind: VirtualDisk
+      - path: spec/blockDeviceRefs/name
+        kind: VirtualMachine
+  - kind: ClusterVirtualImage
+    version: v1alpha2 # optional
+    fieldSpecs:
+      - path: spec/dataSource/objectRef/name
+        kind: ClusterVirtualImage
+      - path: spec/dataSource/objectRef/name
+        kind: VirtualImage
+      - path: spec/dataSource/objectRef/name
+        kind: VirtualDisk
+      - path: spec/blockDeviceRefs/name
+        kind: VirtualMachine
+  - kind: VirtualDisk
+    version: v1alpha2 # optional
+    fieldSpecs:
+      - path: spec/blockDeviceRefs/name
+        kind: VirtualMachine
+      - path: spec/blockDeviceRef/name
+        kind: VirtualMachineBlockDeviceAttachment
+  - kind: Secret
+    fieldSpecs:
+      - path: spec/provisioning/userDataRef/name
+        kind: VirtualMachine
+  - kind: VirtualMachineIPAddress
+    version: v1alpha2
+    fieldSpecs:
+      - path: spec/virtualMachineIPAddressName
+        kind: VirtualMachine
+  - kind: VirtualMachine
+    version: v1alpha2
+    fieldSpecs:
+      - path: spec/virtualMachineName
+        kind: VirtualMachineBlockDeviceAttachment
+  - kind: VirtualMachineClass
+    version: v1alpha2
+    fieldSpecs:
+      - path: spec/virtualMachineClassName
+        kind: VirtualMachine

--- a/tests/e2e/testdata/vm-migration-cancel/vi/kustomization.yaml
+++ b/tests/e2e/testdata/vm-migration-cancel/vi/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - vi-alpine-http-bios.yaml
+  - vi-alpine-http-uefi.yaml

--- a/tests/e2e/testdata/vm-migration-cancel/vi/vi-alpine-http-bios.yaml
+++ b/tests/e2e/testdata/vm-migration-cancel/vi/vi-alpine-http-bios.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-alpine-http-bios
+spec:
+  storage: ContainerRegistry
+  dataSource:
+    type: HTTP
+    http:
+      url: https://89d64382-20df-4581-8cc7-80df331f67fa.selstorage.ru/alpine/alpine-3-21-bios-base.qcow2

--- a/tests/e2e/testdata/vm-migration-cancel/vi/vi-alpine-http-uefi.yaml
+++ b/tests/e2e/testdata/vm-migration-cancel/vi/vi-alpine-http-uefi.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-alpine-http-uefi
+spec:
+  storage: ContainerRegistry
+  dataSource:
+    type: HTTP
+    http:
+      url: https://89d64382-20df-4581-8cc7-80df331f67fa.selstorage.ru/alpine/alpine-3-21-uefi-base.qcow2

--- a/tests/e2e/testdata/vm-migration-cancel/vm/base/cfg/cloudinit.yaml
+++ b/tests/e2e/testdata/vm-migration-cancel/vm/base/cfg/cloudinit.yaml
@@ -1,0 +1,11 @@
+#cloud-config
+users:
+  - name: cloud
+    # passwd: cloud
+    passwd: $6$rounds=4096$vln/.aPHBOI7BMYR$bBMkqQvuGs5Gyd/1H5DP4m9HjQSy.kgrxpaGEHwkX7KEFV8BS.HZWPitAtZ2Vd8ZqIZRqmlykRCagTgPejt1i.
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    lock_passwd: false
+    ssh_authorized_keys:
+      # testcases
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFxcXHmwaGnJ8scJaEN5RzklBPZpVSic4GdaAsKjQoeA your_email@example.com

--- a/tests/e2e/testdata/vm-migration-cancel/vm/base/kustomization.yaml
+++ b/tests/e2e/testdata/vm-migration-cancel/vm/base/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./vm.yaml
+  - ./vd-root.yaml
+  - ./vd-blank.yaml
+configurations:
+  - transformer.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+secretGenerator:
+  - files:
+      - userData=cfg/cloudinit.yaml
+    name: cloud-init
+    type: provisioning.virtualization.deckhouse.io/cloud-init

--- a/tests/e2e/testdata/vm-migration-cancel/vm/base/transformer.yaml
+++ b/tests/e2e/testdata/vm-migration-cancel/vm/base/transformer.yaml
@@ -1,0 +1,54 @@
+# https://github.com/kubernetes-sigs/kustomize/blob/master/examples/transformerconfigs/README.md#transformer-configurations
+
+namespace:
+  - kind: ClusterVirtualImage
+    path: spec/dataSource/objectRef/namespace
+nameReference:
+  - kind: VirtualImage
+    version: v1alpha2 # optional
+    fieldSpecs:
+      - path: spec/dataSource/objectRef/name
+        kind: ClusterVirtualImage
+      - path: spec/dataSource/objectRef/name
+        kind: VirtualImage
+      - path: spec/dataSource/objectRef/name
+        kind: VirtualDisk
+      - path: spec/blockDeviceRefs/name
+        kind: VirtualMachine
+  - kind: ClusterVirtualImage
+    version: v1alpha2 # optional
+    fieldSpecs:
+      - path: spec/dataSource/objectRef/name
+        kind: ClusterVirtualImage
+      - path: spec/dataSource/objectRef/name
+        kind: VirtualImage
+      - path: spec/dataSource/objectRef/name
+        kind: VirtualDisk
+      - path: spec/blockDeviceRefs/name
+        kind: VirtualMachine
+  - kind: VirtualDisk
+    version: v1alpha2 # optional
+    fieldSpecs:
+      - path: spec/blockDeviceRefs/name
+        kind: VirtualMachine
+      - path: spec/blockDeviceRef/name
+        kind: VirtualMachineBlockDeviceAttachment
+  - kind: Secret
+    fieldSpecs:
+      - path: spec/provisioning/userDataRef/name
+        kind: VirtualMachine
+  - kind: VirtualMachineIPAddress
+    version: v1alpha2
+    fieldSpecs:
+      - path: spec/virtualMachineIPAddressName
+        kind: VirtualMachine
+  - kind: VirtualMachine
+    version: v1alpha2
+    fieldSpecs:
+      - path: spec/virtualMachineName
+        kind: VirtualMachineBlockDeviceAttachment
+  - kind: VirtualMachineClass
+    version: v1alpha2
+    fieldSpecs:
+      - path: spec/virtualMachineClassName
+        kind: VirtualMachine

--- a/tests/e2e/testdata/vm-migration-cancel/vm/base/vd-blank.yaml
+++ b/tests/e2e/testdata/vm-migration-cancel/vm/base/vd-blank.yaml
@@ -1,0 +1,7 @@
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualDisk
+metadata:
+  name: vd-blank
+spec:
+  persistentVolumeClaim:
+    size: 100Mi

--- a/tests/e2e/testdata/vm-migration-cancel/vm/base/vd-root.yaml
+++ b/tests/e2e/testdata/vm-migration-cancel/vm/base/vd-root.yaml
@@ -1,0 +1,12 @@
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualDisk
+metadata:
+  name: vd-root
+spec:
+  persistentVolumeClaim:
+    size: 512Mi
+  dataSource:
+    type: ObjectRef
+    objectRef:
+      kind: VirtualImage
+      name: vi-alpine-http

--- a/tests/e2e/testdata/vm-migration-cancel/vm/base/vm.yaml
+++ b/tests/e2e/testdata/vm-migration-cancel/vm/base/vm.yaml
@@ -1,0 +1,24 @@
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualMachine
+metadata:
+  name: vm
+spec:
+  bootloader: EFI
+  virtualMachineClassName: generic
+  cpu:
+    cores: 1
+    coreFraction: 5%
+  memory:
+    size: 4Gi
+  disruptions:
+    restartApprovalMode: Manual
+  provisioning:
+    type: UserDataRef
+    userDataRef:
+      kind: Secret
+      name: cloud-init
+  blockDeviceRefs:
+    - kind: VirtualDisk
+      name: vd-root
+    - kind: VirtualDisk
+      name: vd-blank

--- a/tests/e2e/testdata/vm-migration-cancel/vm/kustomization.yaml
+++ b/tests/e2e/testdata/vm-migration-cancel/vm/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - overlays/migration-bios
+  - overlays/migration-uefi

--- a/tests/e2e/testdata/vm-migration-cancel/vm/overlays/migration-bios/kustomization.yaml
+++ b/tests/e2e/testdata/vm-migration-cancel/vm/overlays/migration-bios/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+nameSuffix: -migration-bios
+resources:
+  - ../../base
+patches:
+  - path: vd.image.patch.yaml
+  - patch: |-
+      - op: replace
+        path: /spec/bootloader
+        value: BIOS
+    target:
+      kind: VirtualMachine
+      name: vm

--- a/tests/e2e/testdata/vm-migration-cancel/vm/overlays/migration-bios/vd.image.patch.yaml
+++ b/tests/e2e/testdata/vm-migration-cancel/vm/overlays/migration-bios/vd.image.patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualDisk
+metadata:
+  name: vd-root
+spec:
+  dataSource:
+    type: ObjectRef
+    objectRef:
+      kind: VirtualImage
+      name: vi-alpine-http-bios

--- a/tests/e2e/testdata/vm-migration-cancel/vm/overlays/migration-uefi/kustomization.yaml
+++ b/tests/e2e/testdata/vm-migration-cancel/vm/overlays/migration-uefi/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+nameSuffix: -migration-uefi
+resources:
+  - ../../base
+patches:
+  - path: vd.image.patch.yaml
+  - path: vm.bootloader.patch.yaml

--- a/tests/e2e/testdata/vm-migration-cancel/vm/overlays/migration-uefi/vd.image.patch.yaml
+++ b/tests/e2e/testdata/vm-migration-cancel/vm/overlays/migration-uefi/vd.image.patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualDisk
+metadata:
+  name: vd-root
+spec:
+  dataSource:
+    type: ObjectRef
+    objectRef:
+      kind: VirtualImage
+      name: vi-alpine-http-uefi

--- a/tests/e2e/testdata/vm-migration-cancel/vm/overlays/migration-uefi/vm.bootloader.patch.yaml
+++ b/tests/e2e/testdata/vm-migration-cancel/vm/overlays/migration-uefi/vm.bootloader.patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualMachine
+metadata:
+  name: vm
+spec:
+  bootloader: EFI

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -297,7 +297,10 @@ func WaitByLabel(resource kc.Resource, opts kc.WaitOptions) {
 	})
 	Expect(res.Error()).NotTo(HaveOccurred(), res.StdErr())
 
-	resources := strings.Split(res.StdOut(), " ")
+	var resources []string
+	if stdout := res.StdOut(); stdout != "" {
+		resources = strings.Split(res.StdOut(), " ")
+	}
 	WaitResources(resources, resource, opts)
 }
 

--- a/tests/e2e/vm_migration_cancel_test.go
+++ b/tests/e2e/vm_migration_cancel_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	virtv1 "kubevirt.io/api/core/v1"
+
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/tests/e2e/config"
+	"github.com/deckhouse/virtualization/tests/e2e/d8"
+	"github.com/deckhouse/virtualization/tests/e2e/ginkgoutil"
+	kc "github.com/deckhouse/virtualization/tests/e2e/kubectl"
+)
+
+var _ = Describe("Virtual machine migration cancel", SIGMigration(), ginkgoutil.CommonE2ETestDecorators(), func() {
+	testCaseLabel := map[string]string{"testcase": "vm-migration-cancel"}
+
+	BeforeEach(func() {
+		kustomization := fmt.Sprintf("%s/%s", conf.TestData.VmMigrationCancel, "kustomization.yaml")
+		ns, err := kustomize.GetNamespace(kustomization)
+		Expect(err).NotTo(HaveOccurred(), "%w", err)
+		conf.SetNamespace(ns)
+
+		res := kubectl.Apply(kc.ApplyOptions{
+			Filename:       []string{conf.TestData.VmMigrationCancel},
+			FilenameOption: kc.Kustomize,
+		})
+		Expect(res.WasSuccess()).To(Equal(true), res.StdErr())
+	})
+
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			SaveTestResources(testCaseLabel, CurrentSpecReport().LeafNodeText)
+		}
+		resourcesToDelete := ResourcesToDelete{
+			AdditionalResources: []AdditionalResource{
+				{
+					Resource: kc.ResourceVMOP,
+					Labels:   testCaseLabel,
+				},
+			},
+		}
+
+		if config.IsCleanUpNeeded() {
+			resourcesToDelete.KustomizationDir = conf.TestData.VmMigrationCancel
+		}
+		DeleteTestCaseResources(resourcesToDelete)
+	})
+
+	It("Cancel migrate", func() {
+		By("Virtual machine agents should be ready")
+		WaitVmAgentReady(kc.WaitOptions{
+			Labels:    testCaseLabel,
+			Namespace: conf.Namespace,
+			Timeout:   MaxWaitTimeout,
+		})
+
+		vms := &virtv2.VirtualMachineList{}
+		err := GetObjects(kc.ResourceVM, vms, kc.GetOptions{Labels: testCaseLabel, Namespace: conf.Namespace})
+		Expect(err).NotTo(HaveOccurred())
+
+		vmNames := make([]string, len(vms.Items))
+		for i, vm := range vms.Items {
+			vmNames[i] = vm.GetName()
+		}
+
+		for _, name := range vmNames {
+			By(fmt.Sprintf("Exec SSHCommand for virtualmachine %s/%s", conf.Namespace, name))
+			res := d8Virtualization.SshCommand(name, "sudo nohup stress-ng --vm 1 --vm-bytes 100% --timeout 600s &>/dev/null &", d8.SshOptions{
+				Namespace:   conf.Namespace,
+				Username:    conf.TestData.SshUser,
+				IdenityFile: conf.TestData.Sshkey,
+				Timeout:     ShortTimeout,
+			})
+			Expect(res.WasSuccess()).To(BeTrue(), res.StdErr())
+		}
+
+		By("Wait until stress-ng loads the memory more heavily")
+		time.Sleep(20 * time.Second)
+
+		By("Starting migrations for virtual machines")
+		MigrateVirtualMachines(testCaseLabel, vmNames...)
+
+		someCompleted := false
+
+		Eventually(func() error {
+			vmops := &virtv2.VirtualMachineOperationList{}
+			err := GetObjects(kc.ResourceVMOP, vmops, kc.GetOptions{Labels: testCaseLabel, Namespace: conf.Namespace})
+			if err != nil {
+				return err
+			}
+
+			if len(vmops.Items) == 0 {
+				return nil
+			}
+
+			kvvmis := &virtv1.VirtualMachineInstanceList{}
+			err = GetObjects(kc.ResourceKubevirtVMI, kvvmis, kc.GetOptions{Labels: testCaseLabel, Namespace: conf.Namespace})
+			if err != nil {
+				return err
+			}
+
+			kvvmisByName := make(map[string]*virtv1.VirtualMachineInstance, len(kvvmis.Items))
+			for _, kvvmi := range kvvmis.Items {
+				kvvmisByName[kvvmi.Name] = &kvvmi
+			}
+
+			migrationReady := make(map[string]struct{})
+			for _, vmop := range vmops.Items {
+				if kvvmi := kvvmisByName[vmop.Spec.VirtualMachine]; kvvmi != nil {
+					if kvvmi.Status.MigrationState != nil && !kvvmi.Status.MigrationState.StartTimestamp.IsZero() {
+						migrationReady[vmop.Name] = struct{}{}
+					}
+				}
+			}
+
+			for _, vmop := range vmops.Items {
+				switch vmop.Status.Phase {
+				case virtv2.VMOPPhaseInProgress:
+					_, readyToDelete := migrationReady[vmop.Name]
+
+					if readyToDelete && vmop.GetDeletionTimestamp().IsZero() {
+						res := kubectl.Delete(kc.DeleteOptions{
+							Resource:  kc.ResourceVMOP,
+							Name:      vmop.GetName(),
+							Namespace: vmop.GetNamespace(),
+						})
+						if !res.WasSuccess() {
+							return res.Error()
+						}
+					}
+				case virtv2.VMOPPhaseFailed, virtv2.VMOPPhaseCompleted:
+					someCompleted = true
+					return nil
+				}
+			}
+			return fmt.Errorf("retry because not all vmops canceled")
+
+		}).WithTimeout(MaxWaitTimeout).WithPolling(time.Second).ShouldNot(HaveOccurred())
+
+		Expect(someCompleted).Should(BeFalse())
+
+		By("Get Kubevirt VMIs for check abort status")
+		kvvmis := &virtv1.VirtualMachineInstanceList{}
+		err = GetObjects(kc.ResourceKubevirtVMI, kvvmis, kc.GetOptions{Labels: testCaseLabel, Namespace: conf.Namespace})
+		Expect(err).NotTo(HaveOccurred())
+
+		for _, kvvmi := range kvvmis.Items {
+			migrationState := kvvmi.Status.MigrationState
+			Expect(migrationState).NotTo(BeNil())
+
+			Expect(migrationState.AbortRequested).To(BeTrue())
+
+			validAbortStatus := migrationState.AbortStatus == virtv1.MigrationAbortFailed || migrationState.AbortStatus == virtv1.MigrationAbortSucceeded
+			Expect(validAbortStatus).To(BeTrue())
+		}
+	})
+})

--- a/tests/e2e/vm_migration_test.go
+++ b/tests/e2e/vm_migration_test.go
@@ -29,17 +29,12 @@ import (
 	kc "github.com/deckhouse/virtualization/tests/e2e/kubectl"
 )
 
-const (
-	InternalApiVersion = "internal.virtualization.deckhouse.io/v1"
-	KubevirtVMIMKind   = "InternalVirtualizationVirtualMachineInstanceMigration"
-)
-
-func MigrateVirtualMachines(label map[string]string, templatePath string, virtualMachines ...string) {
+func MigrateVirtualMachines(label map[string]string, virtualMachines ...string) {
 	GinkgoHelper()
-	CreateAndApplyVMOPs(label, virtv2.VMOPTypeMigrate, virtualMachines...)
+	CreateAndApplyVMOPs(label, virtv2.VMOPTypeEvict, virtualMachines...)
 }
 
-var _ = Describe("Virtual machine migration", ginkgoutil.CommonE2ETestDecorators(), func() {
+var _ = Describe("Virtual machine migration", SIGMigration(), ginkgoutil.CommonE2ETestDecorators(), func() {
 	testCaseLabel := map[string]string{"testcase": "vm-migration"}
 
 	AfterEach(func() {
@@ -80,28 +75,6 @@ var _ = Describe("Virtual machine migration", ginkgoutil.CommonE2ETestDecorators
 		})
 	})
 
-	Context("When virtual images are applied", func() {
-		It("checks VIs phases", func() {
-			By(fmt.Sprintf("VIs should be in %s phases", PhaseReady))
-			WaitPhaseByLabel(kc.ResourceVI, PhaseReady, kc.WaitOptions{
-				Labels:    testCaseLabel,
-				Namespace: conf.Namespace,
-				Timeout:   MaxWaitTimeout,
-			})
-		})
-	})
-
-	Context("When virtual disks are applied", func() {
-		It("checks VDs phases", func() {
-			By(fmt.Sprintf("VDs should be in %s phases", PhaseReady))
-			WaitPhaseByLabel(kc.ResourceVD, PhaseReady, kc.WaitOptions{
-				Labels:    testCaseLabel,
-				Namespace: conf.Namespace,
-				Timeout:   MaxWaitTimeout,
-			})
-		})
-	})
-
 	Context("When virtual machines are applied", func() {
 		It("checks VMs phases", func() {
 			By("Virtual machine agents should be ready")
@@ -123,7 +96,7 @@ var _ = Describe("Virtual machine migration", ginkgoutil.CommonE2ETestDecorators
 			Expect(res.WasSuccess()).To(Equal(true), res.StdErr())
 
 			vms := strings.Split(res.StdOut(), " ")
-			MigrateVirtualMachines(testCaseLabel, conf.TestData.VmMigration, vms...)
+			MigrateVirtualMachines(testCaseLabel, vms...)
 		})
 	})
 


### PR DESCRIPTION
## Description
add test vmop migration cancel


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [X] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: vmop
type: feature
summary: add test vmop migration cancel 
impact_level: low
```
