### PR TITLE
feat: support hotplug of PVCs with filesystem volume mode 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ bin
 tmp/
 tmp/*
 tmp
+*.tmp
 # Kubernetes
 .kube
 local.Dockerfile

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -143,7 +143,8 @@ tasks:
 
   dlv:virt-controller:build:
     desc: "Build image virt-controller with dlv"
-    cmd: docker build -f ./images/virt-controller/debug/dlv.Dockerfile -t "{{ .DLV_IMAGE }}" .
+    cmds:
+      - docker build --build-arg BRANCH=$BRANCH -f ./images/virt-controller/debug/dlv.Dockerfile -t "{{ .DLV_IMAGE }}" . --platform linux/amd64 .
 
   dlv:virt-controller:build-push:
     desc: "Build and Push image virt-controller with dlv"
@@ -176,7 +177,8 @@ tasks:
 
   dlv:virt-handler:build:
     desc: "Build image virt-handler with dlv"
-    cmd: docker build -f ./images/virt-handler/debug/dlv.Dockerfile -t "{{ .DLV_IMAGE }}" --platform linux/amd64 .
+    cmds:
+      - docker build --build-arg BRANCH=$BRANCH -f ./images/virt-handler/debug/dlv.Dockerfile -t "{{ .DLV_IMAGE }}" --platform linux/amd64 .
 
   dlv:virt-handler:build-push:
     desc: "Build and Push image virt-handler with dlv"
@@ -209,7 +211,8 @@ tasks:
 
   dlv:virt-api:build:
     desc: "Build image virt-api with dlv"
-    cmd: docker build -f ./images/virt-api/debug/dlv.Dockerfile -t "{{ .DLV_IMAGE }}" --platform linux/amd64 .
+    cmds:
+      - docker build --build-arg BRANCH=$BRANCH -f ./images/virt-api/debug/dlv.Dockerfile -t "{{ .DLV_IMAGE }}" --platform linux/amd64 .
 
   dlv:virt-api:build-push:
     desc: "Build and Push image virt-api with dlv"

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -1,7 +1,7 @@
 ---
 # Source https://github.com/kubevirt/kubevirt/blob/v1.3.1/hack/dockerized#L15
 {{- $version := "v1.3.1" }}
-{{- $tag := print $version "-v12n.2"}}
+{{- $tag := print $version "-v12n.3"}}
 
 {{- $name := print $.ImageName "-dependencies" -}}
 {{- define "$name" -}}


### PR DESCRIPTION
## Description
This PR adds support for hot-plugging PVCs in Filesystem mode in KubeVirt. If the expected disk image file (e.g., disk.img) is missing, KubeVirt will now create it automatically before attaching the volume to a running Virtual Machine.
https://github.com/deckhouse/3p-kubevirt/pull/3


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: vm
type: feature
summary: support hotplug of PVCs with filesystem volume mode
```
