### PR TITLE
fix(vd,vi): fix issues with storage class condition display

### DIFF
--- a/api/core/v1alpha2/events.go
+++ b/api/core/v1alpha2/events.go
@@ -64,12 +64,11 @@ const (
 	// ReasonVMOPInProgress is event reason that the operation is in progress
 	ReasonVMOPInProgress = "VirtualMachineOperationInProgress"
 
-	// ReasonVDStorageClassWasDeleted is event reason that VDStorageClass was deleted.
-	ReasonVDStorageClassWasDeleted = "VirtualDiskStorageClassWasDeleted"
-	// ReasonVDStorageClassNotFound is event reason that VDStorageClass not found.
-	ReasonVDStorageClassNotFound = "VirtualDiskStorageClassNotFound"
-	// ReasonVDSpecChanged is event reason that VDStorageClass is chanded.
-	ReasonVDSpecChanged = "VirtualDiskSpecChanged"
+	// ReasonVDSpecHasBeenChanged is event reason that spec of virtual disk has been changed.
+	ReasonVDSpecHasBeenChanged = "VirtualDiskSpecHasBeenChanged"
+	// ReasonVISpecHasBeenChanged is event reason that spec of virtual image has been changed.
+	ReasonVISpecHasBeenChanged = "VirtualImageSpecHasBeenChanged"
+
 	// ReasonVDContainerRegistrySecretNotFound is event reason that VDContainerRegistrySecret not found.
 	ReasonVDContainerRegistrySecretNotFound = "VirtualDiskContainerRegistrySecretNotFound"
 

--- a/api/core/v1alpha2/vicondition/condition.go
+++ b/api/core/v1alpha2/vicondition/condition.go
@@ -87,6 +87,8 @@ const (
 	QuotaExceeded ReadyReason = "QuotaExceeded"
 	// ImagePullFailed indicates that there was an issue with importing from DVCR.
 	ImagePullFailed ReadyReason = "ImagePullFailed"
+	// DatasourceNotReady indicates that the datasource is not ready, which prevents the import process from starting.
+	DatasourceNotReady ReadyReason = "DatasourceNotReady"
 
 	// Lost indicates that the underlying PersistentVolumeClaim has been lost and the `VirtualImage` can no longer be used.
 	Lost ReadyReason = "PVCLost"

--- a/images/virtualization-artifact/pkg/controller/service/base_storage_class_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/base_storage_class_service.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"context"
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/deckhouse/virtualization-controller/pkg/common/annotations"
+	"github.com/deckhouse/virtualization-controller/pkg/common/object"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/supplements"
+)
+
+type BaseStorageClassService struct {
+	client client.Client
+}
+
+func NewBaseStorageClassService(client client.Client) *BaseStorageClassService {
+	return &BaseStorageClassService{client: client}
+}
+
+func (s BaseStorageClassService) GetDefaultStorageClass(ctx context.Context) (*storagev1.StorageClass, error) {
+	var scs storagev1.StorageClassList
+	err := s.client.List(ctx, &scs, &client.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	var defaultClasses []*storagev1.StorageClass
+	for idx := range scs.Items {
+		if scs.Items[idx].Annotations[annotations.AnnDefaultStorageClass] == "true" {
+			defaultClasses = append(defaultClasses, &scs.Items[idx])
+		}
+	}
+
+	if len(defaultClasses) == 0 {
+		return nil, ErrDefaultStorageClassNotFound
+	}
+
+	// Primary sort by creation timestamp, newest first.
+	// Secondary sort by class name, ascending order.
+	sort.Slice(defaultClasses, func(i, j int) bool {
+		if defaultClasses[i].CreationTimestamp.UnixNano() == defaultClasses[j].CreationTimestamp.UnixNano() {
+			return defaultClasses[i].Name < defaultClasses[j].Name
+		}
+		return defaultClasses[i].CreationTimestamp.UnixNano() > defaultClasses[j].CreationTimestamp.UnixNano()
+	})
+
+	return defaultClasses[0], nil
+}
+
+func (s BaseStorageClassService) GetStorageClass(ctx context.Context, scName string) (*storagev1.StorageClass, error) {
+	return object.FetchObject(ctx, types.NamespacedName{Name: scName}, s.client, &storagev1.StorageClass{})
+}
+
+func (s BaseStorageClassService) GetPersistentVolumeClaim(ctx context.Context, sup *supplements.Generator) (*corev1.PersistentVolumeClaim, error) {
+	return object.FetchObject(ctx, sup.PersistentVolumeClaim(), s.client, &corev1.PersistentVolumeClaim{})
+}

--- a/images/virtualization-artifact/pkg/controller/service/errors.go
+++ b/images/virtualization-artifact/pkg/controller/service/errors.go
@@ -18,14 +18,11 @@ package service
 
 import (
 	"errors"
-	"fmt"
 )
 
 var (
-	ErrStorageClassNotFound               = errors.New("storage class not found")
 	ErrStorageProfileNotFound             = errors.New("storage profile not found")
 	ErrDefaultStorageClassNotFound        = errors.New("default storage class not found")
-	ErrStorageClassNotAllowed             = errors.New("storage class not allowed")
 	ErrDataVolumeNotRunning               = errors.New("pvc importer is not running")
 	ErrDataVolumeProvisionerUnschedulable = errors.New("provisioner unschedulable")
 )
@@ -34,31 +31,3 @@ var (
 	ErrIPAddressAlreadyExist = errors.New("the IP address is already allocated")
 	ErrIPAddressOutOfRange   = errors.New("the IP address is out of range")
 )
-
-type VirtualDiskUsedByImageError struct {
-	vdName string
-}
-
-func (e VirtualDiskUsedByImageError) Error() string {
-	return fmt.Sprintf("the virtual disk %q already used by creating image", e.vdName)
-}
-
-func NewVirtualDiskUsedByImageError(name string) error {
-	return VirtualDiskUsedByImageError{
-		vdName: name,
-	}
-}
-
-type VirtualDiskUsedByVirtualMachineError struct {
-	vdName string
-}
-
-func (e VirtualDiskUsedByVirtualMachineError) Error() string {
-	return fmt.Sprintf("the virtual disk %q already used by running virtual machine", e.vdName)
-}
-
-func NewVirtualDiskUsedByVirtualMachineError(name string) error {
-	return VirtualDiskUsedByVirtualMachineError{
-		vdName: name,
-	}
-}

--- a/images/virtualization-artifact/pkg/controller/service/mock.go
+++ b/images/virtualization-artifact/pkg/controller/service/mock.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sync"
 )
@@ -31,7 +32,7 @@ var _ Client = &ClientMock{}
 //			DeleteAllOfFunc: func(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
 //				panic("mock out the DeleteAllOf method")
 //			},
-//			GetFunc: func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+//			GetFunc: func(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
 //				panic("mock out the Get method")
 //			},
 //			GroupVersionKindForFunc: func(obj runtime.Object) (schema.GroupVersionKind, error) {
@@ -78,7 +79,7 @@ type ClientMock struct {
 	DeleteAllOfFunc func(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error
 
 	// GetFunc mocks the Get method.
-	GetFunc func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error
+	GetFunc func(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error
 
 	// GroupVersionKindForFunc mocks the GroupVersionKindFor method.
 	GroupVersionKindForFunc func(obj runtime.Object) (schema.GroupVersionKind, error)
@@ -141,7 +142,7 @@ type ClientMock struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// Key is the key argument value.
-			Key client.ObjectKey
+			Key types.NamespacedName
 			// Obj is the obj argument value.
 			Obj client.Object
 			// Opts is the opts argument value.
@@ -337,13 +338,13 @@ func (mock *ClientMock) DeleteAllOfCalls() []struct {
 }
 
 // Get calls GetFunc.
-func (mock *ClientMock) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+func (mock *ClientMock) Get(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
 	if mock.GetFunc == nil {
 		panic("ClientMock.GetFunc: method is nil but Client.Get was just called")
 	}
 	callInfo := struct {
 		Ctx  context.Context
-		Key  client.ObjectKey
+		Key  types.NamespacedName
 		Obj  client.Object
 		Opts []client.GetOption
 	}{
@@ -364,13 +365,13 @@ func (mock *ClientMock) Get(ctx context.Context, key client.ObjectKey, obj clien
 //	len(mockedClient.GetCalls())
 func (mock *ClientMock) GetCalls() []struct {
 	Ctx  context.Context
-	Key  client.ObjectKey
+	Key  types.NamespacedName
 	Obj  client.Object
 	Opts []client.GetOption
 } {
 	var calls []struct {
 		Ctx  context.Context
-		Key  client.ObjectKey
+		Key  types.NamespacedName
 		Obj  client.Object
 		Opts []client.GetOption
 	}

--- a/images/virtualization-artifact/pkg/controller/vd/internal/interfaces.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/interfaces.go
@@ -41,7 +41,6 @@ type Sources interface {
 type DiskService interface {
 	Resize(ctx context.Context, pvc *corev1.PersistentVolumeClaim, newSize resource.Quantity) error
 	GetPersistentVolumeClaim(ctx context.Context, sup *supplements.Generator) (*corev1.PersistentVolumeClaim, error)
-	GetStorageClass(ctx context.Context, storageClassName *string) (*storagev1.StorageClass, error)
 }
 
 type StorageClassService interface {

--- a/images/virtualization-artifact/pkg/controller/vd/internal/life_cycle.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/life_cycle.go
@@ -73,7 +73,7 @@ func (h LifeCycleHandler) Handle(ctx context.Context, vd *virtv2.VirtualDisk) (r
 		h.recorder.Event(
 			vd,
 			corev1.EventTypeNormal,
-			virtv2.ReasonVDStorageClassWasDeleted,
+			virtv2.ReasonVDSpecHasBeenChanged,
 			"Spec changes are detected: import process is restarted by controller",
 		)
 

--- a/images/virtualization-artifact/pkg/controller/vd/internal/mock.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/mock.go
@@ -403,9 +403,6 @@ var _ DiskService = &DiskServiceMock{}
 //			GetPersistentVolumeClaimFunc: func(ctx context.Context, sup *supplements.Generator) (*corev1.PersistentVolumeClaim, error) {
 //				panic("mock out the GetPersistentVolumeClaim method")
 //			},
-//			GetStorageClassFunc: func(ctx context.Context, storageClassName *string) (*storagev1.StorageClass, error) {
-//				panic("mock out the GetStorageClass method")
-//			},
 //			ResizeFunc: func(ctx context.Context, pvc *corev1.PersistentVolumeClaim, newSize resource.Quantity) error {
 //				panic("mock out the Resize method")
 //			},
@@ -419,9 +416,6 @@ type DiskServiceMock struct {
 	// GetPersistentVolumeClaimFunc mocks the GetPersistentVolumeClaim method.
 	GetPersistentVolumeClaimFunc func(ctx context.Context, sup *supplements.Generator) (*corev1.PersistentVolumeClaim, error)
 
-	// GetStorageClassFunc mocks the GetStorageClass method.
-	GetStorageClassFunc func(ctx context.Context, storageClassName *string) (*storagev1.StorageClass, error)
-
 	// ResizeFunc mocks the Resize method.
 	ResizeFunc func(ctx context.Context, pvc *corev1.PersistentVolumeClaim, newSize resource.Quantity) error
 
@@ -434,13 +428,6 @@ type DiskServiceMock struct {
 			// Sup is the sup argument value.
 			Sup *supplements.Generator
 		}
-		// GetStorageClass holds details about calls to the GetStorageClass method.
-		GetStorageClass []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// StorageClassName is the storageClassName argument value.
-			StorageClassName *string
-		}
 		// Resize holds details about calls to the Resize method.
 		Resize []struct {
 			// Ctx is the ctx argument value.
@@ -452,7 +439,6 @@ type DiskServiceMock struct {
 		}
 	}
 	lockGetPersistentVolumeClaim sync.RWMutex
-	lockGetStorageClass          sync.RWMutex
 	lockResize                   sync.RWMutex
 }
 
@@ -489,42 +475,6 @@ func (mock *DiskServiceMock) GetPersistentVolumeClaimCalls() []struct {
 	mock.lockGetPersistentVolumeClaim.RLock()
 	calls = mock.calls.GetPersistentVolumeClaim
 	mock.lockGetPersistentVolumeClaim.RUnlock()
-	return calls
-}
-
-// GetStorageClass calls GetStorageClassFunc.
-func (mock *DiskServiceMock) GetStorageClass(ctx context.Context, storageClassName *string) (*storagev1.StorageClass, error) {
-	if mock.GetStorageClassFunc == nil {
-		panic("DiskServiceMock.GetStorageClassFunc: method is nil but DiskService.GetStorageClass was just called")
-	}
-	callInfo := struct {
-		Ctx              context.Context
-		StorageClassName *string
-	}{
-		Ctx:              ctx,
-		StorageClassName: storageClassName,
-	}
-	mock.lockGetStorageClass.Lock()
-	mock.calls.GetStorageClass = append(mock.calls.GetStorageClass, callInfo)
-	mock.lockGetStorageClass.Unlock()
-	return mock.GetStorageClassFunc(ctx, storageClassName)
-}
-
-// GetStorageClassCalls gets all the calls that were made to GetStorageClass.
-// Check the length with:
-//
-//	len(mockedDiskService.GetStorageClassCalls())
-func (mock *DiskServiceMock) GetStorageClassCalls() []struct {
-	Ctx              context.Context
-	StorageClassName *string
-} {
-	var calls []struct {
-		Ctx              context.Context
-		StorageClassName *string
-	}
-	mock.lockGetStorageClass.RLock()
-	calls = mock.calls.GetStorageClass
-	mock.lockGetStorageClass.RUnlock()
 	return calls
 }
 

--- a/images/virtualization-artifact/pkg/controller/vd/internal/service/vd_storage_class_service_test.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/service/vd_storage_class_service_test.go
@@ -19,28 +19,28 @@ package service
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	storev1 "k8s.io/api/storage/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	"github.com/deckhouse/virtualization-controller/pkg/config"
 )
 
-var _ = Describe("VirtualImageStorageClassService", func() {
+var _ = Describe("VirtualDiskStorageClassService", func() {
 	var (
-		service                    *VirtualImageStorageClassService
-		storageClassSettings       config.VirtualImageStorageClassSettings
-		clusterDefaultStorageClass *storev1.StorageClass
+		service                    *VirtualDiskStorageClassService
+		storageClassSettings       config.VirtualDiskStorageClassSettings
+		clusterDefaultStorageClass *storagev1.StorageClass
 	)
 
 	BeforeEach(func() {
-		clusterDefaultStorageClass = &storev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "default-cluster-storage"}}
+		clusterDefaultStorageClass = &storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "default-cluster-storage"}}
 	})
 
 	Context("when settings are empty", func() {
 		It("returns the storageClassFromSpec", func() {
-			storageClassSettings = config.VirtualImageStorageClassSettings{}
-			service = NewVirtualImageStorageClassService(storageClassSettings, nil)
+			storageClassSettings = config.VirtualDiskStorageClassSettings{}
+			service = NewVirtualDiskStorageClassService(nil, storageClassSettings)
 			sc := ptr.To("requested-storage-class")
 			storageClass, err := service.GetValidatedStorageClass(sc, clusterDefaultStorageClass)
 
@@ -51,8 +51,8 @@ var _ = Describe("VirtualImageStorageClassService", func() {
 
 	Context("when settings are empty and storageClassFromSpec is empty", func() {
 		It("returns the storageClassFromSpec", func() {
-			storageClassSettings = config.VirtualImageStorageClassSettings{}
-			service = NewVirtualImageStorageClassService(storageClassSettings, nil)
+			storageClassSettings = config.VirtualDiskStorageClassSettings{}
+			service = NewVirtualDiskStorageClassService(nil, storageClassSettings)
 
 			storageClass, err := service.GetValidatedStorageClass(nil, clusterDefaultStorageClass)
 
@@ -63,8 +63,8 @@ var _ = Describe("VirtualImageStorageClassService", func() {
 
 	Context("when settings and clusterDefaultStorageClass are empty", func() {
 		It("returns the storageClassFromSpec", func() {
-			storageClassSettings = config.VirtualImageStorageClassSettings{}
-			service = NewVirtualImageStorageClassService(storageClassSettings, nil)
+			storageClassSettings = config.VirtualDiskStorageClassSettings{}
+			service = NewVirtualDiskStorageClassService(nil, storageClassSettings)
 			sc := ptr.To("requested-storage-class")
 			storageClass, err := service.GetValidatedStorageClass(sc, nil)
 
@@ -73,40 +73,13 @@ var _ = Describe("VirtualImageStorageClassService", func() {
 		})
 	})
 
-	Context("when settings and clusterDefaultStorageClass are empty, but StorageClassName exist", func() {
-		BeforeEach(func() {
-			storageClassSettings = config.VirtualImageStorageClassSettings{
-				StorageClassName: "storage-class-name",
-			}
-			service = NewVirtualImageStorageClassService(storageClassSettings, nil)
-		})
-
-		It("return the StorageClassName if storageClassFromSpec is empty", func() {
-			storageClass, err := service.GetValidatedStorageClass(nil, nil)
-			Expect(err).To(BeNil())
-			Expect(storageClass).To(Equal(&storageClassSettings.StorageClassName))
-		})
-
-		It("return the StorageClassName if storageClassFromSpec equal StorageClassName", func() {
-			storageClass, err := service.GetValidatedStorageClass(&storageClassSettings.StorageClassName, nil)
-			Expect(err).To(BeNil())
-			Expect(storageClass).To(Equal(&storageClassSettings.StorageClassName))
-		})
-
-		It("return the err if storageClassFromSpec not equal StorageClassName", func() {
-			sc := ptr.To("requested-storage-class")
-			_, err := service.GetValidatedStorageClass(sc, nil)
-			Expect(err).To(Equal(ErrStorageClassNotAllowed))
-		})
-	})
-
 	Context("when AllowedStorageClassNames exist, but DefaultStorageClassName is empty", func() {
 		BeforeEach(func() {
-			storageClassSettings = config.VirtualImageStorageClassSettings{
+			storageClassSettings = config.VirtualDiskStorageClassSettings{
 				AllowedStorageClassNames: []string{"allowed-storage-class"},
 				DefaultStorageClassName:  "",
 			}
-			service = NewVirtualImageStorageClassService(storageClassSettings, nil)
+			service = NewVirtualDiskStorageClassService(nil, storageClassSettings)
 		})
 
 		It("returns the requested storage class if it's in the allowed list", func() {
@@ -132,11 +105,11 @@ var _ = Describe("VirtualImageStorageClassService", func() {
 
 	Context("when AllowedStorageClassNames is empty, but DefaultStorageClassName exist", func() {
 		BeforeEach(func() {
-			storageClassSettings = config.VirtualImageStorageClassSettings{
+			storageClassSettings = config.VirtualDiskStorageClassSettings{
 				AllowedStorageClassNames: []string{},
 				DefaultStorageClassName:  "default-storage-class",
 			}
-			service = NewVirtualImageStorageClassService(storageClassSettings, nil)
+			service = NewVirtualDiskStorageClassService(nil, storageClassSettings)
 		})
 
 		It("returns the default storage class if storageClassFromSpec is empty", func() {
@@ -163,11 +136,11 @@ var _ = Describe("VirtualImageStorageClassService", func() {
 
 	Context("when both AllowedStorageClassNames and DefaultStorageClassName exist", func() {
 		BeforeEach(func() {
-			storageClassSettings = config.VirtualImageStorageClassSettings{
+			storageClassSettings = config.VirtualDiskStorageClassSettings{
 				AllowedStorageClassNames: []string{"allowed-storage-class"},
 				DefaultStorageClassName:  "default-storage-class",
 			}
-			service = NewVirtualImageStorageClassService(storageClassSettings, nil)
+			service = NewVirtualDiskStorageClassService(nil, storageClassSettings)
 		})
 
 		It("returns the default storage class if storageClassFromSpec is empty", func() {

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/http.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/http.go
@@ -22,8 +22,10 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -49,13 +51,12 @@ import (
 const httpDataSource = "http"
 
 type HTTPDataSource struct {
-	statService         *service.StatService
-	importerService     *service.ImporterService
-	diskService         *service.DiskService
-	dvcrSettings        *dvcr.Settings
-	storageClassService *service.VirtualDiskStorageClassService
-	client              client.Client
-	recorder            eventrecord.EventRecorderLogger
+	statService     *service.StatService
+	importerService *service.ImporterService
+	diskService     *service.DiskService
+	dvcrSettings    *dvcr.Settings
+	client          client.Client
+	recorder        eventrecord.EventRecorderLogger
 }
 
 func NewHTTPDataSource(
@@ -64,17 +65,15 @@ func NewHTTPDataSource(
 	importerService *service.ImporterService,
 	diskService *service.DiskService,
 	dvcrSettings *dvcr.Settings,
-	storageClassService *service.VirtualDiskStorageClassService,
 	client client.Client,
 ) *HTTPDataSource {
 	return &HTTPDataSource{
-		statService:         statService,
-		importerService:     importerService,
-		diskService:         diskService,
-		dvcrSettings:        dvcrSettings,
-		storageClassService: storageClassService,
-		client:              client,
-		recorder:            recorder,
+		statService:     statService,
+		importerService: importerService,
+		diskService:     diskService,
+		dvcrSettings:    dvcrSettings,
+		client:          client,
+		recorder:        recorder,
 	}
 }
 
@@ -96,12 +95,6 @@ func (ds HTTPDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (reco
 	}
 	pvc, err := ds.diskService.GetPersistentVolumeClaim(ctx, supgen)
 	if err != nil {
-		return reconcile.Result{}, err
-	}
-
-	clusterDefaultSC, _ := ds.diskService.GetDefaultStorageClass(ctx)
-	sc, err := ds.storageClassService.GetValidatedStorageClass(vd.Spec.PersistentVolumeClaim.StorageClass, clusterDefaultSC)
-	if updated, err := setConditionFromStorageClassError(err, cb); err != nil || updated {
 		return reconcile.Result{}, err
 	}
 
@@ -251,6 +244,11 @@ func (ds HTTPDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (reco
 			return reconcile.Result{}, fmt.Errorf("failed to get importer tolerations: %w", err)
 		}
 
+		var sc *storagev1.StorageClass
+		sc, err = ds.diskService.GetStorageClass(ctx, vd.Status.StorageClassName)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
 		err = ds.diskService.Start(ctx, diskSize, sc, source, vd, supgen, service.WithNodePlacement(nodePlacement))
 		if updated, err := setPhaseConditionFromStorageError(err, vd, cb); err != nil || updated {
 			return reconcile.Result{}, err
@@ -321,10 +319,12 @@ func (ds HTTPDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (reco
 			return reconcile.Result{}, err
 		}
 
-		sc, err := ds.diskService.GetStorageClass(ctx, pvc.Spec.StorageClassName)
-		if updated, err := setPhaseConditionFromStorageError(err, vd, cb); err != nil || updated {
+		var sc *storagev1.StorageClass
+		sc, err = ds.diskService.GetStorageClass(ctx, ptr.Deref(pvc.Spec.StorageClassName, ""))
+		if err != nil {
 			return reconcile.Result{}, err
 		}
+
 		if err = setPhaseConditionForPVCProvisioningDisk(ctx, dv, vd, pvc, sc, cb, ds.diskService); err != nil {
 			return reconcile.Result{}, err
 		}

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/mock.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/mock.go
@@ -9,7 +9,7 @@ import (
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 	vsv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
-	storev1 "k8s.io/api/storage/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sync"
 )
@@ -239,7 +239,7 @@ var _ BlankDataSourceDiskService = &BlankDataSourceDiskServiceMock{}
 //			GetCapacityFunc: func(pvc *corev1.PersistentVolumeClaim) string {
 //				panic("mock out the GetCapacity method")
 //			},
-//			GetVolumeAndAccessModesFunc: func(ctx context.Context, sc *storev1.StorageClass) (corev1.PersistentVolumeMode, corev1.PersistentVolumeAccessMode, error) {
+//			GetVolumeAndAccessModesFunc: func(ctx context.Context, sc *storagev1.StorageClass) (corev1.PersistentVolumeMode, corev1.PersistentVolumeAccessMode, error) {
 //				panic("mock out the GetVolumeAndAccessModes method")
 //			},
 //		}
@@ -256,7 +256,7 @@ type BlankDataSourceDiskServiceMock struct {
 	GetCapacityFunc func(pvc *corev1.PersistentVolumeClaim) string
 
 	// GetVolumeAndAccessModesFunc mocks the GetVolumeAndAccessModes method.
-	GetVolumeAndAccessModesFunc func(ctx context.Context, sc *storev1.StorageClass) (corev1.PersistentVolumeMode, corev1.PersistentVolumeAccessMode, error)
+	GetVolumeAndAccessModesFunc func(ctx context.Context, sc *storagev1.StorageClass) (corev1.PersistentVolumeMode, corev1.PersistentVolumeAccessMode, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -277,7 +277,7 @@ type BlankDataSourceDiskServiceMock struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// Sc is the sc argument value.
-			Sc *storev1.StorageClass
+			Sc *storagev1.StorageClass
 		}
 	}
 	lockCleanUp                 sync.RWMutex
@@ -354,13 +354,13 @@ func (mock *BlankDataSourceDiskServiceMock) GetCapacityCalls() []struct {
 }
 
 // GetVolumeAndAccessModes calls GetVolumeAndAccessModesFunc.
-func (mock *BlankDataSourceDiskServiceMock) GetVolumeAndAccessModes(ctx context.Context, sc *storev1.StorageClass) (corev1.PersistentVolumeMode, corev1.PersistentVolumeAccessMode, error) {
+func (mock *BlankDataSourceDiskServiceMock) GetVolumeAndAccessModes(ctx context.Context, sc *storagev1.StorageClass) (corev1.PersistentVolumeMode, corev1.PersistentVolumeAccessMode, error) {
 	if mock.GetVolumeAndAccessModesFunc == nil {
 		panic("BlankDataSourceDiskServiceMock.GetVolumeAndAccessModesFunc: method is nil but BlankDataSourceDiskService.GetVolumeAndAccessModes was just called")
 	}
 	callInfo := struct {
 		Ctx context.Context
-		Sc  *storev1.StorageClass
+		Sc  *storagev1.StorageClass
 	}{
 		Ctx: ctx,
 		Sc:  sc,
@@ -377,11 +377,11 @@ func (mock *BlankDataSourceDiskServiceMock) GetVolumeAndAccessModes(ctx context.
 //	len(mockedBlankDataSourceDiskService.GetVolumeAndAccessModesCalls())
 func (mock *BlankDataSourceDiskServiceMock) GetVolumeAndAccessModesCalls() []struct {
 	Ctx context.Context
-	Sc  *storev1.StorageClass
+	Sc  *storagev1.StorageClass
 } {
 	var calls []struct {
 		Ctx context.Context
-		Sc  *storev1.StorageClass
+		Sc  *storagev1.StorageClass
 	}
 	mock.lockGetVolumeAndAccessModes.RLock()
 	calls = mock.calls.GetVolumeAndAccessModes

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref.go
@@ -45,14 +45,13 @@ func NewObjectRefDataSource(
 	statService *service.StatService,
 	diskService *service.DiskService,
 	client client.Client,
-	storageClassService *service.VirtualDiskStorageClassService,
 ) *ObjectRefDataSource {
 	return &ObjectRefDataSource{
 		diskService:      diskService,
 		vdSnapshotSyncer: NewObjectRefVirtualDiskSnapshot(recorder, diskService, client),
-		viDVCRSyncer:     NewObjectRefVirtualImageDVCR(recorder, statService, diskService, storageClassService, client),
-		viPVCSyncer:      NewObjectRefVirtualImagePVC(recorder, diskService, storageClassService, client),
-		cviSyncer:        NewObjectRefClusterVirtualImage(recorder, statService, diskService, storageClassService, client),
+		viDVCRSyncer:     NewObjectRefVirtualImageDVCR(recorder, statService, diskService, client),
+		viPVCSyncer:      NewObjectRefVirtualImagePVC(recorder, diskService, client),
+		cviSyncer:        NewObjectRefClusterVirtualImage(recorder, statService, diskService, client),
 	}
 }
 

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_vi_dvcr.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_vi_dvcr.go
@@ -22,8 +22,10 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -44,26 +46,23 @@ import (
 )
 
 type ObjectRefVirtualImageDVCR struct {
-	statService         *service.StatService
-	diskService         *service.DiskService
-	storageClassService *service.VirtualDiskStorageClassService
-	client              client.Client
-	recorder            eventrecord.EventRecorderLogger
+	statService *service.StatService
+	diskService *service.DiskService
+	client      client.Client
+	recorder    eventrecord.EventRecorderLogger
 }
 
 func NewObjectRefVirtualImageDVCR(
 	recorder eventrecord.EventRecorderLogger,
 	statService *service.StatService,
 	diskService *service.DiskService,
-	storageClassService *service.VirtualDiskStorageClassService,
 	client client.Client,
 ) *ObjectRefVirtualImageDVCR {
 	return &ObjectRefVirtualImageDVCR{
-		statService:         statService,
-		diskService:         diskService,
-		storageClassService: storageClassService,
-		client:              client,
-		recorder:            recorder,
+		statService: statService,
+		diskService: diskService,
+		client:      client,
+		recorder:    recorder,
 	}
 }
 
@@ -93,12 +92,6 @@ func (ds ObjectRefVirtualImageDVCR) Sync(ctx context.Context, vd *virtv2.Virtual
 	}
 	if vi == nil {
 		return reconcile.Result{}, errors.New("the source virtual image not found")
-	}
-
-	clusterDefaultSC, _ := ds.diskService.GetDefaultStorageClass(ctx)
-	sc, err := ds.storageClassService.GetValidatedStorageClass(vd.Spec.PersistentVolumeClaim.StorageClass, clusterDefaultSC)
-	if updated, err := setConditionFromStorageClassError(err, cb); err != nil || updated {
-		return reconcile.Result{}, err
 	}
 
 	var dvQuotaNotExceededCondition *cdiv1.DataVolumeCondition
@@ -163,6 +156,12 @@ func (ds ObjectRefVirtualImageDVCR) Sync(ctx context.Context, vd *virtv2.Virtual
 		if err != nil {
 			setPhaseConditionToFailed(cb, &vd.Status.Phase, fmt.Errorf("unexpected error: %w", err))
 			return reconcile.Result{}, fmt.Errorf("failed to get importer tolerations: %w", err)
+		}
+
+		var sc *storagev1.StorageClass
+		sc, err = ds.diskService.GetStorageClass(ctx, vd.Status.StorageClassName)
+		if err != nil {
+			return reconcile.Result{}, err
 		}
 
 		err = ds.diskService.Start(ctx, diskSize, sc, source, vd, supgen, service.WithNodePlacement(nodePlacement))
@@ -233,10 +232,13 @@ func (ds ObjectRefVirtualImageDVCR) Sync(ctx context.Context, vd *virtv2.Virtual
 		if err != nil {
 			return reconcile.Result{}, err
 		}
-		sc, err := ds.diskService.GetStorageClass(ctx, pvc.Spec.StorageClassName)
-		if updated, err := setPhaseConditionFromStorageError(err, vd, cb); err != nil || updated {
+
+		var sc *storagev1.StorageClass
+		sc, err = ds.diskService.GetStorageClass(ctx, ptr.Deref(pvc.Spec.StorageClassName, ""))
+		if err != nil {
 			return reconcile.Result{}, err
 		}
+
 		if err = setPhaseConditionForPVCProvisioningDisk(ctx, dv, vd, pvc, sc, cb, ds.diskService); err != nil {
 			return reconcile.Result{}, err
 		}

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/registry.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/registry.go
@@ -22,9 +22,11 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -50,13 +52,12 @@ import (
 const registryDataSource = "registry"
 
 type RegistryDataSource struct {
-	statService         *service.StatService
-	importerService     *service.ImporterService
-	diskService         *service.DiskService
-	dvcrSettings        *dvcr.Settings
-	client              client.Client
-	storageClassService *service.VirtualDiskStorageClassService
-	recorder            eventrecord.EventRecorderLogger
+	statService     *service.StatService
+	importerService *service.ImporterService
+	diskService     *service.DiskService
+	dvcrSettings    *dvcr.Settings
+	client          client.Client
+	recorder        eventrecord.EventRecorderLogger
 }
 
 func NewRegistryDataSource(
@@ -66,16 +67,14 @@ func NewRegistryDataSource(
 	diskService *service.DiskService,
 	dvcrSettings *dvcr.Settings,
 	client client.Client,
-	storageClassService *service.VirtualDiskStorageClassService,
 ) *RegistryDataSource {
 	return &RegistryDataSource{
-		statService:         statService,
-		importerService:     importerService,
-		diskService:         diskService,
-		dvcrSettings:        dvcrSettings,
-		client:              client,
-		storageClassService: storageClassService,
-		recorder:            recorder,
+		statService:     statService,
+		importerService: importerService,
+		diskService:     diskService,
+		dvcrSettings:    dvcrSettings,
+		client:          client,
+		recorder:        recorder,
 	}
 }
 
@@ -97,12 +96,6 @@ func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (
 	}
 	pvc, err := ds.diskService.GetPersistentVolumeClaim(ctx, supgen)
 	if err != nil {
-		return reconcile.Result{}, err
-	}
-
-	clusterDefaultSC, _ := ds.diskService.GetDefaultStorageClass(ctx)
-	sc, err := ds.storageClassService.GetValidatedStorageClass(vd.Spec.PersistentVolumeClaim.StorageClass, clusterDefaultSC)
-	if updated, err := setConditionFromStorageClassError(err, cb); err != nil || updated {
 		return reconcile.Result{}, err
 	}
 
@@ -250,6 +243,12 @@ func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (
 			return reconcile.Result{}, fmt.Errorf("failed to get importer tolerations: %w", err)
 		}
 
+		var sc *storagev1.StorageClass
+		sc, err = ds.diskService.GetStorageClass(ctx, vd.Status.StorageClassName)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
 		err = ds.diskService.Start(ctx, diskSize, sc, source, vd, supgen, service.WithNodePlacement(nodePlacement))
 		if updated, err := setPhaseConditionFromStorageError(err, vd, cb); err != nil || updated {
 			return reconcile.Result{}, err
@@ -318,10 +317,13 @@ func (ds RegistryDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) (
 		if err != nil {
 			return reconcile.Result{}, err
 		}
-		sc, err := ds.diskService.GetStorageClass(ctx, pvc.Spec.StorageClassName)
-		if updated, err := setPhaseConditionFromStorageError(err, vd, cb); err != nil || updated {
+
+		var sc *storagev1.StorageClass
+		sc, err = ds.diskService.GetStorageClass(ctx, ptr.Deref(pvc.Spec.StorageClassName, ""))
+		if err != nil {
 			return reconcile.Result{}, err
 		}
+
 		if err = setPhaseConditionForPVCProvisioningDisk(ctx, dv, vd, pvc, sc, cb, ds.diskService); err != nil {
 			return reconcile.Result{}, err
 		}

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/sources.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/sources.go
@@ -130,27 +130,6 @@ type CheckImportProcess interface {
 	CheckImportProcess(ctx context.Context, dv *cdiv1.DataVolume, pvc *corev1.PersistentVolumeClaim) error
 }
 
-func setConditionFromStorageClassError(err error, cb *conditions.ConditionBuilder) (bool, error) {
-	switch {
-	case err == nil:
-		return false, nil
-	case errors.Is(err, service.ErrStorageClassNotFound):
-		cb.
-			Status(metav1.ConditionFalse).
-			Reason(vdcondition.ProvisioningFailed).
-			Message("Provided StorageClass not found in the cluster.")
-		return true, nil
-	case errors.Is(err, service.ErrStorageClassNotAllowed):
-		cb.
-			Status(metav1.ConditionFalse).
-			Reason(vdcondition.ProvisioningFailed).
-			Message("Specified StorageClass is not allowed: please check the module settings.")
-		return true, nil
-	default:
-		return false, err
-	}
-}
-
 func setPhaseConditionFromStorageError(err error, vd *virtv2.VirtualDisk, cb *conditions.ConditionBuilder) (bool, error) {
 	switch {
 	case err == nil:
@@ -161,13 +140,6 @@ func setPhaseConditionFromStorageError(err error, vd *virtv2.VirtualDisk, cb *co
 			Status(metav1.ConditionFalse).
 			Reason(vdcondition.ProvisioningFailed).
 			Message("StorageProfile not found in the cluster: Please check a StorageClass name in the cluster or set a default StorageClass.")
-		return true, nil
-	case errors.Is(err, service.ErrStorageClassNotFound):
-		vd.Status.Phase = virtv2.DiskPending
-		cb.
-			Status(metav1.ConditionFalse).
-			Reason(vdcondition.ProvisioningFailed).
-			Message("Provided StorageClass not found in the cluster.")
 		return true, nil
 	case errors.Is(err, service.ErrDefaultStorageClassNotFound):
 		vd.Status.Phase = virtv2.DiskPending

--- a/images/virtualization-artifact/pkg/controller/vi/internal/life_cycle.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/life_cycle.go
@@ -20,24 +20,29 @@ import (
 	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/vi/internal/source"
+	"github.com/deckhouse/virtualization-controller/pkg/eventrecord"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vicondition"
 )
 
 type LifeCycleHandler struct {
-	client  client.Client
-	sources Sources
+	client   client.Client
+	sources  Sources
+	recorder eventrecord.EventRecorderLogger
 }
 
-func NewLifeCycleHandler(sources Sources, client client.Client) *LifeCycleHandler {
+func NewLifeCycleHandler(recorder eventrecord.EventRecorderLogger, sources Sources, client client.Client) *LifeCycleHandler {
 	return &LifeCycleHandler{
-		client:  client,
-		sources: sources,
+		recorder: recorder,
+		client:   client,
+		sources:  sources,
 	}
 }
 
@@ -62,20 +67,17 @@ func (h LifeCycleHandler) Handle(ctx context.Context, vi *virtv2.VirtualImage) (
 		vi.Status.Phase = virtv2.ImagePending
 	}
 
-	dataSourceReadyCondition, exists := conditions.GetCondition(vicondition.DatasourceReadyType, vi.Status.Conditions)
-	if !exists {
-		return reconcile.Result{}, fmt.Errorf("condition %s not found, but required", vicondition.DatasourceReadyType)
-	}
-
-	if dataSourceReadyCondition.Status != metav1.ConditionTrue {
-		return reconcile.Result{}, nil
-	}
-
 	if readyCondition.Status != metav1.ConditionTrue && h.sources.Changed(ctx, vi) {
+		h.recorder.Event(
+			vi,
+			corev1.EventTypeNormal,
+			virtv2.ReasonVISpecHasBeenChanged,
+			"Spec changes are detected: import process is restarted by controller",
+		)
+
+		// Reset status and start import again.
 		vi.Status = virtv2.VirtualImageStatus{
-			Phase:              virtv2.ImagePending,
-			Conditions:         vi.Status.Conditions,
-			ObservedGeneration: vi.Status.ObservedGeneration,
+			Phase: virtv2.ImagePending,
 		}
 
 		_, err := h.sources.CleanUp(ctx, vi)
@@ -83,41 +85,38 @@ func (h LifeCycleHandler) Handle(ctx context.Context, vi *virtv2.VirtualImage) (
 			return reconcile.Result{}, err
 		}
 
-		vi.Status.StorageClassName = ""
-
 		return reconcile.Result{Requeue: true}, nil
 	}
 
-	storageClassReadyCondition, ok := conditions.GetCondition(vicondition.StorageClassReadyType, vi.Status.Conditions)
-	if !ok {
-		return reconcile.Result{Requeue: true}, fmt.Errorf("condition %s not found", vicondition.StorageClassReadyType)
-	}
+	cb := conditions.NewConditionBuilder(vicondition.ReadyType).Generation(vi.Generation)
 
-	if readyCondition.Status != metav1.ConditionTrue && (vi.Spec.Storage == virtv2.StorageKubernetes || vi.Spec.Storage == virtv2.StoragePersistentVolumeClaim) && storageClassReadyCondition.Status != metav1.ConditionTrue {
-		readyCB := conditions.NewConditionBuilder(vicondition.ReadyType).
-			Generation(vi.Generation).
+	// TODO: Reconciliation in source handlers for ready images should not be blocked by a missing datasource.
+	datasourceReadyCondition, _ := conditions.GetCondition(vicondition.DatasourceReadyType, vi.Status.Conditions)
+	if datasourceReadyCondition.Status != metav1.ConditionTrue || !conditions.IsLastUpdated(datasourceReadyCondition, vi) {
+		cb.
 			Status(metav1.ConditionFalse).
-			Reason(vicondition.StorageClassNotReady).
-			Message("Storage class is not ready, please read the StorageClassReady condition state.")
-		conditions.SetCondition(readyCB, &vi.Status.Conditions)
+			Reason(vicondition.DatasourceNotReady).
+			Message("Datasource is not ready.")
+		conditions.SetCondition(cb, &vi.Status.Conditions)
+
+		return reconcile.Result{}, nil
 	}
 
-	if (vi.Spec.Storage == virtv2.StorageKubernetes || vi.Spec.Storage == virtv2.StoragePersistentVolumeClaim) &&
-		readyCondition.Status != metav1.ConditionTrue &&
-		storageClassReadyCondition.Status != metav1.ConditionTrue &&
-		vi.Status.StorageClassName != "" {
-		vi.Status = virtv2.VirtualImageStatus{
-			Phase:              virtv2.ImagePending,
-			Conditions:         vi.Status.Conditions,
-			ObservedGeneration: vi.Status.ObservedGeneration,
-			StorageClassName:   vi.Status.StorageClassName,
+	if !source.IsImageProvisioningFinished(readyCondition) && (vi.Spec.Storage == virtv2.StorageKubernetes || vi.Spec.Storage == virtv2.StoragePersistentVolumeClaim) {
+		storageClassReady, _ := conditions.GetCondition(vicondition.StorageClassReadyType, vi.Status.Conditions)
+		if storageClassReady.Status != metav1.ConditionTrue || !conditions.IsLastUpdated(storageClassReady, vi) {
+			cb.
+				Status(metav1.ConditionFalse).
+				Reason(vicondition.StorageClassNotReady).
+				Message("Storage class in not ready")
+			conditions.SetCondition(cb, &vi.Status.Conditions)
+
+			return reconcile.Result{}, nil
 		}
 
-		_, err := h.sources.CleanUp(ctx, vi)
-		if err != nil {
-			return reconcile.Result{}, fmt.Errorf("failed to clean up to restart import process: %w", err)
+		if vi.Status.StorageClassName == "" {
+			return reconcile.Result{}, fmt.Errorf("empty storage class in status")
 		}
-		return reconcile.Result{}, nil
 	}
 
 	ds, exists := h.sources.For(vi.Spec.DataSource.Type)
@@ -125,21 +124,14 @@ func (h LifeCycleHandler) Handle(ctx context.Context, vi *virtv2.VirtualImage) (
 		return reconcile.Result{}, fmt.Errorf("data source runner not found for type: %s", vi.Spec.DataSource.Type)
 	}
 
-	var result reconcile.Result
-	var err error
-	if vi.Spec.Storage == virtv2.StorageKubernetes || vi.Spec.Storage == virtv2.StoragePersistentVolumeClaim {
-		if vi.Status.StorageClassName != "" && storageClassReadyCondition.Status == metav1.ConditionTrue {
-			result, err = ds.StoreToPVC(ctx, vi)
-		}
-	} else {
-		result, err = ds.StoreToDVCR(ctx, vi)
+	switch vi.Spec.Storage {
+	case virtv2.StorageKubernetes, virtv2.StoragePersistentVolumeClaim:
+		return ds.StoreToPVC(ctx, vi)
+	case virtv2.StorageContainerRegistry:
+		return ds.StoreToDVCR(ctx, vi)
+	default:
+		return reconcile.Result{}, fmt.Errorf("unknown spec storage: %s", vi.Spec.Storage)
 	}
-
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
-	return result, nil
 }
 
 func (h LifeCycleHandler) Name() string {

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/http.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/http.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
@@ -44,12 +45,11 @@ import (
 )
 
 type HTTPDataSource struct {
-	statService         Stat
-	importerService     Importer
-	dvcrSettings        *dvcr.Settings
-	diskService         *service.DiskService
-	storageClassService *service.VirtualImageStorageClassService
-	recorder            eventrecord.EventRecorderLogger
+	statService     Stat
+	importerService Importer
+	dvcrSettings    *dvcr.Settings
+	diskService     *service.DiskService
+	recorder        eventrecord.EventRecorderLogger
 }
 
 func NewHTTPDataSource(
@@ -58,15 +58,13 @@ func NewHTTPDataSource(
 	importerService Importer,
 	dvcrSettings *dvcr.Settings,
 	diskService *service.DiskService,
-	storageClassService *service.VirtualImageStorageClassService,
 ) *HTTPDataSource {
 	return &HTTPDataSource{
-		statService:         statService,
-		importerService:     importerService,
-		dvcrSettings:        dvcrSettings,
-		diskService:         diskService,
-		storageClassService: storageClassService,
-		recorder:            recorder,
+		statService:     statService,
+		importerService: importerService,
+		dvcrSettings:    dvcrSettings,
+		diskService:     diskService,
+		recorder:        recorder,
 	}
 }
 
@@ -84,7 +82,7 @@ func (ds HTTPDataSource) StoreToDVCR(ctx context.Context, vi *virtv2.VirtualImag
 	}
 
 	switch {
-	case isDiskProvisioningFinished(condition):
+	case IsImageProvisioningFinished(condition):
 		log.Info("Virtual image provisioning finished: clean up")
 
 		cb.
@@ -210,12 +208,6 @@ func (ds HTTPDataSource) StoreToPVC(ctx context.Context, vi *virtv2.VirtualImage
 		return reconcile.Result{}, err
 	}
 
-	clusterDefaultSC, _ := ds.diskService.GetDefaultStorageClass(ctx)
-	sc, err := ds.storageClassService.GetValidatedStorageClass(vi.Spec.PersistentVolumeClaim.StorageClass, clusterDefaultSC)
-	if updated, err := setConditionFromStorageClassError(err, cb); err != nil || updated {
-		return reconcile.Result{}, err
-	}
-
 	var dvQuotaNotExceededCondition *cdiv1.DataVolumeCondition
 	var dvRunningCondition *cdiv1.DataVolumeCondition
 	if dv != nil {
@@ -224,7 +216,7 @@ func (ds HTTPDataSource) StoreToPVC(ctx context.Context, vi *virtv2.VirtualImage
 	}
 
 	switch {
-	case isDiskProvisioningFinished(condition):
+	case IsImageProvisioningFinished(condition):
 		log.Info("Image provisioning finished: clean up")
 
 		setPhaseConditionForFinishedImage(pvc, cb, &vi.Status.Phase, supgen)
@@ -337,6 +329,11 @@ func (ds HTTPDataSource) StoreToPVC(ctx context.Context, vi *virtv2.VirtualImage
 
 		source := ds.getSource(supgen, ds.statService.GetDVCRImageName(pod))
 
+		var sc *storagev1.StorageClass
+		sc, err = ds.diskService.GetStorageClass(ctx, vi.Status.StorageClassName)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
 		err = ds.diskService.StartImmediate(ctx, diskSize, sc, source, vi, supgen)
 		if updated, err := setPhaseConditionFromStorageError(err, vi, cb); err != nil || updated {
 			return reconcile.Result{}, err

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vi_on_pvc.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref_vi_on_pvc.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
@@ -46,13 +47,12 @@ import (
 )
 
 type ObjectRefDataVirtualImageOnPVC struct {
-	statService         Stat
-	importerService     Importer
-	dvcrSettings        *dvcr.Settings
-	client              client.Client
-	diskService         *service.DiskService
-	storageClassService *service.VirtualImageStorageClassService
-	recorder            eventrecord.EventRecorderLogger
+	statService     Stat
+	importerService Importer
+	dvcrSettings    *dvcr.Settings
+	client          client.Client
+	diskService     *service.DiskService
+	recorder        eventrecord.EventRecorderLogger
 }
 
 func NewObjectRefDataVirtualImageOnPVC(
@@ -62,16 +62,14 @@ func NewObjectRefDataVirtualImageOnPVC(
 	dvcrSettings *dvcr.Settings,
 	client client.Client,
 	diskService *service.DiskService,
-	storageClassService *service.VirtualImageStorageClassService,
 ) *ObjectRefDataVirtualImageOnPVC {
 	return &ObjectRefDataVirtualImageOnPVC{
-		statService:         statService,
-		importerService:     importerService,
-		dvcrSettings:        dvcrSettings,
-		client:              client,
-		diskService:         diskService,
-		storageClassService: storageClassService,
-		recorder:            recorder,
+		statService:     statService,
+		importerService: importerService,
+		dvcrSettings:    dvcrSettings,
+		client:          client,
+		diskService:     diskService,
+		recorder:        recorder,
 	}
 }
 
@@ -86,7 +84,7 @@ func (ds ObjectRefDataVirtualImageOnPVC) StoreToDVCR(ctx context.Context, vi, vi
 
 	condition, _ := conditions.GetCondition(vicondition.ReadyType, vi.Status.Conditions)
 	switch {
-	case isDiskProvisioningFinished(condition):
+	case IsImageProvisioningFinished(condition):
 		log.Info("Virtual image provisioning finished: clean up")
 
 		cb.
@@ -205,12 +203,6 @@ func (ds ObjectRefDataVirtualImageOnPVC) StoreToPVC(ctx context.Context, vi, viR
 		return reconcile.Result{}, err
 	}
 
-	clusterDefaultSC, _ := ds.diskService.GetDefaultStorageClass(ctx)
-	sc, err := ds.storageClassService.GetValidatedStorageClass(vi.Spec.PersistentVolumeClaim.StorageClass, clusterDefaultSC)
-	if updated, err := setConditionFromStorageClassError(err, cb); err != nil || updated {
-		return reconcile.Result{}, err
-	}
-
 	var dvQuotaNotExceededCondition *cdiv1.DataVolumeCondition
 	var dvRunningCondition *cdiv1.DataVolumeCondition
 	if dv != nil {
@@ -220,7 +212,7 @@ func (ds ObjectRefDataVirtualImageOnPVC) StoreToPVC(ctx context.Context, vi, viR
 
 	condition, _ := conditions.GetCondition(vicondition.ReadyType, vi.Status.Conditions)
 	switch {
-	case isDiskProvisioningFinished(condition):
+	case IsImageProvisioningFinished(condition):
 		log.Info("Disk provisioning finished: clean up")
 
 		setPhaseConditionForFinishedImage(pvc, cb, &vi.Status.Phase, supgen)
@@ -250,7 +242,8 @@ func (ds ObjectRefDataVirtualImageOnPVC) StoreToPVC(ctx context.Context, vi, viR
 		vi.Status.Progress = "0%"
 		vi.Status.SourceUID = pointer.GetPointer(viRef.GetUID())
 
-		size, err := ds.getPVCSize(viRef.Status.Size)
+		var size resource.Quantity
+		size, err = ds.getPVCSize(viRef.Status.Size)
 		if err != nil {
 			setPhaseConditionToFailed(cb, &vi.Status.Phase, err)
 
@@ -268,6 +261,11 @@ func (ds ObjectRefDataVirtualImageOnPVC) StoreToPVC(ctx context.Context, vi, viR
 			},
 		}
 
+		var sc *storagev1.StorageClass
+		sc, err = ds.diskService.GetStorageClass(ctx, vi.Status.StorageClassName)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
 		err = ds.diskService.StartImmediate(ctx, size, sc, source, vi, supgen)
 		if updated, err := setPhaseConditionFromStorageError(err, vi, cb); err != nil || updated {
 			return reconcile.Result{}, err

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/registry.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/registry.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -48,13 +49,12 @@ import (
 const registryDataSource = "registry"
 
 type RegistryDataSource struct {
-	statService         Stat
-	importerService     Importer
-	dvcrSettings        *dvcr.Settings
-	client              client.Client
-	diskService         *service.DiskService
-	storageClassService *service.VirtualImageStorageClassService
-	recorder            eventrecord.EventRecorderLogger
+	statService     Stat
+	importerService Importer
+	dvcrSettings    *dvcr.Settings
+	client          client.Client
+	diskService     *service.DiskService
+	recorder        eventrecord.EventRecorderLogger
 }
 
 func NewRegistryDataSource(
@@ -64,16 +64,14 @@ func NewRegistryDataSource(
 	dvcrSettings *dvcr.Settings,
 	client client.Client,
 	diskService *service.DiskService,
-	storageClassService *service.VirtualImageStorageClassService,
 ) *RegistryDataSource {
 	return &RegistryDataSource{
-		statService:         statService,
-		importerService:     importerService,
-		dvcrSettings:        dvcrSettings,
-		client:              client,
-		diskService:         diskService,
-		storageClassService: storageClassService,
-		recorder:            recorder,
+		statService:     statService,
+		importerService: importerService,
+		dvcrSettings:    dvcrSettings,
+		client:          client,
+		diskService:     diskService,
+		recorder:        recorder,
 	}
 }
 
@@ -98,12 +96,6 @@ func (ds RegistryDataSource) StoreToPVC(ctx context.Context, vi *virtv2.VirtualI
 		return reconcile.Result{}, err
 	}
 
-	clusterDefaultSC, _ := ds.diskService.GetDefaultStorageClass(ctx)
-	sc, err := ds.storageClassService.GetValidatedStorageClass(vi.Spec.PersistentVolumeClaim.StorageClass, clusterDefaultSC)
-	if updated, err := setConditionFromStorageClassError(err, cb); err != nil || updated {
-		return reconcile.Result{}, err
-	}
-
 	var dvQuotaNotExceededCondition *cdiv1.DataVolumeCondition
 	var dvRunningCondition *cdiv1.DataVolumeCondition
 	if dv != nil {
@@ -112,7 +104,7 @@ func (ds RegistryDataSource) StoreToPVC(ctx context.Context, vi *virtv2.VirtualI
 	}
 
 	switch {
-	case isDiskProvisioningFinished(condition):
+	case IsImageProvisioningFinished(condition):
 		log.Info("Disk provisioning finished: clean up")
 
 		setPhaseConditionForFinishedImage(pvc, cb, &vi.Status.Phase, supgen)
@@ -218,6 +210,11 @@ func (ds RegistryDataSource) StoreToPVC(ctx context.Context, vi *virtv2.VirtualI
 
 		source := ds.getSource(supgen, ds.statService.GetDVCRImageName(pod))
 
+		var sc *storagev1.StorageClass
+		sc, err = ds.diskService.GetStorageClass(ctx, vi.Status.StorageClassName)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
 		err = ds.diskService.StartImmediate(ctx, diskSize, sc, source, vi, supgen)
 		if updated, err := setPhaseConditionFromStorageError(err, vi, cb); err != nil || updated {
 			return reconcile.Result{}, err
@@ -302,7 +299,7 @@ func (ds RegistryDataSource) StoreToDVCR(ctx context.Context, vi *virtv2.Virtual
 	}
 
 	switch {
-	case isDiskProvisioningFinished(condition):
+	case IsImageProvisioningFinished(condition):
 		log.Info("Virtual image provisioning finished: clean up")
 
 		cb.

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/upload.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/upload.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
@@ -46,12 +47,11 @@ import (
 const uploadDataSource = "upload"
 
 type UploadDataSource struct {
-	statService         Stat
-	uploaderService     Uploader
-	dvcrSettings        *dvcr.Settings
-	diskService         *service.DiskService
-	storageClassService *service.VirtualImageStorageClassService
-	recorder            eventrecord.EventRecorderLogger
+	statService     Stat
+	uploaderService Uploader
+	dvcrSettings    *dvcr.Settings
+	diskService     *service.DiskService
+	recorder        eventrecord.EventRecorderLogger
 }
 
 func NewUploadDataSource(
@@ -60,15 +60,13 @@ func NewUploadDataSource(
 	uploaderService Uploader,
 	dvcrSettings *dvcr.Settings,
 	diskService *service.DiskService,
-	storageClassService *service.VirtualImageStorageClassService,
 ) *UploadDataSource {
 	return &UploadDataSource{
-		recorder:            recorder,
-		statService:         statService,
-		uploaderService:     uploaderService,
-		dvcrSettings:        dvcrSettings,
-		diskService:         diskService,
-		storageClassService: storageClassService,
+		recorder:        recorder,
+		statService:     statService,
+		uploaderService: uploaderService,
+		dvcrSettings:    dvcrSettings,
+		diskService:     diskService,
 	}
 }
 
@@ -101,12 +99,6 @@ func (ds UploadDataSource) StoreToPVC(ctx context.Context, vi *virtv2.VirtualIma
 		return reconcile.Result{}, err
 	}
 
-	clusterDefaultSC, _ := ds.diskService.GetDefaultStorageClass(ctx)
-	sc, err := ds.storageClassService.GetValidatedStorageClass(vi.Spec.PersistentVolumeClaim.StorageClass, clusterDefaultSC)
-	if updated, err := setConditionFromStorageClassError(err, cb); err != nil || updated {
-		return reconcile.Result{}, err
-	}
-
 	var dvQuotaNotExceededCondition *cdiv1.DataVolumeCondition
 	var dvRunningCondition *cdiv1.DataVolumeCondition
 	if dv != nil {
@@ -115,7 +107,7 @@ func (ds UploadDataSource) StoreToPVC(ctx context.Context, vi *virtv2.VirtualIma
 	}
 
 	switch {
-	case isDiskProvisioningFinished(condition):
+	case IsImageProvisioningFinished(condition):
 		log.Info("Disk provisioning finished: clean up")
 
 		setPhaseConditionForFinishedImage(pvc, cb, &vi.Status.Phase, supgen)
@@ -260,6 +252,11 @@ func (ds UploadDataSource) StoreToPVC(ctx context.Context, vi *virtv2.VirtualIma
 
 		source := ds.getSource(supgen, ds.statService.GetDVCRImageName(pod))
 
+		var sc *storagev1.StorageClass
+		sc, err = ds.diskService.GetStorageClass(ctx, vi.Status.StorageClassName)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
 		err = ds.diskService.StartImmediate(ctx, diskSize, sc, source, vi, supgen)
 		if updated, err := setPhaseConditionFromStorageError(err, vi, cb); err != nil || updated {
 			return reconcile.Result{}, err
@@ -360,7 +357,7 @@ func (ds UploadDataSource) StoreToDVCR(ctx context.Context, vi *virtv2.VirtualIm
 	}
 
 	switch {
-	case isDiskProvisioningFinished(condition):
+	case IsImageProvisioningFinished(condition):
 		log.Info("Virtual image provisioning finished: clean up")
 
 		cb.

--- a/images/virtualization-artifact/pkg/controller/vi/vi_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vi/vi_controller.go
@@ -27,9 +27,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
+
 	"github.com/deckhouse/virtualization-controller/pkg/config"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vi/internal"
+	intsvc "github.com/deckhouse/virtualization-controller/pkg/controller/vi/internal/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vi/internal/source"
 	"github.com/deckhouse/virtualization-controller/pkg/dvcr"
 	"github.com/deckhouse/virtualization-controller/pkg/eventrecord"
@@ -65,20 +67,20 @@ func NewController(
 	uploader := service.NewUploaderService(dvcr, mgr.GetClient(), uploaderImage, requirements, PodPullPolicy, PodVerbose, ControllerName, protection)
 	bounder := service.NewBounderPodService(dvcr, mgr.GetClient(), bounderImage, requirements, PodPullPolicy, PodVerbose, ControllerName, protection)
 	disk := service.NewDiskService(mgr.GetClient(), dvcr, protection, ControllerName)
-	scService := service.NewVirtualImageStorageClassService(storageClassSettings, disk)
+	scService := intsvc.NewVirtualImageStorageClassService(service.NewBaseStorageClassService(mgr.GetClient()), storageClassSettings)
 	recorder := eventrecord.NewEventRecorderLogger(mgr, ControllerName)
 
 	sources := source.NewSources()
-	sources.Set(virtv2.DataSourceTypeHTTP, source.NewHTTPDataSource(recorder, stat, importer, dvcr, disk, scService))
-	sources.Set(virtv2.DataSourceTypeContainerImage, source.NewRegistryDataSource(recorder, stat, importer, dvcr, mgr.GetClient(), disk, scService))
-	sources.Set(virtv2.DataSourceTypeObjectRef, source.NewObjectRefDataSource(recorder, stat, importer, bounder, dvcr, mgr.GetClient(), disk, scService))
-	sources.Set(virtv2.DataSourceTypeUpload, source.NewUploadDataSource(recorder, stat, uploader, dvcr, disk, scService))
+	sources.Set(virtv2.DataSourceTypeHTTP, source.NewHTTPDataSource(recorder, stat, importer, dvcr, disk))
+	sources.Set(virtv2.DataSourceTypeContainerImage, source.NewRegistryDataSource(recorder, stat, importer, dvcr, mgr.GetClient(), disk))
+	sources.Set(virtv2.DataSourceTypeObjectRef, source.NewObjectRefDataSource(recorder, stat, importer, bounder, dvcr, mgr.GetClient(), disk))
+	sources.Set(virtv2.DataSourceTypeUpload, source.NewUploadDataSource(recorder, stat, uploader, dvcr, disk))
 
 	reconciler := NewReconciler(
 		mgr.GetClient(),
 		internal.NewStorageClassReadyHandler(recorder, scService),
 		internal.NewDatasourceReadyHandler(sources),
-		internal.NewLifeCycleHandler(sources, mgr.GetClient()),
+		internal.NewLifeCycleHandler(recorder, sources, mgr.GetClient()),
 		internal.NewDeletionHandler(sources),
 		internal.NewAttacheeHandler(mgr.GetClient()),
 	)


### PR DESCRIPTION
## Description

1. The `Start` and `StartImmediate` methods of `DiskService` now take a `*storagev1.StorageClass` instead of a `string` as the storage class parameter.

2. The global services `VirtualImageStorageClassService` and `VirtualDiskStorageClassService` have been moved to the _internal/service_ package of the corresponding resource.

3. All checks related to `StorageClass` are now performed exclusively in the `StorageClassReady` handlers. The `LifeCycle` handler (and all source handlers) now rely on the `StorageClassReady` condition and no longer perform redundant checks.

4. A new service, `BaseStorageClassService`, which integrates internal storage class services in order to use the base logic for working with `StorageClass`.

5. Refactored `LifeCycle` for vi similarly to how it’s done for vd.


## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries

```changes
section: api 
type: fix
summary: fix issues with storage class condition display
```
