### PR TITLE
chore(ci): build libaudit

### DIFF
--- a/component_versions/version_map.yml
+++ b/component_versions/version_map.yml
@@ -20,4 +20,5 @@ package:
   libblkid: v2.41
   libattr: v2.5.2
   libbsd: 0.12.2
+  libaudit: v4.0.3
   file: FILE5_45

--- a/images/packages/binaries/libaudit/werf.inc.yaml
+++ b/images/packages/binaries/libaudit/werf.inc.yaml
@@ -1,0 +1,60 @@
+---
+image: {{ $.ImageType }}/{{ $.ImageName }}
+final: false
+fromImage: builder/scratch
+import:
+- image: {{ $.ImageType }}/{{ $.ImageName }}-builder
+  add: /out
+  to: /libaudit
+  before: setup
+
+---
+{{- $version := get $.Package $.ImageName }}
+{{- $gitRepoUrl := "linux-audit/audit-userspace.git" }}
+
+{{- $name := print $.ImageName "-dependencies" -}}
+{{- define "$name" -}}
+packages:
+- gcc
+- git make libtool
+{{- end -}}
+
+{{ $builderDependencies := include "$name" . | fromYaml }}
+
+image: {{ $.ImageType }}/{{ $.ImageName }}-builder
+final: false
+fromImage: builder/alt
+secrets:
+- id: SOURCE_REPO
+  value: {{ $.SOURCE_REPO_GIT }}
+shell:
+  beforeInstall:
+  {{- include "alt packages proxy" . | nindent 2 }}
+  - |
+    apt-get install -y \
+      {{ $builderDependencies.packages | join " " }}
+
+  {{- include "alt packages clean" . | nindent 2 }}
+
+  install:
+  - |
+    OUTDIR=/out
+    mkdir -p ~/.ssh && echo "StrictHostKeyChecking accept-new" > ~/.ssh/config
+
+    git clone --depth=1 $(cat /run/secrets/SOURCE_REPO)/{{ $gitRepoUrl }} --branch {{ $version }} /src
+    cd /src
+    ./autogen.sh
+    mkdir ../build
+    cd ../build
+
+    ../src/configure \
+      --prefix=/usr \
+      --libdir=/usr/lib64 \
+      --enable-shared \
+      --disable-static \
+      --without-zos-ldif \
+      --disable-zos-remote
+
+    make -j$(nproc)
+    make DESTDIR=$OUTDIR install
+

--- a/images/packages/binaries/libaudit/werf.inc.yaml
+++ b/images/packages/binaries/libaudit/werf.inc.yaml
@@ -44,17 +44,12 @@ shell:
     git clone --depth=1 $(cat /run/secrets/SOURCE_REPO)/{{ $gitRepoUrl }} --branch {{ $version }} /src
     cd /src
     ./autogen.sh
-    mkdir ../build
-    cd ../build
-
-    ../src/configure \
+    ./configure \
       --prefix=/usr \
       --libdir=/usr/lib64 \
       --enable-shared \
       --disable-static \
       --without-zos-ldif \
       --disable-zos-remote
-
     make -j$(nproc)
     make DESTDIR=$OUTDIR install
-


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Build libaudit library.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
We want more control when building libraries files, as well as making images more secure

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
All work as expected

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: core
type: chore
summary: build libaudit
impact_level: low
```
