### PR TITLE
chore(core): set live migrations defaults

### DIFF
--- a/images/hooks/cmd/discovery-workload-nodes/main.go
+++ b/images/hooks/cmd/discovery-workload-nodes/main.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/deckhouse/module-sdk/pkg"
+	"github.com/deckhouse/module-sdk/pkg/app"
+	"github.com/deckhouse/module-sdk/pkg/registry"
+	"k8s.io/utils/ptr"
+
+	"hooks/pkg/common"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	discoveryNodesSnapshot = "discovery-nodes"
+	nodeLabel              = "kubevirt.internal.virtualization.deckhouse.io/schedulable"
+	nodeLabelValue         = "true"
+
+	virtHandlerNodeCountPath = "virtualization.internal.virtHandler.nodeCount"
+)
+
+var _ = registry.RegisterFunc(configDiscoveryService, handleDiscoveryNodes)
+
+var configDiscoveryService = &pkg.HookConfig{
+	OnBeforeHelm: &pkg.OrderedConfig{Order: 5},
+	Kubernetes: []pkg.KubernetesConfig{
+		{
+			Name:       discoveryNodesSnapshot,
+			APIVersion: "v1",
+			Kind:       "Node",
+			JqFilter:   ".metadata.name",
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					nodeLabel: nodeLabelValue,
+				},
+			},
+			ExecuteHookOnSynchronization: ptr.To(false),
+		},
+	},
+
+	Queue: fmt.Sprintf("modules/%s", common.MODULE_NAME),
+}
+
+func handleDiscoveryNodes(_ context.Context, input *pkg.HookInput) error {
+	nodeCount := len(input.Snapshots.Get(discoveryNodesSnapshot))
+	input.Values.Set(virtHandlerNodeCountPath, nodeCount)
+	return nil
+}
+
+func main() {
+	app.Run()
+}

--- a/images/hooks/werf.inc.yaml
+++ b/images/hooks/werf.inc.yaml
@@ -34,3 +34,4 @@ shell:
   - go build -ldflags="-s -w" -o /hooks/prevent-default-vmclasses-deletion ./cmd/prevent-default-vmclasses-deletion
   - go build -ldflags="-s -w" -o /hooks/generate-secret-for-dvcr ./cmd/generate-secret-for-dvcr
   - go build -ldflags="-s -w" -o /hooks/discovery-clusterip-service-for-dvcr ./cmd/discovery-clusterip-service-for-dvcr
+  - go build -ldflags="-s -w" -o /hooks/discovery-workload-nodes ./cmd/discovery-workload-nodes

--- a/openapi/values.yaml
+++ b/openapi/values.yaml
@@ -116,3 +116,9 @@ properties:
           key:
             type: string
             default: ""
+      virtHandler:
+        type: object
+        default: {}
+        properties:
+          nodeCount:
+            type: integer

--- a/templates/kubevirt/kubevirt.yaml
+++ b/templates/kubevirt/kubevirt.yaml
@@ -28,10 +28,10 @@ spec:
             qps: 5000
             burst: 6000
     migrations:
-      bandwidthPerMigration: 64Mi
+      bandwidthPerMigration: 640Mi
       completionTimeoutPerGiB: 800
-      parallelMigrationsPerCluster: 5
-      parallelOutboundMigrationsPerNode: 2
+      parallelMigrationsPerCluster: {{ .Values.virtualization.internal | dig "virtHandler" "nodeCount" 1 }}
+      parallelOutboundMigrationsPerNode: 1
       progressTimeout: 150
     smbios:
       manufacturer: Flant


### PR DESCRIPTION
## Description

Set the default live migration parameters as follows:

- Migration bandwidth: 5 Gbps (approximately 640 MiB/s)
- Limit one outbound migration stream per node
- The total number of concurrent migrations in a cluster is limited to the number of nodes that are running virtual machines

## Why do we need it, and what problem does it solve?
Previously, the defaults were set to:

- 0.5 Gbps per migration
- 2 outbound migrations per node
- Maximum of 5 concurrent migrations cluster-wide

This setup could lead to several issues:

- Low per-migration bandwidth (0.5 Gbps) slowed down migration operations unnecessarily.
- Multiple outbound migrations per node (2) could cause network contention and resource starvation on the source node.
- Hard limit of 5 total migrations per cluster did not scale well with larger clusters and created bottlenecks during large-scale maintenance or rebalancing.

The new defaults address these limitations by:

- Increasing bandwidth for faster migrations
- Limiting each node to one outbound migration at a time to prevent local resource overuse
- Scaling the total number of concurrent migrations based on the number of nodes in use, enabling better throughput in larger clusters


## What is the expected result?

- Live migrations will run with up to 5 Gbps of bandwidth allocated per operation
- Each node will perform at most one outbound migration at a time
- The total number of concurrent migrations across the cluster will be equal to the number of nodes hosting VMs

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: core
type: fix
summary: set live migrations defaults
```
