### PR TITLE
fix(vm): add removing VM's conditions by design

### DIFF
--- a/api/core/v1alpha2/vmcondition/condition.go
+++ b/api/core/v1alpha2/vmcondition/condition.go
@@ -29,7 +29,6 @@ const (
 	TypeRunning                             Type = "Running"
 	TypeMigrating                           Type = "Migrating"
 	TypeMigratable                          Type = "Migratable"
-	TypePodStarted                          Type = "PodStarted"
 	TypeProvisioningReady                   Type = "ProvisioningReady"
 	TypeAgentReady                          Type = "AgentReady"
 	TypeAgentVersionNotSupported            Type = "AgentVersionNotSupported"
@@ -81,15 +80,12 @@ const (
 	ReasonRestartAwaitingVMClassChangesExist Reason = "RestartAwaitingVMClassChangesExist"
 	ReasonRestartNoNeed                      Reason = "NoNeedRestart"
 
-	ReasonPodStarted    Reason = "PodStarted"
-	ReasonPodNotFound   Reason = "PodNotFound"
 	ReasonPodNotStarted Reason = "PodNotStarted"
 
 	ReasonMigratable    Reason = "VirtualMachineMigratable"
 	ReasonNotMigratable Reason = "VirtualMachineNotMigratable"
 
 	ReasonVmIsMigrating                  Reason = "VirtualMachineMigrating"
-	ReasonVmIsNotMigrating               Reason = "VirtualMachineNotMigrating"
 	ReasonLastMigrationFinishedWithError Reason = "LastMigrationFinishedWithError"
 	ReasonVmIsNotRunning                 Reason = "VirtualMachineNotRunning"
 	ReasonVmIsRunning                    Reason = "VirtualMachineRunning"
@@ -101,7 +97,6 @@ const (
 	WaitingForTheSnapshotToStart Reason = "WaitingForTheSnapshotToStart"
 	ReasonSnapshottingInProgress Reason = "SnapshottingInProgress"
 
-	ReasonSizingPolicyMatched            Reason = "SizingPolicyMatched"
 	ReasonSizingPolicyNotMatched         Reason = "SizingPolicyNotMatched"
 	ReasonVirtualMachineClassTerminating Reason = "VirtualMachineClassTerminating"
 	ReasonVirtualMachineClassNotExists   Reason = "VirtalMachineClassNotExists"

--- a/api/core/v1alpha2/vmcondition/condition.go
+++ b/api/core/v1alpha2/vmcondition/condition.go
@@ -80,16 +80,16 @@ const (
 	ReasonRestartAwaitingVMClassChangesExist Reason = "RestartAwaitingVMClassChangesExist"
 	ReasonRestartNoNeed                      Reason = "NoNeedRestart"
 
-	ReasonPodNotStarted Reason = "PodNotStarted"
-
 	ReasonMigratable    Reason = "VirtualMachineMigratable"
 	ReasonNotMigratable Reason = "VirtualMachineNotMigratable"
 
 	ReasonVmIsMigrating                  Reason = "VirtualMachineMigrating"
+	ReasonVmIsNotMigrating               Reason = "VirtualMachineNotMigrating"
 	ReasonLastMigrationFinishedWithError Reason = "LastMigrationFinishedWithError"
 	ReasonVmIsNotRunning                 Reason = "VirtualMachineNotRunning"
 	ReasonVmIsRunning                    Reason = "VirtualMachineRunning"
 	ReasonInternalVirtualMachineError    Reason = "InternalVirtualMachineError"
+	ReasonPodNotStarted                  Reason = "PodNotStarted"
 
 	// 	ReasonFilesystemFrozen indicates that virtual machine's filesystem has been successfully frozen.
 	ReasonFilesystemFrozen Reason = "Frozen"

--- a/images/virtualization-artifact/pkg/controller/vm/internal/agent.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/agent.go
@@ -119,14 +119,12 @@ func (h *AgentHandler) syncAgentVersionNotSupport(vm *virtv2.VirtualMachine, kvv
 		case virtv2.MachinePending, virtv2.MachineStarting, virtv2.MachineStopped:
 			conditions.RemoveCondition(vmcondition.TypeAgentVersionNotSupported, &vm.Status.Conditions)
 
-		case virtv2.MachineRunning:
-			if cb.Condition().Status == metav1.ConditionFalse {
-				conditions.RemoveCondition(vmcondition.TypeAgentVersionNotSupported, &vm.Status.Conditions)
-			} else {
-				conditions.SetCondition(cb, &vm.Status.Conditions)
-			}
 		default:
-			conditions.SetCondition(cb, &vm.Status.Conditions)
+			if cb.Condition().Status == metav1.ConditionTrue {
+				conditions.SetCondition(cb, &vm.Status.Conditions)
+			} else {
+				conditions.RemoveCondition(vmcondition.TypeAgentVersionNotSupported, &vm.Status.Conditions)
+			}
 		}
 	}()
 

--- a/images/virtualization-artifact/pkg/controller/vm/internal/agent.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/agent.go
@@ -31,11 +31,6 @@ import (
 
 const nameAgentHandler = "AgentHandler"
 
-var agentConditions = []vmcondition.Type{
-	vmcondition.TypeAgentReady,
-	vmcondition.TypeAgentVersionNotSupported,
-}
-
 func NewAgentHandler() *AgentHandler {
 	return &AgentHandler{}
 }
@@ -48,10 +43,6 @@ func (h *AgentHandler) Handle(ctx context.Context, s state.VirtualMachineState) 
 	}
 	current := s.VirtualMachine().Current()
 	changed := s.VirtualMachine().Changed()
-
-	if update := addAllUnknown(changed, agentConditions...); update {
-		return reconcile.Result{Requeue: true}, nil
-	}
 
 	if isDeletion(current) {
 		return reconcile.Result{}, nil
@@ -80,7 +71,14 @@ func (h *AgentHandler) syncAgentReady(vm *virtv2.VirtualMachine, kvvmi *virtv1.V
 
 	cb := conditions.NewConditionBuilder(vmcondition.TypeAgentReady).Generation(vm.GetGeneration())
 
-	defer func() { conditions.SetCondition(cb, &vm.Status.Conditions) }()
+	defer func() {
+		phase := vm.Status.Phase
+		if phase == virtv2.MachinePending || phase == virtv2.MachineStarting || phase == virtv2.MachineStopped {
+			conditions.RemoveCondition(vmcondition.TypeAgentReady, &vm.Status.Conditions)
+		} else {
+			conditions.SetCondition(cb, &vm.Status.Conditions)
+		}
+	}()
 
 	if kvvmi == nil {
 		cb.Status(metav1.ConditionFalse).
@@ -116,7 +114,21 @@ func (h *AgentHandler) syncAgentVersionNotSupport(vm *virtv2.VirtualMachine, kvv
 
 	cb := conditions.NewConditionBuilder(vmcondition.TypeAgentVersionNotSupported).Generation(vm.GetGeneration())
 
-	defer func() { conditions.SetCondition(cb, &vm.Status.Conditions) }()
+	defer func() {
+		switch vm.Status.Phase {
+		case virtv2.MachinePending, virtv2.MachineStarting, virtv2.MachineStopped:
+			conditions.RemoveCondition(vmcondition.TypeAgentVersionNotSupported, &vm.Status.Conditions)
+
+		case virtv2.MachineRunning:
+			if cb.Condition().Status == metav1.ConditionFalse {
+				conditions.RemoveCondition(vmcondition.TypeAgentVersionNotSupported, &vm.Status.Conditions)
+			} else {
+				conditions.SetCondition(cb, &vm.Status.Conditions)
+			}
+		default:
+			conditions.SetCondition(cb, &vm.Status.Conditions)
+		}
+	}()
 
 	if kvvmi == nil {
 		cb.Status(metav1.ConditionFalse).

--- a/images/virtualization-artifact/pkg/controller/vm/internal/agent_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/agent_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	virtv1 "kubevirt.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmbuilder "github.com/deckhouse/virtualization-controller/pkg/builder/vm"
+	"github.com/deckhouse/virtualization-controller/pkg/common/testutil"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/reconciler"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/vm/internal/state"
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmcondition"
+)
+
+var _ = Describe("AgentHandler Tests", func() {
+	const (
+		name      = "vm-agent"
+		namespace = "default"
+	)
+
+	var (
+		ctx        = testutil.ContextBackgroundWithNoOpLogger()
+		fakeClient client.WithWatch
+		resource   *reconciler.Resource[*virtv2.VirtualMachine, virtv2.VirtualMachineStatus]
+		vmState    state.VirtualMachineState
+	)
+
+	AfterEach(func() {
+		fakeClient = nil
+		resource = nil
+		vmState = nil
+	})
+
+	newVM := func(phase virtv2.MachinePhase) *virtv2.VirtualMachine {
+		vm := vmbuilder.NewEmpty(name, namespace)
+		vm.Status.Phase = phase
+		return vm
+	}
+
+	newKVVMI := func(agentConnected bool, agentUnsupported bool) *virtv1.VirtualMachineInstance {
+		conditions := make([]virtv1.VirtualMachineInstanceCondition, 0)
+		if agentConnected {
+			conditions = append(conditions, virtv1.VirtualMachineInstanceCondition{
+				Type:   virtv1.VirtualMachineInstanceAgentConnected,
+				Status: corev1.ConditionTrue,
+			})
+		}
+		if agentUnsupported {
+			conditions = append(conditions, virtv1.VirtualMachineInstanceCondition{
+				Type:   virtv1.VirtualMachineInstanceUnsupportedAgent,
+				Status: corev1.ConditionTrue,
+			})
+		} else {
+			conditions = append(conditions, virtv1.VirtualMachineInstanceCondition{
+				Type:   virtv1.VirtualMachineInstanceUnsupportedAgent,
+				Status: corev1.ConditionFalse,
+			})
+		}
+		vmi := &virtv1.VirtualMachineInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Status: virtv1.VirtualMachineInstanceStatus{
+				Conditions: conditions,
+			},
+		}
+		return vmi
+	}
+
+	reconcile := func() {
+		h := NewAgentHandler()
+		_, err := h.Handle(ctx, vmState)
+		Expect(err).NotTo(HaveOccurred())
+		err = resource.Update(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	DescribeTable("AgentReady Condition Tests",
+		func(phase virtv2.MachinePhase, agentConnected bool, expectedStatus metav1.ConditionStatus, expectedExistence bool) {
+			vm := newVM(phase)
+			vmi := newKVVMI(agentConnected, false)
+			fakeClient, resource, vmState = setupEnvironment(vm, vmi)
+
+			reconcile()
+
+			newVM := new(virtv2.VirtualMachine)
+			err := fakeClient.Get(ctx, client.ObjectKeyFromObject(vm), newVM)
+			Expect(err).NotTo(HaveOccurred())
+
+			cond, exists := conditions.GetCondition(vmcondition.TypeAgentReady, newVM.Status.Conditions)
+			Expect(exists).To(Equal(expectedExistence))
+			if exists {
+				Expect(cond.Status).To(Equal(expectedStatus))
+			}
+		},
+		Entry("Should add AgentReady as True if agent is connected", virtv2.MachineRunning, true, metav1.ConditionTrue, true),
+		Entry("Should add AgentReady as False if agent is not connected", virtv2.MachineRunning, false, metav1.ConditionFalse, true),
+
+		Entry("Should add AgentReady as True if agent is connected", virtv2.MachineStopping, true, metav1.ConditionTrue, true),
+		Entry("Should add AgentReady as False if agent is not connected", virtv2.MachineStopping, false, metav1.ConditionFalse, true),
+
+		Entry("Should add AgentReady as True if agent is connected", virtv2.MachineMigrating, true, metav1.ConditionTrue, true),
+		Entry("Should add AgentReady as False if agent is not connected", virtv2.MachineMigrating, false, metav1.ConditionFalse, true),
+
+		Entry("Should not add AgentReady if VM is in Pending phase if agent is connected", virtv2.MachinePending, true, metav1.ConditionUnknown, false),
+		Entry("Should not add AgentReady if VM is in Pending phase if agent is not connected", virtv2.MachinePending, false, metav1.ConditionUnknown, false),
+
+		Entry("Should not add AgentReady if VM is in Starting phase if agent is connected", virtv2.MachineStarting, true, metav1.ConditionUnknown, false),
+		Entry("Should not add AgentReady if VM is in Starting phase if agent is not connected", virtv2.MachineStarting, false, metav1.ConditionUnknown, false),
+
+		Entry("Should not add AgentReady if VM is in Stopped phase if agent is connected", virtv2.MachineStopped, true, metav1.ConditionUnknown, false),
+		Entry("Should not add AgentReady if VM is in Stopped phase if agent is not connected", virtv2.MachineStopped, false, metav1.ConditionUnknown, false),
+	)
+
+	DescribeTable("AgentVersionNotSupported Condition Tests",
+		func(phase virtv2.MachinePhase, agentUnsupported bool, expectedStatus metav1.ConditionStatus, expectedExistence bool) {
+			vm := newVM(phase)
+			vmi := newKVVMI(true, agentUnsupported)
+			fakeClient, resource, vmState = setupEnvironment(vm, vmi)
+
+			reconcile()
+
+			newVM := new(virtv2.VirtualMachine)
+			err := fakeClient.Get(ctx, client.ObjectKeyFromObject(vm), newVM)
+			Expect(err).NotTo(HaveOccurred())
+
+			cond, exists := conditions.GetCondition(vmcondition.TypeAgentVersionNotSupported, newVM.Status.Conditions)
+			Expect(exists).To(Equal(expectedExistence))
+			if exists {
+				Expect(cond.Status).To(Equal(expectedStatus))
+			}
+		},
+		Entry("Should set unsupported version condition as True in Running phase", virtv2.MachineRunning, true, metav1.ConditionTrue, true),
+		Entry("Should not set unsupported version condition as False in Running phase", virtv2.MachineRunning, false, metav1.ConditionUnknown, false),
+
+		Entry("Should set unsupported version condition as True in Stopping phase", virtv2.MachineStopping, true, metav1.ConditionTrue, true),
+		Entry("Should set unsupported version condition as False in Stopping phase", virtv2.MachineStopping, false, metav1.ConditionFalse, true),
+
+		Entry("Should set unsupported version condition as True in Migrating phase", virtv2.MachineMigrating, true, metav1.ConditionTrue, true),
+		Entry("Should set unsupported version condition as False in Migrating phase", virtv2.MachineMigrating, false, metav1.ConditionFalse, true),
+
+		Entry("Should not set unsupported version condition as True in Pending phase", virtv2.MachinePending, true, metav1.ConditionUnknown, false),
+		Entry("Should not set unsupported version condition as False in Pending phase", virtv2.MachinePending, false, metav1.ConditionUnknown, false),
+
+		Entry("Should not set unsupported version condition as True in Starting phase", virtv2.MachineStarting, true, metav1.ConditionUnknown, false),
+		Entry("Should not set unsupported version condition as False in Starting phase", virtv2.MachineStarting, false, metav1.ConditionUnknown, false),
+
+		Entry("Should not set unsupported version condition as True in Stopped phase", virtv2.MachineStopped, true, metav1.ConditionUnknown, false),
+		Entry("Should not set unsupported version condition as False in Stopped phase", virtv2.MachineStopped, false, metav1.ConditionUnknown, false),
+	)
+})

--- a/images/virtualization-artifact/pkg/controller/vm/internal/firmware_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/firmware_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	virtv1 "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -74,7 +75,15 @@ var _ = Describe("TestFirmwareHandler", func() {
 
 	DescribeTable("Condition TypeFirmwareUpToDate should be in expected state",
 		func(vm *virtv2.VirtualMachine, kvvmi *virtv1.VirtualMachineInstance, expectedStatus metav1.ConditionStatus, expectedReason vmcondition.Reason) {
-			fakeClient, resource, vmState = setupEnvironment(vm, kvvmi)
+			vmPod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: namespace,
+					Labels:    map[string]string{virtv1.VirtualMachineNameLabel: name},
+				},
+			}
+
+			fakeClient, resource, vmState = setupEnvironment(vm, kvvmi, vmPod)
 			reconcile()
 
 			newVM := &virtv2.VirtualMachine{}

--- a/images/virtualization-artifact/pkg/controller/vm/internal/firmware_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/firmware_test.go
@@ -21,7 +21,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	virtv1 "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -74,16 +73,8 @@ var _ = Describe("TestFirmwareHandler", func() {
 	}
 
 	DescribeTable("Condition TypeFirmwareUpToDate should be in expected state",
-		func(vm *virtv2.VirtualMachine, kvvmi *virtv1.VirtualMachineInstance, expectedStatus metav1.ConditionStatus, expectedReason vmcondition.Reason) {
-			vmPod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pod",
-					Namespace: namespace,
-					Labels:    map[string]string{virtv1.VirtualMachineNameLabel: name},
-				},
-			}
-
-			fakeClient, resource, vmState = setupEnvironment(vm, kvvmi, vmPod)
+		func(vm *virtv2.VirtualMachine, kvvmi *virtv1.VirtualMachineInstance, expectedStatus metav1.ConditionStatus, expectedReason vmcondition.Reason, expectedExistence bool) {
+			fakeClient, resource, vmState = setupEnvironment(vm, kvvmi)
 			reconcile()
 
 			newVM := &virtv2.VirtualMachine{}
@@ -91,52 +82,51 @@ var _ = Describe("TestFirmwareHandler", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			upToDate, exists := conditions.GetCondition(vmcondition.TypeFirmwareUpToDate, newVM.Status.Conditions)
-			Expect(exists).To(BeTrue())
-			Expect(upToDate.Status).To(Equal(expectedStatus))
-			Expect(upToDate.Reason).To(Equal(expectedReason.String()))
+			Expect(exists).To(Equal(expectedExistence))
+			if exists {
+				Expect(upToDate.Status).To(Equal(expectedStatus))
+				Expect(upToDate.Reason).To(Equal(expectedReason.String()))
+			}
 		},
-		Entry("Should be up to date", newVM(), newKVVMI(expectedImage), metav1.ConditionTrue, vmcondition.ReasonFirmwareUpToDate),
-		Entry("Should be up to date because kvvmi is not exists", newVM(), nil, metav1.ConditionTrue, vmcondition.ReasonFirmwareUpToDate),
-		Entry("Should be out of date 1", newVM(), newKVVMI("other-image-1"), metav1.ConditionFalse, vmcondition.ReasonFirmwareOutOfDate),
-		Entry("Should be out of date 2", newVM(), newKVVMI("other-image-2"), metav1.ConditionFalse, vmcondition.ReasonFirmwareOutOfDate),
-		Entry("Should be out of date 3", newVM(), newKVVMI("other-image-3"), metav1.ConditionFalse, vmcondition.ReasonFirmwareOutOfDate),
-		Entry("Should be out of date 4", newVM(), newKVVMI("other-image-4"), metav1.ConditionFalse, vmcondition.ReasonFirmwareOutOfDate),
-		Entry("Should be out of date 5", newVM(), newKVVMI("other-image-5"), metav1.ConditionFalse, vmcondition.ReasonFirmwareOutOfDate),
+		Entry("Should be up to date", newVM(), newKVVMI(expectedImage), metav1.ConditionTrue, vmcondition.ReasonFirmwareUpToDate, false),
+		Entry("Should be up to date because kvvmi is not exists", newVM(), nil, metav1.ConditionTrue, vmcondition.ReasonFirmwareUpToDate, false),
+		Entry("Should be out of date 1", newVM(), newKVVMI("other-image-1"), metav1.ConditionFalse, vmcondition.ReasonFirmwareOutOfDate, true),
+		Entry("Should be out of date 2", newVM(), newKVVMI("other-image-2"), metav1.ConditionFalse, vmcondition.ReasonFirmwareOutOfDate, true),
+		Entry("Should be out of date 3", newVM(), newKVVMI("other-image-3"), metav1.ConditionFalse, vmcondition.ReasonFirmwareOutOfDate, true),
+		Entry("Should be out of date 4", newVM(), newKVVMI("other-image-4"), metav1.ConditionFalse, vmcondition.ReasonFirmwareOutOfDate, true),
+		Entry("Should be out of date 5", newVM(), newKVVMI("other-image-5"), metav1.ConditionFalse, vmcondition.ReasonFirmwareOutOfDate, true),
 	)
 
-	Describe("Test TypeFirmwareUpToDate condition presence with a missing pod", func() {
-		It("Should remove condition if pod is missing", func() {
-			vm := newVM()
-			vm.Status.Conditions = append(vm.Status.Conditions, metav1.Condition{
-				Type:   vmcondition.TypeFirmwareUpToDate.String(),
-				Status: metav1.ConditionFalse,
-				Reason: vmcondition.ReasonFirmwareOutOfDate.String(),
-			})
-
-			fakeClient, resource, vmState = setupEnvironment(vm, newKVVMI(expectedImage))
+	DescribeTable("Condition TypeFirmwareUpToDate should be in the expected state considering the VM phase",
+		func(vm *virtv2.VirtualMachine, phase virtv2.MachinePhase, kvvmi *virtv1.VirtualMachineInstance, expectedStatus metav1.ConditionStatus, expectedExistence bool) {
+			vm.Status.Phase = phase
+			fakeClient, resource, vmState = setupEnvironment(vm, kvvmi)
 			reconcile()
-
-			newVM := new(virtv2.VirtualMachine)
+			newVM := &virtv2.VirtualMachine{}
 			err := fakeClient.Get(ctx, client.ObjectKeyFromObject(vm), newVM)
 			Expect(err).NotTo(HaveOccurred())
+			upToDate, exists := conditions.GetCondition(vmcondition.TypeFirmwareUpToDate, newVM.Status.Conditions)
+			Expect(exists).To(Equal(expectedExistence))
+			if exists {
+				Expect(upToDate.Status).To(Equal(expectedStatus))
+			}
+		},
+		Entry("Running phase, condition should not be set", newVM(), virtv2.MachineRunning, newKVVMI(expectedImage), metav1.ConditionUnknown, false),
+		Entry("Running phase, condition should be set", newVM(), virtv2.MachineRunning, newKVVMI("other-image-1"), metav1.ConditionFalse, true),
 
-			_, exists := conditions.GetCondition(vmcondition.TypeFirmwareUpToDate, newVM.Status.Conditions)
-			Expect(exists).To(BeFalse())
-		})
+		Entry("Migrating phase, condition should not be set", newVM(), virtv2.MachineMigrating, newKVVMI(expectedImage), metav1.ConditionUnknown, false),
+		Entry("Migrating phase, condition should be set", newVM(), virtv2.MachineMigrating, newKVVMI("other-image-1"), metav1.ConditionFalse, true),
 
-		It("Should not add condition if pod is missing and condition was absent", func() {
-			vm := newVM()
-			vm.Status.Conditions = []metav1.Condition{}
+		Entry("Stopping phase, condition should not be set", newVM(), virtv2.MachineStopping, newKVVMI(expectedImage), metav1.ConditionUnknown, false),
+		Entry("Stopping phase, condition should be set", newVM(), virtv2.MachineStopping, newKVVMI("other-image-1"), metav1.ConditionFalse, true),
 
-			fakeClient, resource, vmState = setupEnvironment(vm, newKVVMI(expectedImage))
-			reconcile()
+		Entry("Pending phase, condition should not be set", newVM(), virtv2.MachinePending, newKVVMI(expectedImage), metav1.ConditionUnknown, false),
+		Entry("Pending phase, condition should not be set", newVM(), virtv2.MachinePending, newKVVMI("other-image-1"), metav1.ConditionUnknown, false),
 
-			newVM := new(virtv2.VirtualMachine)
-			err := fakeClient.Get(ctx, client.ObjectKeyFromObject(vm), newVM)
-			Expect(err).NotTo(HaveOccurred())
+		Entry("Starting phase, condition should not be set", newVM(), virtv2.MachineStarting, newKVVMI(expectedImage), metav1.ConditionUnknown, false),
+		Entry("Starting phase, condition should not be set", newVM(), virtv2.MachineStarting, newKVVMI("other-image-1"), metav1.ConditionUnknown, false),
 
-			_, exists := conditions.GetCondition(vmcondition.TypeFirmwareUpToDate, newVM.Status.Conditions)
-			Expect(exists).To(BeFalse())
-		})
-	})
+		Entry("Stopped phase, condition should not be set", newVM(), virtv2.MachineStopped, newKVVMI(expectedImage), metav1.ConditionUnknown, false),
+		Entry("Stopped phase, condition should not be set", newVM(), virtv2.MachineStopped, newKVVMI("other-image-1"), metav1.ConditionUnknown, false),
+	)
 })

--- a/images/virtualization-artifact/pkg/controller/vm/internal/lifecycle.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/lifecycle.go
@@ -28,8 +28,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/deckhouse/virtualization-controller/pkg/common/annotations"
-	podutil "github.com/deckhouse/virtualization-controller/pkg/common/pod"
-	commonvmop "github.com/deckhouse/virtualization-controller/pkg/common/vmop"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vm/internal/state"
@@ -37,15 +35,7 @@ import (
 	"github.com/deckhouse/virtualization-controller/pkg/logger"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmcondition"
-	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmopcondition"
 )
-
-var lifeCycleConditions = []vmcondition.Type{
-	vmcondition.TypeRunning,
-	vmcondition.TypeMigrating,
-	vmcondition.TypeMigratable,
-	vmcondition.TypePodStarted,
-}
 
 const nameLifeCycleHandler = "LifeCycleHandler"
 
@@ -87,7 +77,7 @@ func (h *LifeCycleHandler) Handle(ctx context.Context, s state.VirtualMachineSta
 		return reconcile.Result{}, nil
 	}
 
-	if updated := addAllUnknown(changed, lifeCycleConditions...); updated || changed.Status.Phase == "" {
+	if updated := addAllUnknown(changed, vmcondition.TypeRunning); updated || changed.Status.Phase == "" {
 		changed.Status.Phase = virtv2.MachinePending
 		return reconcile.Result{Requeue: true}, nil
 	}
@@ -109,18 +99,9 @@ func (h *LifeCycleHandler) Handle(ctx context.Context, s state.VirtualMachineSta
 		return reconcile.Result{}, err
 	}
 
-	vmops, err := s.VMOPs(ctx)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
 	log := logger.FromContext(ctx).With(logger.SlogHandler(nameLifeCycleHandler))
 
-	h.syncMigrationState(changed, kvvmi)
-	h.syncMigrating(changed, kvvmi, vmops, log)
-	h.syncMigratable(changed, kvvm)
-	h.syncPodStarted(changed, kvvm, kvvmi, pod)
-	h.syncRunning(changed, kvvm, kvvmi, log)
+	h.syncRunning(changed, kvvm, kvvmi, pod, log)
 	return reconcile.Result{}, nil
 }
 
@@ -128,104 +109,9 @@ func (h *LifeCycleHandler) Name() string {
 	return nameLifeCycleHandler
 }
 
-func (h *LifeCycleHandler) syncMigrationState(vm *virtv2.VirtualMachine, kvvmi *virtv1.VirtualMachineInstance) {
-	if kvvmi == nil || kvvmi.Status.MigrationState == nil {
-		vm.Status.MigrationState = nil
-	} else {
-		vm.Status.MigrationState = h.wrapMigrationState(kvvmi.Status.MigrationState)
-	}
-}
+func (h *LifeCycleHandler) syncRunning(vm *virtv2.VirtualMachine, kvvm *virtv1.VirtualMachine, kvvmi *virtv1.VirtualMachineInstance, pod *corev1.Pod, log *slog.Logger) {
+	cb := conditions.NewConditionBuilder(vmcondition.TypeRunning).Generation(vm.GetGeneration())
 
-func (h *LifeCycleHandler) syncMigrating(vm *virtv2.VirtualMachine, kvvmi *virtv1.VirtualMachineInstance, vmops []*virtv2.VirtualMachineOperation, log *slog.Logger) {
-	cbMigrating := conditions.NewConditionBuilder(vmcondition.TypeMigrating).Generation(vm.GetGeneration())
-
-	var vmop *virtv2.VirtualMachineOperation
-	{
-		var inProgressVmops []*virtv2.VirtualMachineOperation
-		for _, op := range vmops {
-			if commonvmop.IsMigration(op) && op.Status.Phase == virtv2.VMOPPhaseInProgress {
-				inProgressVmops = append(inProgressVmops, op)
-			}
-		}
-
-		switch length := len(inProgressVmops); length {
-		case 0:
-		case 1:
-			vmop = inProgressVmops[0]
-		default:
-			log.Error("Found vmops in progress phase. This is unexpected. Please report a bug.", slog.Int("VMOPCount", length))
-		}
-	}
-
-	switch {
-	case liveMigrationInProgress(vm.Status.MigrationState):
-		cbMigrating.Status(metav1.ConditionTrue).Reason(vmcondition.ReasonVmIsMigrating)
-		conditions.SetCondition(cbMigrating, &vm.Status.Conditions)
-
-	case vmop != nil:
-		cbMigrating.Status(metav1.ConditionFalse).Reason(vmcondition.ReasonVmIsNotMigrating)
-		completed, _ := conditions.GetCondition(vmopcondition.TypeCompleted, vmop.Status.Conditions)
-		switch completed.Reason {
-		case vmopcondition.ReasonMigrationPending.String():
-			cbMigrating.Message("Migration is awaiting start.")
-		case vmopcondition.ReasonMigrationPrepareTarget.String():
-			cbMigrating.Message("Migration is awaiting target preparation.")
-		case vmopcondition.ReasonMigrationTargetReady.String():
-			cbMigrating.Message("Migration is awaiting execution.")
-		case vmopcondition.ReasonMigrationRunning.String():
-			cbMigrating.Status(metav1.ConditionTrue).Reason(vmcondition.ReasonVmIsRunning)
-		}
-		conditions.SetCondition(cbMigrating, &vm.Status.Conditions)
-
-	case kvvmi != nil && liveMigrationFailed(vm.Status.MigrationState):
-		msg := kvvmi.Status.MigrationState.FailureReason
-		cbMigrating.Status(metav1.ConditionFalse).
-			Reason(vmcondition.ReasonLastMigrationFinishedWithError).
-			Message(msg)
-		conditions.SetCondition(cbMigrating, &vm.Status.Conditions)
-
-	default:
-		cbMigrating.Status(metav1.ConditionFalse).Reason(vmcondition.ReasonVmIsNotMigrating)
-		conditions.SetCondition(cbMigrating, &vm.Status.Conditions)
-	}
-
-}
-
-func (h *LifeCycleHandler) syncMigratable(vm *virtv2.VirtualMachine, kvvm *virtv1.VirtualMachine) {
-	cbMigratable := conditions.NewConditionBuilder(vmcondition.TypeMigratable).Generation(vm.GetGeneration())
-
-	if kvvm != nil {
-		liveMigratable := service.GetKVVMCondition(string(virtv1.VirtualMachineInstanceIsMigratable), kvvm.Status.Conditions)
-		if liveMigratable != nil && liveMigratable.Status == corev1.ConditionFalse && liveMigratable.Reason == virtv1.VirtualMachineInstanceReasonDisksNotMigratable {
-			cbMigratable.Status(metav1.ConditionFalse).
-				Reason(vmcondition.ReasonNotMigratable).
-				Message("Live migration requires that all PVCs must be shared (using ReadWriteMany access mode)")
-			conditions.SetCondition(cbMigratable, &vm.Status.Conditions)
-			return
-		}
-	}
-	cbMigratable.Status(metav1.ConditionTrue).Reason(vmcondition.ReasonMigratable)
-	conditions.SetCondition(cbMigratable, &vm.Status.Conditions)
-}
-
-func liveMigrationInProgress(migrationState *virtv2.VirtualMachineMigrationState) bool {
-	return migrationState != nil && migrationState.StartTimestamp != nil && migrationState.EndTimestamp == nil
-}
-
-func liveMigrationFailed(migrationState *virtv2.VirtualMachineMigrationState) bool {
-	return migrationState != nil && migrationState.EndTimestamp != nil && migrationState.Result == virtv2.MigrationResultFailed
-}
-
-func (h *LifeCycleHandler) syncPodStarted(vm *virtv2.VirtualMachine, kvvm *virtv1.VirtualMachine, kvvmi *virtv1.VirtualMachineInstance, pod *corev1.Pod) {
-	cb := conditions.NewConditionBuilder(vmcondition.TypePodStarted).Generation(vm.GetGeneration())
-
-	if podutil.IsPodStarted(pod) {
-		cb.Status(metav1.ConditionTrue).Reason(vmcondition.ReasonPodStarted)
-		conditions.SetCondition(cb, &vm.Status.Conditions)
-		return
-	}
-
-	// Try to extract error from pod.
 	if pod != nil && pod.Status.Message != "" {
 		cb.Status(metav1.ConditionFalse).
 			Reason(vmcondition.ReasonPodNotStarted).
@@ -235,13 +121,16 @@ func (h *LifeCycleHandler) syncPodStarted(vm *virtv2.VirtualMachine, kvvm *virtv
 	}
 
 	if kvvm != nil {
-		// Try to extract error from kvvm PodScheduled condition.
-		cond := service.GetKVVMCondition(string(corev1.PodScheduled), kvvm.Status.Conditions)
-		if cond != nil && cond.Status == corev1.ConditionFalse && cond.Message != "" {
-			cb.Status(metav1.ConditionFalse).
-				Reason(vmcondition.ReasonPodNotStarted).
-				Message(fmt.Sprintf("%s: %s", cond.Reason, cond.Message))
-			conditions.SetCondition(cb, &vm.Status.Conditions)
+		podScheduled := service.GetKVVMCondition(string(corev1.PodScheduled), kvvm.Status.Conditions)
+		if podScheduled != nil && podScheduled.Status == corev1.ConditionFalse {
+			vm.Status.Phase = virtv2.MachinePending
+			if podScheduled.Message != "" {
+				cb.Status(metav1.ConditionFalse).
+					Reason(vmcondition.ReasonPodNotStarted).
+					Message(fmt.Sprintf("%s: %s", podScheduled.Reason, podScheduled.Message))
+				conditions.SetCondition(cb, &vm.Status.Conditions)
+			}
+
 			return
 		}
 
@@ -259,23 +148,6 @@ func (h *LifeCycleHandler) syncPodStarted(vm *virtv2.VirtualMachine, kvvm *virtv
 				Reason(vmcondition.ReasonPodNotStarted).
 				Message(msg)
 			conditions.SetCondition(cb, &vm.Status.Conditions)
-			return
-		}
-	}
-
-	cb.Status(metav1.ConditionFalse).
-		Reason(vmcondition.ReasonPodNotFound).
-		Message("Pod of the virtual machine was not found")
-	conditions.SetCondition(cb, &vm.Status.Conditions)
-}
-
-func (h *LifeCycleHandler) syncRunning(vm *virtv2.VirtualMachine, kvvm *virtv1.VirtualMachine, kvvmi *virtv1.VirtualMachineInstance, log *slog.Logger) {
-	cb := conditions.NewConditionBuilder(vmcondition.TypeRunning).Generation(vm.GetGeneration())
-
-	if kvvm != nil {
-		podScheduled := service.GetKVVMCondition(string(corev1.PodScheduled), kvvm.Status.Conditions)
-		if podScheduled != nil && podScheduled.Status == corev1.ConditionFalse {
-			vm.Status.Phase = virtv2.MachinePending
 			return
 		}
 
@@ -329,36 +201,4 @@ func (h *LifeCycleHandler) syncRunning(vm *virtv2.VirtualMachine, kvvm *virtv1.V
 	}
 	cb.Reason(vmcondition.ReasonVmIsNotRunning).Status(metav1.ConditionFalse)
 	conditions.SetCondition(cb, &vm.Status.Conditions)
-}
-
-func (h *LifeCycleHandler) wrapMigrationState(state *virtv1.VirtualMachineInstanceMigrationState) *virtv2.VirtualMachineMigrationState {
-	if state == nil {
-		return nil
-	}
-	return &virtv2.VirtualMachineMigrationState{
-		StartTimestamp: state.StartTimestamp,
-		EndTimestamp:   state.EndTimestamp,
-		Target: virtv2.VirtualMachineLocation{
-			Node: state.TargetNode,
-			Pod:  state.TargetPod,
-		},
-		Source: virtv2.VirtualMachineLocation{
-			Node: state.SourceNode,
-		},
-		Result: h.getResult(state),
-	}
-}
-
-func (h *LifeCycleHandler) getResult(state *virtv1.VirtualMachineInstanceMigrationState) virtv2.MigrationResult {
-	if state == nil {
-		return ""
-	}
-	switch {
-	case state.Completed && !state.Failed:
-		return virtv2.MigrationResultSucceeded
-	case state.Failed:
-		return virtv2.MigrationResultFailed
-	default:
-		return ""
-	}
 }

--- a/images/virtualization-artifact/pkg/controller/vm/internal/migrating.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/migrating.go
@@ -18,17 +18,21 @@ package internal
 
 import (
 	"context"
+	"log/slog"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	virtv1 "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	commonvmop "github.com/deckhouse/virtualization-controller/pkg/common/vmop"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vm/internal/state"
+	"github.com/deckhouse/virtualization-controller/pkg/logger"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmcondition"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmopcondition"
 )
 
 const nameMigratingHandler = "MigratingHandler"
@@ -51,65 +55,26 @@ func (h *MigratingHandler) Handle(ctx context.Context, s state.VirtualMachineSta
 		return reconcile.Result{}, nil
 	}
 
-	kvvmi, err := s.KVVMI(ctx)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
-	if kvvmi == nil || kvvmi.Status.MigrationState == nil {
-		vm.Status.MigrationState = nil
-	} else {
-		vm.Status.MigrationState = h.wrapMigrationState(kvvmi.Status.MigrationState)
-	}
-
-	cbMigrating := conditions.NewConditionBuilder(vmcondition.TypeMigrating).Generation(vm.GetGeneration())
-	defer func() {
-		if cbMigrating.Condition().Status == metav1.ConditionTrue || cbMigrating.Condition().Reason == vmcondition.ReasonLastMigrationFinishedWithError.String() {
-			conditions.SetCondition(cbMigrating, &vm.Status.Conditions)
-		} else {
-			conditions.RemoveCondition(vmcondition.TypeMigrating, &vm.Status.Conditions)
-		}
-	}()
-
-	switch {
-	case vm.Status.MigrationState != nil &&
-		vm.Status.MigrationState.StartTimestamp != nil &&
-		vm.Status.MigrationState.EndTimestamp == nil:
-
-		cbMigrating.Status(metav1.ConditionTrue).Reason(vmcondition.ReasonVmIsMigrating)
-		conditions.SetCondition(cbMigrating, &vm.Status.Conditions)
-
-	case kvvmi != nil && kvvmi.Status.MigrationState != nil &&
-		kvvmi.Status.MigrationState.EndTimestamp != nil &&
-		kvvmi.Status.MigrationState.Failed:
-
-		msg := kvvmi.Status.MigrationState.FailureReason
-		cbMigrating.Status(metav1.ConditionFalse).
-			Reason(vmcondition.ReasonLastMigrationFinishedWithError).
-			Message(msg)
-		conditions.SetCondition(cbMigrating, &vm.Status.Conditions)
-	}
-
-	cbMigratable := conditions.NewConditionBuilder(vmcondition.TypeMigratable).Generation(vm.GetGeneration())
-
 	kvvm, err := s.KVVM(ctx)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	if kvvm != nil {
-		liveMigratable := service.GetKVVMCondition(string(virtv1.VirtualMachineInstanceIsMigratable), kvvm.Status.Conditions)
-		if liveMigratable != nil && liveMigratable.Status == corev1.ConditionFalse && liveMigratable.Reason == virtv1.VirtualMachineInstanceReasonDisksNotMigratable {
-			cbMigratable.Status(metav1.ConditionFalse).
-				Reason(vmcondition.ReasonNotMigratable).
-				Message("Live migration requires that all PVCs must be shared (using ReadWriteMany access mode)")
-			conditions.SetCondition(cbMigratable, &vm.Status.Conditions)
-			return reconcile.Result{}, nil
-		}
+	kvvmi, err := s.KVVMI(ctx)
+	if err != nil {
+		return reconcile.Result{}, err
 	}
-	cbMigratable.Status(metav1.ConditionTrue).Reason(vmcondition.ReasonMigratable)
-	conditions.SetCondition(cbMigratable, &vm.Status.Conditions)
 
+	vmops, err := s.VMOPs(ctx)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	log := logger.FromContext(ctx).With(logger.SlogHandler(nameLifeCycleHandler))
+	vm.Status.MigrationState = h.wrapMigrationState(kvvmi)
+
+	h.syncMigrating(vm, kvvmi, vmops, log)
+	h.syncMigratable(vm, kvvm)
 	return reconcile.Result{}, nil
 }
 
@@ -117,25 +82,32 @@ func (h *MigratingHandler) Name() string {
 	return nameMigratingHandler
 }
 
-func (h *MigratingHandler) wrapMigrationState(state *virtv1.VirtualMachineInstanceMigrationState) *virtv2.VirtualMachineMigrationState {
-	if state == nil {
+func (h *MigratingHandler) wrapMigrationState(kvvmi *virtv1.VirtualMachineInstance) *virtv2.VirtualMachineMigrationState {
+	if kvvmi == nil {
 		return nil
 	}
+
+	migrationState := kvvmi.Status.MigrationState
+
+	if migrationState == nil {
+		return nil
+	}
+
 	return &virtv2.VirtualMachineMigrationState{
-		StartTimestamp: state.StartTimestamp,
-		EndTimestamp:   state.EndTimestamp,
+		StartTimestamp: migrationState.StartTimestamp,
+		EndTimestamp:   migrationState.EndTimestamp,
 		Target: virtv2.VirtualMachineLocation{
-			Node: state.TargetNode,
-			Pod:  state.TargetPod,
+			Node: migrationState.TargetNode,
+			Pod:  migrationState.TargetPod,
 		},
 		Source: virtv2.VirtualMachineLocation{
-			Node: state.SourceNode,
+			Node: migrationState.SourceNode,
 		},
-		Result: h.getResult(state),
+		Result: h.getMigrationResult(migrationState),
 	}
 }
 
-func (h *MigratingHandler) getResult(state *virtv1.VirtualMachineInstanceMigrationState) virtv2.MigrationResult {
+func (h *MigratingHandler) getMigrationResult(state *virtv1.VirtualMachineInstanceMigrationState) virtv2.MigrationResult {
 	if state == nil {
 		return ""
 	}
@@ -147,4 +119,88 @@ func (h *MigratingHandler) getResult(state *virtv1.VirtualMachineInstanceMigrati
 	default:
 		return ""
 	}
+}
+
+func (h *MigratingHandler) syncMigrating(vm *virtv2.VirtualMachine, kvvmi *virtv1.VirtualMachineInstance, vmops []*virtv2.VirtualMachineOperation, log *slog.Logger) {
+	cb := conditions.NewConditionBuilder(vmcondition.TypeMigrating).Generation(vm.GetGeneration())
+	defer func() {
+		if cb.Condition().Status == metav1.ConditionTrue ||
+			cb.Condition().Reason == vmcondition.ReasonLastMigrationFinishedWithError.String() ||
+			cb.Condition().Message != "" {
+			conditions.SetCondition(cb, &vm.Status.Conditions)
+		} else {
+			conditions.RemoveCondition(vmcondition.TypeMigrating, &vm.Status.Conditions)
+		}
+	}()
+
+	var vmop *virtv2.VirtualMachineOperation
+	{
+		var inProgressVmops []*virtv2.VirtualMachineOperation
+		for _, op := range vmops {
+			if commonvmop.IsMigration(op) && op.Status.Phase == virtv2.VMOPPhaseInProgress {
+				inProgressVmops = append(inProgressVmops, op)
+			}
+		}
+
+		switch length := len(inProgressVmops); length {
+		case 0:
+		case 1:
+			vmop = inProgressVmops[0]
+		default:
+			log.Error("Found vmops in progress phase. This is unexpected. Please report a bug.", slog.Int("VMOPCount", length))
+		}
+	}
+
+	switch {
+	case liveMigrationInProgress(vm.Status.MigrationState):
+		cb.Status(metav1.ConditionTrue).Reason(vmcondition.ReasonVmIsMigrating)
+		conditions.SetCondition(cb, &vm.Status.Conditions)
+
+	case vmop != nil:
+		cb.Status(metav1.ConditionFalse).Reason(vmcondition.ReasonVmIsNotMigrating)
+		completed, _ := conditions.GetCondition(vmopcondition.TypeCompleted, vmop.Status.Conditions)
+		switch completed.Reason {
+		case vmopcondition.ReasonMigrationPending.String():
+			cb.Message("Migration is awaiting start.")
+		case vmopcondition.ReasonMigrationPrepareTarget.String():
+			cb.Message("Migration is awaiting target preparation.")
+		case vmopcondition.ReasonMigrationTargetReady.String():
+			cb.Message("Migration is awaiting execution.")
+		case vmopcondition.ReasonMigrationRunning.String():
+			cb.Status(metav1.ConditionTrue).Reason(vmcondition.ReasonVmIsMigrating)
+		}
+		conditions.SetCondition(cb, &vm.Status.Conditions)
+
+	case kvvmi != nil && liveMigrationFailed(vm.Status.MigrationState):
+		msg := kvvmi.Status.MigrationState.FailureReason
+		cb.Status(metav1.ConditionFalse).
+			Reason(vmcondition.ReasonLastMigrationFinishedWithError).
+			Message(msg)
+		conditions.SetCondition(cb, &vm.Status.Conditions)
+	}
+}
+
+func (h *MigratingHandler) syncMigratable(vm *virtv2.VirtualMachine, kvvm *virtv1.VirtualMachine) {
+	cb := conditions.NewConditionBuilder(vmcondition.TypeMigratable).Generation(vm.GetGeneration())
+
+	if kvvm != nil {
+		liveMigratable := service.GetKVVMCondition(string(virtv1.VirtualMachineInstanceIsMigratable), kvvm.Status.Conditions)
+		if liveMigratable != nil && liveMigratable.Status == corev1.ConditionFalse && liveMigratable.Reason == virtv1.VirtualMachineInstanceReasonDisksNotMigratable {
+			cb.Status(metav1.ConditionFalse).
+				Reason(vmcondition.ReasonNotMigratable).
+				Message("Live migration requires that all PVCs must be shared (using ReadWriteMany access mode)")
+			conditions.SetCondition(cb, &vm.Status.Conditions)
+			return
+		}
+	}
+	cb.Status(metav1.ConditionTrue).Reason(vmcondition.ReasonMigratable)
+	conditions.SetCondition(cb, &vm.Status.Conditions)
+}
+
+func liveMigrationInProgress(migrationState *virtv2.VirtualMachineMigrationState) bool {
+	return migrationState != nil && migrationState.StartTimestamp != nil && migrationState.EndTimestamp == nil
+}
+
+func liveMigrationFailed(migrationState *virtv2.VirtualMachineMigrationState) bool {
+	return migrationState != nil && migrationState.EndTimestamp != nil && migrationState.Result == virtv2.MigrationResultFailed
 }

--- a/images/virtualization-artifact/pkg/controller/vm/internal/migrating.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/migrating.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	virtv1 "kubevirt.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/vm/internal/state"
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmcondition"
+)
+
+const nameMigratingHandler = "MigratingHandler"
+
+type MigratingHandler struct {
+}
+
+func NewMigratingHandler() *MigratingHandler {
+	return &MigratingHandler{}
+}
+
+func (h *MigratingHandler) Handle(ctx context.Context, s state.VirtualMachineState) (reconcile.Result, error) {
+	vm := s.VirtualMachine().Changed()
+
+	if isDeletion(vm) {
+		return reconcile.Result{}, nil
+	}
+
+	if vm == nil {
+		return reconcile.Result{}, nil
+	}
+
+	kvvmi, err := s.KVVMI(ctx)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if kvvmi == nil || kvvmi.Status.MigrationState == nil {
+		vm.Status.MigrationState = nil
+	} else {
+		vm.Status.MigrationState = h.wrapMigrationState(kvvmi.Status.MigrationState)
+	}
+
+	cbMigrating := conditions.NewConditionBuilder(vmcondition.TypeMigrating).Generation(vm.GetGeneration())
+	defer func() {
+		if cbMigrating.Condition().Status == metav1.ConditionTrue || cbMigrating.Condition().Reason == vmcondition.ReasonLastMigrationFinishedWithError.String() {
+			conditions.SetCondition(cbMigrating, &vm.Status.Conditions)
+		} else {
+			conditions.RemoveCondition(vmcondition.TypeMigrating, &vm.Status.Conditions)
+		}
+	}()
+
+	switch {
+	case vm.Status.MigrationState != nil &&
+		vm.Status.MigrationState.StartTimestamp != nil &&
+		vm.Status.MigrationState.EndTimestamp == nil:
+
+		cbMigrating.Status(metav1.ConditionTrue).Reason(vmcondition.ReasonVmIsMigrating)
+		conditions.SetCondition(cbMigrating, &vm.Status.Conditions)
+
+	case kvvmi != nil && kvvmi.Status.MigrationState != nil &&
+		kvvmi.Status.MigrationState.EndTimestamp != nil &&
+		kvvmi.Status.MigrationState.Failed:
+
+		msg := kvvmi.Status.MigrationState.FailureReason
+		cbMigrating.Status(metav1.ConditionFalse).
+			Reason(vmcondition.ReasonLastMigrationFinishedWithError).
+			Message(msg)
+		conditions.SetCondition(cbMigrating, &vm.Status.Conditions)
+	}
+
+	cbMigratable := conditions.NewConditionBuilder(vmcondition.TypeMigratable).Generation(vm.GetGeneration())
+
+	kvvm, err := s.KVVM(ctx)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if kvvm != nil {
+		liveMigratable := service.GetKVVMCondition(string(virtv1.VirtualMachineInstanceIsMigratable), kvvm.Status.Conditions)
+		if liveMigratable != nil && liveMigratable.Status == corev1.ConditionFalse && liveMigratable.Reason == virtv1.VirtualMachineInstanceReasonDisksNotMigratable {
+			cbMigratable.Status(metav1.ConditionFalse).
+				Reason(vmcondition.ReasonNotMigratable).
+				Message("Live migration requires that all PVCs must be shared (using ReadWriteMany access mode)")
+			conditions.SetCondition(cbMigratable, &vm.Status.Conditions)
+			return reconcile.Result{}, nil
+		}
+	}
+	cbMigratable.Status(metav1.ConditionTrue).Reason(vmcondition.ReasonMigratable)
+	conditions.SetCondition(cbMigratable, &vm.Status.Conditions)
+
+	return reconcile.Result{}, nil
+}
+
+func (h *MigratingHandler) Name() string {
+	return nameMigratingHandler
+}
+
+func (h *MigratingHandler) wrapMigrationState(state *virtv1.VirtualMachineInstanceMigrationState) *virtv2.VirtualMachineMigrationState {
+	if state == nil {
+		return nil
+	}
+	return &virtv2.VirtualMachineMigrationState{
+		StartTimestamp: state.StartTimestamp,
+		EndTimestamp:   state.EndTimestamp,
+		Target: virtv2.VirtualMachineLocation{
+			Node: state.TargetNode,
+			Pod:  state.TargetPod,
+		},
+		Source: virtv2.VirtualMachineLocation{
+			Node: state.SourceNode,
+		},
+		Result: h.getResult(state),
+	}
+}
+
+func (h *MigratingHandler) getResult(state *virtv1.VirtualMachineInstanceMigrationState) virtv2.MigrationResult {
+	if state == nil {
+		return ""
+	}
+	switch {
+	case state.Completed && !state.Failed:
+		return virtv2.MigrationResultSucceeded
+	case state.Failed:
+		return virtv2.MigrationResultFailed
+	default:
+		return ""
+	}
+}

--- a/images/virtualization-artifact/pkg/controller/vm/internal/migrating_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/migrating_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	virtv1 "kubevirt.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmbuilder "github.com/deckhouse/virtualization-controller/pkg/builder/vm"
+	"github.com/deckhouse/virtualization-controller/pkg/common/testutil"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/reconciler"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/vm/internal/state"
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmcondition"
+)
+
+var _ = Describe("MigratingHandler", func() {
+	const (
+		name      = "vm-migrating"
+		namespace = "default"
+	)
+
+	var (
+		ctx        = testutil.ContextBackgroundWithNoOpLogger()
+		fakeClient client.WithWatch
+		resource   *reconciler.Resource[*virtv2.VirtualMachine, virtv2.VirtualMachineStatus]
+		vmState    state.VirtualMachineState
+	)
+
+	AfterEach(func() {
+		fakeClient = nil
+		resource = nil
+		vmState = nil
+	})
+
+	newVM := func() *virtv2.VirtualMachine {
+		return vmbuilder.NewEmpty(name, namespace)
+	}
+
+	newKVVMI := func(migrationState *virtv1.VirtualMachineInstanceMigrationState) *virtv1.VirtualMachineInstance {
+		return &virtv1.VirtualMachineInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Status: virtv1.VirtualMachineInstanceStatus{
+				MigrationState: migrationState,
+			},
+		}
+	}
+
+	reconcile := func() {
+		h := NewMigratingHandler()
+		_, err := h.Handle(ctx, vmState)
+		Expect(err).NotTo(HaveOccurred())
+		err = resource.Update(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	Describe("Condition presence and absence scenarios", func() {
+		It("Should display migrating condition when migration is in progress", func() {
+			vm := newVM()
+			migrationState := &virtv1.VirtualMachineInstanceMigrationState{
+				StartTimestamp: &metav1.Time{Time: time.Now()},
+				EndTimestamp:   nil,
+			}
+			kvvmi := newKVVMI(migrationState)
+			fakeClient, resource, vmState = setupEnvironment(vm, kvvmi)
+			reconcile()
+
+			newVM := new(virtv2.VirtualMachine)
+			err := fakeClient.Get(ctx, client.ObjectKeyFromObject(vm), newVM)
+			Expect(err).NotTo(HaveOccurred())
+
+			cond, exists := conditions.GetCondition(vmcondition.TypeMigrating, newVM.Status.Conditions)
+			Expect(exists).To(BeTrue())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(cond.Reason).To(Equal(vmcondition.ReasonVmIsMigrating.String()))
+		})
+
+		It("Should display condition for last unsuccessful migration", func() {
+			vm := newVM()
+			migrationState := &virtv1.VirtualMachineInstanceMigrationState{
+				StartTimestamp: &metav1.Time{Time: time.Now()},
+				EndTimestamp:   &metav1.Time{Time: time.Now()},
+				Failed:         true,
+				FailureReason:  "Network issues",
+			}
+			kvvmi := newKVVMI(migrationState)
+			fakeClient, resource, vmState = setupEnvironment(vm, kvvmi)
+			reconcile()
+
+			newVM := new(virtv2.VirtualMachine)
+			err := fakeClient.Get(ctx, client.ObjectKeyFromObject(vm), newVM)
+			Expect(err).NotTo(HaveOccurred())
+
+			cond, exists := conditions.GetCondition(vmcondition.TypeMigrating, newVM.Status.Conditions)
+			Expect(exists).To(BeTrue())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal(vmcondition.ReasonLastMigrationFinishedWithError.String()))
+			Expect(cond.Message).To(Equal("Network issues"))
+		})
+
+		It("Should remove migrating condition when migration is not in progress", func() {
+			vm := newVM()
+			vm.Status.Conditions = []metav1.Condition{
+				{
+					Type:   vmcondition.TypeMigrating.String(),
+					Status: metav1.ConditionTrue,
+				},
+			}
+			kvvmi := newKVVMI(nil)
+			fakeClient, resource, vmState = setupEnvironment(vm, kvvmi)
+			reconcile()
+
+			newVM := new(virtv2.VirtualMachine)
+			err := fakeClient.Get(ctx, client.ObjectKeyFromObject(vm), newVM)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, exists := conditions.GetCondition(vmcondition.TypeMigrating, newVM.Status.Conditions)
+			Expect(exists).To(BeFalse())
+		})
+	})
+})

--- a/images/virtualization-artifact/pkg/controller/vm/internal/size_policy_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/size_policy_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmbuilder "github.com/deckhouse/virtualization-controller/pkg/builder/vm"
+	"github.com/deckhouse/virtualization-controller/pkg/common/testutil"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/reconciler"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/vm/internal/state"
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmcondition"
+)
+
+var _ = Describe("SizePolicyHandler", func() {
+	const (
+		name        = "vm-size"
+		namespace   = "default"
+		vmClassName = "vmclass"
+	)
+
+	var (
+		ctx        = testutil.ContextBackgroundWithNoOpLogger()
+		fakeClient client.WithWatch
+		resource   *reconciler.Resource[*virtv2.VirtualMachine, virtv2.VirtualMachineStatus]
+		vmState    state.VirtualMachineState
+	)
+
+	AfterEach(func() {
+		fakeClient = nil
+		resource = nil
+		vmState = nil
+	})
+
+	newVM := func(vmClassName string) *virtv2.VirtualMachine {
+		vm := vmbuilder.NewEmpty(name, namespace)
+		if vmClassName != "" {
+			vm.Spec.VirtualMachineClassName = vmClassName
+		}
+
+		return vm
+	}
+
+	reconcile := func() {
+		h := NewSizePolicyHandler()
+		_, err := h.Handle(ctx, vmState)
+		Expect(err).NotTo(HaveOccurred())
+		err = resource.Update(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	Describe("Condition presence and absence scenarios", func() {
+		It("Should add condition if it was absent and size policy does not match", func() {
+			vm := newVM("")
+			fakeClient, resource, vmState = setupEnvironment(vm)
+			reconcile()
+
+			newVM := new(virtv2.VirtualMachine)
+			err := fakeClient.Get(ctx, client.ObjectKeyFromObject(vm), newVM)
+			Expect(err).NotTo(HaveOccurred())
+			cond, exists := conditions.GetCondition(vmcondition.TypeSizingPolicyMatched, newVM.Status.Conditions)
+			Expect(exists).To(BeTrue())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+		})
+
+		It("Should remove condition if it was present and size policy matches now", func() {
+			vm := newVM(vmClassName)
+			vm.Status.Conditions = []metav1.Condition{
+				{
+					Type:   vmcondition.TypeSizingPolicyMatched.String(),
+					Status: metav1.ConditionFalse,
+				},
+			}
+
+			vmClass := &virtv2.VirtualMachineClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: vmClassName,
+				},
+			}
+			fakeClient, resource, vmState = setupEnvironment(vm, vmClass)
+			reconcile()
+
+			newVM := new(virtv2.VirtualMachine)
+			err := fakeClient.Get(ctx, client.ObjectKeyFromObject(vm), newVM)
+			Expect(err).NotTo(HaveOccurred())
+			_, exists := conditions.GetCondition(vmcondition.TypeSizingPolicyMatched, newVM.Status.Conditions)
+			Expect(exists).To(BeFalse())
+		})
+
+		It("Should not add condition if it was absent and size policy matches", func() {
+			vm := newVM(vmClassName)
+
+			vmClass := &virtv2.VirtualMachineClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: vmClassName,
+				},
+			}
+			fakeClient, resource, vmState = setupEnvironment(vm, vmClass)
+			reconcile()
+
+			newVM := new(virtv2.VirtualMachine)
+			err := fakeClient.Get(ctx, client.ObjectKeyFromObject(vm), newVM)
+			Expect(err).NotTo(HaveOccurred())
+			_, exists := conditions.GetCondition(vmcondition.TypeSizingPolicyMatched, newVM.Status.Conditions)
+			Expect(exists).To(BeFalse())
+		})
+	})
+})

--- a/images/virtualization-artifact/pkg/controller/vm/internal/size_policy_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/size_policy_test.go
@@ -77,7 +77,7 @@ var _ = Describe("SizePolicyHandler", func() {
 			fakeClient, resource, vmState = setupEnvironment(vm)
 			reconcile()
 
-			newVM := new(virtv2.VirtualMachine)
+			newVM := &virtv2.VirtualMachine{}
 			err := fakeClient.Get(ctx, client.ObjectKeyFromObject(vm), newVM)
 			Expect(err).NotTo(HaveOccurred())
 			cond, exists := conditions.GetCondition(vmcondition.TypeSizingPolicyMatched, newVM.Status.Conditions)
@@ -102,7 +102,7 @@ var _ = Describe("SizePolicyHandler", func() {
 			fakeClient, resource, vmState = setupEnvironment(vm, vmClass)
 			reconcile()
 
-			newVM := new(virtv2.VirtualMachine)
+			newVM := &virtv2.VirtualMachine{}
 			err := fakeClient.Get(ctx, client.ObjectKeyFromObject(vm), newVM)
 			Expect(err).NotTo(HaveOccurred())
 			_, exists := conditions.GetCondition(vmcondition.TypeSizingPolicyMatched, newVM.Status.Conditions)
@@ -120,7 +120,7 @@ var _ = Describe("SizePolicyHandler", func() {
 			fakeClient, resource, vmState = setupEnvironment(vm, vmClass)
 			reconcile()
 
-			newVM := new(virtv2.VirtualMachine)
+			newVM := &virtv2.VirtualMachine{}
 			err := fakeClient.Get(ctx, client.ObjectKeyFromObject(vm), newVM)
 			Expect(err).NotTo(HaveOccurred())
 			_, exists := conditions.GetCondition(vmcondition.TypeSizingPolicyMatched, newVM.Status.Conditions)

--- a/images/virtualization-artifact/pkg/controller/vm/internal/snapshotting_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/snapshotting_test.go
@@ -87,7 +87,7 @@ var _ = Describe("SnapshottingHandler", func() {
 
 			reconcile()
 
-			newVM := new(virtv2.VirtualMachine)
+			newVM := &virtv2.VirtualMachine{}
 			err := fakeClient.Get(ctx, client.ObjectKeyFromObject(vm), newVM)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -102,7 +102,7 @@ var _ = Describe("SnapshottingHandler", func() {
 			fakeClient, resource, vmState = setupEnvironment(vm, snapshot)
 			reconcile()
 
-			newVM := new(virtv2.VirtualMachine)
+			newVM := &virtv2.VirtualMachine{}
 			err := fakeClient.Get(ctx, client.ObjectKeyFromObject(vm), newVM)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -115,7 +115,7 @@ var _ = Describe("SnapshottingHandler", func() {
 			fakeClient, resource, vmState = setupEnvironment(vm)
 			reconcile()
 
-			newVM := new(virtv2.VirtualMachine)
+			newVM := &virtv2.VirtualMachine{}
 			err := fakeClient.Get(ctx, client.ObjectKeyFromObject(vm), newVM)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -134,7 +134,7 @@ var _ = Describe("SnapshottingHandler", func() {
 			fakeClient, resource, vmState = setupEnvironment(vm)
 			reconcile()
 
-			newVM := new(virtv2.VirtualMachine)
+			newVM := &virtv2.VirtualMachine{}
 			err := fakeClient.Get(ctx, client.ObjectKeyFromObject(vm), newVM)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/images/virtualization-artifact/pkg/controller/vm/internal/snapshotting_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/snapshotting_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmbuilder "github.com/deckhouse/virtualization-controller/pkg/builder/vm"
+	"github.com/deckhouse/virtualization-controller/pkg/common/testutil"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/reconciler"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/vm/internal/state"
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmcondition"
+)
+
+var _ = Describe("SnapshottingHandler", func() {
+	const (
+		name      = "vm-snapshot"
+		namespace = "default"
+	)
+
+	var (
+		ctx        = testutil.ContextBackgroundWithNoOpLogger()
+		fakeClient client.WithWatch
+		resource   *reconciler.Resource[*virtv2.VirtualMachine, virtv2.VirtualMachineStatus]
+		vmState    state.VirtualMachineState
+	)
+
+	AfterEach(func() {
+		fakeClient = nil
+		resource = nil
+		vmState = nil
+	})
+
+	newVM := func() *virtv2.VirtualMachine {
+		return vmbuilder.NewEmpty(name, namespace)
+	}
+
+	newVMSnapshot := func(vmName string, phase virtv2.VirtualMachineSnapshotPhase) *virtv2.VirtualMachineSnapshot {
+		return &virtv2.VirtualMachineSnapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      vmName + "-snapshot",
+				Namespace: namespace,
+			},
+			Spec: virtv2.VirtualMachineSnapshotSpec{
+				VirtualMachineName: vmName,
+			},
+			Status: virtv2.VirtualMachineSnapshotStatus{
+				Phase: phase,
+			},
+		}
+	}
+
+	reconcile := func() {
+		h := NewSnapshottingHandler(fakeClient)
+		_, err := h.Handle(ctx, vmState)
+		Expect(err).NotTo(HaveOccurred())
+		err = resource.Update(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	Describe("Condition presence and absence scenarios", func() {
+		It("Should add condition if snapshot is in progress", func() {
+			vm := newVM()
+			snapshot := newVMSnapshot(vm.Name, virtv2.VirtualMachineSnapshotPhaseInProgress)
+			fakeClient, resource, vmState = setupEnvironment(vm, snapshot)
+
+			reconcile()
+
+			newVM := new(virtv2.VirtualMachine)
+			err := fakeClient.Get(ctx, client.ObjectKeyFromObject(vm), newVM)
+			Expect(err).NotTo(HaveOccurred())
+
+			cond, exists := conditions.GetCondition(vmcondition.TypeSnapshotting, newVM.Status.Conditions)
+			Expect(exists).To(BeTrue())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+		})
+
+		It("Should not add condition if snapshot is ready", func() {
+			vm := newVM()
+			snapshot := newVMSnapshot(vm.Name, virtv2.VirtualMachineSnapshotPhaseReady)
+			fakeClient, resource, vmState = setupEnvironment(vm, snapshot)
+			reconcile()
+
+			newVM := new(virtv2.VirtualMachine)
+			err := fakeClient.Get(ctx, client.ObjectKeyFromObject(vm), newVM)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, exists := conditions.GetCondition(vmcondition.TypeSnapshotting, newVM.Status.Conditions)
+			Expect(exists).To(BeFalse())
+		})
+
+		It("Should not add condition if no snapshots exist", func() {
+			vm := newVM()
+			fakeClient, resource, vmState = setupEnvironment(vm)
+			reconcile()
+
+			newVM := new(virtv2.VirtualMachine)
+			err := fakeClient.Get(ctx, client.ObjectKeyFromObject(vm), newVM)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, exists := conditions.GetCondition(vmcondition.TypeSnapshotting, newVM.Status.Conditions)
+			Expect(exists).To(BeFalse())
+		})
+
+		It("Should remove condition if it was present but no snapshots in progress", func() {
+			vm := newVM()
+			vm.Status.Conditions = []metav1.Condition{
+				{
+					Type:   vmcondition.TypeSnapshotting.String(),
+					Status: metav1.ConditionTrue,
+				},
+			}
+			fakeClient, resource, vmState = setupEnvironment(vm)
+			reconcile()
+
+			newVM := new(virtv2.VirtualMachine)
+			err := fakeClient.Get(ctx, client.ObjectKeyFromObject(vm), newVM)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, exists := conditions.GetCondition(vmcondition.TypeSnapshotting, newVM.Status.Conditions)
+			Expect(exists).To(BeFalse())
+		})
+	})
+})

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
@@ -80,8 +80,27 @@ func (h *SyncKvvmHandler) Handle(ctx context.Context, s state.VirtualMachineStat
 		Reason(vmcondition.ReasonRestartNoNeed)
 
 	defer func() {
-		conditions.SetCondition(cbConfApplied, &changed.Status.Conditions)
-		conditions.SetCondition(cbAwaitingRestart, &changed.Status.Conditions)
+		switch changed.Status.Phase {
+		case virtv2.MachinePending, virtv2.MachineStarting, virtv2.MachineStopped:
+			conditions.RemoveCondition(vmcondition.TypeConfigurationApplied, &changed.Status.Conditions)
+			conditions.RemoveCondition(vmcondition.TypeAwaitingRestartToApplyConfiguration, &changed.Status.Conditions)
+
+		case virtv2.MachineRunning:
+			if cbConfApplied.Condition().Status == metav1.ConditionTrue {
+				conditions.RemoveCondition(vmcondition.TypeConfigurationApplied, &changed.Status.Conditions)
+			} else {
+				conditions.SetCondition(cbConfApplied, &changed.Status.Conditions)
+			}
+
+			if cbAwaitingRestart.Condition().Status == metav1.ConditionFalse {
+				conditions.RemoveCondition(vmcondition.TypeAwaitingRestartToApplyConfiguration, &changed.Status.Conditions)
+			} else {
+				conditions.SetCondition(cbAwaitingRestart, &changed.Status.Conditions)
+			}
+		default:
+			conditions.SetCondition(cbConfApplied, &changed.Status.Conditions)
+			conditions.SetCondition(cbAwaitingRestart, &changed.Status.Conditions)
+		}
 	}()
 
 	if isDeletion(current) {

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
@@ -226,36 +226,7 @@ func (h *SyncKvvmHandler) Name() string {
 }
 
 func (h *SyncKvvmHandler) isWaiting(vm *virtv2.VirtualMachine) bool {
-	for _, c := range vm.Status.Conditions {
-		switch vmcondition.Type(c.Type) {
-		case vmcondition.TypeBlockDevicesReady:
-			if c.Status != metav1.ConditionTrue && c.Reason != vmcondition.ReasonWaitingForProvisioningToPVC.String() {
-				return true
-			}
-
-		case vmcondition.TypeSnapshotting:
-			if c.Status == metav1.ConditionTrue && c.Reason == vmcondition.ReasonSnapshottingInProgress.String() {
-				return true
-			}
-
-		case vmcondition.TypeIPAddressReady:
-			if c.Status != metav1.ConditionTrue && c.Reason != vmcondition.ReasonIPAddressNotAssigned.String() {
-				return true
-			}
-
-		case vmcondition.TypeProvisioningReady,
-			vmcondition.TypeClassReady:
-			if c.Status != metav1.ConditionTrue {
-				return true
-			}
-
-		case vmcondition.TypeSizingPolicyMatched:
-			if c.Status != metav1.ConditionTrue {
-				return true
-			}
-		}
-	}
-	return false
+	return !checkVirtualMachineConfiguration(vm)
 }
 
 func (h *SyncKvvmHandler) syncKVVM(ctx context.Context, s state.VirtualMachineState, allChanges vmchange.SpecChanges) (bool, error) {

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
@@ -85,21 +85,18 @@ func (h *SyncKvvmHandler) Handle(ctx context.Context, s state.VirtualMachineStat
 			conditions.RemoveCondition(vmcondition.TypeConfigurationApplied, &changed.Status.Conditions)
 			conditions.RemoveCondition(vmcondition.TypeAwaitingRestartToApplyConfiguration, &changed.Status.Conditions)
 
-		case virtv2.MachineRunning:
-			if cbConfApplied.Condition().Status == metav1.ConditionTrue {
-				conditions.RemoveCondition(vmcondition.TypeConfigurationApplied, &changed.Status.Conditions)
-			} else {
+		default:
+			if cbConfApplied.Condition().Status == metav1.ConditionFalse {
 				conditions.SetCondition(cbConfApplied, &changed.Status.Conditions)
+			} else {
+				conditions.RemoveCondition(vmcondition.TypeConfigurationApplied, &changed.Status.Conditions)
 			}
 
-			if cbAwaitingRestart.Condition().Status == metav1.ConditionFalse {
-				conditions.RemoveCondition(vmcondition.TypeAwaitingRestartToApplyConfiguration, &changed.Status.Conditions)
-			} else {
+			if cbAwaitingRestart.Condition().Status == metav1.ConditionTrue {
 				conditions.SetCondition(cbAwaitingRestart, &changed.Status.Conditions)
+			} else {
+				conditions.RemoveCondition(vmcondition.TypeAwaitingRestartToApplyConfiguration, &changed.Status.Conditions)
 			}
-		default:
-			conditions.SetCondition(cbConfApplied, &changed.Status.Conditions)
-			conditions.SetCondition(cbAwaitingRestart, &changed.Status.Conditions)
 		}
 	}()
 

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm_test.go
@@ -1,0 +1,245 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	virtv1 "kubevirt.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmbuilder "github.com/deckhouse/virtualization-controller/pkg/builder/vm"
+	"github.com/deckhouse/virtualization-controller/pkg/common/testutil"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/kvbuilder"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/reconciler"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/vm/internal/state"
+	"github.com/deckhouse/virtualization-controller/pkg/eventrecord"
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmcondition"
+)
+
+var _ = Describe("SyncKvvmHandler", func() {
+	const (
+		name      = "vm-sync"
+		namespace = "default"
+	)
+
+	var (
+		ctx        context.Context
+		fakeClient client.WithWatch
+		resource   *reconciler.Resource[*virtv2.VirtualMachine, virtv2.VirtualMachineStatus]
+		vmState    state.VirtualMachineState
+		recorder   *eventrecord.EventRecorderLoggerMock
+	)
+
+	BeforeEach(func() {
+		ctx = testutil.ContextBackgroundWithNoOpLogger()
+		fakeClient = nil
+		resource = nil
+		vmState = nil
+		recorder = &eventrecord.EventRecorderLoggerMock{
+			EventFunc:       func(_ client.Object, _, _, _ string) {},
+			EventfFunc:      func(_ client.Object, _, _, _ string, _ ...interface{}) {},
+			WithLoggingFunc: func(logger eventrecord.InfoLogger) eventrecord.EventRecorderLogger { return recorder },
+		}
+	})
+
+	AfterEach(func() {
+		fakeClient = nil
+		resource = nil
+		vmState = nil
+		recorder = nil
+	})
+
+	newVM := func(phase virtv2.MachinePhase) *virtv2.VirtualMachine {
+		vm := vmbuilder.NewEmpty(name, namespace)
+		vm.Status.Phase = phase
+		return vm
+	}
+
+	newKVVM := func() *virtv1.VirtualMachine {
+		return &virtv1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: virtv1.VirtualMachineSpec{
+				Template: &virtv1.VirtualMachineInstanceTemplateSpec{},
+			},
+		}
+	}
+
+	newKVVMI := func() *virtv1.VirtualMachineInstance {
+		kvvmi := newEmptyKVVMI(name, namespace)
+		return kvvmi
+	}
+
+	reconcile := func() {
+		h := NewSyncKvvmHandler(nil, fakeClient, recorder)
+		_, err := h.Handle(ctx, vmState)
+		Expect(err).NotTo(HaveOccurred())
+		err = resource.Update(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	mutateVM := func(vm *virtv2.VirtualMachine) {
+		vm.Spec.VirtualMachineClassName = "vmclass"
+		vm.Spec.CPU.Cores = 2
+		vm.Spec.RunPolicy = virtv2.ManualPolicy
+		vm.Spec.VirtualMachineIPAddress = "test-ip"
+		vm.Spec.OsType = virtv2.GenericOs
+		vm.Spec.Disruptions = &virtv2.Disruptions{
+			RestartApprovalMode: virtv2.Manual,
+		}
+	}
+
+	mutateKVVM := func(kvvm *virtv1.VirtualMachine) {
+		kvbuilder.SetLastAppliedSpec(kvvm, &virtv2.VirtualMachine{
+			Spec: virtv2.VirtualMachineSpec{
+				CPU: virtv2.CPUSpec{
+					Cores: 1,
+				},
+				VirtualMachineIPAddress: "test-ip",
+				RunPolicy:               virtv2.ManualPolicy,
+				OsType:                  virtv2.GenericOs,
+				VirtualMachineClassName: "vmclass",
+			},
+		})
+
+		kvbuilder.SetLastAppliedClassSpec(kvvm, &virtv2.VirtualMachineClass{
+			Spec: virtv2.VirtualMachineClassSpec{
+				CPU: virtv2.CPU{
+					Type: virtv2.CPUTypeHost,
+				},
+				NodeSelector: virtv2.NodeSelector{
+					MatchLabels: map[string]string{
+						"test": "test",
+					},
+				},
+			},
+		})
+	}
+
+	DescribeTable("AwaitingRestart Condition Tests",
+		func(phase virtv2.MachinePhase, needChange bool, expectedStatus metav1.ConditionStatus, expectedExistence bool) {
+			vm := newVM(phase)
+			kvvm := newKVVM()
+			kvvmi := newKVVMI()
+
+			ip := &virtv2.VirtualMachineIPAddress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ip",
+					Namespace: namespace,
+				},
+				Spec: virtv2.VirtualMachineIPAddressSpec{
+					Type:     virtv2.VirtualMachineIPAddressTypeStatic,
+					StaticIP: "192.168.1.10",
+				},
+				Status: virtv2.VirtualMachineIPAddressStatus{
+					Address: "192.168.1.10",
+					Phase:   virtv2.VirtualMachineIPAddressPhaseAttached,
+				},
+			}
+
+			vmClass := &virtv2.VirtualMachineClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "vmclass",
+				}, Spec: virtv2.VirtualMachineClassSpec{
+					CPU: virtv2.CPU{
+						Type: virtv2.CPUTypeHost,
+					},
+					NodeSelector: virtv2.NodeSelector{
+						MatchLabels: map[string]string{
+							"test2": "test2",
+						},
+					},
+				},
+			}
+
+			if needChange {
+				mutateVM(vm)
+				mutateKVVM(kvvm)
+			}
+
+			fakeClient, resource, vmState = setupEnvironment(vm, kvvm, kvvmi, ip, vmClass)
+			reconcile()
+
+			newVM := new(virtv2.VirtualMachine)
+			err := fakeClient.Get(ctx, client.ObjectKeyFromObject(vm), newVM)
+			Expect(err).NotTo(HaveOccurred())
+
+			awaitCond, awaitExists := conditions.GetCondition(vmcondition.TypeAwaitingRestartToApplyConfiguration, newVM.Status.Conditions)
+			Expect(awaitExists).To(Equal(expectedExistence))
+			if awaitExists {
+				Expect(awaitCond.Status).To(Equal(expectedStatus))
+			}
+		},
+		Entry("Running phase with changes", virtv2.MachineRunning, true, metav1.ConditionTrue, true),
+		Entry("Running phase without changes", virtv2.MachineRunning, false, metav1.ConditionUnknown, false),
+
+		Entry("Stopped phase with changes, shouldn't have condition", virtv2.MachineStopped, true, metav1.ConditionUnknown, false),
+		Entry("Stopped phase without changes, shouldn't have condition", virtv2.MachineStopped, false, metav1.ConditionUnknown, false),
+
+		Entry("Starting phase with changes, shouldn't have condition", virtv2.MachineStarting, true, metav1.ConditionUnknown, false),
+		Entry("Starting phase without changes, shouldn't have condition", virtv2.MachineStarting, false, metav1.ConditionUnknown, false),
+
+		Entry("Pending phase with changes, shouldn't have condition", virtv2.MachinePending, true, metav1.ConditionUnknown, false),
+		Entry("Pending phase without changes, shouldn't have condition", virtv2.MachinePending, false, metav1.ConditionUnknown, false),
+	)
+
+	DescribeTable("ConfigurationApplied Condition Tests",
+		func(phase virtv2.MachinePhase, notReady bool, expectedStatus metav1.ConditionStatus, expectedExistence bool) {
+			vm := newVM(phase)
+			if notReady {
+				vm.Status.Conditions = append(vm.Status.Conditions, metav1.Condition{
+					Type:   vmcondition.TypeBlockDevicesReady.String(),
+					Status: metav1.ConditionFalse,
+					Reason: "BlockDevicesNotReady",
+				})
+			}
+			kvvm := newKVVM()
+
+			fakeClient, resource, vmState = setupEnvironment(vm, kvvm)
+			reconcile()
+
+			newVM := new(virtv2.VirtualMachine)
+			err := fakeClient.Get(ctx, client.ObjectKeyFromObject(vm), newVM)
+			Expect(err).NotTo(HaveOccurred())
+
+			confAppliedCond, confAppliedExists := conditions.GetCondition(vmcondition.TypeConfigurationApplied, newVM.Status.Conditions)
+			Expect(confAppliedExists).To(Equal(expectedExistence))
+			if confAppliedExists {
+				Expect(confAppliedCond.Status).To(Equal(expectedStatus))
+			}
+		},
+		Entry("Running phase with changes applied", virtv2.MachineRunning, false, metav1.ConditionUnknown, false),
+		Entry("Running phase with changes not applied", virtv2.MachineRunning, true, metav1.ConditionFalse, true),
+
+		Entry("Stopped phase with changes applied, condition should not exist", virtv2.MachineStopped, false, metav1.ConditionUnknown, false),
+		Entry("Stopped phase with changes not applied, condition should not exist", virtv2.MachineStopped, true, metav1.ConditionUnknown, false),
+
+		Entry("Starting phase with changes applied, condition should not exist", virtv2.MachineStarting, false, metav1.ConditionUnknown, false),
+		Entry("Starting phase with changes not applied, condition should not exist", virtv2.MachineStarting, true, metav1.ConditionUnknown, false),
+
+		Entry("Pending phase with changes applied, condition should not exist", virtv2.MachinePending, false, metav1.ConditionUnknown, false),
+		Entry("Pending phase with changes not applied, condition should not exist", virtv2.MachinePending, true, metav1.ConditionUnknown, false),
+	)
+})

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm_test.go
@@ -182,7 +182,7 @@ var _ = Describe("SyncKvvmHandler", func() {
 			fakeClient, resource, vmState = setupEnvironment(vm, kvvm, kvvmi, ip, vmClass)
 			reconcile()
 
-			newVM := new(virtv2.VirtualMachine)
+			newVM := &virtv2.VirtualMachine{}
 			err := fakeClient.Get(ctx, client.ObjectKeyFromObject(vm), newVM)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -194,6 +194,12 @@ var _ = Describe("SyncKvvmHandler", func() {
 		},
 		Entry("Running phase with changes", virtv2.MachineRunning, true, metav1.ConditionTrue, true),
 		Entry("Running phase without changes", virtv2.MachineRunning, false, metav1.ConditionUnknown, false),
+
+		Entry("Migrating phase with changes, condition should exist", virtv2.MachineMigrating, true, metav1.ConditionTrue, true),
+		Entry("Migrating phase without changes, condition should not exist", virtv2.MachineMigrating, false, metav1.ConditionUnknown, false),
+
+		Entry("Stopping phase with changes, condition should exist", virtv2.MachineStopping, true, metav1.ConditionTrue, true),
+		Entry("Stopping phase without changes, condition should not exist", virtv2.MachineStopping, false, metav1.ConditionUnknown, false),
 
 		Entry("Stopped phase with changes, shouldn't have condition", virtv2.MachineStopped, true, metav1.ConditionUnknown, false),
 		Entry("Stopped phase without changes, shouldn't have condition", virtv2.MachineStopped, false, metav1.ConditionUnknown, false),
@@ -220,7 +226,7 @@ var _ = Describe("SyncKvvmHandler", func() {
 			fakeClient, resource, vmState = setupEnvironment(vm, kvvm)
 			reconcile()
 
-			newVM := new(virtv2.VirtualMachine)
+			newVM := &virtv2.VirtualMachine{}
 			err := fakeClient.Get(ctx, client.ObjectKeyFromObject(vm), newVM)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -232,6 +238,12 @@ var _ = Describe("SyncKvvmHandler", func() {
 		},
 		Entry("Running phase with changes applied", virtv2.MachineRunning, false, metav1.ConditionUnknown, false),
 		Entry("Running phase with changes not applied", virtv2.MachineRunning, true, metav1.ConditionFalse, true),
+
+		Entry("Migrating phase with changes applied, condition should not exist", virtv2.MachineMigrating, false, metav1.ConditionUnknown, false),
+		Entry("Migrating phase with changes not applied, condition should exist", virtv2.MachineMigrating, true, metav1.ConditionFalse, true),
+
+		Entry("Stopping phase with changes applied, condition should not exist", virtv2.MachineStopping, false, metav1.ConditionUnknown, false),
+		Entry("Stopping phase with changes not applied, condition should exist", virtv2.MachineStopping, true, metav1.ConditionFalse, true),
 
 		Entry("Stopped phase with changes applied, condition should not exist", virtv2.MachineStopped, false, metav1.ConditionUnknown, false),
 		Entry("Stopped phase with changes not applied, condition should not exist", virtv2.MachineStopped, true, metav1.ConditionUnknown, false),

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_power_state.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_power_state.go
@@ -22,18 +22,21 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	virtv1 "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/deckhouse/virtualization-controller/pkg/common/annotations"
 	kvvmutil "github.com/deckhouse/virtualization-controller/pkg/common/kvvm"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/kvbuilder"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/powerstate"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vm/internal/state"
 	"github.com/deckhouse/virtualization-controller/pkg/eventrecord"
 	"github.com/deckhouse/virtualization-controller/pkg/logger"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmcondition"
 )
 
 const nameSyncPowerStateHandler = "SyncPowerStateHandler"

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_power_state.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_power_state.go
@@ -128,7 +128,7 @@ func (h *SyncPowerStateHandler) syncPowerState(
 
 	appliedCondition, _ := conditions.GetCondition(vmcondition.TypeConfigurationApplied,
 		s.VirtualMachine().Changed().Status.Conditions)
-	isConfigurationApplied := appliedCondition.Status == metav1.ConditionTrue &&
+	isConfigurationNotApplied := appliedCondition.Status == metav1.ConditionFalse &&
 		appliedCondition.ObservedGeneration == s.VirtualMachine().Changed().Generation
 
 	var vmAction VMAction
@@ -136,17 +136,17 @@ func (h *SyncPowerStateHandler) syncPowerState(
 	case virtv2.AlwaysOffPolicy:
 		vmAction = h.handleAlwaysOffPolicy(ctx, s, kvvmi)
 	case virtv2.AlwaysOnPolicy:
-		vmAction, err = h.handleAlwaysOnPolicy(ctx, s, kvvm, kvvmi, isConfigurationApplied, shutdownInfo)
+		vmAction, err = h.handleAlwaysOnPolicy(ctx, s, kvvm, kvvmi, isConfigurationNotApplied, shutdownInfo)
 		if err != nil {
 			return err
 		}
 	case virtv2.AlwaysOnUnlessStoppedManually:
-		vmAction, err = h.handleAlwaysOnUnlessStoppedManuallyPolicy(ctx, s, kvvm, kvvmi, isConfigurationApplied, shutdownInfo)
+		vmAction, err = h.handleAlwaysOnUnlessStoppedManuallyPolicy(ctx, s, kvvm, kvvmi, isConfigurationNotApplied, shutdownInfo)
 		if err != nil {
 			return err
 		}
 	case virtv2.ManualPolicy:
-		vmAction = h.handleManualPolicy(ctx, s, kvvm, kvvmi, isConfigurationApplied, shutdownInfo)
+		vmAction = h.handleManualPolicy(ctx, s, kvvm, kvvmi, isConfigurationNotApplied, shutdownInfo)
 	}
 
 	switch vmAction {
@@ -174,11 +174,11 @@ func (h *SyncPowerStateHandler) syncPowerState(
 
 		return nil
 	case Start:
-		return h.start(ctx, s, kvvm, isConfigurationApplied)
+		return h.start(ctx, s, kvvm, isConfigurationNotApplied)
 	case Stop:
 		return h.deleteKVVMI(ctx, kvvmi)
 	case Restart:
-		return h.restart(ctx, s, kvvm, kvvmi, isConfigurationApplied)
+		return h.restart(ctx, s, kvvm, kvvmi, isConfigurationNotApplied)
 	}
 
 	return nil
@@ -204,11 +204,11 @@ func (h *SyncPowerStateHandler) handleManualPolicy(
 	s state.VirtualMachineState,
 	kvvm *virtv1.VirtualMachine,
 	kvvmi *virtv1.VirtualMachineInstance,
-	isConfigurationApplied bool,
+	isConfigurationNotApplied bool,
 	shutdownInfo powerstate.ShutdownInfo,
 ) VMAction {
 	if kvvmi == nil || kvvmi.DeletionTimestamp != nil {
-		if h.checkNeedStartVM(ctx, s, kvvm, isConfigurationApplied, virtv2.ManualPolicy) {
+		if h.checkNeedStartVM(ctx, s, kvvm, isConfigurationNotApplied, virtv2.ManualPolicy) {
 			return Start
 		}
 		return Nothing
@@ -249,7 +249,7 @@ func (h *SyncPowerStateHandler) handleAlwaysOnPolicy(
 	s state.VirtualMachineState,
 	kvvm *virtv1.VirtualMachine,
 	kvvmi *virtv1.VirtualMachineInstance,
-	isConfigurationApplied bool,
+	isConfigurationNotApplied bool,
 	shutdownInfo powerstate.ShutdownInfo,
 ) (VMAction, error) {
 	if kvvmi == nil {
@@ -257,7 +257,7 @@ func (h *SyncPowerStateHandler) handleAlwaysOnPolicy(
 			return Nothing, nil
 		}
 
-		if isConfigurationApplied {
+		if !isConfigurationNotApplied {
 			h.recordStartEventf(ctx, s.VirtualMachine().Current(), "Start initiated "+
 				"by controller for AlwaysOn policy")
 			return Start, nil
@@ -272,7 +272,7 @@ func (h *SyncPowerStateHandler) handleAlwaysOnPolicy(
 	}
 
 	if kvvmi.DeletionTimestamp != nil {
-		if h.checkNeedStartVM(ctx, s, kvvm, isConfigurationApplied, virtv2.AlwaysOnPolicy) {
+		if h.checkNeedStartVM(ctx, s, kvvm, isConfigurationNotApplied, virtv2.AlwaysOnPolicy) {
 			return Start, nil
 		}
 		return Nothing, nil
@@ -305,11 +305,11 @@ func (h *SyncPowerStateHandler) handleAlwaysOnUnlessStoppedManuallyPolicy(
 	s state.VirtualMachineState,
 	kvvm *virtv1.VirtualMachine,
 	kvvmi *virtv1.VirtualMachineInstance,
-	isConfigurationApplied bool,
+	isConfigurationNotApplied bool,
 	shutdownInfo powerstate.ShutdownInfo,
 ) (VMAction, error) {
 	if kvvmi == nil || kvvmi.DeletionTimestamp != nil {
-		if h.checkNeedStartVM(ctx, s, kvvm, isConfigurationApplied, virtv2.AlwaysOnUnlessStoppedManually) {
+		if h.checkNeedStartVM(ctx, s, kvvm, isConfigurationNotApplied, virtv2.AlwaysOnUnlessStoppedManually) {
 			return Start, nil
 		}
 
@@ -378,10 +378,10 @@ func (h *SyncPowerStateHandler) checkNeedStartVM(
 	ctx context.Context,
 	s state.VirtualMachineState,
 	kvvm *virtv1.VirtualMachine,
-	isConfigurationApplied bool,
+	isConfigurationNotApplied bool,
 	runPolicy virtv2.RunPolicy,
 ) bool {
-	if isConfigurationApplied &&
+	if !isConfigurationNotApplied &&
 		(kvvm.Annotations[annotations.AnnVmStartRequested] == "true" || kvvm.Annotations[annotations.AnnVmRestartRequested] == "true") {
 		h.recordStartEventf(ctx, s.VirtualMachine().Current(), "Start initiated by controller for %v policy", runPolicy)
 		return true
@@ -394,9 +394,9 @@ func (h *SyncPowerStateHandler) start(
 	ctx context.Context,
 	s state.VirtualMachineState,
 	kvvm *virtv1.VirtualMachine,
-	isConfigurationApplied bool,
+	isConfigurationNotApplied bool,
 ) error {
-	if !isConfigurationApplied {
+	if isConfigurationNotApplied {
 		h.recordStopEventf(ctx, s.VirtualMachine().Current(),
 			"The virtual machine startup was interrupted because the provided configuration could not be applied.",
 		)
@@ -419,9 +419,9 @@ func (h *SyncPowerStateHandler) restart(
 	s state.VirtualMachineState,
 	kvvm *virtv1.VirtualMachine,
 	kvvmi *virtv1.VirtualMachineInstance,
-	isConfigurationApplied bool,
+	isConfigurationNotApplied bool,
 ) error {
-	if !isConfigurationApplied {
+	if isConfigurationNotApplied {
 		h.recordStopEventf(ctx, s.VirtualMachine().Current(),
 			"The virtual machine startup was interrupted because the provided configuration could not be applied.",
 		)

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_power_state_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_power_state_test.go
@@ -86,7 +86,7 @@ var _ = Describe("Test power actions with VMs", func() {
 		setupKVVMAnnotations(kvvm, annotations.AnnVmStartRequested)
 		setupTestEnvironment()
 
-		err := handler.start(ctx, vmState, kvvm, false)
+		err := handler.start(ctx, vmState, kvvm, true)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(kvvm.Status.StateChangeRequests[0].Action).To(Equal(virtv1.StateChangeRequestAction("Start")))
 		Expect(kvvm.Annotations[annotations.AnnVmStartRequested]).To(Equal(""))
@@ -97,7 +97,7 @@ var _ = Describe("Test power actions with VMs", func() {
 
 		setupTestEnvironment()
 
-		err := handler.restart(ctx, vmState, kvvm, kvvmi, false)
+		err := handler.restart(ctx, vmState, kvvm, kvvmi, true)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(kvvm.Status.StateChangeRequests[0].Action).To(Equal(virtv1.StateChangeRequestAction("Stop")))
 		Expect(kvvm.Status.StateChangeRequests[1].Action).To(Equal(virtv1.StateChangeRequestAction("Start")))
@@ -117,7 +117,7 @@ var _ = Describe("Test power actions with VMs", func() {
 		}
 
 		setupTestEnvironment()
-		err := handler.restart(ctx, vmState, kvvm, kvvmi, true)
+		err := handler.restart(ctx, vmState, kvvm, kvvmi, false)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(kvvm.Annotations[annotations.AnnVmStartRequested]).To(Equal("true"))
 	})
@@ -173,7 +173,7 @@ var _ = Describe("Test action getters for different run policy", func() {
 			setupKVVMAnnotations(kvvm, annotations.AnnVmStartRequested)
 
 			action := handler.handleManualPolicy(
-				ctx, vmState, kvvm, nil, false, powerstate.ShutdownInfo{},
+				ctx, vmState, kvvm, nil, true, powerstate.ShutdownInfo{},
 			)
 
 			Expect(action).To(Equal(Start))
@@ -183,7 +183,7 @@ var _ = Describe("Test action getters for different run policy", func() {
 			kvvmi.Status.Phase = virtv1.Succeeded
 
 			action := handler.handleManualPolicy(
-				ctx, vmState, kvvm, kvvmi, false, powerstate.ShutdownInfo{PodCompleted: true},
+				ctx, vmState, kvvm, kvvmi, true, powerstate.ShutdownInfo{PodCompleted: true},
 			)
 
 			Expect(action).To(Equal(Stop))
@@ -194,7 +194,7 @@ var _ = Describe("Test action getters for different run policy", func() {
 			kvvmi.Status.Phase = virtv1.Running
 
 			action := handler.handleManualPolicy(
-				ctx, vmState, kvvm, kvvmi, false, powerstate.ShutdownInfo{},
+				ctx, vmState, kvvm, kvvmi, true, powerstate.ShutdownInfo{},
 			)
 
 			Expect(action).To(Equal(Restart))
@@ -203,7 +203,7 @@ var _ = Describe("Test action getters for different run policy", func() {
 		It("should return nothing action when conditions are not met", func() {
 			kvvmi.Status.Phase = virtv1.Running
 			action := handler.handleManualPolicy(
-				ctx, vmState, kvvm, kvvmi, true, powerstate.ShutdownInfo{},
+				ctx, vmState, kvvm, kvvmi, false, powerstate.ShutdownInfo{},
 			)
 			Expect(action).To(Equal(Nothing))
 		})
@@ -216,7 +216,7 @@ var _ = Describe("Test action getters for different run policy", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			action, err := handler.handleAlwaysOnPolicy(
-				ctx, vmState, kvvm, nil, true, powerstate.ShutdownInfo{},
+				ctx, vmState, kvvm, nil, false, powerstate.ShutdownInfo{},
 			)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(action).To(Equal(Nothing))
@@ -225,7 +225,7 @@ var _ = Describe("Test action getters for different run policy", func() {
 
 		It("should return start action when kvvmi is nil and configuration applied", func() {
 			action, err := handler.handleAlwaysOnPolicy(
-				ctx, vmState, kvvm, nil, false, powerstate.ShutdownInfo{},
+				ctx, vmState, kvvm, nil, true, powerstate.ShutdownInfo{},
 			)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(action).To(Equal(Start))
@@ -234,7 +234,7 @@ var _ = Describe("Test action getters for different run policy", func() {
 		It("should return nothing action when kvvmi is being deleted", func() {
 			kvvmi.DeletionTimestamp = &metav1.Time{}
 			action, err := handler.handleAlwaysOnPolicy(
-				ctx, vmState, kvvm, kvvmi, false, powerstate.ShutdownInfo{},
+				ctx, vmState, kvvm, kvvmi, true, powerstate.ShutdownInfo{},
 			)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(action).To(Equal(Nothing))
@@ -244,7 +244,7 @@ var _ = Describe("Test action getters for different run policy", func() {
 			setupKVVMAnnotations(kvvm, annotations.AnnVmRestartRequested)
 			kvvmi.Status.Phase = virtv1.Running
 			action, err := handler.handleAlwaysOnPolicy(
-				ctx, vmState, kvvm, kvvmi, false, powerstate.ShutdownInfo{},
+				ctx, vmState, kvvm, kvvmi, true, powerstate.ShutdownInfo{},
 			)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(action).To(Equal(Restart))
@@ -254,7 +254,7 @@ var _ = Describe("Test action getters for different run policy", func() {
 			kvvmi.Status.Phase = virtv1.Succeeded
 			shutdownInfo := powerstate.ShutdownInfo{PodCompleted: true, Reason: powerstate.GuestResetReason}
 			action, err := handler.handleAlwaysOnPolicy(
-				ctx, vmState, kvvm, kvvmi, false, shutdownInfo,
+				ctx, vmState, kvvm, kvvmi, true, shutdownInfo,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(action).To(Equal(Restart))
@@ -263,7 +263,7 @@ var _ = Describe("Test action getters for different run policy", func() {
 		It("should return nothing action when no conditions are met", func() {
 			kvvmi.Status.Phase = virtv1.Running
 			action, err := handler.handleAlwaysOnPolicy(
-				ctx, vmState, kvvm, kvvmi, false, powerstate.ShutdownInfo{},
+				ctx, vmState, kvvm, kvvmi, true, powerstate.ShutdownInfo{},
 			)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(action).To(Equal(Nothing))
@@ -273,7 +273,7 @@ var _ = Describe("Test action getters for different run policy", func() {
 	Context("handleAlwaysOnUnlessStoppedManuallyPolicy", func() {
 		It("should return nothing action when kvvmi is nil", func() {
 			action, err := handler.handleAlwaysOnUnlessStoppedManuallyPolicy(
-				ctx, vmState, kvvm, nil, false, powerstate.ShutdownInfo{},
+				ctx, vmState, kvvm, nil, true, powerstate.ShutdownInfo{},
 			)
 
 			Expect(err).NotTo(HaveOccurred())
@@ -283,7 +283,7 @@ var _ = Describe("Test action getters for different run policy", func() {
 		It("should return nothing when kvvmi is being deleted", func() {
 			kvvmi.DeletionTimestamp = &metav1.Time{}
 			action, err := handler.handleAlwaysOnUnlessStoppedManuallyPolicy(
-				ctx, vmState, kvvm, kvvmi, false, powerstate.ShutdownInfo{},
+				ctx, vmState, kvvm, kvvmi, true, powerstate.ShutdownInfo{},
 			)
 
 			Expect(err).NotTo(HaveOccurred())
@@ -294,7 +294,7 @@ var _ = Describe("Test action getters for different run policy", func() {
 			setupKVVMAnnotations(kvvm, annotations.AnnVmRestartRequested)
 			kvvmi.Status.Phase = virtv1.Running
 			action, err := handler.handleAlwaysOnUnlessStoppedManuallyPolicy(
-				ctx, vmState, kvvm, kvvmi, true, powerstate.ShutdownInfo{},
+				ctx, vmState, kvvm, kvvmi, false, powerstate.ShutdownInfo{},
 			)
 
 			Expect(err).NotTo(HaveOccurred())
@@ -305,7 +305,7 @@ var _ = Describe("Test action getters for different run policy", func() {
 			kvvmi.Status.Phase = virtv1.Succeeded
 			shutdownInfo := powerstate.ShutdownInfo{PodCompleted: true, Reason: powerstate.GuestResetReason}
 			action, err := handler.handleAlwaysOnUnlessStoppedManuallyPolicy(
-				ctx, vmState, kvvm, kvvmi, false, shutdownInfo,
+				ctx, vmState, kvvm, kvvmi, true, shutdownInfo,
 			)
 
 			Expect(err).NotTo(HaveOccurred())
@@ -316,7 +316,7 @@ var _ = Describe("Test action getters for different run policy", func() {
 			kvvmi.Status.Phase = virtv1.Succeeded
 			shutdownInfo := powerstate.ShutdownInfo{PodCompleted: true}
 			action, err := handler.handleAlwaysOnUnlessStoppedManuallyPolicy(
-				ctx, vmState, kvvm, kvvmi, false, shutdownInfo,
+				ctx, vmState, kvvm, kvvmi, true, shutdownInfo,
 			)
 
 			Expect(err).NotTo(HaveOccurred())
@@ -326,7 +326,7 @@ var _ = Describe("Test action getters for different run policy", func() {
 		It("should return restart action for failed phase", func() {
 			kvvmi.Status.Phase = virtv1.Failed
 			action, err := handler.handleAlwaysOnUnlessStoppedManuallyPolicy(
-				ctx, vmState, kvvm, kvvmi, true, powerstate.ShutdownInfo{},
+				ctx, vmState, kvvm, kvvmi, false, powerstate.ShutdownInfo{},
 			)
 
 			Expect(err).NotTo(HaveOccurred())
@@ -336,7 +336,7 @@ var _ = Describe("Test action getters for different run policy", func() {
 		It("should return nothing action when no conditions are met", func() {
 			kvvmi.Status.Phase = virtv1.Running
 			action, err := handler.handleAlwaysOnUnlessStoppedManuallyPolicy(
-				ctx, vmState, kvvm, kvvmi, false, powerstate.ShutdownInfo{},
+				ctx, vmState, kvvm, kvvmi, true, powerstate.ShutdownInfo{},
 			)
 
 			Expect(err).NotTo(HaveOccurred())

--- a/images/virtualization-artifact/pkg/controller/vm/internal/util.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/util.go
@@ -96,8 +96,7 @@ var mapPhases = map[virtv1.VirtualMachinePrintableStatus]PhaseGetter{
 	// VirtualMachineStatusStopped indicates that the virtual machine is currently stopped and isn't expected to start.
 	virtv1.VirtualMachineStatusStopped: func(vm *virtv2.VirtualMachine, kvvm *virtv1.VirtualMachine) virtv2.MachinePhase {
 		if vm != nil && kvvm != nil {
-			confAppliedCondition, _ := conditions.GetCondition(vmcondition.TypeConfigurationApplied, vm.Status.Conditions)
-			if confAppliedCondition.Status == metav1.ConditionFalse &&
+			if !checkVirtualMachineConfiguration(vm) &&
 				kvvm != nil && kvvm.Annotations[annotations.AnnVmStartRequested] == "true" {
 				return virtv2.MachinePending
 			}

--- a/images/virtualization-artifact/pkg/controller/vm/vm_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vm/vm_controller.go
@@ -68,6 +68,7 @@ func SetupController(
 		internal.NewSyncPowerStateHandler(client, recorder),
 		internal.NewSyncMetadataHandler(client),
 		internal.NewLifeCycleHandler(client, recorder),
+		internal.NewMigratingHandler(),
 		internal.NewFirmwareHandler(firmwareImage),
 		internal.NewEvictHandler(),
 		internal.NewStatisticHandler(client),


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
This PR refactors how Virtual Machine (VM) conditions are managed to provide more accurate and relevant status information. Key improvements include:

1. **Condition Cleanup**: Removed unused condition types `PodStarted` and simplified the condition set.

2. **Phase-Aware Conditions**:  
   - Conditions are now dynamically shown/hidden based on the VM's phase (Running, Stopped, etc.)  
   - Example: Agent conditions are hidden when VM is Pending/Starting/Stopped  

3. **Testing**: Added comprehensive unit tests for all condition-handling scenarios.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: vm
type: fix
summary: Improve Status Reporting
```
