### PR TITLE
chore(core): replace linux-utils to self-build

### DIFF
--- a/images/cdi-controller/werf.inc.yaml
+++ b/images/cdi-controller/werf.inc.yaml
@@ -14,7 +14,6 @@ imageSpec:
 {{- define "cdi-controller-deps" -}}
 binaries:
   - /usr/bin/cdi-controller
-  - /usr/sbin/blockdev
 packages:
   - tar
 {{- end -}}
@@ -25,6 +24,12 @@ image: {{ $.ImageName }}-bins
 final: false
 fromImage: base-alt-p11-binaries
 import:
+- image: tools/util-linux
+  add: /
+  to: /relocate/usr
+  after: setup
+  includePaths:
+  - sbin/blockdev
 - image: cdi-artifact-cbuilder
   add: /bins
   to: /relocate/usr/bin

--- a/images/cdi-importer/werf.inc.yaml
+++ b/images/cdi-importer/werf.inc.yaml
@@ -23,12 +23,8 @@ binaries:
   - /usr/sbin/nbdkit
   - /usr/lib/nbdkit/filters/*
   - /usr/lib/nbdkit/plugins/*
-  # Mount
-  - /usr/bin/mount /usr/bin/umount
   # Sqlite libs
   - /usr/lib64/libsqlite3.so.0
-  # Block device binaries
-  - /usr/sbin/blockdev
   # CDI binaries
   - /usr/bin/cdi-containerimage-server /usr/bin/cdi-image-size-detection /usr/bin/cdi-importer /usr/bin/cdi-source-update-poller
 {{- end -}}
@@ -39,6 +35,14 @@ image: {{ $.ImageName }}-bins
 final: false
 fromImage: base-alt-p11-binaries
 import:
+- image: tools/util-linux
+  add: /
+  to: /relocate/usr
+  after: setup
+  includePaths:
+  - sbin/blockdev
+  - bin/mount
+  - bin/umount
 - image: cdi-artifact
   add: /cdi-binaries
   to: /usr/bin

--- a/images/dvcr-artifact/werf.inc.yaml
+++ b/images/dvcr-artifact/werf.inc.yaml
@@ -40,8 +40,8 @@ binaries:
 - /usr/share/file/magic
 - /usr/share/file/magic.mgc
 - /etc/magic
-- /usr/bin/mount
-- /usr/bin/umount
+# - /usr/bin/mount
+# - /usr/bin/umount
 - /usr/local/bin/dvcr-uploader
 - /usr/local/bin/dvcr-cleaner
 {{- end -}}
@@ -52,6 +52,13 @@ image: {{ $.ImageName }}-bins
 final: false
 fromImage: base-alt-p11-binaries
 import:
+- image: tools/util-linux
+  add: /
+  to: /relocate/usr
+  after: setup
+  includePaths:
+  - bin/mount
+  - bin/umount
 - image: {{ $.ImageName }}-builder
   add: /out
   to: /usr/local/bin

--- a/images/dvcr-artifact/werf.inc.yaml
+++ b/images/dvcr-artifact/werf.inc.yaml
@@ -40,8 +40,6 @@ binaries:
 - /usr/share/file/magic
 - /usr/share/file/magic.mgc
 - /etc/magic
-# - /usr/bin/mount
-# - /usr/bin/umount
 - /usr/local/bin/dvcr-uploader
 - /usr/local/bin/dvcr-cleaner
 {{- end -}}

--- a/images/virt-handler/werf.inc.yaml
+++ b/images/virt-handler/werf.inc.yaml
@@ -55,8 +55,8 @@ packages:
 - libnftnl
 - libjansson4
 binaries:
-- /usr/bin/mount
-- /usr/bin/umount
+# - /usr/bin/mount
+# - /usr/bin/umount
 - /usr/bin/getfacl
 - /usr/bin/setfacl
 - /usr/sbin/nft
@@ -73,6 +73,13 @@ image: {{ $.ImageName }}-bins
 final: false
 fromImage: base-alt-p11-binaries
 import:
+- image: tools/util-linux
+  add: /
+  to: /relocate/usr
+  after: setup
+  includePaths:
+  - bin/mount
+  - bin/umount
 - image: packages/binaries/xorriso
   add: /xorriso
   to: /xorriso

--- a/images/virt-handler/werf.inc.yaml
+++ b/images/virt-handler/werf.inc.yaml
@@ -55,8 +55,6 @@ packages:
 - libnftnl
 - libjansson4
 binaries:
-# - /usr/bin/mount
-# - /usr/bin/umount
 - /usr/bin/getfacl
 - /usr/bin/setfacl
 - /usr/sbin/nft

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -145,8 +145,6 @@ binaries:
   - /usr/sbin/biosdecode /usr/sbin/dmidecode
   # Numactl
   - /usr/bin/memhog /usr/bin/migratepages /usr/bin/migspeed /usr/bin/numactl /usr/bin/numastat
-  # Hwclock
-  # - /usr/sbin/hwclock
 {{- end -}}
 
 {{ $virtLauncherDependencies := include "virt-launcher-dependencies" . | fromYaml }}

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -318,7 +318,7 @@ shell:
     LIBS="/usr/lib64/libbsd.so* /usr/lib64/libnbd.so* /usr/lib64/libfuse3.so*"
     LIBS+=" /usr/lib64/libjson-c.so* /usr/lib64/libssh.so* /usr/lib64/libssh2.so*"
     LIBS+=" /usr/lib64/libtpms* /usr/lib64/libjson* /usr/lib64/libfuse*"
-    LIBS+=" /usr/lib64/libxml2.so* /usr/lib64/libgcc_s*"
+    LIBS+=" /usr/lib64/libxml2.so* /usr/lib64/libgcc_s* /usr/lib64/libaudit*"
 
     echo "Relocate additional libs for files in /VBINS"
     ./relocate_binaries.sh -i "$FILES" -o /VBINS

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -146,7 +146,7 @@ binaries:
   # Numactl
   - /usr/bin/memhog /usr/bin/migratepages /usr/bin/migspeed /usr/bin/numactl /usr/bin/numastat
   # Hwclock
-  - /usr/sbin/hwclock
+  # - /usr/sbin/hwclock
 {{- end -}}
 
 {{ $virtLauncherDependencies := include "virt-launcher-dependencies" . | fromYaml }}
@@ -260,6 +260,12 @@ import:
   after: setup
   includePaths:
   - usr/bin/openssl
+- image: tools/util-linux
+  add: /
+  to: /relocate/usr
+  after: setup
+  includePaths:
+  - sbin/hwclock
 
 # GNU utilities
 - image: tools/coreutils
@@ -270,6 +276,7 @@ import:
   - usr/bin/cp
   - usr/bin/sleep
   - usr/bin/coreutils
+
 
 - image: {{ $.ImageName }}-cbuilder
   add: /bins


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Replacing statically build linux-utils in the following images:
- cdi-controller
- cdi-importer
- dvcr-artifact
- virt-handler
- virt-launcher

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
We want more control when building binary files, as well as making images more secure

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: core
type: chore
summary: replace linux-utils to self-build
impact_level: low
```
