### PR TITLE
fix(api): fix snapshotting process

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm/internal/snapshotting.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/snapshotting.go
@@ -81,7 +81,7 @@ func (h *SnapshottingHandler) Handle(ctx context.Context, s state.VirtualMachine
 			continue
 		case virtv2.VirtualMachineSnapshotPhaseInProgress:
 			cb.Status(metav1.ConditionTrue).
-				Message("The virtual machine is the process of snapshotting.").
+				Message("The virtual machine is in the process of snapshotting.").
 				Reason(vmcondition.ReasonSnapshottingInProgress)
 			return reconcile.Result{}, nil
 		default:

--- a/images/virtualization-artifact/pkg/controller/vm/internal/snapshotting.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/snapshotting.go
@@ -74,7 +74,10 @@ func (h *SnapshottingHandler) Handle(ctx context.Context, s state.VirtualMachine
 		}
 
 		switch vmSnapshot.Status.Phase {
-		case virtv2.VirtualMachineSnapshotPhaseReady, virtv2.VirtualMachineSnapshotPhaseTerminating:
+		case virtv2.VirtualMachineSnapshotPhasePending:
+			cb.Status(metav1.ConditionTrue).
+				Message("The virtual machine is selected for taking a snapshot.").
+				Reason(vmcondition.WaitingForTheSnapshotToStart)
 			continue
 		case virtv2.VirtualMachineSnapshotPhaseInProgress:
 			cb.Status(metav1.ConditionTrue).
@@ -82,9 +85,6 @@ func (h *SnapshottingHandler) Handle(ctx context.Context, s state.VirtualMachine
 				Reason(vmcondition.ReasonSnapshottingInProgress)
 			return reconcile.Result{}, nil
 		default:
-			cb.Status(metav1.ConditionTrue).
-				Message("The virtual machine is selected for taking a snapshot.").
-				Reason(vmcondition.WaitingForTheSnapshotToStart)
 			continue
 		}
 	}

--- a/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/life_cycle.go
+++ b/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/life_cycle.go
@@ -209,7 +209,7 @@ func (h LifeCycleHandler) Handle(ctx context.Context, vmSnapshot *virtv2.Virtual
 		return reconcile.Result{}, nil
 	}
 
-	needToFreeze := h.needToFreeze(vm)
+	needToFreeze := h.needToFreeze(vm, vmSnapshot.Spec.RequiredConsistency)
 
 	isAwaitingConsistency := needToFreeze && !h.snapshotter.CanFreeze(vm) && vmSnapshot.Spec.RequiredConsistency
 	if isAwaitingConsistency {
@@ -516,7 +516,11 @@ func (h LifeCycleHandler) areVirtualDiskSnapshotsConsistent(vdSnapshots []*virtv
 	return true
 }
 
-func (h LifeCycleHandler) needToFreeze(vm *virtv2.VirtualMachine) bool {
+func (h LifeCycleHandler) needToFreeze(vm *virtv2.VirtualMachine, requiredConsistency bool) bool {
+	if !requiredConsistency {
+		return false
+	}
+
 	if vm.Status.Phase == virtv2.MachineStopped {
 		return false
 	}


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
- In the vm controller, fix the view condition "Snapshotting" for snapshots in the "Failed" phase.

- In the vmsnapshot controller, add a check for requiredConsistency to determine if a freeze is needed. This will address the issue of creating snapshots in VMs that do not have a guest agent installed.


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: api
type: fix
summary: fix snapshotting process
```
