### PR TITLE
chore(ci): upload artifacts on PR e2e tests

### DIFF
--- a/.github/workflows/dev_module_build.yml
+++ b/.github/workflows/dev_module_build.yml
@@ -537,10 +537,9 @@ jobs:
         if: always()
         with:
           name: resources_from_failed_tests
-          retention-days: 21
+          retention-days: 2
           path: /tmp/e2e_failed__*
           if-no-files-found: ignore
-retention-days: 2
 
       - name: Cleanup E2E resources on cancel
         if: always() && steps.e2e-tests.outcome == 'cancelled'

--- a/.github/workflows/dev_module_build.yml
+++ b/.github/workflows/dev_module_build.yml
@@ -540,6 +540,7 @@ jobs:
           retention-days: 21
           path: /tmp/e2e_failed__*
           if-no-files-found: ignore
+retention-days: 2
 
       - name: Cleanup E2E resources on cancel
         if: always() && steps.e2e-tests.outcome == 'cancelled'

--- a/.github/workflows/dev_module_build.yml
+++ b/.github/workflows/dev_module_build.yml
@@ -202,12 +202,12 @@ jobs:
             # cd "$dir" || { echo "::error::Failed to access directory $dir"; exit 1; }
 
             cd "$dir" || { echo "::error::Failed to access directory $dir"; continue; }
-            
+
             # Run linter with multiple formats
-            
+
             output=$(golangci-lint run --out-format=json 2>/dev/null | jq '{warning: .Report.Warnings, error: .Report.Error}' || true)
             find_errors=$(echo $output | jq '.error | select(.!=null)' | wc -l)
-            
+
             # Track errors
             if [ $find_errors -ne 0 ]; then
               error_count=$(( error_count + 1 ))
@@ -215,7 +215,7 @@ jobs:
             else
               echo "::group::📂 Linting directory ✅: $dir"
             fi
-            
+
             report_out_warning=$(echo $output | jq '.warning')
             report_out_error=$(echo $output | jq '.error')
 
@@ -226,7 +226,7 @@ jobs:
             report+="---\n"
 
             cd - &>/dev/null
-            
+
             if [ $find_errors -ne 0 ]; then
               echo -e "⚠️ Warnings:\n$report_out_warning"
               echo -e "❌ Errors:\n$report_out_error\n"
@@ -532,6 +532,14 @@ jobs:
         working-directory: ./tests/e2e/
         run: |
           task run -v
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: resources_from_failed_tests
+          retention-days: 21
+          path: /tmp/e2e_failed__*
+          if-no-files-found: ignore
 
       - name: Cleanup E2E resources on cancel
         if: always() && steps.e2e-tests.outcome == 'cancelled'


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Upload artifacts of failed resources on e2e runs similar to nightly e2e job.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
To access failed resources after the run.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: ci
type: chore
summary:  upload artifacts on PR e2e tests
```
