### PR TITLE
fix(vmip): list vmips, not vmipleases

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vmip/internal/watcher/vmiplease_watcher.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/watcher/vmiplease_watcher.go
@@ -80,7 +80,7 @@ func (w VirtualMachineIPAddressLeaseWatcher) enqueueRequests(ctx context.Context
 		opts.Namespace = vmipRef.Namespace
 	}
 
-	var vmips virtv2.VirtualMachineIPAddressLeaseList
+	var vmips virtv2.VirtualMachineIPAddressList
 	err := w.client.List(ctx, &vmips, &opts)
 	if err != nil {
 		w.logger.Error(fmt.Sprintf("failed to list vmips: %s", err))


### PR DESCRIPTION
## Description



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries

```changes
section: 
type: 
summary: 
```
