### PR TITLE
feat(vd): remove finalizer from unmounted vd

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vd/internal/protection.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/protection.go
@@ -43,6 +43,17 @@ func (h ProtectionHandler) Handle(ctx context.Context, vd *virtv2.VirtualDisk) (
 	case len(vd.Status.AttachedToVirtualMachines) == 0:
 		log.Debug("Allow virtual disk deletion")
 		controllerutil.RemoveFinalizer(vd, virtv2.FinalizerVDProtection)
+	case len(vd.Status.AttachedToVirtualMachines) != 0:
+		unmounted := true
+		for _, vm := range vd.Status.AttachedToVirtualMachines {
+			if vm.Mounted {
+				unmounted = false
+			}
+		}
+		if unmounted {
+			log.Debug("Allow virtual disk deletion")
+			controllerutil.RemoveFinalizer(vd, virtv2.FinalizerVDProtection)
+		}
 	case vd.DeletionTimestamp == nil:
 		log.Debug("Protect virtual disk from deletion")
 		controllerutil.AddFinalizer(vd, virtv2.FinalizerVDProtection)

--- a/images/virtualization-artifact/pkg/controller/vd/internal/protection_test.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/protection_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	virtv1 "kubevirt.io/api/core/v1"
+
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("The protection handler test", func() {
+	const vdProtection = "virtualization.deckhouse.io/vd-protection"
+
+	var (
+		schema  *runtime.Scheme
+		ctx     context.Context
+		handler *ProtectionHandler
+	)
+
+	BeforeEach(func() {
+		schema = runtime.NewScheme()
+		Expect(clientgoscheme.AddToScheme(schema)).To(Succeed())
+		Expect(virtv2.AddToScheme(schema)).To(Succeed())
+		Expect(virtv1.AddToScheme(schema)).To(Succeed())
+
+		ctx = context.TODO()
+	})
+
+	Context("`VirtualDisk`", func() {
+		When("has the `AttachedToVirtualMachines` status with the `Mounted` false value", func() {
+			It("should remove the `vd-protection` finalizer from the `VirtualDisk`", func() {
+				vd := &virtv2.VirtualDisk{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-virtual-disk",
+						Namespace: "default",
+						Finalizers: []string{
+							vdProtection,
+						},
+					},
+					Status: virtv2.VirtualDiskStatus{
+						Conditions: []metav1.Condition{},
+						AttachedToVirtualMachines: []virtv2.AttachedVirtualMachine{
+							{
+								Name:    "test-virtual-machine",
+								Mounted: false,
+							},
+						},
+					},
+				}
+
+				handler = &ProtectionHandler{}
+				result, err := handler.Handle(ctx, vd)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.IsZero()).To(BeTrue())
+				Expect(vd.Finalizers).NotTo(ContainElement(vdProtection))
+			})
+		})
+
+		When("has the `AttachedToVirtualMachines` status with the `Mounted` true value", func() {
+			It("should not remove the `vd-protection` finalizer from the `VirtualDisk`", func() {
+				vd := &virtv2.VirtualDisk{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-virtual-disk",
+						Namespace: "default",
+						Finalizers: []string{
+							vdProtection,
+						},
+					},
+					Status: virtv2.VirtualDiskStatus{
+						Conditions: []metav1.Condition{},
+						AttachedToVirtualMachines: []virtv2.AttachedVirtualMachine{
+							{
+								Name:    "test-virtual-machine",
+								Mounted: true,
+							},
+						},
+					},
+				}
+
+				handler = &ProtectionHandler{}
+				result, err := handler.Handle(ctx, vd)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.IsZero()).To(BeTrue())
+				Expect(vd.Finalizers).To(ContainElement(vdProtection))
+			})
+		})
+	})
+})


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
`vd-protection` will be removed from the virtual disk if the virtual machine is stopped.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
This is necessary for the new feature, 'Restore Virtual Machine with Force Option.' Before restoring the virtual machine, it should be stopped to restore the virtual disk.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: vd
type: feature
summary: "The `vd-protection` finalizer will be removed from the virtual disk if the virtual machine is stopped."
```
