### PR TITLE
fix(vm): choose correct active pod

### DIFF
--- a/images/virtualization-artifact/pkg/builder/vm/option.go
+++ b/images/virtualization-artifact/pkg/builder/vm/option.go
@@ -17,11 +17,13 @@ limitations under the License.
 package vm
 
 import (
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	"github.com/deckhouse/virtualization-controller/pkg/builder/meta"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
-type Option func(vmop *v1alpha2.VirtualMachine)
+type Option func(vm *v1alpha2.VirtualMachine)
 
 var (
 	WithName         = meta.WithName[*v1alpha2.VirtualMachine]
@@ -32,3 +34,18 @@ var (
 	WithAnnotation   = meta.WithAnnotation[*v1alpha2.VirtualMachine]
 	WithAnnotations  = meta.WithAnnotations[*v1alpha2.VirtualMachine]
 )
+
+func WithCPU(cores int, coreFraction *string) Option {
+	return func(vm *v1alpha2.VirtualMachine) {
+		vm.Spec.CPU.Cores = cores
+		if coreFraction != nil {
+			vm.Spec.CPU.CoreFraction = *coreFraction
+		}
+	}
+}
+
+func WithMemory(size resource.Quantity) Option {
+	return func(vm *v1alpha2.VirtualMachine) {
+		vm.Spec.Memory.Size = size
+	}
+}

--- a/images/virtualization-artifact/pkg/controller/vm/internal/statistic_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/statistic_test.go
@@ -35,7 +35,7 @@ import (
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
-var _ = Describe("TestStatisticHandler2", func() {
+var _ = Describe("TestStatisticHandler", func() {
 	const (
 		vmName                = "vm"
 		vmNamespace           = "default"
@@ -177,6 +177,40 @@ var _ = Describe("TestStatisticHandler2", func() {
 
 				MemorySize:            536870912,
 				MemoryRuntimeOverhead: 254803968,
+			},
+		),
+		Entry("Case 2",
+			newVM(4, ptr.To("25%"), "8Gi"),
+			newKVVMI("1", "4", "8Gi", "8Gi"),
+			newPod("1", "4", "8Gi", "8Gi"),
+			expectedValues{
+				CPUCores:           4,
+				CPUCoreFraction:    "25%",
+				CPURequestedCores:  1000,
+				CPURuntimeOverhead: 0,
+
+				TopologyCoresPerSocket: 4,
+				TopologySockets:        1,
+
+				MemorySize:            8589934592,
+				MemoryRuntimeOverhead: 0,
+			},
+		),
+		Entry("Case 3",
+			newVM(2, ptr.To("100%"), "2Gi"),
+			newKVVMI("2", "2", "2Gi", "2Gi"),
+			newPod("2", "2", "2Gi", "2Gi"),
+			expectedValues{
+				CPUCores:           2,
+				CPUCoreFraction:    "100%",
+				CPURequestedCores:  2000,
+				CPURuntimeOverhead: 0,
+
+				TopologyCoresPerSocket: 2,
+				TopologySockets:        1,
+
+				MemorySize:            2147483648,
+				MemoryRuntimeOverhead: 0,
 			},
 		),
 	)

--- a/images/virtualization-artifact/pkg/controller/vm/internal/suite_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/suite_test.go
@@ -22,8 +22,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	virtv1 "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -47,11 +47,7 @@ func setupEnvironment(vm *virtv2.VirtualMachine, objs ...client.Object) (client.
 	fakeClient, err := testutil.NewFakeClientWithObjects(allObjects...)
 	Expect(err).NotTo(HaveOccurred())
 
-	key := types.NamespacedName{
-		Name:      vm.GetName(),
-		Namespace: vm.GetNamespace(),
-	}
-	resource := reconciler.NewResource(key, fakeClient,
+	resource := reconciler.NewResource(client.ObjectKeyFromObject(vm), fakeClient,
 		func() *virtv2.VirtualMachine {
 			return &virtv2.VirtualMachine{}
 		},
@@ -75,6 +71,22 @@ func newEmptyKVVMI(name, namespace string) *virtv1.VirtualMachineInstance {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+		},
+	}
+}
+
+func newEmptyPOD(name, namespace, vmName string) *corev1.Pod {
+	return &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				virtv1.VirtualMachineNameLabel: vmName,
+			},
 		},
 	}
 }


### PR DESCRIPTION
## Description
Сhoose correct active pod
In some cases, we display an incorrect active pod for a VM. For example,
if there was a migration via vmop and it failed, the VM status will show an incorrect pod as active.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: vm
type: fix
summary: Choose a correct active pod to show in the VM status
```
