### PR TITLE
chore(core): fix svacer issues in virt-launcher and virt-handler

### DIFF
--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -1,7 +1,7 @@
 ---
 # Source https://github.com/kubevirt/kubevirt/blob/v1.3.1/hack/dockerized#L15
 {{- $version := "v1.3.1" }}
-{{- $tag := print $version "-v12n.dlopatin5"}}
+{{- $tag := print $version "-v12n.2"}}
 
 {{- $name := print $.ImageName "-dependencies" -}}
 {{- define "$name" -}}

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -1,7 +1,7 @@
 ---
 # Source https://github.com/kubevirt/kubevirt/blob/v1.3.1/hack/dockerized#L15
 {{- $version := "v1.3.1" }}
-{{- $tag := print $version "-v12n.1"}}
+{{- $tag := print $version "-v12n.dlopatin3"}}
 
 {{- $name := print $.ImageName "-dependencies" -}}
 {{- define "$name" -}}

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -1,7 +1,7 @@
 ---
 # Source https://github.com/kubevirt/kubevirt/blob/v1.3.1/hack/dockerized#L15
 {{- $version := "v1.3.1" }}
-{{- $tag := print $version "-v12n.dlopatin4"}}
+{{- $tag := print $version "-v12n.dlopatin5"}}
 
 {{- $name := print $.ImageName "-dependencies" -}}
 {{- define "$name" -}}

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -1,7 +1,7 @@
 ---
 # Source https://github.com/kubevirt/kubevirt/blob/v1.3.1/hack/dockerized#L15
 {{- $version := "v1.3.1" }}
-{{- $tag := print $version "-v12n.dlopatin3"}}
+{{- $tag := print $version "-v12n.dlopatin4"}}
 
 {{- $name := print $.ImageName "-dependencies" -}}
 {{- define "$name" -}}


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Switch the project to a new tag of KubeVirt with static analyzer warnings resolved.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
Fixed issues in virt-launcher:
- After having been compared to a nil value at rt_wrapper.go:45, pointer 'request.URL' is passed in call to function 'kubevirt.io/kubevirt/pkg/monitoring/metrics/common/client.parseURLResourceOperation' at rt_wrapper.go:49, where it is dereferenced at rt_wrapper.go:67.
- After having been compared to a nil value at client.go:455, pointer 'domainCache' is passed as 2nd parameter in call to function 'kubevirt.io/kubevirt/pkg/virt-launcher/notify-client.eventCallback' at client.go:447, where it is dereferenced at client.go:247.
- After having been compared to a nil value at manager.go:341, pointer 'vmi' is passed as 1st parameter in call to function 'kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api.VMINamespaceKeyFunc' at manager.go:347, where it is dereferenced at schema.go:1302.
- After having been compared to a nil value at manager.go:516, pointer 'vmi' is passed as 1st parameter in call to function 'kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api.VMINamespaceKeyFunc' at manager.go:522, where it is dereferenced at schema.go:1302.
- After having been compared to a nil value at manager.go:633, pointer 'vmi' is passed as 1st parameter in call to function 'kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap.LibvirtDomainManager.hotPlugHostDevices' at manager.go:636, where it is dereferenced at manager.go:656.
- After having been compared to a nil value at manager.go:1176, pointer 'vmi' is passed as 1st parameter in call to function 'kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter.Convert_v1_VirtualMachineInstance_To_api_Domain' at manager.go:1190, where it is dereferenced at converter.go:1362.
- After having been compared to a nil value at manager.go:341, pointer 'vmi' is passed as 1st parameter in call to function 'kubevirt.io/kubevirt/pkg/liveupdate/memory.BuildMemoryDevice' at manager.go:354, where it is dereferenced at memory.go:111.
- After having been compared to a nil value at manager.go:516, pointer 'vmi' is passed as 1st parameter in call to function 'kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/vcpu.GetCPUTopology' at manager.go:532, where it is dereferenced at vcpu.go:297.
---
Fixed issues in virt-handler:
- After having been compared to a nil value at rt_wrapper.go:45, pointer 'request.URL' is passed in call to function 'kubevirt.io/kubevirt/pkg/monitoring/metrics/common/client.parseURLResourceOperation' at rt_wrapper.go:49, where it is dereferenced at rt_wrapper.go:67.
- After having been assigned to a nil value at mount.go:487, pointer 'targetInitrdPath' is passed as 2nd parameter in call to function 'kubevirt.io/kubevirt/pkg/virt-handler/virt-chroot.MountChroot' at mount.go:534, where it is dereferenced at virt-chroot.go:51.
- After having been compared to a nil value at vm.go:562, pointer 'vmi.Status->MigrationState' is dereferenced at vm.go:570.
- After having been compared to a nil value at vm.go:711, pointer 'vmi.Status->MigrationState' is dereferenced at vm.go:725.
- After having been assigned to a nil value at common.go:183, pointer 'lines[0]' is dereferenced at common.go:191.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
Addressing static analyzer warnings in virt-handler and virt-launcher.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: core 
type: chore
summary: Addressing static analyzer warnings in virt-handler and virt-launcher.
```
