### PR TITLE
chore(ci): build gmp

### DIFF
--- a/component_versions/version_map.yml
+++ b/component_versions/version_map.yml
@@ -22,7 +22,7 @@ package:
   libbsd: 0.12.2
   libaudit: v4.0.3
   file: FILE5_45
-  libgmp10: 6.3.0
+  gmp: 6.3.0
   lvm2: v2_03_32
   dtc: v1.7.2
   fuse3: fuse-3.16.2

--- a/images/packages/binaries/gmp/werf.inc.yaml
+++ b/images/packages/binaries/gmp/werf.inc.yaml
@@ -9,8 +9,8 @@ import:
   before: setup
 
 ---
-{{- $version := "6.3.0" }}
-{{- $gitRepoUrl := "gmp/gmp-6.3" }}
+{{- $version := get $.Package $.ImageName }}
+{{- $gitRepoUrl := "gmp/gmp" }}
 
 {{- $name := print $.ImageName "-dependencies" -}}
 {{- define "$name" -}}
@@ -42,7 +42,7 @@ shell:
     OUTDIR=/out
     mkdir -p ~/.ssh && echo "StrictHostKeyChecking accept-new" > ~/.ssh/config
 
-    git clone --depth=1 $(cat /run/secrets/SOURCE_REPO)/{{ $gitRepoUrl }} --branch gmp /src
+    git clone --depth=1 $(cat /run/secrets/SOURCE_REPO)/{{ $gitRepoUrl }} --branch {{ $version }} /src
     cd /src
 
     ./configure \


### PR DESCRIPTION
## Description
Build gmp because we need libgmp10.


## Why do we need it, and what problem does it solve?
We want more control when building libraries files, as well as making images more secure


## What is the expected result?
All work as expected


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: core
type: chore
summary: build gmp
impact_level: low
```
