### PR TITLE
chore(core): replace binaries with self-build binaries in virt-launcher and virt-handler

### DIFF
--- a/base-images/deckhouse_images.yml
+++ b/base-images/deckhouse_images.yml
@@ -1,20 +1,22 @@
-# version v0.4.1
+# version v0.4.2
 # REGISTRY_PATH is a special key which is concatenated with other base images
 REGISTRY_PATH: registry.deckhouse.io/base_images
 base/distroless: "sha256:f2ac3320ce677484d7aef4608f99ddf0055d8907cc3509f8cccc8513f314c31a" # fromImage: builder/scratch
 base/nginx-static: "sha256:28a844d4ff777dc704d3808bdd1240108315f4d1ed1668e762627b9c4ddc8d66" # fromImage: base/distroless
-base/python: "sha256:432f19eaeb5035ea38e3fbc721576e6802c679fd0fb7a8e6d441fdb36944c180" # fromImage: base/distroless
+base/python: "sha256:05fb7868d518fe6c562233e1ee1c9304f6d5142920959e7b2d51acdc49cce0c3" # fromImage: base/distroless
 builder/alpine: "sha256:92adb9e8a387c645ba4eeedb08f9a6de0583c5d1d496bf9c9b3a89fe963a6a06" # from: alpine:3.20.6
-builder/alt: "sha256:6fe06774a942e293e28b85cf3307e0f6e79a1593352c9c5ca97a6cbefdce0a55" # from: registry.altlinux.org/p11/alt:20241211
+builder/alt: "sha256:622b42515875104dccaa5c6ff411962b6cb973522a388b8fdf3dcb2349be98bc" # from: registry.altlinux.org/p11/alt:20250321
 builder/golang-alpine: "sha256:482aab8cb49614acb14ce9397861b02d05cc222d893d689abd205c9bd2c17b46" # from: golang:1.24.2-alpine3.20
 builder/golang-bookworm: "sha256:3755a67e7d3f16995b1615694a2aae7a95618a1ff9603b23f347764dfa0242b2" # from: golang:1.24.2-bookworm
 builder/golang-bullseye: "sha256:7f2838a3779bb9759accba1cbea7ea7aa086cc67ec763718004febb47948570c" # from: golang:1.24.2-bullseye
 builder/node-alpine: "sha256:f09f957ee8e960c7afee93d7a30f20116e76660c0408d35109ee9a9fa2a4d5b0" # from: node:23.10.0-alpine3.20
 builder/scratch: "sha256:10b5855ae3e20ecc2ba6eb3d7f8365ee2facc98a62c9e4840927ad4074bd2317" # from: registry.werf.io/werf/scratch
+builder/src: "sha256:c3a2d14cfe649b836c53fe570ea72555b9981d9dc2ab05377f1c63d9d1cd0378" # fromImage: builder/alt
 tools/bash: "sha256:892cd63bafb70b529377833c374009db5e9759c0aa72b165aff4ba52b59a45c6" # fromImage: builder/scratch
+tools/coreutils: "sha256:72b1d2d7aa251da697ee6251330affca25df5972519948dba5f1831012ee16a3" # fromImage: builder/scratch
 tools/cosign: "sha256:d62c8deb048d9d02e5ea3b9f1efa9a940625c746f3c568a283c346c844a8acf8" # fromImage: builder/scratch
 tools/grep: "sha256:48e485161d6cec13d5283d03e69e2d1ff9e1c6146d040dc3bf623d856b62a636" # fromImage: builder/scratch
 tools/jq: "sha256:71aac8b711bef4dbef462d6309e283812358b9920301ad3de23a5734a18a23f2" # fromImage: builder/scratch
 tools/less: "sha256:259d88c1a732e7d3fc8d067ea0324684e1fe73a3bbb3eb7e2a9d88212a4ee2a0" # fromImage: builder/scratch
-tools/vim: "sha256:66db26b1475c389df02b8a8f9b98ff6993b2a2b51085f88a0cf618b915086de6" # fromImage: builder/scratch
+tools/vim: "sha256:0764a55e7a2d4a1a332092b315bcabca027e1d16c8897193dd1e816b71055001" # fromImage: builder/scratch
 tools/yq4: "sha256:35911ea155806ec3b29c5d6eec90184d3d836bb42037f9865fb5949ab7a4cd6c" # fromImage: builder/scratch

--- a/images/virt-handler/werf.inc.yaml
+++ b/images/virt-handler/werf.inc.yaml
@@ -6,6 +6,15 @@ import:
   add: /relocate
   to: /
   after: install
+# GNU utilities
+# deps for 031-hotplug-container-disk.patch
+- image: tools/coreutils
+  add: /
+  to: /
+  after: install
+  includePaths:
+  - usr/bin/cp
+  - usr/bin/coreutils
 - image: virt-artifact
   add: /kubevirt-binaries/
   to: /usr/bin
@@ -47,8 +56,6 @@ packages:
 - qemu-img
 - xorriso
 binaries:
-# deps for 031-hotplug-container-disk.patch
-- /usr/bin/cp
 - /usr/bin/qemu-img
 - /usr/bin/qemu-nbd
 - /usr/bin/mount

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -136,9 +136,6 @@ packages:
   - msulogin
   - xorriso
 binaries:
-  # GNU utilities
-  - /usr/bin/cp
-  - /usr/bin/sleep
   # Gnu utils (requared for swtpm)
   - /usr/bin/certtool
   - /usr/bin/gnutls-cli
@@ -241,6 +238,15 @@ import:
   add: /swtpm
   to: /relocate
   after: setup
+- image: tools/coreutils
+  add: /
+  to: /relocate
+  after: setup
+  includePaths:
+    # GNU utilities
+  - usr/bin/cp
+  - usr/bin/sleep
+  - usr/bin/coreutils
 - image: {{ $.ImageName }}-cbuilder
   add: /bins
   to: /relocate/usr/bin


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Replace `cp` and `sleep` to self-build binaries coreutils
- virt-launcher `cp` and `sleep`
- virt-handler `cp`

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
We want more control when building binary files, as well as making images more secure

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
All work as expected

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: core
type: chore
summary: replace binaries with self-build binaries in virt-launcher and virt-handler
impact_level: low
```
