### PR TITLE
fix(kubevirt): Fix VM migration with container disks (CVI, VI)

### DIFF
--- a/images/virt-artifact/patches/050-mount-containerdisk-always-readonly.patch
+++ b/images/virt-artifact/patches/050-mount-containerdisk-always-readonly.patch
@@ -10,3 +10,19 @@ index cc09800afc..346eb883ae 100644
  	disk.Type = "file"
  	disk.Driver.Type = "qcow2"
  	disk.Driver.ErrorPolicy = v1.DiskErrorPolicyStop
+diff --git a/pkg/virt-launcher/virtwrap/live-migration-source.go b/pkg/virt-launcher/virtwrap/live-migration-source.go
+index f580d06e52..afbc2538d3 100644
+--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
++++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
+@@ -289,9 +289,9 @@ func classifyVolumesForMigration(vmi *v1.VirtualMachineInstance) *migrationDisks
+ 
+ 		case volSrc.ConfigMap != nil || volSrc.Secret != nil || volSrc.DownwardAPI != nil ||
+ 			volSrc.ServiceAccount != nil || volSrc.CloudInitNoCloud != nil ||
+-			volSrc.CloudInitConfigDrive != nil || (volSrc.ContainerDisk != nil && !volSrc.ContainerDisk.Hotpluggable):
++			volSrc.CloudInitConfigDrive != nil:
+ 			disks.generated[volume.Name] = true
+-		case volSrc.ContainerDisk != nil && volSrc.ContainerDisk.Hotpluggable:
++		case volSrc.ContainerDisk != nil:
+ 			disks.shared[volume.Name] = true
+ 		}
+ 	}

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
@@ -337,6 +337,7 @@ func (b *KVVM) SetDisk(name string, opts SetDiskOptions) error {
 		vs.Ephemeral = &virtv1.EphemeralVolumeSource{
 			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 				ClaimName: *opts.PersistentVolumeClaim,
+				ReadOnly:  true,
 			},
 		}
 

--- a/tests/e2e/testdata/vm-migration/cvi/cvi-cirros.yaml
+++ b/tests/e2e/testdata/vm-migration/cvi/cvi-cirros.yaml
@@ -1,0 +1,9 @@
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: ClusterVirtualImage
+metadata:
+  name: cvi-cirros
+spec:
+  dataSource:
+    type: "HTTP"
+    http:
+      url: "https://89d64382-20df-4581-8cc7-80df331f67fa.selstorage.ru/cirros/cirros-0.5.1.qcow2"

--- a/tests/e2e/testdata/vm-migration/cvi/kustomization.yaml
+++ b/tests/e2e/testdata/vm-migration/cvi/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cvi-cirros.yaml
+

--- a/tests/e2e/testdata/vm-migration/cvi/kustomization.yaml
+++ b/tests/e2e/testdata/vm-migration/cvi/kustomization.yaml
@@ -2,4 +2,3 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - cvi-cirros.yaml
-

--- a/tests/e2e/testdata/vm-migration/kustomization.yaml
+++ b/tests/e2e/testdata/vm-migration/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: testcases
 namePrefix: pr-number-or-commit-hash-
 resources:
   - vi
+  - cvi
   - vm
   - ns.yaml
 configurations:

--- a/tests/e2e/testdata/vm-migration/vm/kustomization.yaml
+++ b/tests/e2e/testdata/vm-migration/vm/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - overlays/migration-bios
   - overlays/migration-uefi
+  - overlays/with-cvi

--- a/tests/e2e/testdata/vm-migration/vm/overlays/with-cvi/kustomization.yaml
+++ b/tests/e2e/testdata/vm-migration/vm/overlays/with-cvi/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+nameSuffix: -migration-with-cvi
+resources:
+  - ../../base
+patches:
+  - path: vd.image.patch.yaml
+  - path: vm.bootloader.patch.yaml
+  - patch: |-
+      - op: add
+        path: /spec/blockDeviceRefs/-
+        value: {
+          "kind": "ClusterVirtualImage",
+          "name": "cvi-cirros"
+        }
+    target:
+      kind: VirtualMachine
+      name: vm

--- a/tests/e2e/testdata/vm-migration/vm/overlays/with-cvi/vd.image.patch.yaml
+++ b/tests/e2e/testdata/vm-migration/vm/overlays/with-cvi/vd.image.patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualDisk
+metadata:
+  name: vd-root
+spec:
+  dataSource:
+    type: ObjectRef
+    objectRef:
+      kind: VirtualImage
+      name: vi-alpine-http-uefi

--- a/tests/e2e/testdata/vm-migration/vm/overlays/with-cvi/vm.bootloader.patch.yaml
+++ b/tests/e2e/testdata/vm-migration/vm/overlays/with-cvi/vm.bootloader.patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualMachine
+metadata:
+  name: vm
+spec:
+  bootloader: EFI

--- a/tests/e2e/vm_migration_cancel_test.go
+++ b/tests/e2e/vm_migration_cancel_test.go
@@ -33,7 +33,7 @@ import (
 	kc "github.com/deckhouse/virtualization/tests/e2e/kubectl"
 )
 
-var _ = Describe("Virtual machine migration cancel", SIGMigration(), ginkgoutil.CommonE2ETestDecorators(), func() {
+var _ = Describe("Virtual machine cancel migration", SIGMigration(), ginkgoutil.CommonE2ETestDecorators(), func() {
 	testCaseLabel := map[string]string{"testcase": "vm-migration-cancel"}
 
 	BeforeEach(func() {


### PR DESCRIPTION
## Description
After mounting `CVI` and `VI` in read-only mode, we encountered a migration issue:  
"Operation not supported: Cannot migrate empty or read-only disk ..."
This fix ensures proper handling of disk mounting modes during migration to prevent the error.
![Screenshot From 2025-05-05 17-49-12](https://github.com/user-attachments/assets/bc701577-2c45-4c6a-ac08-214306a6e351)

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: kubevirt 
type: fix
summary: Fix VM migration with container disks (CVI, VI)
impact_level: low
```
