### PR TITLE
feat(vm):  set error policy report as default

### DIFF
--- a/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/add_volume.go
+++ b/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/add_volume.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/utils/ptr"
 	virtv1 "kubevirt.io/api/core/v1"
 
 	"github.com/deckhouse/virtualization-controller/pkg/tls/certmanager"
@@ -122,9 +123,10 @@ func (r AddVolumeREST) genMutateRequestHook(opts *subresources.VirtualMachineAdd
 	hotplugRequest := AddVolumeOptions{
 		Name: opts.Name,
 		Disk: &virtv1.Disk{
-			Name:       opts.Name,
-			DiskDevice: dd,
-			Serial:     serial,
+			Name:        opts.Name,
+			DiskDevice:  dd,
+			Serial:      serial,
+			ErrorPolicy: ptr.To(virtv1.DiskErrorPolicyReport),
 		},
 	}
 	switch opts.VolumeKind {

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	virtv1 "kubevirt.io/api/core/v1"
 
 	"github.com/deckhouse/virtualization-controller/pkg/common"
@@ -307,9 +308,10 @@ func (b *KVVM) SetDisk(name string, opts SetDiskOptions) error {
 	}
 
 	disk := virtv1.Disk{
-		Name:       name,
-		DiskDevice: dd,
-		Serial:     opts.Serial,
+		Name:        name,
+		DiskDevice:  dd,
+		Serial:      opts.Serial,
+		ErrorPolicy: ptr.To(virtv1.DiskErrorPolicyReport),
 	}
 
 	if opts.BootOrder > 0 {


### PR DESCRIPTION
## Description
Change VM behavior to I/O problems for disks.

Previously, the presence of I/O problems stopped the VM and paused it.

Now, instead of stopping the VM, I/O errors will be reported to the guest OS, allowing the guest system to deal with the problem (e.g., through retry mechanisms,
failover).

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: vm
type: feature
summary: Report I/O errors to guest OS instead of stopping VM, allowing the guest system to deal with the problem (e.g., through retry mechanisms, failover).
```
