### PR TITLE
fix(module): update deckhouse requirements

### DIFF
--- a/module.yaml
+++ b/module.yaml
@@ -8,7 +8,7 @@ descriptions:
   ru: Модуль виртуализации позволяет запускать и управлять виртуальными машинами в рамках платформы Deckhouse.
 tags: ["virtualization"]
 requirements:
-  deckhouse: ">= 1.68"
+  deckhouse: ">= 1.68.14"
   modules:
     cni-cilium: ">= 0.0.0"
 disable:


### PR DESCRIPTION
## Description

Update deckhouse requirements.
To enable virtual machine migration, a Deckhouse version of at least 1.68.14 is required.

```changes
section: module 
type: fix
summary: To enable virtual machine migration, a Deckhouse version of at least 1.68.14 is required.
```
