### PR TITLE
fix(module): patch spec.strategy for cdi-deployment

### DIFF
--- a/templates/cdi/config.yaml
+++ b/templates/cdi/config.yaml
@@ -59,7 +59,7 @@ spec:
       # HA settings for deploy/cdi-deployment.
       - resourceType: Deployment
         resourceName: cdi-deployment
-        patch: '[{"op":"replace","path":"/spec/replicas","value":2},{"op":"replace","path":"/spec/strategy","value":{"type":"RollingUpdate"}}]'
+        patch: '[{"op":"replace","path":"/spec/replicas","value":2}]'
         type: json
       - resourceType: Deployment
         resourceName: cdi-deployment


### PR DESCRIPTION
- Fix patching spec.strategy: remove dublicate patch for cdi-deployment.

## Description
<!---
  Describe your changes with technical details.
-->


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->

Duplicate patches work unpredictable. It seems that Deployment/cdi-deployment got null for rollingUpdate settings after patching.


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->

Deployment/cdi-deployment should have this spec.strategy in HA mode:

```
{
  "rollingUpdate": {
    "maxSurge": 0,
    "maxUnavailable": 1
  },
  "type": "RollingUpdate"
}
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: module
type: fix
summary: Fixed a hang during virtualization version upgrade in an HA cluster with two system nodes.
```
