### PR TITLE
chore(core): build acl

### DIFF
--- a/component_versions/version_map.yml
+++ b/component_versions/version_map.yml
@@ -12,3 +12,4 @@ package:
   gnutls: 3.8.6
   dmidecode: 3-6
   glib2: 2.82.5
+  acl: 2.3.1

--- a/images/packages/binaries/acl/werf.inc.yaml
+++ b/images/packages/binaries/acl/werf.inc.yaml
@@ -1,0 +1,57 @@
+---
+image: {{ $.ImageType }}/{{ $.ImageName }}
+final: false
+fromImage: builder/scratch
+import:
+- image: {{ $.ImageType }}/{{ $.ImageName }}-builder
+  add: /out
+  to: /{{ $.ImageName }}
+  before: setup
+
+---
+{{- $version := get $.Package $.ImageName }}
+{{- $gitRepoUrl := "acl.git" }}
+
+{{- $name := print $.ImageName "-dependencies" -}}
+{{- define "$name" -}}
+packages:
+- gcc
+- git gettext-tools autoconf libtool gcc make
+- libattr-devel
+- tree
+{{- end -}}
+
+{{ $builderDependencies := include "$name" . | fromYaml }}
+
+image: {{ $.ImageType }}/{{ $.ImageName }}-builder
+final: false
+fromImage: builder/alt
+secrets:
+- id: SOURCE_REPO
+  value: {{ $.SOURCE_REPO_GIT }}
+shell:
+  beforeInstall:
+    - |
+      apt-get update && apt-get install -y \
+        {{ $builderDependencies.packages | join " " }}
+      rm --recursive --force /var/lib/apt/lists/ftp.altlinux.org* /var/cache/apt/*.bin
+
+  install:
+    - |
+      OUTDIR=/out
+      mkdir -p ~/.ssh && echo "StrictHostKeyChecking accept-new" > ~/.ssh/config
+
+      git clone --depth=1 $(cat /run/secrets/SOURCE_REPO)/{{ $gitRepoUrl }} --branch v{{ $version }} /src
+      cd /src
+
+      ./autogen.sh
+
+      ./configure \
+        --prefix=/usr \
+        --libdir=/usr/lib64 \
+
+      make -j$(nproc)
+
+      make DESTDIR=$OUTDIR install
+
+      strip $OUTDIR/usr/bin/*

--- a/images/virt-handler/werf.inc.yaml
+++ b/images/virt-handler/werf.inc.yaml
@@ -51,7 +51,6 @@ imageSpec:
 {{- $name := print $.ImageName "-dependencies" -}}
 {{- define "$name" -}}
 packages:
-- acl
 - libnftnl
 - libjansson4
 binaries:
@@ -86,6 +85,10 @@ import:
   add: /nftables
   to: /nftables
   before: install
+- image: packages/binaries/acl
+  add: /acl
+  to: /acl
+  before: install
 - image: qemu
   add: /qemu-img
   to: /relocate
@@ -99,6 +102,7 @@ shell:
   - rm --recursive --force /var/lib/apt/lists/ftp.altlinux.org* /var/cache/apt/*.bin
   - cp -a /xorriso/. /
   - cp -a /nftables/. /
+  - cp -a /acl/. /
   setup:
   - |
     /relocate_binaries.sh -i "{{ $virtHandlerDependencies.binaries | join " " }}" -o /relocate

--- a/images/virt-handler/werf.inc.yaml
+++ b/images/virt-handler/werf.inc.yaml
@@ -103,6 +103,8 @@ shell:
   - cp -a /xorriso/. /
   - cp -a /nftables/. /
   - cp -a /acl/. /
+  
+  - rm -rf /{xorriso,nftables,acl}
   setup:
   - |
     /relocate_binaries.sh -i "{{ $virtHandlerDependencies.binaries | join " " }}" -o /relocate

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -102,8 +102,6 @@ libs:
   - libsystemd-devel
   - libjson-c-devel
   - systemtap-sdt-devel
-  - libacl
-  - libacl-devel
   - libtpms-devel libtpms
   - glib2-devel
   - libgio-devel
@@ -115,7 +113,6 @@ libs:
   - libisofs
   - libburn
 packages:
-  - acl
   - attr
   - ethtool
   - fdisk
@@ -250,6 +247,10 @@ import:
   add: /gnutls
   to: /gnutls
   before: install
+- image: packages/binaries/acl
+  add: /acl
+  to: /acl
+  before: install
 
 # Statically builded
 - image: packages/binaries/openssl
@@ -333,6 +334,7 @@ shell:
     cp -a /numactl/. /
     cp -a /gnutls/. /
     cp -a /dmidecode/. /
+    cp -a /acl/. /
 
     echo "Show libs after relocation in /relocate/usr/lib64"
     ls -la /relocate/usr/lib64

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -339,7 +339,7 @@ shell:
     echo "Show libs after relocation in /relocate/usr/lib64"
     ls -la /relocate/usr/lib64
     # Cleanup
-    rm -rf /{VBINS,qemu-bins,libvirt-bins,xorriso,swtpm,numactl,gnutls,dmidecode}
+    rm -rf /{VBINS,qemu-bins,libvirt-bins,xorriso,swtpm,numactl,gnutls,dmidecode,acl}
 
   setup:
   - |


### PR DESCRIPTION
## Description
Build acl binary for virt-handler.

## Why do we need it, and what problem does it solve?
We want more control when building binaries files, as well as making images more secure

## What is the expected result?
All work as expected



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: core
type: chore
summary: build acl
```
