### PR TITLE
fix(vd): refactor object ref cvi data source

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/interfaces.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/interfaces.go
@@ -26,7 +26,7 @@ import (
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
-//go:generate moq -rm -out mock.go . Handler BlankDataSourceDiskService ObjectRefVirtualImageDiskService ObjectRefVirtualDiskSnapshotDiskService
+//go:generate moq -rm -out mock.go . Handler BlankDataSourceDiskService ObjectRefVirtualImageDiskService ObjectRefClusterVirtualImageDiskService ObjectRefVirtualDiskSnapshotDiskService
 
 type Handler interface {
 	Name() string
@@ -43,6 +43,13 @@ type BlankDataSourceDiskService interface {
 }
 
 type ObjectRefVirtualImageDiskService interface {
+	step.ReadyStepDiskService
+	step.WaitForDVStepDiskService
+	step.CreateDataVolumeStepDiskService
+	step.EnsureNodePlacementStepDiskService
+}
+
+type ObjectRefClusterVirtualImageDiskService interface {
 	step.ReadyStepDiskService
 	step.WaitForDVStepDiskService
 	step.CreateDataVolumeStepDiskService

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref.go
@@ -41,7 +41,6 @@ type ObjectRefDataSource struct {
 
 func NewObjectRefDataSource(
 	recorder eventrecord.EventRecorderLogger,
-	statService *service.StatService,
 	diskService *service.DiskService,
 	client client.Client,
 ) *ObjectRefDataSource {
@@ -49,7 +48,7 @@ func NewObjectRefDataSource(
 		diskService:      diskService,
 		vdSnapshotSyncer: NewObjectRefVirtualDiskSnapshot(recorder, diskService, client),
 		viSyncer:         NewObjectRefVirtualImage(diskService, client),
-		cviSyncer:        NewObjectRefClusterVirtualImage(recorder, statService, diskService, client),
+		cviSyncer:        NewObjectRefClusterVirtualImage(diskService, client),
 	}
 }
 

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_cvi.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_cvi.go
@@ -20,50 +20,35 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	storagev1 "k8s.io/api/storage/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
+	"k8s.io/apimachinery/pkg/types"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/deckhouse/virtualization-controller/pkg/common"
 	"github.com/deckhouse/virtualization-controller/pkg/common/annotations"
-	"github.com/deckhouse/virtualization-controller/pkg/common/imageformat"
 	"github.com/deckhouse/virtualization-controller/pkg/common/object"
-	"github.com/deckhouse/virtualization-controller/pkg/common/pointer"
-	"github.com/deckhouse/virtualization-controller/pkg/common/provisioner"
+	"github.com/deckhouse/virtualization-controller/pkg/common/steptaker"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
-	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/supplements"
-	"github.com/deckhouse/virtualization-controller/pkg/eventrecord"
-	"github.com/deckhouse/virtualization-controller/pkg/logger"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/vd/internal/source/step"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
 )
 
 type ObjectRefClusterVirtualImage struct {
-	statService *service.StatService
-	diskService *service.DiskService
+	diskService ObjectRefClusterVirtualImageDiskService
 	client      client.Client
-	recorder    eventrecord.EventRecorderLogger
 }
 
 func NewObjectRefClusterVirtualImage(
-	recorder eventrecord.EventRecorderLogger,
-	statService *service.StatService,
-	diskService *service.DiskService,
+	diskService ObjectRefClusterVirtualImageDiskService,
 	client client.Client,
 ) *ObjectRefClusterVirtualImage {
 	return &ObjectRefClusterVirtualImage{
-		statService: statService,
 		diskService: diskService,
 		client:      client,
-		recorder:    recorder,
 	}
 }
 
@@ -72,182 +57,29 @@ func (ds ObjectRefClusterVirtualImage) Sync(ctx context.Context, vd *virtv2.Virt
 		return reconcile.Result{}, errors.New("object ref missed for data source")
 	}
 
-	log, ctx := logger.GetDataSourceContext(ctx, objectRefDataSource)
+	supgen := supplements.NewGenerator(annotations.VDShortName, vd.Name, vd.Namespace, vd.UID)
 
-	condition, _ := conditions.GetCondition(vdcondition.ReadyType, vd.Status.Conditions)
 	cb := conditions.NewConditionBuilder(vdcondition.ReadyType).Generation(vd.Generation)
-
 	defer func() { conditions.SetCondition(cb, &vd.Status.Conditions) }()
 
-	supgen := supplements.NewGenerator(annotations.VDShortName, vd.Name, vd.Namespace, vd.UID)
-	dv, err := ds.diskService.GetDataVolume(ctx, supgen)
+	pvc, err := object.FetchObject(ctx, supgen.PersistentVolumeClaim(), ds.client, &corev1.PersistentVolumeClaim{})
 	if err != nil {
-		return reconcile.Result{}, err
+		return reconcile.Result{}, fmt.Errorf("fetch pvc: %w", err)
 	}
-	pvc, err := ds.diskService.GetPersistentVolumeClaim(ctx, supgen)
+
+	dv, err := object.FetchObject(ctx, supgen.DataVolume(), ds.client, &cdiv1.DataVolume{})
 	if err != nil {
-		return reconcile.Result{}, err
-	}
-	cvi, err := ds.diskService.GetClusterVirtualImage(ctx, vd.Spec.DataSource.ObjectRef.Name)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-	if cvi == nil {
-		return reconcile.Result{}, errors.New("the source cluster virtual image not found")
+		return reconcile.Result{}, fmt.Errorf("fetch dv: %w", err)
 	}
 
-	var dvQuotaNotExceededCondition *cdiv1.DataVolumeCondition
-	var dvRunningCondition *cdiv1.DataVolumeCondition
-	if dv != nil {
-		dvQuotaNotExceededCondition = service.GetDataVolumeCondition(DVQoutaNotExceededConditionType, dv.Status.Conditions)
-		dvRunningCondition = service.GetDataVolumeCondition(DVRunningConditionType, dv.Status.Conditions)
-	}
-
-	switch {
-	case IsDiskProvisioningFinished(condition):
-		log.Debug("Disk provisioning finished: clean up")
-
-		setPhaseConditionForFinishedDisk(pvc, cb, &vd.Status.Phase, supgen)
-
-		// Protect Ready Disk and underlying PVC.
-		err = ds.diskService.Protect(ctx, vd, nil, pvc)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-
-		err = ds.diskService.Unprotect(ctx, dv)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-
-		return CleanUpSupplements(ctx, vd, ds)
-	case object.AnyTerminating(dv, pvc):
-		log.Info("Waiting for supplements to be terminated")
-	case dv == nil:
-		ds.recorder.Event(
-			vd,
-			corev1.EventTypeNormal,
-			virtv2.ReasonDataSourceSyncStarted,
-			"The ObjectRef DataSource import to PVC has started",
-		)
-
-		vd.Status.Progress = "0%"
-		vd.Status.SourceUID = pointer.GetPointer(cvi.GetUID())
-
-		if imageformat.IsISO(cvi.Status.Format) {
-			setPhaseConditionToFailed(cb, &vd.Status.Phase, ErrISOSourceNotSupported)
-			return reconcile.Result{}, nil
-		}
-
-		var diskSize resource.Quantity
-		diskSize, err = ds.getPVCSize(vd, cvi.Status.Size)
-		if err != nil {
-			setPhaseConditionToFailed(cb, &vd.Status.Phase, err)
-
-			if errors.Is(err, service.ErrInsufficientPVCSize) {
-				return reconcile.Result{}, nil
-			}
-
-			return reconcile.Result{}, err
-		}
-
-		source := ds.getSource(supgen, cvi)
-
-		var nodePlacement *provisioner.NodePlacement
-		nodePlacement, err = getNodePlacement(ctx, ds.client, vd)
-		if err != nil {
-			setPhaseConditionToFailed(cb, &vd.Status.Phase, fmt.Errorf("unexpected error: %w", err))
-			return reconcile.Result{}, fmt.Errorf("failed to get importer tolerations: %w", err)
-		}
-
-		var sc *storagev1.StorageClass
-		sc, err = ds.diskService.GetStorageClass(ctx, vd.Status.StorageClassName)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-		err = ds.diskService.Start(ctx, diskSize, sc, source, vd, supgen, service.WithNodePlacement(nodePlacement))
-		if updated, err := setPhaseConditionFromStorageError(err, vd, cb); err != nil || updated {
-			return reconcile.Result{}, err
-		}
-
-		vd.Status.Phase = virtv2.DiskProvisioning
-		cb.
-			Status(metav1.ConditionFalse).
-			Reason(vdcondition.Provisioning).
-			Message("PVC Provisioner not found: create the new one.")
-
-		return reconcile.Result{RequeueAfter: time.Second}, nil
-	case dvQuotaNotExceededCondition != nil && dvQuotaNotExceededCondition.Status == corev1.ConditionFalse:
-		vd.Status.Phase = virtv2.DiskPending
-		cb.
-			Status(metav1.ConditionFalse).
-			Reason(vdcondition.QuotaExceeded).
-			Message(dvQuotaNotExceededCondition.Message)
-		return reconcile.Result{}, nil
-	case dvRunningCondition != nil && dvRunningCondition.Status != corev1.ConditionTrue && dvRunningCondition.Reason == DVImagePullFailedReason:
-		vd.Status.Phase = virtv2.DiskPending
-		cb.
-			Status(metav1.ConditionFalse).
-			Reason(vdcondition.ImagePullFailed).
-			Message(dvRunningCondition.Message)
-		ds.recorder.Event(vd, corev1.EventTypeWarning, vdcondition.ImagePullFailed.String(), dvRunningCondition.Message)
-		return reconcile.Result{}, nil
-	case pvc == nil:
-		vd.Status.Phase = virtv2.DiskProvisioning
-		cb.
-			Status(metav1.ConditionFalse).
-			Reason(vdcondition.Provisioning).
-			Message("PVC not found: waiting for creation.")
-		return reconcile.Result{RequeueAfter: time.Second}, nil
-	case ds.diskService.IsImportDone(dv, pvc):
-		log.Info("Import has completed", "dvProgress", dv.Status.Progress, "dvPhase", dv.Status.Phase, "pvcPhase", pvc.Status.Phase)
-		ds.recorder.Event(
-			vd,
-			corev1.EventTypeNormal,
-			virtv2.ReasonDataSourceSyncCompleted,
-			"The ObjectRef DataSource import has completed",
-		)
-
-		vd.Status.Phase = virtv2.DiskReady
-		cb.
-			Status(metav1.ConditionTrue).
-			Reason(vdcondition.Ready).
-			Message("")
-
-		vd.Status.Progress = "100%"
-		vd.Status.Capacity = ds.diskService.GetCapacity(pvc)
-		vd.Status.Target.PersistentVolumeClaim = dv.Status.ClaimName
-	default:
-		log.Info("Provisioning to PVC is in progress", "dvProgress", dv.Status.Progress, "dvPhase", dv.Status.Phase, "pvcPhase", pvc.Status.Phase)
-
-		err = ds.diskService.CheckProvisioning(ctx, pvc)
-		if err != nil {
-			return reconcile.Result{}, setPhaseConditionFromProvisioningError(ctx, err, cb, vd, dv, ds.diskService, ds.client)
-		}
-
-		vd.Status.Progress = ds.diskService.GetProgress(dv, vd.Status.Progress, service.NewScaleOption(0, 100))
-		vd.Status.Capacity = ds.diskService.GetCapacity(pvc)
-		vd.Status.Target.PersistentVolumeClaim = dv.Status.ClaimName
-
-		err = ds.diskService.Protect(ctx, vd, dv, pvc)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-
-		var sc *storagev1.StorageClass
-		sc, err = ds.diskService.GetStorageClass(ctx, ptr.Deref(pvc.Spec.StorageClassName, ""))
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-
-		if err = setPhaseConditionForPVCProvisioningDisk(ctx, dv, vd, pvc, sc, cb, ds.diskService); err != nil {
-			return reconcile.Result{}, err
-		}
-
-		return reconcile.Result{}, nil
-	}
-
-	return reconcile.Result{RequeueAfter: time.Second}, nil
+	return steptaker.NewStepTakers[*virtv2.VirtualDisk](
+		step.NewReadyStep(ds.diskService, pvc, cb),
+		step.NewTerminatingStep(pvc),
+		step.NewCreateDataVolumeFromClusterVirtualImageStep(pvc, dv, ds.diskService, ds.client, cb),
+		step.NewEnsureNodePlacementStep(pvc, dv, ds.diskService, ds.client, cb),
+		step.NewWaitForDVStep(pvc, dv, ds.diskService, ds.client, cb),
+		step.NewWaitForPVCStep(pvc, ds.client, cb),
+	).Run(ctx, vd)
 }
 
 func (ds ObjectRefClusterVirtualImage) Validate(ctx context.Context, vd *virtv2.VirtualDisk) error {
@@ -255,51 +87,15 @@ func (ds ObjectRefClusterVirtualImage) Validate(ctx context.Context, vd *virtv2.
 		return errors.New("object ref missed for data source")
 	}
 
-	cvi, err := ds.diskService.GetClusterVirtualImage(ctx, vd.Spec.DataSource.ObjectRef.Name)
+	cviRefKey := types.NamespacedName{Name: vd.Spec.DataSource.ObjectRef.Name}
+	cviRef, err := object.FetchObject(ctx, cviRefKey, ds.client, &virtv2.ClusterVirtualImage{})
 	if err != nil {
-		return err
+		return fmt.Errorf("fetch vi %q: %w", cviRefKey, err)
 	}
-	if cvi == nil || cvi.Status.Phase != virtv2.ImageReady || cvi.Status.Target.RegistryURL == "" {
+
+	if cviRef == nil || cviRef.Status.Phase != virtv2.ImageReady || cviRef.Status.Target.RegistryURL == "" {
 		return NewClusterImageNotReadyError(vd.Spec.DataSource.ObjectRef.Name)
 	}
 
 	return nil
-}
-
-func (ds ObjectRefClusterVirtualImage) CleanUpSupplements(ctx context.Context, vd *virtv2.VirtualDisk) (reconcile.Result, error) {
-	supgen := supplements.NewGenerator(annotations.VDShortName, vd.Name, vd.Namespace, vd.UID)
-
-	requeue, err := ds.diskService.CleanUpSupplements(ctx, supgen)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
-	if requeue {
-		return reconcile.Result{RequeueAfter: time.Second}, nil
-	} else {
-		return reconcile.Result{}, nil
-	}
-}
-
-func (ds ObjectRefClusterVirtualImage) getSource(sup *supplements.Generator, cvi *virtv2.ClusterVirtualImage) *cdiv1.DataVolumeSource {
-	url := common.DockerRegistrySchemePrefix + cvi.Status.Target.RegistryURL
-	secretName := sup.DVCRAuthSecretForDV().Name
-	certConfigMapName := sup.DVCRCABundleConfigMapForDV().Name
-
-	return &cdiv1.DataVolumeSource{
-		Registry: &cdiv1.DataVolumeSourceRegistry{
-			URL:           &url,
-			SecretRef:     &secretName,
-			CertConfigMap: &certConfigMapName,
-		},
-	}
-}
-
-func (ds ObjectRefClusterVirtualImage) getPVCSize(vd *virtv2.VirtualDisk, size virtv2.ImageStatusSize) (resource.Quantity, error) {
-	unpackedSize, err := resource.ParseQuantity(size.UnpackedBytes)
-	if err != nil {
-		return resource.Quantity{}, fmt.Errorf("failed to parse unpacked bytes %s: %w", size.UnpackedBytes, err)
-	}
-
-	return service.GetValidatedPVCSize(vd.Spec.PersistentVolumeClaim.Size, unpackedSize)
 }

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_cvi_test.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_cvi_test.go
@@ -1,0 +1,274 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	"context"
+	"log/slog"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/deckhouse/virtualization-controller/pkg/common/annotations"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/supplements"
+	"github.com/deckhouse/virtualization-controller/pkg/logger"
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
+)
+
+var _ = Describe("ObjectRef ClusterVirtualImage", func() {
+	var (
+		ctx    context.Context
+		scheme *runtime.Scheme
+		cvi    *virtv2.ClusterVirtualImage
+		vd     *virtv2.VirtualDisk
+		sc     *storagev1.StorageClass
+		pvc    *corev1.PersistentVolumeClaim
+		dv     *cdiv1.DataVolume
+		svc    *ObjectRefVirtualImageDiskServiceMock
+	)
+
+	BeforeEach(func() {
+		ctx = logger.ToContext(context.TODO(), slog.Default())
+
+		scheme = runtime.NewScheme()
+		Expect(virtv2.AddToScheme(scheme)).To(Succeed())
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+		Expect(cdiv1.AddToScheme(scheme)).To(Succeed())
+		Expect(storagev1.AddToScheme(scheme)).To(Succeed())
+
+		svc = &ObjectRefVirtualImageDiskServiceMock{
+			GetProgressFunc: func(_ *cdiv1.DataVolume, _ string, _ ...service.GetProgressOption) string {
+				return "10%"
+			},
+			GetCapacityFunc: func(_ *corev1.PersistentVolumeClaim) string {
+				return "100Mi"
+			},
+			CleanUpSupplementsFunc: func(_ context.Context, _ *supplements.Generator) (bool, error) {
+				return false, nil
+			},
+			ProtectFunc: func(_ context.Context, _ client.Object, _ *cdiv1.DataVolume, _ *corev1.PersistentVolumeClaim) error {
+				return nil
+			},
+		}
+
+		sc = &storagev1.StorageClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "sc",
+			},
+		}
+
+		cvi = &virtv2.ClusterVirtualImage{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "vi",
+				Generation: 1,
+				UID:        "11111111-1111-1111-1111-111111111111",
+			},
+			Status: virtv2.ClusterVirtualImageStatus{
+				Size: virtv2.ImageStatusSize{
+					UnpackedBytes: "100Mi",
+				},
+			},
+		}
+
+		vd = &virtv2.VirtualDisk{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "vd",
+				Generation: 1,
+				UID:        "22222222-2222-2222-2222-222222222222",
+			},
+			Spec: virtv2.VirtualDiskSpec{
+				DataSource: &virtv2.VirtualDiskDataSource{
+					Type: virtv2.DataSourceTypeObjectRef,
+					ObjectRef: &virtv2.VirtualDiskObjectRef{
+						Kind: virtv2.VirtualDiskObjectRefKindClusterVirtualImage,
+						Name: cvi.Name,
+					},
+				},
+			},
+			Status: virtv2.VirtualDiskStatus{
+				StorageClassName: sc.Name,
+			},
+		}
+
+		supgen := supplements.NewGenerator(annotations.VDShortName, vd.Name, vd.Namespace, vd.UID)
+
+		pvc = &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      supgen.PersistentVolumeClaim().Name,
+				Namespace: vd.Namespace,
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				StorageClassName: ptr.To(sc.Name),
+			},
+			Status: corev1.PersistentVolumeClaimStatus{
+				Capacity: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse(cvi.Status.Size.UnpackedBytes),
+				},
+			},
+		}
+
+		dv = &cdiv1.DataVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      supgen.DataVolume().Name,
+				Namespace: vd.Namespace,
+			},
+			Status: cdiv1.DataVolumeStatus{
+				ClaimName: pvc.Name,
+			},
+		}
+	})
+
+	Context("VirtualDisk has just been created", func() {
+		It("must create DataVolume", func() {
+			var dvCreated bool
+			vd.Status = virtv2.VirtualDiskStatus{}
+			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cvi, sc).Build()
+			svc.StartFunc = func(_ context.Context, _ resource.Quantity, _ *storagev1.StorageClass, _ *cdiv1.DataVolumeSource, _ service.ObjectKind, _ *supplements.Generator, _ ...service.Option) error {
+				dvCreated = true
+				return nil
+			}
+
+			syncer := NewObjectRefClusterVirtualImage(svc, client)
+
+			res, err := syncer.Sync(ctx, vd)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.IsZero()).To(BeTrue())
+
+			Expect(dvCreated).To(BeTrue())
+
+			ExpectCondition(vd, metav1.ConditionFalse, vdcondition.Provisioning, true)
+			Expect(vd.Status.Phase).To(Equal(virtv2.DiskProvisioning))
+			Expect(vd.Status.Progress).ToNot(BeEmpty())
+			Expect(vd.Status.Target.PersistentVolumeClaim).ToNot(BeEmpty())
+		})
+	})
+
+	Context("VirtualDisk waits for the PVC to be Bound", func() {
+		BeforeEach(func() {
+			svc.CheckProvisioningFunc = func(_ context.Context, _ *corev1.PersistentVolumeClaim) error {
+				return nil
+			}
+		})
+
+		It("waits for the first consumer", func() {
+			dv.Status.Phase = cdiv1.PendingPopulation
+			sc.VolumeBindingMode = ptr.To(storagev1.VolumeBindingWaitForFirstConsumer)
+			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc, dv, sc).Build()
+
+			syncer := NewObjectRefClusterVirtualImage(svc, client)
+
+			res, err := syncer.Sync(ctx, vd)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.IsZero()).To(BeTrue())
+
+			ExpectCondition(vd, metav1.ConditionFalse, vdcondition.WaitingForFirstConsumer, true)
+			Expect(vd.Status.Phase).To(Equal(virtv2.DiskWaitForFirstConsumer))
+			Expect(vd.Status.Progress).ToNot(BeEmpty())
+			Expect(vd.Status.Target.PersistentVolumeClaim).ToNot(BeEmpty())
+		})
+
+		It("is in provisioning", func() {
+			pvc.Status.Phase = corev1.ClaimPending
+			sc.VolumeBindingMode = ptr.To(storagev1.VolumeBindingImmediate)
+			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc, dv, sc).Build()
+
+			syncer := NewObjectRefClusterVirtualImage(svc, client)
+
+			res, err := syncer.Sync(ctx, vd)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.IsZero()).To(BeTrue())
+
+			ExpectCondition(vd, metav1.ConditionFalse, vdcondition.Provisioning, true)
+			Expect(vd.Status.Phase).To(Equal(virtv2.DiskProvisioning))
+			Expect(vd.Status.Progress).ToNot(BeEmpty())
+			Expect(vd.Status.Target.PersistentVolumeClaim).ToNot(BeEmpty())
+		})
+	})
+
+	Context("VirtualDisk is ready", func() {
+		It("checks that the VirtualDisk is ready", func() {
+			dv.Status.Phase = cdiv1.Succeeded
+			pvc.Status.Phase = corev1.ClaimBound
+			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(dv, pvc).Build()
+
+			syncer := NewObjectRefClusterVirtualImage(svc, client)
+
+			res, err := syncer.Sync(ctx, vd)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.IsZero()).To(BeTrue())
+
+			ExpectCondition(vd, metav1.ConditionTrue, vdcondition.Ready, false)
+			Expect(vd.Status.Phase).To(Equal(virtv2.DiskReady))
+			ExpectStats(vd)
+		})
+	})
+
+	Context("VirtualDisk is lost", func() {
+		BeforeEach(func() {
+			vd.Status.Progress = "100%"
+		})
+
+		It("is lost when PVC is not found", func() {
+			vd.Status.Target.PersistentVolumeClaim = pvc.Name
+			vd.Status.Conditions = []metav1.Condition{
+				{
+					Type:   vdcondition.ReadyType.String(),
+					Reason: vdcondition.Ready.String(),
+					Status: metav1.ConditionTrue,
+				},
+			}
+			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects().Build()
+
+			syncer := NewObjectRefClusterVirtualImage(svc, client)
+
+			res, err := syncer.Sync(ctx, vd)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.IsZero()).To(BeTrue())
+
+			ExpectCondition(vd, metav1.ConditionFalse, vdcondition.Lost, true)
+			Expect(vd.Status.Phase).To(Equal(virtv2.DiskLost))
+			Expect(vd.Status.Target.PersistentVolumeClaim).NotTo(BeEmpty())
+		})
+
+		It("is lost when PVC is lost as well", func() {
+			pvc.Status.Phase = corev1.ClaimLost
+			vd.Status.Target.PersistentVolumeClaim = pvc.Name
+			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc).Build()
+
+			syncer := NewObjectRefClusterVirtualImage(svc, client)
+
+			res, err := syncer.Sync(ctx, vd)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.IsZero()).To(BeTrue())
+
+			ExpectCondition(vd, metav1.ConditionFalse, vdcondition.Lost, true)
+			Expect(vd.Status.Phase).To(Equal(virtv2.DiskLost))
+			Expect(vd.Status.Target.PersistentVolumeClaim).NotTo(BeEmpty())
+		})
+	})
+})

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/step/create_dv_from_cvi_step.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/step/create_dv_from_cvi_step.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package step
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/deckhouse/virtualization-controller/pkg/common"
+	"github.com/deckhouse/virtualization-controller/pkg/common/annotations"
+	"github.com/deckhouse/virtualization-controller/pkg/common/imageformat"
+	"github.com/deckhouse/virtualization-controller/pkg/common/object"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/supplements"
+	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
+)
+
+type CreateDataVolumeFromClusterVirtualImageStep struct {
+	pvc    *corev1.PersistentVolumeClaim
+	dv     *cdiv1.DataVolume
+	disk   CreateDataVolumeStepDiskService
+	client client.Client
+	cb     *conditions.ConditionBuilder
+}
+
+func NewCreateDataVolumeFromClusterVirtualImageStep(
+	pvc *corev1.PersistentVolumeClaim,
+	dv *cdiv1.DataVolume,
+	disk CreateDataVolumeStepDiskService,
+	client client.Client,
+	cb *conditions.ConditionBuilder,
+) *CreateDataVolumeFromClusterVirtualImageStep {
+	return &CreateDataVolumeFromClusterVirtualImageStep{
+		pvc:    pvc,
+		dv:     dv,
+		disk:   disk,
+		client: client,
+		cb:     cb,
+	}
+}
+
+func (s CreateDataVolumeFromClusterVirtualImageStep) Take(ctx context.Context, vd *virtv2.VirtualDisk) (*reconcile.Result, error) {
+	if s.pvc != nil || s.dv != nil {
+		return nil, nil
+	}
+
+	cviRefKey := types.NamespacedName{Name: vd.Spec.DataSource.ObjectRef.Name}
+	cviRef, err := object.FetchObject(ctx, cviRefKey, s.client, &virtv2.ClusterVirtualImage{})
+	if err != nil {
+		return nil, fmt.Errorf("fetch cvi %q: %w", cviRefKey, err)
+	}
+
+	if cviRef == nil {
+		return nil, fmt.Errorf("cvi object ref %q is nil", cviRefKey)
+	}
+
+	vd.Status.SourceUID = ptr.To(cviRef.UID)
+
+	if imageformat.IsISO(cviRef.Status.Format) {
+		vd.Status.Phase = virtv2.DiskFailed
+		s.cb.
+			Status(metav1.ConditionFalse).
+			Reason(vdcondition.ProvisioningFailed).
+			Message(service.CapitalizeFirstLetter(ErrISOSourceNotSupported.Error()) + ".")
+		return &reconcile.Result{}, nil
+	}
+
+	source := s.getSource(vd, cviRef)
+
+	size, err := s.getPVCSize(vd, cviRef)
+	if err != nil {
+		if errors.Is(err, service.ErrInsufficientPVCSize) {
+			return &reconcile.Result{}, nil
+		}
+
+		return nil, err
+	}
+
+	return NewCreateDataVolumeStep(s.dv, s.disk, s.client, source, size, s.cb).Take(ctx, vd)
+}
+
+func (s CreateDataVolumeFromClusterVirtualImageStep) getPVCSize(vd *virtv2.VirtualDisk, cviRef *virtv2.ClusterVirtualImage) (resource.Quantity, error) {
+	unpackedSize, err := resource.ParseQuantity(cviRef.Status.Size.UnpackedBytes)
+	if err != nil {
+		return resource.Quantity{}, fmt.Errorf("failed to parse unpacked bytes %s: %w", cviRef.Status.Size.UnpackedBytes, err)
+	}
+
+	if unpackedSize.IsZero() {
+		return resource.Quantity{}, errors.New("got zero unpacked size from data source")
+	}
+
+	return service.GetValidatedPVCSize(vd.Spec.PersistentVolumeClaim.Size, unpackedSize)
+}
+
+func (s CreateDataVolumeFromClusterVirtualImageStep) getSource(vd *virtv2.VirtualDisk, cviRef *virtv2.ClusterVirtualImage) *cdiv1.DataVolumeSource {
+	supgen := supplements.NewGenerator(annotations.VDShortName, vd.Name, vd.Namespace, vd.UID)
+
+	url := common.DockerRegistrySchemePrefix + cviRef.Status.Target.RegistryURL
+	secretName := supgen.DVCRAuthSecretForDV().Name
+	certConfigMapName := supgen.DVCRCABundleConfigMapForDV().Name
+
+	return &cdiv1.DataVolumeSource{
+		Registry: &cdiv1.DataVolumeSourceRegistry{
+			URL:           &url,
+			SecretRef:     &secretName,
+			CertConfigMap: &certConfigMapName,
+		},
+	}
+}

