### PR TITLE
chore(ci): set github runner to ubuntu-22.04 for validation ci

### DIFF
--- a/.github/workflows/dev_validation.yaml
+++ b/.github/workflows/dev_validation.yaml
@@ -32,7 +32,7 @@ defaults:
 jobs:
   paths_filter:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'validation/skip/helm_templates') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Filter changed paths
     outputs:
       helm_templates: ${{ steps.paths_filter.outputs.helm_templates }}
@@ -53,7 +53,7 @@ jobs:
 
   no_cyrillic:
     if: "!contains(github.event.pull_request.labels.*.name, 'validation/skip/no_cyrillic')"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Validation no-cyrillic
     steps:
       - name: Set up Go ${{ env.GO_VERSION }}
@@ -77,7 +77,7 @@ jobs:
 
   doc_changes:
     if: "!contains(github.event.pull_request.labels.*.name, 'validation/skip/doc_changes')"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Validation doc-changes
     steps:
       - name: Set up Go ${{ env.GO_VERSION }}
@@ -101,7 +101,7 @@ jobs:
 
   copyright:
     if: "!contains(github.event.pull_request.labels.*.name, 'validation/skip/copyright')"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Validation copyright
     steps:
       - name: Set up Go ${{ env.GO_VERSION }}
@@ -127,7 +127,7 @@ jobs:
   helm_templates:
     needs: paths_filter
     if: ${{ needs.paths_filter.outputs.helm_templates == 'true' && !contains(github.event.pull_request.labels.*.name, 'validation/skip/helm_templates') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Validate helm templates with OpenAPI schemas
     steps:
       - name: Install Task

--- a/.github/workflows/dev_validation.yaml
+++ b/.github/workflows/dev_validation.yaml
@@ -32,7 +32,7 @@ defaults:
 jobs:
   paths_filter:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'validation/skip/helm_templates') }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     name: Filter changed paths
     outputs:
       helm_templates: ${{ steps.paths_filter.outputs.helm_templates }}
@@ -53,7 +53,7 @@ jobs:
 
   no_cyrillic:
     if: "!contains(github.event.pull_request.labels.*.name, 'validation/skip/no_cyrillic')"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     name: Validation no-cyrillic
     steps:
       - name: Set up Go ${{ env.GO_VERSION }}
@@ -77,7 +77,7 @@ jobs:
 
   doc_changes:
     if: "!contains(github.event.pull_request.labels.*.name, 'validation/skip/doc_changes')"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     name: Validation doc-changes
     steps:
       - name: Set up Go ${{ env.GO_VERSION }}
@@ -101,7 +101,7 @@ jobs:
 
   copyright:
     if: "!contains(github.event.pull_request.labels.*.name, 'validation/skip/copyright')"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     name: Validation copyright
     steps:
       - name: Set up Go ${{ env.GO_VERSION }}
@@ -127,6 +127,8 @@ jobs:
   helm_templates:
     needs: paths_filter
     if: ${{ needs.paths_filter.outputs.helm_templates == 'true' && !contains(github.event.pull_request.labels.*.name, 'validation/skip/helm_templates') }}
+    # 22.04 image contains Helm v3.17.2, it is not affected by MaxDecompressedFileSize limit.
+    # TODO change back to latest after Helm people fix this issue: https://github.com/helm/helm/issues/30738
     runs-on: ubuntu-22.04
     name: Validate helm templates with OpenAPI schemas
     steps:


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Set github runner to ubuntu-22.04 for validation ci to resolve issue in helm`MaxDecompressedFileSize in v3.17.3`

_Github runner [ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#package-management) has Helm 3.17.2_

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
Fix issue for Helm MaxDecompressedFileSize in v3.17.3 breaks existing charts

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
This kind of error should not appear
```
Error: chart file "pack-06f1f1e37225d4f66574349a84f9965285a33fa6.pack" is larger than the maximum file size 5242880

[51](https://github.com/deckhouse/virtualization/actions/runs/14497617070/job/40669259973?pr=919#step:4:52)helm.go:86: 2025-04-16 16:22:33.394135655 +0000 UTC m=+11.354853839 \[debug\] chart file "pack-06f1f1e37225d4f66574349a84f9965285a33fa6.pack" is larger than the maximum file size 5242880
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: ci
type: chore
summary: set github runner to ubuntu-22.04 for validation ci to resolve issue in helm`MaxDecompressedFileSize in v3.17.3`
```
