### PR TITLE
feat(vmop): improve phase handling for migrate operations

### DIFF
--- a/api/core/v1alpha2/vmopcondition/condition.go
+++ b/api/core/v1alpha2/vmopcondition/condition.go
@@ -26,8 +26,8 @@ const (
 	// TypeCompleted is a type for condition that indicates operation is complete.
 	TypeCompleted Type = "Completed"
 
-	// SignalSentType is a type for condition that indicates operation signal has been sent.
-	SignalSentType Type = "SignalSent"
+	// TypeSignalSent is a type for condition that indicates operation signal has been sent.
+	TypeSignalSent Type = "SignalSent"
 )
 
 // ReasonCompleted represents specific reasons for the 'Completed' condition type.
@@ -50,8 +50,11 @@ const (
 	// ReasonNotApplicableForLiveMigrationPolicy is a ReasonCompleted indicating that the specified operation type is not applicable for the virtual machine live migration policy.
 	ReasonNotApplicableForLiveMigrationPolicy ReasonCompleted = "NotApplicableForLiveMigrationPolicy"
 
-	// ReasonOtherOperationsAreInProgress is a ReasonCompleted indicating that there are other operations in progress.
-	ReasonOtherOperationsAreInProgress ReasonCompleted = "OtherOperationsAreInProgress"
+	// ReasonNotReadyToBeExecuted is a ReasonCompleted indicating that the operation is not ready to be executed.
+	ReasonNotReadyToBeExecuted ReasonCompleted = "NotReadyToBeExecuted"
+
+	// ReasonReadyToBeExecuted is a ReasonCompleted indicating that the operation is ready to be executed.
+	ReasonReadyToBeExecuted ReasonCompleted = "ReadyToBeExecuted"
 
 	// ReasonRestartInProgress is a ReasonCompleted indicating that the restart signal has been sent and restart is in progress.
 	ReasonRestartInProgress ReasonCompleted = "RestartInProgress"

--- a/images/virtualization-artifact/pkg/controller/vmop/internal/lifecycle.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/internal/lifecycle.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	virtv1 "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -73,7 +74,7 @@ func (h LifecycleHandler) Handle(ctx context.Context, vmop *virtv2.VirtualMachin
 
 	completedCond := conditions.NewConditionBuilder(vmopcondition.TypeCompleted).
 		Generation(vmop.GetGeneration())
-	signalSendCond := conditions.NewConditionBuilder(vmopcondition.SignalSentType).
+	signalSendCond := conditions.NewConditionBuilder(vmopcondition.TypeSignalSent).
 		Generation(vmop.GetGeneration())
 
 	// Initialize new VMOP resource: set label with vm name, set phase to Pending and all conditions to Unknown.
@@ -123,32 +124,38 @@ func (h LifecycleHandler) Handle(ctx context.Context, vmop *virtv2.VirtualMachin
 	}
 	annotations.AddLabel(vmop, annotations.LabelVirtualMachineUID, string(vm.GetUID()))
 
-	if vmop.Status.Phase == virtv2.VMOPPhaseInProgress {
+	if isOperationInProgress(vmop) {
 		log.Debug("Operation in progress, check if VM is completed", "vm.phase", vm.Status.Phase, "vmop.phase", vmop.Status.Phase)
-		return h.syncOperationComplete(ctx, vmop, vm, svcOp)
+		return h.syncOperationComplete(ctx, vmop, svcOp)
 	}
 
 	// At this point VMOP is in Pending phase, do some validation checks.
 
-	// Fail if there is at least one other VirtualMachineOperation in progress.
-	found, err := h.otherVMOPIsInProgress(ctx, vmop)
+	can, err := h.canBeRun(ctx, vmop)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-	if found {
-		vmop.Status.Phase = virtv2.VMOPPhaseFailed
-		h.recorder.Event(vmop, corev1.EventTypeWarning, virtv2.ReasonErrVMOPFailed, "Other VirtualMachineOperations are in progress")
+	if can {
+		vmop.Status.Phase = virtv2.VMOPPhasePending
 		conditions.SetCondition(
 			completedCond.
-				Reason(vmopcondition.ReasonOtherOperationsAreInProgress).
-				Status(metav1.ConditionFalse).
-				Message("Other VirtualMachineOperations are in progress"),
+				Reason(vmopcondition.ReasonReadyToBeExecuted).
+				Message("VMOP is waiting to be executed.").
+				Status(metav1.ConditionFalse),
+			&vmop.Status.Conditions)
+	} else {
+		vmop.Status.Phase = virtv2.VMOPPhaseFailed
+		conditions.SetCondition(
+			completedCond.
+				Reason(vmopcondition.ReasonNotReadyToBeExecuted).
+				Message("VMOP cannot be executed now. Other operation is in progress or other vmop should be executed first.").
+				Status(metav1.ConditionFalse),
 			&vmop.Status.Conditions)
 		return reconcile.Result{}, nil
 	}
 
 	// Fail if there is at least one other migration in progress.
-	found, err = h.otherMigrationsAreInProgress(ctx, vmop)
+	found, err := h.otherMigrationsAreInProgress(ctx, vmop)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -219,8 +226,7 @@ func (h LifecycleHandler) Name() string {
 }
 
 // syncOperationComplete detects if operation is completed and VM has desired phase.
-// TODO detect if VM is stuck to prevent infinite InProgress state.
-func (h LifecycleHandler) syncOperationComplete(ctx context.Context, changed *virtv2.VirtualMachineOperation, vm *virtv2.VirtualMachine, svcOp service.Operation) (reconcile.Result, error) {
+func (h LifecycleHandler) syncOperationComplete(ctx context.Context, changed *virtv2.VirtualMachineOperation, svcOp service.Operation) (reconcile.Result, error) {
 	completedCond := conditions.NewConditionBuilder(vmopcondition.TypeCompleted).
 		Generation(changed.GetGeneration())
 
@@ -255,50 +261,56 @@ func (h LifecycleHandler) syncOperationComplete(ctx context.Context, changed *vi
 
 	// Keep InProgress phase as-is (InProgress), set complete condition to false.
 	reason, err := svcOp.GetInProgressReason(ctx)
-	if vm.Status.Phase == virtv2.MachinePending {
-		conditions.SetCondition(
-			completedCond.
-				Reason(reason).
-				Status(metav1.ConditionFalse).
-				Message("The request to restart the VirtualMachine has been sent. "+
-					"The VirtualMachine is currently in the 'Pending' phase. "+
-					"We are waiting for it to enter the 'Starting' phase."),
-			&changed.Status.Conditions)
-	} else {
-		conditions.SetCondition(
-			completedCond.
-				Reason(reason).
-				Status(metav1.ConditionFalse).
-				Message("Wait until operation completed"),
-			&changed.Status.Conditions)
+	if commonvmop.IsMigration(changed) && reason != vmopcondition.ReasonMigrationPending {
+		changed.Status.Phase = virtv2.VMOPPhaseInProgress
 	}
+
+	conditions.SetCondition(
+		completedCond.
+			Reason(reason).
+			Status(metav1.ConditionFalse).
+			Message("Wait until operation completed"),
+		&changed.Status.Conditions)
 
 	return reconcile.Result{}, err
 }
 
-// otherVMOPIsInProgress check if there is at least one VMOP for the same VM in progress phase.
-func (h LifecycleHandler) otherVMOPIsInProgress(ctx context.Context, vmop *virtv2.VirtualMachineOperation) (bool, error) {
+// Should run oldest VMOP first.
+// If reconciling VMOP is oldest, and it is not finished, it should be run.
+func (h LifecycleHandler) canBeRun(ctx context.Context, vmop *virtv2.VirtualMachineOperation) (bool, error) {
 	var vmopList virtv2.VirtualMachineOperationList
 	err := h.client.List(ctx, &vmopList, client.InNamespace(vmop.GetNamespace()))
 	if err != nil {
 		return false, err
 	}
 
+	oldest := vmop
 	for _, other := range vmopList.Items {
-		// Ignore ourself.
-		if other.GetName() == vmop.GetName() {
-			continue
-		}
-		// Ignore VMOPs for different VMs.
 		if other.Spec.VirtualMachine != vmop.Spec.VirtualMachine {
 			continue
 		}
-		// Return true if other VMOP is in progress.
-		if other.Status.Phase == virtv2.VMOPPhaseInProgress {
-			return true, nil
+		if commonvmop.IsFinished(&other) {
+			continue
+		}
+		if other.GetUID() == vmop.GetUID() {
+			continue
+		}
+
+		if other.CreationTimestamp.Before(ptr.To(oldest.CreationTimestamp)) {
+			return false, nil
+		}
+		if isOperationInProgress(&other) {
+			return false, nil
 		}
 	}
-	return false, nil
+
+	return true, nil
+}
+
+func isOperationInProgress(vmop *virtv2.VirtualMachineOperation) bool {
+	sent, _ := conditions.GetCondition(vmopcondition.TypeSignalSent, vmop.Status.Conditions)
+	completed, _ := conditions.GetCondition(vmopcondition.TypeCompleted, vmop.Status.Conditions)
+	return sent.Status == metav1.ConditionTrue && completed.Status != metav1.ConditionTrue
 }
 
 func (h LifecycleHandler) otherMigrationsAreInProgress(ctx context.Context, vmop *virtv2.VirtualMachineOperation) (bool, error) {

--- a/images/virtualization-artifact/pkg/controller/vmop/internal/lifecycle_test.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/internal/lifecycle_test.go
@@ -54,13 +54,15 @@ var _ = Describe("LifecycleHandler", func() {
 	})
 
 	newVMOPEvictPending := func(opts ...vmopbuilder.Option) *virtv2.VirtualMachineOperation {
-		vmop := vmopbuilder.NewEmpty(name, namespace)
-		vmop.Status.Phase = virtv2.VMOPPhasePending
-		vmopbuilder.ApplyOptions(vmop,
+		options := []vmopbuilder.Option{
+			vmopbuilder.WithName(name),
+			vmopbuilder.WithNamespace(namespace),
 			vmopbuilder.WithType(virtv2.VMOPTypeEvict),
 			vmopbuilder.WithVirtualMachine(name),
-		)
-		vmopbuilder.ApplyOptions(vmop, opts...)
+		}
+		options = append(options, opts...)
+		vmop := vmopbuilder.New(options...)
+		vmop.Status.Phase = virtv2.VMOPPhasePending
 		return vmop
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vmop/internal/service/operation.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/internal/service/operation.go
@@ -64,7 +64,7 @@ func isFinalState(vmop *virtv2.VirtualMachineOperation) bool {
 func isAfterSignalSentOrCreation(timestamp time.Time, vmop *virtv2.VirtualMachineOperation) bool {
 	// Use vmop creation time or time from SignalSent condition.
 	signalSentTime := vmop.GetCreationTimestamp().Time
-	signalSendCond, found := conditions.GetCondition(vmopcondition.SignalSentType, vmop.Status.Conditions)
+	signalSendCond, found := conditions.GetCondition(vmopcondition.TypeSignalSent, vmop.Status.Conditions)
 	if found && signalSendCond.Status == metav1.ConditionTrue && signalSendCond.LastTransitionTime.After(signalSentTime) {
 		signalSentTime = signalSendCond.LastTransitionTime.Time
 	}

--- a/images/virtualization-artifact/pkg/controller/vmop/vmop_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/vmop_controller.go
@@ -49,9 +49,9 @@ func SetupController(
 	svcOpCreator := internal.NewSvcOpCreator(client)
 
 	handlers := []Handler{
+		internal.NewDeletionHandler(svcOpCreator),
 		internal.NewLifecycleHandler(client, svcOpCreator, recorder),
 		internal.NewOperationHandler(client, svcOpCreator, recorder),
-		internal.NewDeletionHandler(svcOpCreator),
 	}
 
 	reconciler := NewReconciler(client, handlers...)


### PR DESCRIPTION
## Description
Improved phase handling for the `migrate` and `evict` operations:  
Previously, `vmop` would transition to `InProgress` as soon as the child migration resource was created.  
Now it remains in `Pending` state until the child resource actually starts executing.


## Why do we need it, and what problem does it solve?
Ensures predictable and ordered execution of VM operations, improving system stability and user experience.

Delays phase transition for `migrate` operations until actual execution starts, providing more accurate status tracking and better visibility into operation state.


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: vmop 
type: feature
summary: Improved phase handling for the `migrate` and `evict` operation
```
