### PR TITLE
chore(module): add hook to cleanup virtualization node labels

### DIFF
--- a/images/hooks/cmd/cleanup-labels/main.go
+++ b/images/hooks/cmd/cleanup-labels/main.go
@@ -26,11 +26,11 @@ import (
 	"github.com/deckhouse/module-sdk/pkg"
 	"github.com/deckhouse/module-sdk/pkg/app"
 	"github.com/deckhouse/module-sdk/pkg/registry"
-	"k8s.io/utils/ptr"
 
 	"hooks/pkg/common"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -49,9 +49,9 @@ type NodeInfo struct {
 	Labels map[string]string `json:"labels"`
 }
 
-var _ = registry.RegisterFunc(configDiscoveryService, handleCleanUpNodeLabels)
+var _ = registry.RegisterFunc(configVirtHandlerNodeCleanUp, handleCleanUpNodeLabels)
 
-var configDiscoveryService = &pkg.HookConfig{
+var configVirtHandlerNodeCleanUp = &pkg.HookConfig{
 	OnAfterDeleteHelm: &pkg.OrderedConfig{Order: 5},
 	Kubernetes: []pkg.KubernetesConfig{
 		{
@@ -68,7 +68,7 @@ var configDiscoveryService = &pkg.HookConfig{
 				},
 			},
 			ExecuteHookOnSynchronization: ptr.To(false),
-			ExecuteHookOnEvents:          ptr.To(false),
+			// ExecuteHookOnEvents:          ptr.To(false),
 		},
 	},
 
@@ -83,32 +83,32 @@ func handleCleanUpNodeLabels(_ context.Context, input *pkg.HookInput) error {
 		return nil
 	}
 
-	for _, node := range nodes {
-		nodeInfo := &NodeInfo{}
-		if err := node.UnmarshalTo(nodeInfo); err != nil {
-			input.Logger.Error(fmt.Sprintf("Failed to unmarshal node metadata %v", err))
-			continue
-		}
+	// for _, node := range nodes {
+	// 	nodeInfo := &NodeInfo{}
+	// 	if err := node.UnmarshalTo(nodeInfo); err != nil {
+	// 		input.Logger.Error(fmt.Sprintf("Failed to unmarshal node metadata %v", err))
+	// 		continue
+	// 	}
 
-		patches := make([]map[string]string, 0)
+	// 	patches := make([]map[string]string, 0)
 
-		for key, _ := range nodeInfo.Labels {
-			if strings.Contains(key, labelPattern) {
-				patches = append(patches, map[string]string{
-					"op":   "remove",
-					"path": fmt.Sprintf("/metadata/labels/%s", jsonPatchEscape(key)),
-				})
-			}
-		}
+	// 	for key, _ := range nodeInfo.Labels {
+	// 		if strings.Contains(key, labelPattern) {
+	// 			patches = append(patches, map[string]string{
+	// 				"op":   "remove",
+	// 				"path": fmt.Sprintf("/metadata/labels/%s", jsonPatchEscape(key)),
+	// 			})
+	// 		}
+	// 	}
 
-		if len(patches) == 0 {
-			continue
-		} else {
-			input.Logger.Info(fmt.Sprintf(logMessageTemplate, len(patches), labelPattern, nodeInfo.Name))
-		}
+	// 	if len(patches) == 0 {
+	// 		continue
+	// 	} else {
+	// 		input.Logger.Info(fmt.Sprintf(logMessageTemplate, len(patches), labelPattern, nodeInfo.Name))
+	// 	}
 
-		input.PatchCollector.PatchWithJSON(patches, "v1", "Node", "", nodeInfo.Name)
-	}
+	// 	input.PatchCollector.PatchWithJSON(patches, "v1", "Node", "", nodeInfo.Name)
+	// }
 	return nil
 }
 

--- a/images/hooks/cmd/cleanup-labels/main.go
+++ b/images/hooks/cmd/cleanup-labels/main.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// The purpose of this hook is to prevent already launched virt-handler pods from flapping, since the node group configuration virtualization-detect-kvm.sh will be responsible for installing the label virtualization.deckhouse.io/kvm-enabled.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/deckhouse/module-sdk/pkg"
+	"github.com/deckhouse/module-sdk/pkg/app"
+	"github.com/deckhouse/module-sdk/pkg/registry"
+	"k8s.io/utils/ptr"
+
+	"hooks/pkg/common"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	nodesMetadataSnapshot = "virthandler-nodes"
+	virtHandlerLabel      = "kubevirt.internal.virtualization.deckhouse.io/schedulable"
+	nodeJQFilter          = ".metadata"
+)
+
+var _ = registry.RegisterFunc(configDiscoveryService, handleVirtHandlerNodes)
+
+var configDiscoveryService = &pkg.HookConfig{
+	OnAfterDeleteHelm: &pkg.OrderedConfig{Order: 5},
+	Kubernetes: []pkg.KubernetesConfig{
+		{
+			Name:       nodesMetadataSnapshot,
+			APIVersion: "v1",
+			Kind:       "Node",
+			JqFilter:   nodeJQFilter,
+			LabelSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      virtHandlerLabel,
+						Operator: metav1.LabelSelectorOpExists,
+					},
+				},
+			},
+			ExecuteHookOnSynchronization: ptr.To(false),
+			ExecuteHookOnEvents:          ptr.To(false),
+		},
+	},
+
+	Queue: fmt.Sprintf("modules/%s", common.MODULE_NAME),
+}
+
+func handleVirtHandlerNodes(_ context.Context, input *pkg.HookInput) error {
+	input.Logger.Info("Start.")
+
+	nodeMetadatas := input.Snapshots.Get(nodesMetadataSnapshot)
+	input.Logger.Info(fmt.Sprintf("Found %d nodes", len(nodeMetadatas)))
+	if len(nodeMetadatas) == 0 {
+		return nil
+	}
+
+	for _, nodeMetadata := range nodeMetadatas {
+		metadata := &metav1.ObjectMeta{}
+		if err := nodeMetadata.UnmarshalTo(metadata); err != nil {
+			input.Logger.Error(fmt.Sprintf("Failed to unmarshal node metadata %v", err))
+			continue
+		}
+
+		patches := []map[string]interface{}{}
+
+		for key, _ := range metadata.Labels {
+			if strings.Contains(key, "virtualization.deckhouse.io") {
+				patches = append(patches, map[string]interface{}{
+					"op":   "remove",
+					"path": fmt.Sprintf("/metadata/labels/%s", jsonPatchEscape(key)),
+				})
+			}
+		}
+
+		if len(patches) == 0 {
+			input.Logger.Info("No labels found, nothing to do.")
+			continue
+		} else {
+			input.Logger.Info(fmt.Sprintf("Removing %d labels from node %s", len(patches), metadata.Name))
+		}
+
+		input.PatchCollector.PatchWithJSON(patches, "v1", "Node", "", metadata.Name)
+	}
+	input.Logger.Info("Done.")
+	return nil
+}
+
+func jsonPatchEscape(s string) string {
+	s = strings.ReplaceAll(s, "~", "~0")
+	s = strings.ReplaceAll(s, "/", "~1")
+	return s
+}
+
+func main() {
+	app.Run()
+}

