### PR TITLE
fix(ci): fix run e2e if audit disabled

### DIFF
--- a/.github/workflows/dev_module_build.yml
+++ b/.github/workflows/dev_module_build.yml
@@ -42,6 +42,11 @@ on:
         required: false
   pull_request:
     types: [opened, reopened, synchronize, labeled, unlabeled]
+    # == debug only ==
+    branches:
+      - main
+      - fix/ci/fix-run-e2e-with-audit
+    # ================
   push:
     branches:
       - main

--- a/.github/workflows/dev_module_build.yml
+++ b/.github/workflows/dev_module_build.yml
@@ -42,11 +42,6 @@ on:
         required: false
   pull_request:
     types: [opened, reopened, synchronize, labeled, unlabeled]
-    # == debug only ==
-    branches:
-      - main
-      - fix/ci/fix-run-e2e-with-audit
-    # ================
   push:
     branches:
       - main

--- a/tests/e2e/Taskfile.yaml
+++ b/tests/e2e/Taskfile.yaml
@@ -180,12 +180,34 @@ tasks:
           echo "Error: Deckhouse is not ready."
           exit 1
         fi
-        d8 k patch mpo virtualization --type merge -p "{\"spec\":{\"imageTag\":\"$v12n_tag\"}}"
+
+        d8 k patch mpo virtualization --type merge -p "{\"spec\":{\"imageTag\":\"$v12n_tag\"}}" 
         images_hash=$(crane export "dev-registry.deckhouse.io/sys/deckhouse-oss/modules/virtualization:$v12n_tag" - | tar -Oxf - images_digests.json)
+
         v12n_pods=$(kubectl -n d8-virtualization get pods -o json | jq -c)
+        
+        audit_status=$(kubectl get mc virtualization -o=jsonpath='{.spec.settings.audit.enabled}')
+        audit_image_skip=$(if [ -z $audit_status ] || [ $audit_status == "false" ]; then echo "false";else echo "true";fi)
+
         retry_count=0
         max_retries=120
-        sleep_interval=5
+        sleep_interval=5 
+
+        if [ $audit_image_skip == "true" ]; then
+          SKIP_IMAGES=("virtualizationAudit")
+        fi
+
+        is_skipped_image() {
+          local img="$1"
+          if [ ${#img} -eq 0 ]; then return 1 ;fi
+
+          for skip in "${SKIP_IMAGES[@]}"; do
+            if [[ "$img" == "$skip" ]]; then
+              return 0  # image found in skip list
+            fi
+          done
+          return 1  # image not in skip list
+        }
 
         while true; do
           all_hashes_found=true
@@ -199,6 +221,11 @@ tasks:
             hash=$(echo "$image_entry" | jq -r '.value')
 
             if [[ "${image,,}" =~ (libguestfs|predeletehook) ]]; then
+              continue
+            fi
+
+            if is_skipped_image "$image"; then
+              echo "- ⏭️  Skipping $image"
               continue
             fi
 

--- a/tests/e2e/Taskfile.yaml
+++ b/tests/e2e/Taskfile.yaml
@@ -185,7 +185,7 @@ tasks:
         images_hash=$(crane export "dev-registry.deckhouse.io/sys/deckhouse-oss/modules/virtualization:$v12n_tag" - | tar -Oxf - images_digests.json)
 
         v12n_pods=$(kubectl -n d8-virtualization get pods -o json | jq -c)
-        
+
         audit_status=$(kubectl get mc virtualization -o=jsonpath='{.spec.settings.audit.enabled}')
         audit_image_skip=$(if [ -z $audit_status ] || [ $audit_status == "false" ]; then echo "false";else echo "true";fi)
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Fix run e2e if audit disabled

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: ci
type: chore
summary: fix run e2e if audit disabled
```
