### PR TITLE
feat(kubevirt): add tini to virt-launcher

### DIFF
--- a/images/virt-artifact/patches/052-add-tini-to-virt-launcher.patch
+++ b/images/virt-artifact/patches/052-add-tini-to-virt-launcher.patch
@@ -11,3 +11,25 @@ index 7e2519d129..6a2b908fe4 100644
  			"--qemu-timeout", generateQemuTimeoutWithJitter(t.launcherQemuTimeout),
  			"--name", domain,
  			"--uid", string(vmi.UID),
+diff --git a/pkg/virt-controller/services/template_test.go b/pkg/virt-controller/services/template_test.go
+index 80dab4e808..ed869e0e4b 100644
+--- a/pkg/virt-controller/services/template_test.go
++++ b/pkg/virt-controller/services/template_test.go
+@@ -443,7 +443,7 @@ var _ = Describe("Template", func() {
+ 					k8sv1.LabelArchStable: arch,
+ 				}))
+ 
+-				Expect(pod.Spec.Containers[0].Command).To(Equal([]string{"/usr/bin/virt-launcher-monitor",
++				Expect(pod.Spec.Containers[0].Command).To(Equal([]string{"/usr/bin/tini", "--", "/usr/bin/virt-launcher-monitor",
+ 					"--qemu-timeout", validateAndExtractQemuTimeoutArg(pod.Spec.Containers[0].Command),
+ 					"--name", "testvmi",
+ 					"--uid", "1234",
+@@ -1249,7 +1249,7 @@ var _ = Describe("Template", func() {
+ 					v1.NodeSchedulable:    "true",
+ 					k8sv1.LabelArchStable: arch,
+ 				}))
+-				Expect(pod.Spec.Containers[0].Command).To(Equal([]string{"/usr/bin/virt-launcher-monitor",
++				Expect(pod.Spec.Containers[0].Command).To(Equal([]string{"/usr/bin/tini", "--", "/usr/bin/virt-launcher-monitor",
+ 					"--qemu-timeout", validateAndExtractQemuTimeoutArg(pod.Spec.Containers[0].Command),
+ 					"--name", "testvmi",
+ 					"--uid", "1234",

--- a/images/virt-artifact/patches/052-add-tini-to-virt-launcher.patch
+++ b/images/virt-artifact/patches/052-add-tini-to-virt-launcher.patch
@@ -1,0 +1,13 @@
+diff --git a/pkg/virt-controller/services/template.go b/pkg/virt-controller/services/template.go
+index 7e2519d129..6a2b908fe4 100644
+--- a/pkg/virt-controller/services/template.go
++++ b/pkg/virt-controller/services/template.go
+@@ -384,7 +384,7 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
+ 		logger.Infof("RUNNING doppleganger pod for %s", vmi.Name)
+ 		command = []string{"temp_pod"}
+ 	} else {
+-		command = []string{"/usr/bin/virt-launcher-monitor",
++		command = []string{"/usr/bin/tini", "--", "/usr/bin/virt-launcher-monitor",
+ 			"--qemu-timeout", generateQemuTimeoutWithJitter(t.launcherQemuTimeout),
+ 			"--name", domain,
+ 			"--uid", string(vmi.UID),

--- a/images/virt-artifact/patches/README.md
+++ b/images/virt-artifact/patches/README.md
@@ -347,3 +347,20 @@ AllowAutoConverge is a global configuration option or should be changed in clust
 This patch disables setting migration configuration from MigrationPolicies resources,
 and forces source virt-handler to wait for migrationConfiguration in KVVMI status before
 starting migration.
+
+#### `052-add-tini-to-virt-launcher.patch`
+
+##### Problem
+
+During normal operation, certain errors may occur that lead to incorrect termination of processes inside the `virt-launcher` container. As a result, orphaned or zombie processes can be left behind.
+
+##### Solution
+
+This patch adds [`Tini`](https://github.com/krallin/tini ) as the primary entry point for the `virt-launcher` container.  
+Tini is a minimal init system designed specifically for containers — it ensures proper reaping of zombie processes and forwards signals correctly to all child processes.
+
+Now, `virt-launcher` starts like this:
+```bash
+/usr/bin/tini -- /usr/bin/virt-launcher-monitor [...]
+```
+This improves container reliability and helps prevent issues caused by leftover processes after virtual machine shutdown.

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -7,6 +7,10 @@ import:
     add: /relocate
     to: /
     after: install
+  - image: tools/tini-v0.19.0
+    add: /usr/bin/tini
+    to: /usr/bin/tini
+    after: install
 imageSpec:
   config:
     user: 0


### PR DESCRIPTION
## Description
This pr adds [`Tini`](https://github.com/krallin/tini ) as the primary entry point for the `virt-launcher` container.  
Tini is a minimal init system designed specifically for containers — it ensures proper reaping of zombie processes and forwards signals correctly to all child processes.

Now, `virt-launcher` starts like this:
```bash
/usr/bin/tini -- /usr/bin/virt-launcher-monitor [...]
```
This improves container reliability and helps prevent issues caused by leftover processes after virtual machine shutdown.


## Why do we need it, and what problem does it solve?
During normal operation, certain errors may occur that lead to incorrect termination of processes inside the virt-launcher container. As a result, orphaned or zombie processes can be left behind.


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: vm
type: feature
summary: Add Tini as the init process in virt-launcher container to properly handle orphaned/zombie processes and improve container stability. 
```
