### PR TITLE
chore(module): rewrite dvcr secret generator to go

### DIFF
--- a/images/hooks/cmd/006-generate-dvcr-secret/main.go
+++ b/images/hooks/cmd/006-generate-dvcr-secret/main.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2025 Flant JSC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"hooks/pkg/common"
+	"math/big"
+	"strings"
+
+	"github.com/deckhouse/module-sdk/pkg"
+	"github.com/deckhouse/module-sdk/pkg/app"
+	"github.com/deckhouse/module-sdk/pkg/registry"
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/bcrypt"
+)
+
+const (
+	dvcrSecretSnapshotName = "secrets"
+	dvcrSecretName         = "dvcr-secrets"
+	dvcrSecretJqFilter     = `{
+	  "data": .data
+	}`
+	dvcrUser           = "admin"
+	dvcrPasswordRWPath = "virtualization.internal.dvcr.passwordRW"
+	dvcrHtpasswdPath   = "virtualization.internal.dvcr.htpasswd"
+	dvcrSaltPath       = "virtualization.internal.dvcr.salt"
+)
+
+type dvcrSecretData struct {
+	Data struct {
+		Htpasswd   string `json:"htpasswd"`
+		PasswordRW string `json:"passwordRW"`
+		Salt       string `json:"salt"`
+	} `json:"data"`
+}
+
+func (d dvcrSecretData) GetHtpasswd() (string, error) {
+	// decode base64 string to byte array
+	htpasswdBytes, err := base64.StdEncoding.DecodeString(d.Data.Htpasswd)
+	if err != nil {
+		return "", err
+	}
+
+	return string(htpasswdBytes), nil
+}
+
+func (d dvcrSecretData) GetPasswordRW() (string, error) {
+	// decode base64 string to byte array
+	PasswordRWBytes, err := base64.StdEncoding.DecodeString(d.Data.PasswordRW)
+	if err != nil {
+		return "", err
+	}
+
+	return string(PasswordRWBytes), nil
+}
+
+func (d dvcrSecretData) GetSalt() (string, error) {
+	// decode base64 string to byte array
+	SaltBytes, err := base64.StdEncoding.DecodeString(d.Data.Salt)
+	if err != nil {
+		return "", err
+	}
+
+	return string(SaltBytes), nil
+}
+
+var config = &pkg.HookConfig{
+	OnBeforeHelm: &pkg.OrderedConfig{Order: 10},
+	Kubernetes: []pkg.KubernetesConfig{
+		{
+			Name:       dvcrSecretSnapshotName,
+			APIVersion: "v1",
+			Kind:       "Secret",
+			JqFilter:   dvcrSecretJqFilter,
+			NamespaceSelector: &pkg.NamespaceSelector{
+				NameSelector: &pkg.NameSelector{
+					MatchNames: []string{common.MODULE_NAMESPACE},
+				},
+			},
+			NameSelector: &pkg.NameSelector{
+				MatchNames: []string{dvcrSecretName},
+			},
+		},
+	},
+
+	Queue: fmt.Sprintf("modules/%s", common.MODULE_NAME),
+}
+
+var _ = registry.RegisterFunc(config, GenerateSecret)
+
+func generateAlphaNum(n int) (string, error) {
+	const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	charLen := big.NewInt(int64(len(chars)))
+	b := make([]byte, n)
+	for i := range b {
+		idx, err := rand.Int(rand.Reader, charLen)
+		if err != nil {
+			return "", err
+		}
+		b[i] = chars[idx.Int64()]
+	}
+	return string(b), nil
+}
+
+func ValidateHtpasswdWithSalt(storedLine, password, salt string) bool {
+	saltedPassword := password + salt
+	parts := strings.SplitN(storedLine, ":", 2)
+	if len(parts) != 2 {
+		return false
+	}
+	hash := parts[1]
+	return bcrypt.CompareHashAndPassword([]byte(hash), []byte(saltedPassword)) == nil
+}
+
+func GenerateSecret(_ context.Context, input *pkg.HookInput) error {
+	input.Logger.Info("🟥🟧🟥")
+	secrets := input.Snapshots.Get(dvcrSecretSnapshotName)
+
+	var secretData dvcrSecretData
+
+	if len(secrets) == 0 {
+		// generate PasswordRW
+		PasswordRW, err := generateAlphaNum(32)
+		if err != nil {
+			return errors.Wrap(err, "generate alpha num")
+		}
+
+		input.Values.Set(dvcrHtpasswdPath, base64.StdEncoding.EncodeToString([]byte(PasswordRW)))
+
+		// generate Salt
+		Salt, err := generateAlphaNum(40)
+		if err != nil {
+			return errors.Wrap(err, "generate alpha num")
+		}
+		input.Values.Set(dvcrSaltPath, base64.StdEncoding.EncodeToString([]byte(Salt)))
+
+		// generate htpasswd
+		saltedPassword := PasswordRW + Salt
+		hashBytes, err := bcrypt.GenerateFromPassword([]byte(saltedPassword), bcrypt.DefaultCost)
+		if err != nil {
+			return err
+		}
+		input.Logger.Info(string(hashBytes))
+		// input.Values.Set(dvcrSaltPath, base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", dvcrUser, string(hashBytes)))))
+
+		return nil
+	}
+
+	err := secrets[0].UnmarhalTo(&secretData)
+	if err != nil {
+		input.Logger.Error("Unable to unmarshal secret" + err.Error())
+	}
+
+	password, _ := secretData.GetPasswordRW()
+	salt, _ := secretData.GetSalt()
+	htpasswd, _ := secretData.GetHtpasswd()
+
+	if !ValidateHtpasswdWithSalt(htpasswd, password, salt) {
+
+		saltedPassword := password + salt
+		hashBytes, err := bcrypt.GenerateFromPassword([]byte(saltedPassword), bcrypt.DefaultCost)
+		if err != nil {
+			input.Logger.Log("⛔ hehehehe")
+			return err
+		}
+		input.Logger.Info(string(hashBytes))
+		//input.Values.Set(dvcrSaltPath, base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", dvcrUser, string(hashBytes)))))
+	}
+
+	// input.Values.Set(dvcrHtpasswdPath, secretData.Data.Htpasswd)
+	// input.Values.Set(dvcrPasswordRWPath, secretData.Data.PasswordRW)
+	// input.Values.Set(dvcrSaltPath, secretData.Data.Salt)
+
+	return nil
+}
+
+func main() {
+	app.Run()
+}

--- a/images/hooks/werf.inc.yaml
+++ b/images/hooks/werf.inc.yaml
@@ -29,3 +29,4 @@ shell:
   - go build -ldflags="-s -w" -o /hooks/003-tls-certificates-api ./cmd/003-tls-certificates-api
   - go build -ldflags="-s -w" -o /hooks/004-tls-certificates-api-proxy ./cmd/004-tls-certificates-api-proxy
   - go build -ldflags="-s -w" -o /hooks/005-prevent-default-vmclasses-deletion ./cmd/005-prevent-default-vmclasses-deletion
+  - go build -ldflags="-s -w" -o /hooks/006-generate-dvcr-secret ./cmd/006-generate-dvcr-secret


### PR DESCRIPTION
## Description
rewrite dvcr secret generator to go

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: module
type: chore
summary: rewrite dvcr secret generator to go
impact_level: low
```
