### PR TITLE
feat(vmiplease): add events for Bound and Released states

### DIFF
--- a/api/core/v1alpha2/events.go
+++ b/api/core/v1alpha2/events.go
@@ -128,6 +128,8 @@ const (
 	ReasonIPAddressHasBeenAllocated = "IPAddressHasBeenAllocated"
 	// ReasonBound is the event reason indicating that a VirtualMachineIPLease is bound to a VirtualMachineIPAddress.
 	ReasonBound = "Bound"
+	// ReasonReleased is the event reason indicating that a VirtualMachineIPLease is released.
+	ReasonReleased = "Released"
 	// ReasonFailed is the event reason indicating that the binding of a VirtualMachineIPLease to a VirtualMachineIPAddress has failed.
 	ReasonFailed = "Failed"
 

--- a/images/virtualization-artifact/pkg/controller/vmiplease/internal/lifecycle_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmiplease/internal/lifecycle_handler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,17 +30,20 @@ import (
 	"github.com/deckhouse/virtualization-controller/pkg/common/ip"
 	"github.com/deckhouse/virtualization-controller/pkg/common/object"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
+	"github.com/deckhouse/virtualization-controller/pkg/eventrecord"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmiplcondition"
 )
 
 type LifecycleHandler struct {
-	client client.Client
+	client   client.Client
+	recorder eventrecord.EventRecorderLogger
 }
 
-func NewLifecycleHandler(client client.Client) *LifecycleHandler {
+func NewLifecycleHandler(client client.Client, recorder eventrecord.EventRecorderLogger) *LifecycleHandler {
 	return &LifecycleHandler{
-		client: client,
+		client:   client,
+		recorder: recorder,
 	}
 }
 
@@ -60,6 +64,9 @@ func (h *LifecycleHandler) Handle(ctx context.Context, lease *virtv2.VirtualMach
 	// Lease is Bound, if there is a vmip with matched Ref.
 	if isBound(lease, vmip) {
 		annotations.AddLabel(lease, annotations.LabelVirtualMachineIPAddressUID, string(vmip.UID))
+		if lease.Status.Phase != virtv2.VirtualMachineIPAddressLeasePhaseBound {
+			h.recorder.Eventf(lease, corev1.EventTypeNormal, virtv2.ReasonBound, "VirtualMachineIPAddressLease is bound to \"%s/%s\".", vmip.Namespace, vmip.Name)
+		}
 		lease.Status.Phase = virtv2.VirtualMachineIPAddressLeasePhaseBound
 		cb.
 			Status(metav1.ConditionTrue).
@@ -72,6 +79,9 @@ func (h *LifecycleHandler) Handle(ctx context.Context, lease *virtv2.VirtualMach
 			lease.Spec.VirtualMachineIPAddressRef.Name = ""
 		}
 
+		if lease.Status.Phase != virtv2.VirtualMachineIPAddressLeasePhaseReleased {
+			h.recorder.Eventf(lease, corev1.EventTypeWarning, virtv2.ReasonReleased, "VirtualMachineIPAddressLease is released.")
+		}
 		lease.Status.Phase = virtv2.VirtualMachineIPAddressLeasePhaseReleased
 		cb.
 			Status(metav1.ConditionFalse).

--- a/images/virtualization-artifact/pkg/controller/vmiplease/vmiplease_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vmiplease/vmiplease_controller.go
@@ -27,7 +27,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
-
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vmiplease/internal"
 	"github.com/deckhouse/virtualization-controller/pkg/eventrecord"
 	"github.com/deckhouse/virtualization-controller/pkg/logger"

--- a/images/virtualization-artifact/pkg/controller/vmiplease/vmiplease_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vmiplease/vmiplease_controller.go
@@ -27,7 +27,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
+
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vmiplease/internal"
+	"github.com/deckhouse/virtualization-controller/pkg/eventrecord"
 	"github.com/deckhouse/virtualization-controller/pkg/logger"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
@@ -42,13 +44,14 @@ func NewController(
 	log *log.Logger,
 	retentionDurationStr string,
 ) (controller.Controller, error) {
+	recorder := eventrecord.NewEventRecorderLogger(mgr, ControllerName)
 	retentionDuration, err := time.ParseDuration(retentionDurationStr)
 	if err != nil {
 		return nil, fmt.Errorf("parse retention duration: %w", err)
 	}
 
 	handlers := []Handler{
-		internal.NewLifecycleHandler(mgr.GetClient()),
+		internal.NewLifecycleHandler(mgr.GetClient(), recorder),
 		internal.NewProtectionHandler(),
 		internal.NewRetentionHandler(retentionDuration, mgr.GetClient()),
 	}


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Add events for the Bound and Released states of the VirtualMachineIPAddressLease.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: core
type: feature
summary: Add events for the Bound and Released states of the VirtualMachineIPAddressLease.
```