--- a/images/virtualization-artifact/pkg/controller/vd/vd_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vd/vd_controller.go
@@ -74,7 +74,7 @@ func NewController(
 	sources := source.NewSources()
 	sources.Set(virtv2.DataSourceTypeHTTP, source.NewHTTPDataSource(recorder, stat, importer, disk, dvcr, mgr.GetClient()))
 	sources.Set(virtv2.DataSourceTypeContainerImage, source.NewRegistryDataSource(recorder, stat, importer, disk, dvcr, mgr.GetClient()))
-	sources.Set(virtv2.DataSourceTypeObjectRef, source.NewObjectRefDataSource(recorder, stat, disk, mgr.GetClient()))
+	sources.Set(virtv2.DataSourceTypeObjectRef, source.NewObjectRefDataSource(recorder, disk, mgr.GetClient()))
 	sources.Set(virtv2.DataSourceTypeUpload, source.NewUploadDataSource(recorder, stat, uploader, disk, dvcr, mgr.GetClient()))
 
 	reconciler := NewReconciler(


### PR DESCRIPTION
## Description

Refactor the cvi data source using step-based design to fix the update of observed generation for a disk in the Ready state if the data source image was deleted.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries


```changes
section: vd  
type: fix
summary: Fix the update of observed generation for a disk in the Ready state if the data source image was deleted.
```
