### PR TITLE
chore(module): spec.strategy for HA on CDI and Kubevirt deployments

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 system-cluster-critical
 {{- end }}
 
-{{- define "strategic_affinity_patch" -}}
+{{- define "spec_template_spec_antiaffinity_patch" -}}
   {{- $key := index . 0 -}}
   {{- $labelValue := index . 1 -}}
   '{{ include "tmplAntiAffinity" (list $key $labelValue) | fromYaml | toJson }}'
@@ -24,4 +24,17 @@ spec:
                 values:
                 - {{ $labelValue }}
             topologyKey: kubernetes.io/hostname
+{{- end -}}
+
+{{- define "spec_strategy_rolling_update_patch" -}}
+  '{{ include "tmplSpecStrategyRollingUpdate" . | fromYaml | toJson }}'
+{{- end }}
+
+{{- define "tmplSpecStrategyRollingUpdate" -}}
+spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
 {{- end -}}

--- a/templates/cdi/cdi-operator/deployment.yaml
+++ b/templates/cdi/cdi-operator/deployment.yaml
@@ -81,7 +81,7 @@ spec:
       {{- $kubeRbacProxySettings := dict }}
       {{- $_ := set $kubeRbacProxySettings "runAsUserNobody" true }}
       {{- $_ := set $kubeRbacProxySettings "upstreams" (list
-          (dict "upstream" "http://127.0.0.1:9090/metrics" "path" "/proxy/metrics" "name" "kube-api-rewriter") 
+          (dict "upstream" "http://127.0.0.1:9090/metrics" "path" "/proxy/metrics" "name" "kube-api-rewriter")
       ) }}
       {{- include "kube_rbac_proxy.sidecar_container" (tuple . $kubeRbacProxySettings) | nindent 6 }}
       - name: cdi-operator

--- a/templates/cdi/config.yaml
+++ b/templates/cdi/config.yaml
@@ -45,22 +45,31 @@ spec:
         type: json
 
     {{- if (include "helm_lib_ha_enabled" .) }}
+      # HA settings for deploy/cdi-apiserver.
       - resourceType: Deployment
         resourceName: cdi-apiserver
         patch: '[{"op":"replace","path":"/spec/replicas","value":2}]'
         type: json
       - resourceType: Deployment
         resourceName: cdi-apiserver
-        patch: {{ include "strategic_affinity_patch" (list "cdi.io" "cdi-apiserver") }}
+        patch: {{ include "spec_template_spec_antiaffinity_patch" (list "cdi.kubevirt.io" "cdi-apiserver") }}
         type: strategic
-
+      - resourceType: Deployment
+        resourceName: cdi-apiserver
+        patch: {{ include "spec_strategy_rolling_update_patch" . }}
+        type: strategic
+      # HA settings for deploy/cdi-deployment.
       - resourceType: Deployment
         resourceName: cdi-deployment
-        patch: '[{"op":"replace","path":"/spec/replicas","value":2}]'
+        patch: '[{"op":"replace","path":"/spec/replicas","value":2},{"op":"replace","path":"/spec/strategy","value":{"type":"RollingUpdate"}}]'
         type: json
       - resourceType: Deployment
         resourceName: cdi-deployment
-        patch: {{ include "strategic_affinity_patch" (list "cdi.io" "cdi-deployment") }}
+        patch: {{ include "spec_template_spec_antiaffinity_patch" (list "cdi.kubevirt.io" "cdi-deployment") }}
+        type: strategic
+      - resourceType: Deployment
+        resourceName: cdi-deployment
+        patch: {{ include "spec_strategy_rolling_update_patch" . }}
         type: strategic
     {{- end }}
 

--- a/templates/kubevirt/kubevirt.yaml
+++ b/templates/kubevirt/kubevirt.yaml
@@ -85,14 +85,25 @@ spec:
       resourceName: virt-handler
       patch: '[{"op":"replace","path":"/spec/template/spec/tolerations","value":{{ $tolerationsAnyNode }}}]'
       type: json
+
     {{- if (include "helm_lib_ha_enabled" .) }}
+    # HA settings for deploy/virt-api.
     - resourceType: Deployment
       resourceName: virt-api
