### PR TITLE
fix(vm): fix live migration with image hotplug

### DIFF
--- a/images/virtualization-artifact/pkg/controller/livemigration/live_migration_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/livemigration/live_migration_reconciler.go
@@ -103,7 +103,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 			jsonPatch := client.RawPatch(types.JSONPatchType, patchBytes)
 			if err := r.client.Patch(ctx, kvvmi.Current(), jsonPatch); err != nil {
-				return fmt.Errorf("error updating status subresource: %w", err)
+				return fmt.Errorf("error patching status field: %w", err)
 			}
 
 			return nil

--- a/images/virtualization-artifact/pkg/controller/livemigration/live_migration_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/livemigration/live_migration_reconciler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/types"
 	virtv1 "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -88,15 +89,23 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return h.Handle(ctx, kvvmi.Changed())
 	})
 	rec.SetResourceUpdater(func(ctx context.Context) error {
-		if livemigration.IsMigrationConfigurationChanged(kvvmi.Current(), kvvmi.Changed()) {
-			// Directly update kvvmi and not use kvvmi.Update as kvvmi status is a regular field, not a subresource.
+
+		patchBytes, err := livemigration.GenerateMigrationConfigurationPatch(kvvmi.Current(), kvvmi.Changed())
+		if err != nil {
+			return err
+		}
+
+		if patchBytes != nil {
 			log.Debug("About to update changed kvvmi",
 				"changed.migration.configuration", livemigration.DumpKVVMIMigrationConfiguration(kvvmi.Changed()),
 				"current.migration.configuration", livemigration.DumpKVVMIMigrationConfiguration(kvvmi.Current()),
 			)
-			if err := r.client.Update(ctx, kvvmi.Changed()); err != nil {
+
+			jsonPatch := client.RawPatch(types.JSONPatchType, patchBytes)
+			if err := r.client.Patch(ctx, kvvmi.Current(), jsonPatch); err != nil {
 				return fmt.Errorf("error updating status subresource: %w", err)
 			}
+
 			return nil
 		}
 

--- a/images/virtualization-artifact/pkg/livemigration/migration_configuration.go
+++ b/images/virtualization-artifact/pkg/livemigration/migration_configuration.go
@@ -97,7 +97,7 @@ func DumpKVVMIMigrationConfiguration(kvvmi *virtv1.VirtualMachineInstance) strin
 
 func GenerateMigrationConfigurationPatch(current, changed *virtv1.VirtualMachineInstance) ([]byte, error) {
 	if current.Status.MigrationState == nil || changed.Status.MigrationState == nil {
-		return nil, fmt.Errorf("MigrationState is not set")
+		return nil, nil
 	}
 	currentConf := current.Status.MigrationState.MigrationConfiguration
 	changedConf := changed.Status.MigrationState.MigrationConfiguration


### PR DESCRIPTION
## Description
fix live migration with image hotplug


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: vm 
type: fix
summary: fix live migration with image hotplug
impact_level: low
```
