### PR TITLE
fix(images): disable false positive error logs about not ready datasource

### DIFF
--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref.go
@@ -104,7 +104,7 @@ func (ds ObjectRefDataSource) Sync(ctx context.Context, cvi *virtv2.ClusterVirtu
 		}
 
 		if vi == nil {
-			return reconcile.Result{}, nil
+			return reconcile.Result{}, fmt.Errorf("VI object ref source %s is nil", cvi.Spec.DataSource.ObjectRef.Name)
 		}
 
 		if vi.Spec.Storage == virtv2.StorageKubernetes || vi.Spec.Storage == virtv2.StoragePersistentVolumeClaim {
@@ -118,7 +118,7 @@ func (ds ObjectRefDataSource) Sync(ctx context.Context, cvi *virtv2.ClusterVirtu
 		}
 
 		if vd == nil {
-			return reconcile.Result{}, nil
+			return reconcile.Result{}, fmt.Errorf("VD object ref source %s is nil", cvi.Spec.DataSource.ObjectRef.Name)
 		}
 
 		return ds.vdSyncer.Sync(ctx, cvi, vd, cb)
@@ -131,7 +131,7 @@ func (ds ObjectRefDataSource) Sync(ctx context.Context, cvi *virtv2.ClusterVirtu
 		}
 
 		if vdSnapshot == nil {
-			return reconcile.Result{}, nil
+			return reconcile.Result{}, fmt.Errorf("VDSnapshot object ref %s is nil", vdSnapshotKey)
 		}
 
 		return ds.vdSnapshotSyncer.Sync(ctx, cvi, vdSnapshot, cb)

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref.go
@@ -104,7 +104,7 @@ func (ds ObjectRefDataSource) Sync(ctx context.Context, cvi *virtv2.ClusterVirtu
 		}
 
 		if vi == nil {
-			return reconcile.Result{}, fmt.Errorf("VI object ref source %s is nil", cvi.Spec.DataSource.ObjectRef.Name)
+			return reconcile.Result{}, nil
 		}
 
 		if vi.Spec.Storage == virtv2.StorageKubernetes || vi.Spec.Storage == virtv2.StoragePersistentVolumeClaim {
@@ -118,7 +118,7 @@ func (ds ObjectRefDataSource) Sync(ctx context.Context, cvi *virtv2.ClusterVirtu
 		}
 
 		if vd == nil {
-			return reconcile.Result{}, fmt.Errorf("VD object ref source %s is nil", cvi.Spec.DataSource.ObjectRef.Name)
+			return reconcile.Result{}, nil
 		}
 
 		return ds.vdSyncer.Sync(ctx, cvi, vd, cb)
@@ -131,7 +131,7 @@ func (ds ObjectRefDataSource) Sync(ctx context.Context, cvi *virtv2.ClusterVirtu
 		}
 
 		if vdSnapshot == nil {
-			return reconcile.Result{}, fmt.Errorf("VDSnapshot object ref %s is nil", vdSnapshotKey)
+			return reconcile.Result{}, nil
 		}
 
 		return ds.vdSnapshotSyncer.Sync(ctx, cvi, vdSnapshot, cb)
@@ -317,7 +317,7 @@ func (ds ObjectRefDataSource) CleanUp(ctx context.Context, cvi *virtv2.ClusterVi
 
 func (ds ObjectRefDataSource) Validate(ctx context.Context, cvi *virtv2.ClusterVirtualImage) error {
 	if cvi.Spec.DataSource.ObjectRef == nil {
-		return fmt.Errorf("nil object ref: %s", cvi.Spec.DataSource.Type)
+		return nil
 	}
 
 	switch cvi.Spec.DataSource.ObjectRef.Kind {
@@ -368,7 +368,7 @@ func (ds ObjectRefDataSource) Validate(ctx context.Context, cvi *virtv2.ClusterV
 		}
 
 		if vdSnapshot == nil {
-			return fmt.Errorf("VDSnapshot object ref %s is nil", vdSnapshotKey)
+			return NewVirtualDiskSnapshotNotReadyError(cvi.Spec.DataSource.ObjectRef.Name)
 		}
 
 		return ds.vdSnapshotSyncer.Validate(ctx, cvi)

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/object_ref.go
@@ -317,7 +317,7 @@ func (ds ObjectRefDataSource) CleanUp(ctx context.Context, cvi *virtv2.ClusterVi
 
 func (ds ObjectRefDataSource) Validate(ctx context.Context, cvi *virtv2.ClusterVirtualImage) error {
 	if cvi.Spec.DataSource.ObjectRef == nil {
-		return nil
+		return fmt.Errorf("nil object ref: %s", cvi.Spec.DataSource.Type)
 	}
 
 	switch cvi.Spec.DataSource.ObjectRef.Kind {

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref.go
@@ -72,7 +72,7 @@ func (ds ObjectRefDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) 
 		}
 
 		if vi == nil {
-			return reconcile.Result{}, nil
+			return reconcile.Result{}, fmt.Errorf("VI object ref source %s is nil", vd.Spec.DataSource.ObjectRef.Name)
 		}
 
 		switch vi.Spec.Storage {

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref.go
@@ -72,7 +72,7 @@ func (ds ObjectRefDataSource) Sync(ctx context.Context, vd *virtv2.VirtualDisk) 
 		}
 
 		if vi == nil {
-			return reconcile.Result{}, fmt.Errorf("VI object ref source %s is nil", vd.Spec.DataSource.ObjectRef.Name)
+			return reconcile.Result{}, nil
 		}
 
 		switch vi.Spec.Storage {

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref.go
@@ -110,7 +110,7 @@ func (ds ObjectRefDataSource) StoreToPVC(ctx context.Context, vi *virtv2.Virtual
 		}
 
 		if viRef == nil {
-			return reconcile.Result{}, nil
+			return reconcile.Result{}, fmt.Errorf("VI object ref %s is nil", viKey)
 		}
 
 		if viRef.Spec.Storage == virtv2.StorageKubernetes || viRef.Spec.Storage == virtv2.StoragePersistentVolumeClaim {
@@ -124,7 +124,7 @@ func (ds ObjectRefDataSource) StoreToPVC(ctx context.Context, vi *virtv2.Virtual
 		}
 
 		if vd == nil {
-			return reconcile.Result{}, nil
+			return reconcile.Result{}, fmt.Errorf("VD object ref %s is nil", vdKey)
 		}
 
 		return ds.vdSyncer.StoreToPVC(ctx, vi, vd, cb)
@@ -317,7 +317,7 @@ func (ds ObjectRefDataSource) StoreToDVCR(ctx context.Context, vi *virtv2.Virtua
 		}
 
 		if viRef == nil {
-			return reconcile.Result{}, nil
+			return reconcile.Result{}, fmt.Errorf("VI object ref source %s is nil", vi.Spec.DataSource.ObjectRef.Name)
 		}
 
 		if viRef.Spec.Storage == virtv2.StorageKubernetes || viRef.Spec.Storage == virtv2.StoragePersistentVolumeClaim {
@@ -331,7 +331,7 @@ func (ds ObjectRefDataSource) StoreToDVCR(ctx context.Context, vi *virtv2.Virtua
 		}
 
 		if vd == nil {
-			return reconcile.Result{}, nil
+			return reconcile.Result{}, fmt.Errorf("VD object ref %s is nil", viKey)
 		}
 
 		return ds.vdSyncer.StoreToDVCR(ctx, vi, vd, cb)

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/object_ref.go
@@ -110,7 +110,7 @@ func (ds ObjectRefDataSource) StoreToPVC(ctx context.Context, vi *virtv2.Virtual
 		}
 
 		if viRef == nil {
-			return reconcile.Result{}, fmt.Errorf("VI object ref %s is nil", viKey)
+			return reconcile.Result{}, nil
 		}
 
 		if viRef.Spec.Storage == virtv2.StorageKubernetes || viRef.Spec.Storage == virtv2.StoragePersistentVolumeClaim {
@@ -124,7 +124,7 @@ func (ds ObjectRefDataSource) StoreToPVC(ctx context.Context, vi *virtv2.Virtual
 		}
 
 		if vd == nil {
-			return reconcile.Result{}, fmt.Errorf("VD object ref %s is nil", vdKey)
+			return reconcile.Result{}, nil
 		}
 
 		return ds.vdSyncer.StoreToPVC(ctx, vi, vd, cb)
@@ -317,7 +317,7 @@ func (ds ObjectRefDataSource) StoreToDVCR(ctx context.Context, vi *virtv2.Virtua
 		}
 
 		if viRef == nil {
-			return reconcile.Result{}, fmt.Errorf("VI object ref source %s is nil", vi.Spec.DataSource.ObjectRef.Name)
+			return reconcile.Result{}, nil
 		}
 
 		if viRef.Spec.Storage == virtv2.StorageKubernetes || viRef.Spec.Storage == virtv2.StoragePersistentVolumeClaim {
@@ -331,7 +331,7 @@ func (ds ObjectRefDataSource) StoreToDVCR(ctx context.Context, vi *virtv2.Virtua
 		}
 
 		if vd == nil {
-			return reconcile.Result{}, fmt.Errorf("VD object ref %s is nil", viKey)
+			return reconcile.Result{}, nil
 		}
 
 		return ds.vdSyncer.StoreToDVCR(ctx, vi, vd, cb)
@@ -501,7 +501,7 @@ func (ds ObjectRefDataSource) Validate(ctx context.Context, vi *virtv2.VirtualIm
 		}
 
 		if viRef == nil {
-			return fmt.Errorf("VI object ref source %s is nil", vi.Spec.DataSource.ObjectRef.Name)
+			return NewImageNotReadyError(vi.Spec.DataSource.ObjectRef.Name)
 		}
 
 		if viRef.Spec.Storage == virtv2.StorageKubernetes || viRef.Spec.Storage == virtv2.StoragePersistentVolumeClaim {

--- a/tests/e2e/default_config.yaml
+++ b/tests/e2e/default_config.yaml
@@ -42,7 +42,7 @@ logFilter:
   - "Server rejected event (will not retry!)" # Msg.
   - "validation failed for data source objectref" # Err.
   - "clean up failed for data source registry" # Err.
-  - "error patching metadata: the server rejected our request due to an error in our request" # Err.
+  - "the server rejected our request due to an error in our request" # Err.
   - "failed to sync powerstate" # Msg.
   - "failed to sync virtual disk data source objectref" # "err": "failed to sync virtual disk data source objectref: admission webhook \"datavolume-validate.cdi.kubevirt.io\" denied the request:  Destination PVC winwin/vd-win2022-8a136ef9-32d9-4ae3-a27f-e42e15c15f47 already exists"
   - "failed to detach: intvirtvm not found to unplug" # "err": "failed to detach: intvirtvm not found to unplug"

--- a/tests/e2e/default_config.yaml
+++ b/tests/e2e/default_config.yaml
@@ -42,10 +42,7 @@ logFilter:
   - "Server rejected event (will not retry!)" # Msg.
   - "validation failed for data source objectref" # Err.
   - "clean up failed for data source registry" # Err.
-  - "VDSnapshot object ref" # Err.
-  - "VirtualDiskSnapshot " # Err.
-  - "VI object ref source " # Err.
-  - "the server rejected our request due to an error in our request" # Err.
+  - "error patching metadata: the server rejected our request due to an error in our request" # Err.
   - "failed to sync powerstate" # Msg.
   - "failed to sync virtual disk data source objectref" # "err": "failed to sync virtual disk data source objectref: admission webhook \"datavolume-validate.cdi.kubevirt.io\" denied the request:  Destination PVC winwin/vd-win2022-8a136ef9-32d9-4ae3-a27f-e42e15c15f47 already exists"
   - "failed to detach: intvirtvm not found to unplug" # "err": "failed to detach: intvirtvm not found to unplug"


### PR DESCRIPTION
## Description
Disable false positive error logs about not ready datasource.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: images 
type: fix
summary: Disable false positive error logs about not ready datasource.
impact_level: low
```
