### PR TITLE
fix(module): fix Kubernetes version detection in templates

### DIFF
--- a/templates/admission-policy.yaml
+++ b/templates/admission-policy.yaml
@@ -1,4 +1,4 @@
-{{- $kubeVersion := .Values.global.clusterConfiguration.kubernetesVersion }}
+{{- $kubeVersion := .Values.global.discovery.kubernetesVersion }}
 {{- $apiVersion := "" }}
 {{- if semverCompare ">=1.30.0" $kubeVersion }}
 {{- $apiVersion = "admissionregistration.k8s.io/v1" }}

--- a/templates/virtualization-controller/validation-webhook.yaml
+++ b/templates/virtualization-controller/validation-webhook.yaml
@@ -241,7 +241,7 @@ webhooks:
         {{ .Values.virtualization.internal.controller.cert.ca | b64enc }}
     admissionReviewVersions: ["v1"]
     sideEffects: None
-    {{- if semverCompare ">=1.27.0" .Values.global.clusterConfiguration.kubernetesVersion }}
+    {{- if semverCompare ">=1.27.0" .Values.global.discovery.kubernetesVersion }}
     matchConditions:
       - name: 'match-virtualization'
         expression: 'request.name == "virtualization"'


### PR DESCRIPTION
## Description

- Use discovery section instead of clusterConfiguration.
- Module may start before node-manager module, so configuration section may not be in sync with the actual cluster state.



## Why do we need it, and what problem does it solve?

Fix switching kubernetes versions. Newer Deckhouse versions use module.yaml requirements for module order calculation and start virtualization module before node-manager module and queue just stuck forever.

## What is the expected result?

Kubernetes version switch is possible with new Deckhouse versions that support requirements in module.yaml (1.69+).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: module
type: fix
summary: Fix Kubernetes version switch in newer Deckhouse versions (1.69+).
```
