### PR TITLE
feat(core): introduces a descheduler component to automatically rebalance virtual machines (VMs) across cluster nodes

### DIFF
--- a/templates/descheduler/descheduler.yaml
+++ b/templates/descheduler/descheduler.yaml
@@ -1,0 +1,26 @@
+{{- if (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "deschedulers.deckhouse.io") }}
+apiVersion: deckhouse.io/v1alpha2
+kind: Descheduler
+metadata:
+  name: virtualization
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+spec:
+  evictLocalStoragePods: true
+  podLabelSelector:
+    matchExpressions:
+      - key: vm.kubevirt.internal.virtualization.deckhouse.io/name
+        operator: Exists
+  strategies:
+    lowNodeUtilization:
+      enabled: true
+      thresholds:
+        cpu: 50
+      targetThresholds:
+        cpu: 80
+    removePodsViolatingInterPodAntiAffinity:
+      enabled: true
+    removePodsViolatingNodeAffinity:
+      enabled: true
+      nodeAffinityType:
+        - requiredDuringSchedulingIgnoredDuringExecution
+{{- end }}


### PR DESCRIPTION
## Description

This PR introduces a descheduler component to automatically rebalance virtual machines (VMs) across cluster nodes. Functionality becomes active only when descheduler module is enabled

- Load-based rebalancing:
  - Triggers when node CPU utilization exceeds 80%
  - Uses `LowNodeUtilization` policy for balanced resource distribution
  - Ensures even workload distribution across cluster nodes

- Affinity/anti-affinity compliance:
  - Handles cases where nodes no longer meet `requiredDuringSchedulingIgnoredDuringExecution` rules
  - Automatically migrates VMs to compliant nodes when placement constraints are violated

## Why do we need it, and what problem does it solve?

Without active rebalancing, uneven VM distribution can lead to node overutilization (e.g., CPU >80%), causing performance degradation, latency spikes, and potential node failures. 

Changes in node availability, labels, or taints may invalidate existing VM placements that rely on requiredDuringSchedulingIgnoredDuringExecution rules.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: core
type: feature
summary: Automatic VM rebalancing based on CPU utilization (80% threshold) and affinity rules. Functionality becomes active only when descheduler module is enabled
```
