### PR TITLE
chore(vm): add label to prevent node shutdown, remove kubectl anno from kvvmi template

### DIFF
--- a/images/virtualization-artifact/pkg/common/annotations/annotations.go
+++ b/images/virtualization-artifact/pkg/common/annotations/annotations.go
@@ -125,6 +125,9 @@ const (
 	CDILabelValue = "containerized-data-importer"
 	// DVCRLabelValue provides a constant  for DVCR Pod label values.
 	DVCRLabelValue = "dvcr-data-importer"
+
+	// InhibitNodeShutdownLabel is a label to prevent node shutdown is Pod with label is present.
+	InhibitNodeShutdownLabel = "pod.deckhouse.io/inhibit-node-shutdown"
 )
 
 // AddAnnotation adds an annotation to an object

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
@@ -587,18 +587,3 @@ func (b *KVVM) GetBootloaderSettings() map[string]interface{} {
 		},
 	}
 }
-
-func (b *KVVM) SetMetadata(metadata metav1.ObjectMeta) {
-	if b.ResourceExists {
-		// initialize only
-		return
-	}
-	if b.Resource.Spec.Template.ObjectMeta.Labels == nil {
-		b.Resource.Spec.Template.ObjectMeta.Labels = make(map[string]string, len(metadata.Labels))
-	}
-	if b.Resource.Spec.Template.ObjectMeta.Annotations == nil {
-		b.Resource.Spec.Template.ObjectMeta.Annotations = make(map[string]string, len(metadata.Annotations))
-	}
-	maps.Copy(b.Resource.Spec.Template.ObjectMeta.Labels, metadata.Labels)
-	maps.Copy(b.Resource.Spec.Template.ObjectMeta.Annotations, metadata.Annotations)
-}

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
@@ -103,7 +103,6 @@ func ApplyVirtualMachineSpec(
 		return err
 	}
 
-	kvvm.SetMetadata(vm.ObjectMeta)
 	kvvm.SetNetworkInterface(NetworkInterfaceName)
 	kvvm.SetTablet("default-0")
 	kvvm.SetNodeSelector(vm.Spec.NodeSelector, class.Spec.NodeSelector.MatchLabels)

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_metadata.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_metadata.go
@@ -160,7 +160,14 @@ func PropagateVMMetadata(vm *virtv2.VirtualMachine, kvvm *virtv1.VirtualMachine,
 		return false, err
 	}
 
-	newLabels, labelsChanged := merger.ApplyMapChanges(destObj.GetLabels(), lastPropagatedLabels, vm.GetLabels())
+	// Add label to prevent node shutdown.
+	propagateLabels := merger.MergeLabels(
+		vm.GetLabels(),
+		map[string]string{
+			annotations.InhibitNodeShutdownLabel: "",
+		},
+	)
+	newLabels, labelsChanged := merger.ApplyMapChanges(destObj.GetLabels(), lastPropagatedLabels, propagateLabels)
 	if labelsChanged {
 		destObj.SetLabels(newLabels)
 	}


### PR DESCRIPTION
## Description

- Add label pod.deckhouse.io/inhibit-node-shutdown to support upcoming deckhouse feature to prevent node shutdown
- Remove SetMetadata from ApplyVirtualMachineSpec to remove kubectl.kubernetes.io annotation from kvvmi template in new kvvm


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: vm
type: chore
summary: Add node shutdown inhibit label to VM Pod, remove kubectl.kubernetes.io annotation from KVVMI.
```