-      patch: {{ include "strategic_affinity_patch" (list "kubevirt.io" "virt-api") }}
+      patch: {{ include "spec_template_spec_antiaffinity_patch" (list "kubevirt.io" "virt-api") }}
+      type: strategic
+    - resourceType: Deployment
+      resourceName: virt-api
+      patch: {{ include "spec_strategy_rolling_update_patch" . }}
+      type: strategic
+    # HA settings for deploy/virt-controller.
+    - resourceType: Deployment
+      resourceName: virt-controller
+      patch: {{ include "spec_template_spec_antiaffinity_patch" (list "kubevirt.io" "virt-controller") }}
       type: strategic
     - resourceType: Deployment
       resourceName: virt-controller
-      patch: {{ include "strategic_affinity_patch" (list "kubevirt.io" "virt-controller") }}
+      patch: {{ include "spec_strategy_rolling_update_patch" . }}
       type: strategic
     {{- end }}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->

- Add RollingUpdate settings for HA mode for CDI and KubeVirt deployments.


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->

Default settings maxSurge=25% (round up is 1), maxUnavalilable=25% (round down is 0) are not working for 2 replicas on 2 nodes with antiaffinity:

```
# kubectl get no
NAME               STATUS     ROLES                  AGE    VERSION
master-0   Ready      control-plane,master   470d   v1.30.10
master-1   Ready      control-plane,master   442d   v1.30.10
master-2   NotReady   control-plane,master   442d   v1.30.13 <-- Node is not available for Pod scheduling.

# kubectl -n d8-virtualization get po| grep cdi-apiserver
cdi-apiserver-6744668b75-j4j6t               0/3     Pending   0             3m20s  <-- new, updated Pod
cdi-apiserver-f85949dcb-58z6k                3/3     Running   0             5d20h
cdi-apiserver-f85949dcb-r7cww                3/3     Running   0             5d20h

# kubectl -n d8-virtualization describe po/cdi-apiserver-6744668b75-j4j6t
...
  Warning  FailedScheduling  42s (x2 over 44s)  default-scheduler  0/8 nodes are available: 1 node(s) were unschedulable, 2 node(s) didn't match pod anti-affinity rules, 5 node(s) didn't match Pod's node affinity/selector. preemption: 0/8 nodes are available: 2 No preemption victims found for incoming pod, 6 Preemption is not helpful for scheduling.
```


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->

Module can be updated on clusters with 2 available nodes in control-plane or system NodeGroups.

Update log example:
```
# kubectl get no
NAME               STATUS     ROLES                  AGE    VERSION
master-0   Ready      control-plane,master   470d   v1.30.10
master-1   Ready      control-plane,master   442d   v1.30.10
master-2   NotReady   control-plane,master   442d   v1.30.13 <-- Node is not available for Pod scheduling.

# kubectl -n d8-virtualization get po -l cdi.internal.virtualization.deckhouse.io=cdi-apiserver -w
NAME                              READY   STATUS    RESTARTS   AGE     IP             NODE
cdi-apiserver-f85949dcb-58z6k     3/3     Running   0          5d20h   10.111.1.150   d8-virt-master-1
cdi-apiserver-f85949dcb-r7cww     3/3     Running   0          5d20h   10.111.0.27    d8-virt-master-0

...  update stuck, no Nodes to schedule new Pods ...
cdi-apiserver-6744668b75-j4j6t    0/3     Pending   0          0s      <none>         <none>
cdi-apiserver-6744668b75-j4j6t    0/3     Pending   0          0s      <none>         <none>

Apply fix applied to spec.strategy, update continues:

Terminate old Pod so new Pod may schedule to master-0.
cdi-apiserver-f85949dcb-r7cww     3/3     Terminating   0          5d20h   10.111.0.27    master-0
...
New Pod can now start on master-0.
cdi-apiserver-6744668b75-j4j6t    0/3     ContainerCreating   0          5m37s   <none>         master-0
...
cdi-apiserver-6744668b75-j4j6t    3/3     Running             0          5m41s   10.111.0.6     master-0

Same sequence for the second replica.
...
cdi-apiserver-6744668b75-wnvlh    0/3     Pending             0          0s      <none>         <none>
...
cdi-apiserver-f85949dcb-58z6k     0/3     Terminating         0          5d20h   10.111.1.150   master-1
...
cdi-apiserver-6744668b75-wnvlh    0/3     ContainerCreating   0          2s      <none>         master-1
...
cdi-apiserver-6744668b75-wnvlh    3/3     Running             0          6s      10.111.1.45    master-1
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->


```changes
section: module
type: fix
summary: Fix the update parameters for control-plane components in HA mode, which caused the update to hang.
```

