### PR TITLE
chore(ci): buid libgcrypt

### DIFF
--- a/component_versions/version_map.yml
+++ b/component_versions/version_map.yml
@@ -26,3 +26,4 @@ package:
   lvm2: v2_03_32
   dtc: v1.7.2
   fuse3: fuse-3.16.2
+  libgcrypt: libgcrypt-1.10.2

--- a/images/packages/binaries/libgcrypt/werf.inc.yaml
+++ b/images/packages/binaries/libgcrypt/werf.inc.yaml
@@ -1,0 +1,62 @@
+---
+image: {{ $.ImageType }}/{{ $.ImageName }}
+final: false
+fromImage: builder/scratch
+import:
+- image: {{ $.ImageType }}/{{ $.ImageName }}-builder
+  add: /out
+  to: /libcrypt
+  before: setup
+
+---
+{{- $version := get $.Package $.ImageName }}
+{{- $gitRepoUrl := "gpg/libgcrypt" }}
+
+{{- $name := print $.ImageName "-dependencies" -}}
+{{- define "$name" -}}
+packages:
+- git gcc
+- make pkgconfig makeinfo autoconf
+- libtool libgpg-error-devel
+{{- end -}}
+
+{{ $builderDependencies := include "$name" . | fromYaml }}
+
+image: {{ $.ImageType }}/{{ $.ImageName }}-builder
+final: false
+fromImage: builder/alt
+secrets:
+- id: SOURCE_REPO
+  value: {{ $.SOURCE_REPO_GIT }}
+shell:
+  beforeInstall:
+  {{- include "alt packages proxy" . | nindent 2 }}
+  - |
+    apt-get install -y \
+      {{ $builderDependencies.packages | join " " }}
+
+  {{- include "alt packages clean" . | nindent 2 }}
+
+  install:
+  - |
+    OUTDIR=/out
+    mkdir -p ~/.ssh && echo "StrictHostKeyChecking accept-new" > ~/.ssh/config
+
+    git clone --depth=1 $(cat /run/secrets/SOURCE_REPO)/{{ $gitRepoUrl }} --branch {{ $version }} /src
+
+    cd /src
+    autoreconf
+
+    ./configure \
+      --prefix=/usr \
+      --libdir=/usr/lib64 \
+      --enable-shared \
+      --enable-noexecstack \
+      --enable-ld-version-script \
+      --enable-random=linux \
+      --disable-dev-random \
+      --disable-doc
+
+    make -j$(nproc)
+    make DESTDIR=$OUTDIR install
+    libtool --finish /usr/lib64


### PR DESCRIPTION
## Description
Build libgcrypt because we need libgcrypt20 library.

## Why do we need it, and what problem does it solve?
We want more control when building libraries files, as well as making images more secure


## What is the expected result?
All work as expected


## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: core
type: chore
summary: build libgcrypt
impact_level: low
```
