### PR TITLE
fix(vm): remove unnecessary block devices from boot order

### DIFF
--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
@@ -417,16 +417,6 @@ func (b *KVVM) SetTablet(name string) {
 	)
 }
 
-// HasTablet checks tablet presence by its name.
-func (b *KVVM) HasTablet(name string) bool {
-	for _, input := range b.Resource.Spec.Template.Spec.Domain.Devices.Inputs {
-		if input.Name == name && input.Type == virtv1.InputTypeTablet {
-			return true
-		}
-	}
-	return false
-}
-
 func (b *KVVM) SetProvisioning(p *virtv2.Provisioning) error {
 	if p == nil {
 		return nil
@@ -498,24 +488,6 @@ func (b *KVVM) SetOsType(osType virtv2.OsType) error {
 	return nil
 }
 
-// GetOSSettings returns a portion of devices and features related to d8 VM osType.
-func (b *KVVM) GetOSSettings() map[string]interface{} {
-	return map[string]interface{}{
-		"machine": b.Resource.Spec.Template.Spec.Domain.Machine,
-		"devices": map[string]interface{}{
-			"autoattach": b.Resource.Spec.Template.Spec.Domain.Devices.AutoattachInputDevice,
-			"tpm":        b.Resource.Spec.Template.Spec.Domain.Devices.TPM,
-			"rng":        b.Resource.Spec.Template.Spec.Domain.Devices.Rng,
-		},
-		"features": map[string]interface{}{
-			"acpi":   b.Resource.Spec.Template.Spec.Domain.Features.ACPI,
-			"apic":   b.Resource.Spec.Template.Spec.Domain.Features.APIC,
-			"smm":    b.Resource.Spec.Template.Spec.Domain.Features.SMM,
-			"hyperv": b.Resource.Spec.Template.Spec.Domain.Features.Hyperv,
-		},
-	}
-}
-
 func (b *KVVM) SetNetworkInterface(name string) {
 	devPreset := DeviceOptionsPresets.Find(b.opts.EnableParavirtualization)
 
@@ -573,16 +545,6 @@ func (b *KVVM) SetBootloader(bootloader virtv2.BootloaderType) error {
 		return fmt.Errorf("unexpected bootloader type %q. %w", bootloader, common.ErrUnknownType)
 	}
 	return nil
-}
-
-// GetBootloaderSettings returns a portion of features related to d8 VM bootloader.
-func (b *KVVM) GetBootloaderSettings() map[string]interface{} {
-	return map[string]interface{}{
-		"firmare": b.Resource.Spec.Template.Spec.Domain.Firmware,
-		"features": map[string]interface{}{
-			"smm": b.Resource.Spec.Template.Spec.Domain.Features.SMM,
-		},
-	}
 }
 
 func (b *KVVM) SetMetadata(metadata metav1.ObjectMeta) {


### PR DESCRIPTION
## Description
remove unnecessary block devices from boot order

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: vm 
type: fix
summary: Remove unnecessary block devices from boot order
impact_level: low
```
