### PR TITLE
feat(vm): update intvirtvm when vm is stopped

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm_test.go
@@ -97,7 +97,7 @@ var _ = Describe("SyncKvvmHandler", func() {
 		}
 		kvvm.Spec.RunStrategy = pointer.GetPointer(virtv1.RunStrategyAlways)
 
-		kvbuilder.SetLastAppliedSpec(kvvm, &virtv2.VirtualMachine{
+		Expect(kvbuilder.SetLastAppliedSpec(kvvm, &virtv2.VirtualMachine{
 			Spec: virtv2.VirtualMachineSpec{
 				CPU: virtv2.CPUSpec{
 					Cores: vm.Spec.CPU.Cores,
@@ -110,9 +110,9 @@ var _ = Describe("SyncKvvmHandler", func() {
 					RestartApprovalMode: vm.Spec.Disruptions.RestartApprovalMode,
 				},
 			},
-		})
+		})).To(Succeed())
 
-		kvbuilder.SetLastAppliedClassSpec(kvvm, &virtv2.VirtualMachineClass{
+		Expect(kvbuilder.SetLastAppliedClassSpec(kvvm, &virtv2.VirtualMachineClass{
 			Spec: virtv2.VirtualMachineClassSpec{
 				CPU: virtv2.CPU{
 					Type: virtv2.CPUTypeHost,
@@ -123,7 +123,7 @@ var _ = Describe("SyncKvvmHandler", func() {
 					},
 				},
 			},
-		})
+		})).To(Succeed())
 
 		return kvvm
 	}

--- a/images/virtualization-artifact/pkg/controller/vm/internal/util.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/util.go
@@ -66,15 +66,15 @@ func conditionStatus(status string) metav1.ConditionStatus {
 	}
 }
 
-func IsKvvmPending(kvvm *virtv1.VirtualMachine) bool {
+func isVMPending(kvvm *virtv1.VirtualMachine) bool {
 	return getPhase(nil, kvvm) == virtv2.MachinePending
 }
 
-func IsKvvmStopped(kvvm *virtv1.VirtualMachine) bool {
+func isVMStopped(kvvm *virtv1.VirtualMachine) bool {
 	return getPhase(nil, kvvm) == virtv2.MachineStopped
 }
 
-func IsKvvmCreated(kvvm *virtv1.VirtualMachine) bool {
+func isKVVMICreated(kvvm *virtv1.VirtualMachine) bool {
 	return kvvm != nil && kvvm.Status.Created
 }
 

--- a/images/virtualization-artifact/pkg/controller/vm/internal/util.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/util.go
@@ -66,15 +66,15 @@ func conditionStatus(status string) metav1.ConditionStatus {
 	}
 }
 
-func vmIsPending(kvvm *virtv1.VirtualMachine) bool {
+func IsKvvmPending(kvvm *virtv1.VirtualMachine) bool {
 	return getPhase(nil, kvvm) == virtv2.MachinePending
 }
 
-func vmIsStopped(kvvm *virtv1.VirtualMachine) bool {
+func IsKvvmStopped(kvvm *virtv1.VirtualMachine) bool {
 	return getPhase(nil, kvvm) == virtv2.MachineStopped
 }
 
-func vmIsCreated(kvvm *virtv1.VirtualMachine) bool {
+func IsKvvmCreated(kvvm *virtv1.VirtualMachine) bool {
 	return kvvm != nil && kvvm.Status.Created
 }
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
When the `VirtualDisk` is restored from the `VirtualDiskSnapshot`, its `PVC` changes and other components of the `VirtualMachine` can be changed too. This information must be updated in the `InternalVirtualizationVirtualMachine` specification.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: vm
type: feature
summary: "The `InternalVirtualMachine` will be updated if the `VirtualMachine` is stopped."
```
