### PR TITLE
fix(vmip): fix double create VirtualMachineIPLease

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vmip/internal/iplease_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/iplease_handler.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -184,7 +183,7 @@ func (h IPLeaseHandler) createNewLease(ctx context.Context, state state.VMIPStat
 
 	h.recorder.Event(vmip, corev1.EventTypeNormal, virtv2.ReasonBound, "VirtualMachineIPAddress is bound to a new VirtualMachineIPAddressLease.")
 
-	return reconcile.Result{RequeueAfter: 2 * time.Second}, nil
+	return reconcile.Result{}, nil
 }
 
 func (h IPLeaseHandler) Name() string {

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/iplease_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/iplease_handler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -183,7 +184,7 @@ func (h IPLeaseHandler) createNewLease(ctx context.Context, state state.VMIPStat
 
 	h.recorder.Event(vmip, corev1.EventTypeNormal, virtv2.ReasonBound, "VirtualMachineIPAddress is bound to a new VirtualMachineIPAddressLease.")
 
-	return reconcile.Result{}, nil
+	return reconcile.Result{RequeueAfter: 2 * time.Second}, nil
 }
 
 func (h IPLeaseHandler) Name() string {

--- a/images/virtualization-artifact/pkg/controller/vmiplease/internal/lifecycle_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmiplease/internal/lifecycle_handler.go
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/deckhouse/virtualization-controller/pkg/common/ip"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vmiplease/internal/state"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
@@ -55,7 +56,7 @@ func (h *LifecycleHandler) Handle(ctx context.Context, state state.VMIPLeaseStat
 		return reconcile.Result{}, err
 	}
 
-	if vmip != nil {
+	if vmip != nil && vmip.Status.Address == ip.LeaseNameToIP(lease.Name) {
 		if leaseStatus.Phase != virtv2.VirtualMachineIPAddressLeasePhaseBound {
 			leaseStatus.Phase = virtv2.VirtualMachineIPAddressLeasePhaseBound
 			cb.Status(metav1.ConditionTrue).

--- a/images/virtualization-artifact/pkg/controller/vmiplease/internal/protection_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmiplease/internal/protection_handler.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/deckhouse/virtualization-controller/pkg/common/ip"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vmiplease/internal/state"
 	"github.com/deckhouse/virtualization-controller/pkg/logger"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
@@ -44,7 +45,7 @@ func (h *ProtectionHandler) Handle(ctx context.Context, state state.VMIPLeaseSta
 		return reconcile.Result{}, err
 	}
 
-	if vmip != nil {
+	if vmip != nil && vmip.Status.Address == ip.LeaseNameToIP(lease.Name) {
 		controllerutil.AddFinalizer(lease, virtv2.FinalizerIPAddressLeaseCleanup)
 	} else if lease.GetDeletionTimestamp() == nil {
 		log.Info("Deletion observed: remove cleanup finalizer from VirtualMachineIPAddressLease")

--- a/images/virtualization-artifact/pkg/controller/vmiplease/internal/retention_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmiplease/internal/retention_handler.go
@@ -23,6 +23,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/deckhouse/virtualization-controller/pkg/common/ip"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vmiplease/internal/state"
 	"github.com/deckhouse/virtualization-controller/pkg/logger"
@@ -52,7 +53,7 @@ func (h *RetentionHandler) Handle(ctx context.Context, state state.VMIPLeaseStat
 		return reconcile.Result{}, err
 	}
 
-	if vmip == nil {
+	if vmip == nil || vmip.Status.Address != ip.LeaseNameToIP(lease.Name) {
 		if lease.Spec.VirtualMachineIPAddressRef.Name != "" {
 			log.Info("VirtualMachineIP not found: remove this ref from the spec and retain VMIPLease")
 			lease.Spec.VirtualMachineIPAddressRef.Name = ""

--- a/images/virtualization-artifact/pkg/controller/vmiplease/vmiplease_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/vmiplease/vmiplease_reconciler.go
@@ -19,6 +19,7 @@ package vmiplease
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -31,7 +32,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	"github.com/deckhouse/virtualization-controller/pkg/common/ip"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/reconciler"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vmiplease/internal/state"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
@@ -70,7 +70,7 @@ func (r *Reconciler) SetupController(_ context.Context, mgr manager.Manager, ctr
 	return ctr.Watch(source.Kind(mgr.GetCache(), &virtv2.VirtualMachineIPAddressLease{}), &handler.EnqueueRequestForObject{})
 }
 
-func (r *Reconciler) enqueueRequestsFromVMIP(_ context.Context, obj client.Object) []reconcile.Request {
+func (r *Reconciler) enqueueRequestsFromVMIP(ctx context.Context, obj client.Object) []reconcile.Request {
 	vmip, ok := obj.(*virtv2.VirtualMachineIPAddress)
 	if !ok {
 		return nil
@@ -80,13 +80,30 @@ func (r *Reconciler) enqueueRequestsFromVMIP(_ context.Context, obj client.Objec
 		return nil
 	}
 
-	return []reconcile.Request{
-		{
-			NamespacedName: types.NamespacedName{
-				Name: ip.IpToLeaseName(vmip.Status.Address),
-			},
-		},
+	var requests []reconcile.Request
+
+	var vmiplList virtv2.VirtualMachineIPAddressLeaseList
+	err := r.client.List(ctx, &vmiplList, &client.ListOptions{})
+	if err != nil {
+		slog.Default().Error(fmt.Sprintf("failed to list vmipl: %s", err))
+		return requests
 	}
+
+	for _, vmipl := range vmiplList.Items {
+		if vmipl.Spec.VirtualMachineIPAddressRef == nil {
+			continue
+		}
+
+		if vmipl.Spec.VirtualMachineIPAddressRef.Name == obj.GetName() {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name: vmipl.Name,
+				},
+			})
+		}
+	}
+
+	return requests
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
This pull request addresses a critical issue where VirtualMachineIPAddressLease was being created twice during the reconciliation process. 

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: vmip
type: fix
summary: Fixed double creation of VirtualMachineIPAddressLease
```
