### PR TITLE
tests: dump intvirt resources

### DIFF
--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -658,13 +658,26 @@ func IsContainerRestarted(podName, containerName, namespace string, startedAt v1
 }
 
 func SaveTestResources(labels map[string]string, additional string) {
-	cmdr := kubectl.Get("virtualization -A", kc.GetOptions{Output: "yaml", Labels: labels})
-	Expect(cmdr.Error()).NotTo(HaveOccurred(), "cmd: %s\nstderr: %s", cmdr.GetCmd(), cmdr.StdErr())
+	virt := kubectl.Get("virtualization -A", kc.GetOptions{Output: "yaml", Labels: labels})
+	Expect(virt.Error()).NotTo(HaveOccurred(), "cmd: %s\nstderr: %s", virt.GetCmd(), virt.StdErr())
+
+	intVirt := kubectl.Get("intvirt -A", kc.GetOptions{Output: "yaml", Labels: labels})
+	Expect(intVirt.Error()).NotTo(HaveOccurred(), "cmd: %s\nstderr: %s", intVirt.GetCmd(), intVirt.StdErr())
 
 	additional = strings.ToLower(additional)
 	additional = strings.ReplaceAll(strings.ToLower(additional), " ", "_")
 	str := fmt.Sprintf("/tmp/e2e_failed__%s__%s.yaml", labels["testcase"], additional)
 
-	err := os.WriteFile(str, cmdr.StdOutBytes(), 0644)
+	file, err := os.OpenFile(str, os.O_APPEND|os.O_WRONLY, 0644)
+	Expect(err).NotTo(HaveOccurred())
+	defer file.Close()
+
+	_, err = file.Write(virt.StdOutBytes())
+	Expect(err).NotTo(HaveOccurred())
+
+	_, err = file.WriteString("\n---\n")
+	Expect(err).NotTo(HaveOccurred())
+
+	_, err = file.Write(intVirt.StdOutBytes())
 	Expect(err).NotTo(HaveOccurred())
 }


### PR DESCRIPTION
## Description
dump intvirt resources

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: core
type: chore
summary: dump intvirt resources
impact_level: low
```