--- a/images/hooks/cmd/cleanup-labels/main.go
+++ b/images/hooks/cmd/cleanup-labels/main.go
@@ -89,11 +89,11 @@ func cleanUpNodeLabels(_ context.Context, input *pkg.HookInput) error {
 			continue
 		}
 
-		patches := []map[string]interface{}{}
+		patches := make([]map[string]string, 0)
 
 		for key, _ := range nodeInfo.Labels {
 			if strings.Contains(key, labelPattern) {
-				patches = append(patches, map[string]interface{}{
+				patches = append(patches, map[string]string{
 					"op":   "remove",
 					"path": fmt.Sprintf("/metadata/labels/%s", jsonPatchEscape(key)),
 				})

--- a/images/hooks/cmd/cleanup-labels/main_test.go
+++ b/images/hooks/cmd/cleanup-labels/main_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
+	"github.com/deckhouse/module-sdk/pkg"
+	"github.com/deckhouse/module-sdk/testing/mock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func createSnapshotMock(nodeInfo NodeInfo) pkg.Snapshot {
+	m := mock.NewSnapshotMock(GinkgoT())
+	m.UnmarshalToMock.Set(func(v any) error {
+		target, ok := v.(*NodeInfo)
+		if !ok {
+			return fmt.Errorf("expected *NodeInfo, got %T", v)
+		}
+		*target = nodeInfo
+		return nil
+	})
+	return m
+}
+
+func TestCleanUpVirtHandlerNodeLabels(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cleanup virtHandler node labels Suite")
+}
+
+var _ = Describe("Cleanup virtHandler node labels", func() {
+	var (
+		snapshots      *mock.SnapshotsMock
+		values         *mock.PatchableValuesCollectorMock
+		patchCollector *mock.PatchCollectorMock
+		input          *pkg.HookInput
+		buf            *bytes.Buffer
+	)
+
+	BeforeEach(func() {
+		snapshots = mock.NewSnapshotsMock(GinkgoT())
+		values = mock.NewPatchableValuesCollectorMock(GinkgoT())
+		patchCollector = mock.NewPatchCollectorMock(GinkgoT())
+
+		buf = bytes.NewBuffer([]byte{})
+
+		input = &pkg.HookInput{
+			Values:    values,
+			Snapshots: snapshots,
+			Logger: log.NewLogger(log.Options{
+				Level:  log.LevelDebug.Level(),
+				Output: buf,
+				TimeFunc: func(_ time.Time) time.Time {
+					parsedTime, err := time.Parse(time.DateTime, "2006-01-02 15:04:05")
+					Expect(err).ShouldNot(HaveOccurred())
+					return parsedTime
+				},
+			}),
+			PatchCollector: patchCollector,
+		}
+	})
+
+	Context("Empty cluster", func() {
+		It("Hook must execute successfully", func() {
+			snapshots.GetMock.When(nodesSnapshot).Then(
+				[]pkg.Snapshot{},
+			)
+			err := handleCleanUpNodeLabels(context.Background(), input)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
+
+	Context("Nodes should be patched.", func() {
+		It("Hook must execute successfully", func() {
+			expectedNodes := map[string]interface{}{
+				"node1": []map[string]string{
+					map[string]string{
+						"op":   "remove",
+						"path": "/metadata/labels/kubevirt.internal.virtualization.deckhouse.io~1schedulable",
+					},
+				},
+				"node2": []map[string]string{
+					{
+						"op":   "remove",
+						"path": "/metadata/labels/kubevirt.internal.virtualization.deckhouse.io~1schedulable",
+					},
+					map[string]string{
+						"op":   "remove",
+						"path": "/metadata/labels/virtualization.deckhouse.io~1kvm-enabled",
+					},
+				},
+			}
+
+			snapshots.GetMock.When(nodesSnapshot).Then([]pkg.Snapshot{
+				// should be patched
+				createSnapshotMock(NodeInfo{
+					Name: "node1",
+					Labels: map[string]string{
+						"kubevirt.internal.virtualization.deckhouse.io/schedulable": "true",
+					},
+				}),
+				// should be patched
+				createSnapshotMock(NodeInfo{
+					Name: "node2",
+					Labels: map[string]string{
+						"kubevirt.internal.virtualization.deckhouse.io/schedulable": "true",
+						"virtualization.deckhouse.io/kvm-enabled":                   "true",
+					},
+				}),
+			})
+
+			patchCollector.PatchWithJSONMock.Set(func(patch any, apiVersion, kind, namespace, name string, opts ...pkg.PatchCollectorOption) {
+				p, ok := patch.([]map[string]string)
+				Expect(ok).To(BeTrue())
+				Expect(expectedNodes).To(HaveKey(name))
+				Expect(p).To(Equal(expectedNodes[name]))
+				delete(expectedNodes, name)
+			})
+
+			err := handleCleanUpNodeLabels(context.Background(), input)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Expect(buf.String()).To(ContainSubstring(fmt.Sprintf(logMessageTemplate, 1, labelPattern, "node1")))
+			Expect(buf.String()).To(ContainSubstring(fmt.Sprintf(logMessageTemplate, 2, labelPattern, "node2")))
+
+			Expect(expectedNodes).To(HaveLen(0))
+		})
+	})
+})

--- a/images/hooks/werf.inc.yaml
+++ b/images/hooks/werf.inc.yaml
@@ -35,3 +35,4 @@ shell:
   - go build -ldflags="-s -w" -o /hooks/generate-secret-for-dvcr ./cmd/generate-secret-for-dvcr
   - go build -ldflags="-s -w" -o /hooks/discovery-clusterip-service-for-dvcr ./cmd/discovery-clusterip-service-for-dvcr
   - go build -ldflags="-s -w" -o /hooks/discovery-workload-nodes ./cmd/discovery-workload-nodes
+  - go build -ldflags="-s -w" -o /hooks/cleanup-labels ./cmd/cleanup-labels


### PR DESCRIPTION
## Description
Cleanup `.*virtualization.deckhouse.io/.*` node labels after removing module

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: module
type: chore
summary: Cleanup `.*virtualization.deckhouse.io/.*` node labels after removing module
```
