### PR TITLE
chore(vd): fix phase name for PVCLost phase

### DIFF
--- a/api/core/v1alpha2/cluster_virtual_image.go
+++ b/api/core/v1alpha2/cluster_virtual_image.go
@@ -145,10 +145,11 @@ type ClusterVirtualImageStatus struct {
 	// Resource generation last processed by the controller.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 	// Deprecated. Use `imageUploadURLs` instead.
-	UploadCommand    string                          `json:"uploadCommand,omitempty"`
-	ImageUploadURLs  *ImageUploadURLs                `json:"imageUploadURLs,omitempty"`
-	Target           ClusterVirtualImageStatusTarget `json:"target,omitempty"`
-	UsedInNamespaces []string                        `json:"usedInNamespaces,omitempty"`
+	UploadCommand   string                          `json:"uploadCommand,omitempty"`
+	ImageUploadURLs *ImageUploadURLs                `json:"imageUploadURLs,omitempty"`
+	Target          ClusterVirtualImageStatusTarget `json:"target,omitempty"`
+	// Displays the list of namespaces where the image is currently used.
+	UsedInNamespaces []string `json:"usedInNamespaces,omitempty"`
 }
 
 type ClusterVirtualImageStatusTarget struct {

--- a/api/core/v1alpha2/virtual_disk.go
+++ b/api/core/v1alpha2/virtual_disk.go
@@ -38,7 +38,7 @@ const (
 // +kubebuilder:printcolumn:name="Capacity",type=string,JSONPath=`.status.capacity`
 // +kubebuilder:printcolumn:name="InUse",type=string,JSONPath=`.status.conditions[?(@.type=='InUse')].status`,priority=1
 // +kubebuilder:printcolumn:name="Progress",type=string,JSONPath=`.status.progress`,priority=1
-// +kubebuilder:printcolumn:name="StorageClass",type=string,JSONPath=`.spec.persistentVolumeClaim.storageClassName`,priority=1
+// +kubebuilder:printcolumn:name="StorageClass",type=string,JSONPath=`.status.storageClassName`,priority=1
 // +kubebuilder:printcolumn:name="TargetPVC",type=string,JSONPath=`.status.target.persistentVolumeClaimName`,priority=1
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 // +kubebuilder:validation:XValidation:rule="self.metadata.name.size() <= 128",message="The name must be no longer than 128 characters."
@@ -198,17 +198,17 @@ type VirtualDiskList struct {
 // * `Failed`: There was an error when creating the resource.
 // * `PVCLost`: The child PVC of the resource is missing. The resource cannot be used.
 // * `Terminating`: The resource is being deleted.
-// +kubebuilder:validation:Enum:={Pending,Provisioning,WaitForUserUpload,Ready,Failed,Terminating,PVCLost,WaitForFirstConsumer,Resizing}
+// +kubebuilder:validation:Enum:={Pending,Provisioning,WaitForUserUpload,WaitForFirstConsumer,Ready,Resizing,Failed,PVCLost,Terminating}
 type DiskPhase string
 
 const (
 	DiskPending              DiskPhase = "Pending"
+	DiskProvisioning         DiskPhase = "Provisioning"
 	DiskWaitForUserUpload    DiskPhase = "WaitForUserUpload"
 	DiskWaitForFirstConsumer DiskPhase = "WaitForFirstConsumer"
-	DiskProvisioning         DiskPhase = "Provisioning"
-	DiskFailed               DiskPhase = "Failed"
-	DiskLost                 DiskPhase = "Lost"
 	DiskReady                DiskPhase = "Ready"
 	DiskResizing             DiskPhase = "Resizing"
+	DiskFailed               DiskPhase = "Failed"
+	DiskLost                 DiskPhase = "PVCLost"
 	DiskTerminating          DiskPhase = "Terminating"
 )

--- a/api/pkg/apiserver/api/generated/openapi/zz_generated.openapi.go
+++ b/api/pkg/apiserver/api/generated/openapi/zz_generated.openapi.go
@@ -1273,7 +1273,8 @@ func schema_virtualization_api_core_v1alpha2_ClusterVirtualImageStatus(ref commo
 					},
 					"usedInNamespaces": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "Displays the list of namespaces where the image is currently used.",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{

--- a/crds/clustervirtualimages.yaml
+++ b/crds/clustervirtualimages.yaml
@@ -408,8 +408,9 @@ spec:
                   description: Deprecated. Use `imageUploadURLs` instead.
                   type: string
                 usedInNamespaces:
-                  description: |
-                    Displays the list of namespaces where the image is currently used.
+                  description:
+                    Displays the list of namespaces where the image is currently
+                    used.
                   items:
                     type: string
                   type: array

--- a/crds/virtualdisks.yaml
+++ b/crds/virtualdisks.yaml
@@ -386,12 +386,12 @@ spec:
                     - Pending
                     - Provisioning
                     - WaitForUserUpload
-                    - Ready
-                    - Failed
-                    - Terminating
-                    - PVCLost
                     - WaitForFirstConsumer
+                    - Ready
                     - Resizing
+                    - Failed
+                    - PVCLost
+                    - Terminating
                   type: string
                 progress:
                   description:


### PR DESCRIPTION
## Description

- Sync go source for VD: Use "PVCLost" as phase name for DiskLost phase.

Fixes for "CRD only changes":
- Sync go source for VD: change jsonpath for StorageClass column.
- Sync go source for CVI: add description to UsedInNamespaces fields.

## Why do we need it, and what problem does it solve?

Disk deletion is stuck after changes in #859. Phase was not used before, so we don't catch this problem earlier.

## What is the expected result?

- Disk deletion is working.
- E2E tests are working.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: disks
type: chore
summary: Fix const for PVCLost phase, sync Go sources and CRDs (VD, CVI).
```
