### PR TITLE
fix(api): fix resource's names validation

### DIFF
--- a/api/core/v1alpha2/cluster_virtual_image.go
+++ b/api/core/v1alpha2/cluster_virtual_image.go
@@ -43,7 +43,6 @@ const (
 // +kubebuilder:printcolumn:name="UnpackedSize",type=string,JSONPath=`.status.size.unpacked`,priority=1
 // +kubebuilder:printcolumn:name="Registry URL",type=string,JSONPath=`.status.target.registryURL`,priority=1
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
-// +kubebuilder:validation:XValidation:rule="self.metadata.name.size() <= 128",message="The name must be no longer than 128 characters."
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/api/core/v1alpha2/virtual_disk.go
+++ b/api/core/v1alpha2/virtual_disk.go
@@ -41,7 +41,6 @@ const (
 // +kubebuilder:printcolumn:name="StorageClass",type=string,JSONPath=`.status.storageClassName`,priority=1
 // +kubebuilder:printcolumn:name="TargetPVC",type=string,JSONPath=`.status.target.persistentVolumeClaimName`,priority=1
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
-// +kubebuilder:validation:XValidation:rule="self.metadata.name.size() <= 128",message="The name must be no longer than 128 characters."
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type VirtualDisk struct {

--- a/api/core/v1alpha2/virtual_image.go
+++ b/api/core/v1alpha2/virtual_image.go
@@ -44,7 +44,6 @@ const (
 // +kubebuilder:printcolumn:name="Registry URL",type=string,JSONPath=`.status.target.registryURL`,priority=1
 // +kubebuilder:printcolumn:name="TargetPVC",type=string,JSONPath=`.status.target.persistentVolumeClaimName`,priority=1
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
-// +kubebuilder:validation:XValidation:rule="self.metadata.name.size() <= 128",message="The name must be no longer than 128 characters."
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type VirtualImage struct {
 	metav1.TypeMeta `json:",inline"`

--- a/crds/clustervirtualimages.yaml
+++ b/crds/clustervirtualimages.yaml
@@ -418,9 +418,6 @@ spec:
           required:
             - spec
           type: object
-          x-kubernetes-validations:
-            - message: The name must be no longer than 128 characters.
-              rule: self.metadata.name.size() <= 128
       served: true
       storage: true
       subresources:

--- a/crds/virtualdisks.yaml
+++ b/crds/virtualdisks.yaml
@@ -447,9 +447,6 @@ spec:
           required:
             - spec
           type: object
-          x-kubernetes-validations:
-            - message: The name must be no longer than 128 characters.
-              rule: self.metadata.name.size() <= 128
       served: true
       storage: true
       subresources:

--- a/crds/virtualimages.yaml
+++ b/crds/virtualimages.yaml
@@ -427,9 +427,6 @@ spec:
           required:
             - spec
           type: object
-          x-kubernetes-validations:
-            - message: The name must be no longer than 128 characters.
-              rule: self.metadata.name.size() <= 128
       served: true
       storage: true
       subresources:

--- a/crds/virtualmachines.yaml
+++ b/crds/virtualmachines.yaml
@@ -36,9 +36,6 @@ spec:
             - `.spec.runPolicy`.
           required:
             - spec
-          x-kubernetes-validations:
-            - rule: "self.metadata.name.size() <= 128"
-              message: "The name must be no longer than 128 characters."
           properties:
             spec:
               x-kubernetes-validations:

--- a/images/virtualization-artifact/pkg/common/validate/validate.go
+++ b/images/virtualization-artifact/pkg/common/validate/validate.go
@@ -24,12 +24,12 @@ const MaxDiskNameLen = 60
 // MaxVirtualImageNameLen determines the max len of vi.
 // Disk and volume name in kubevirt can be a valid container name (len 63) since disk name can become a container name which will fail to schedule if invalid.
 // We and kubevirt add prefixes "vi-", "volume" and suffix "-init", so max len reduced to 49.
-const MaxVirtualImageNameLen = 49
+const MaxVirtualImageNameLen = 37
 
 // MaxClusterVirtualImageNameLen determines the max len of cvi.
 // Disk and volume name in kubevirt can be a valid container name (len 63) since disk name can become a container name which will fail to schedule if invalid.
 // We and kubevirt add prefixes "cvi-", "volume" and suffix "-init", so max len reduced to 48.
-const MaxClusterVirtualImageNameLen = 48
+const MaxClusterVirtualImageNameLen = 36
 
 // MaxVirtualMachineNameLen determines the max len of vm.
 // The name of the VirtualMachine can be valid with a length of up to 63 characters, as exceeding this limit may cause a failure in creating internal resources.

--- a/images/virtualization-artifact/pkg/common/validate/validate.go
+++ b/images/virtualization-artifact/pkg/common/validate/validate.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package blockdevice
+package validate
 
 // MaxDiskNameLen determines the max len of vd.
 // Disk and volume name in kubevirt can be a valid container name (len 63) since disk name can become a container name which will fail to schedule if invalid.
@@ -30,3 +30,7 @@ const MaxVirtualImageNameLen = 49
 // Disk and volume name in kubevirt can be a valid container name (len 63) since disk name can become a container name which will fail to schedule if invalid.
 // We and kubevirt add prefixes "cvi-", "volume" and suffix "-init", so max len reduced to 48.
 const MaxClusterVirtualImageNameLen = 48
+
+// MaxVirtualMachineNameLen determines the max len of vm.
+// The name of the VirtualMachine can be valid with a length of up to 63 characters, as exceeding this limit may cause a failure in creating internal resources.
+const MaxVirtualMachineNameLen = 63

--- a/images/virtualization-artifact/pkg/common/validate/validate.go
+++ b/images/virtualization-artifact/pkg/common/validate/validate.go
@@ -21,14 +21,9 @@ package validate
 // We add prefix "vd-" for the vd name, so max len reduced to 60.
 const MaxDiskNameLen = 60
 
-// MaxVirtualImageOnDVCRNameLen determines the max len of vi on dvcr.
-// This limit ensures compatibility with hotplug operations
-const MaxVirtualImageOnDVCRNameLen = 37
-
-// MaxVirtualImageOnPVCNameLen determines the max len of vi on pvc.
-// Disk and volume name in kubevirt can be a valid container name (len 63) since disk name can become a container name which will fail to schedule if invalid.
-// We and kubevirt add prefixes "vi-", "volume" and suffix "-init", so max len reduced to 49.
-const MaxVirtualImageOnPVCNameLen = 49
+// MaxVirtualImageNameLen determines the max len of vi on dvcr.
+// This limitation is reportedly associated with mounting image to virtual machine as hotplug.
+const MaxVirtualImageNameLen = 37
 
 // MaxClusterVirtualImageNameLen determines the max len of cvi.
 // Disk and volume name in kubevirt can be a valid container name (len 63) since disk name can become a container name which will fail to schedule if invalid.
@@ -36,5 +31,5 @@ const MaxVirtualImageOnPVCNameLen = 49
 const MaxClusterVirtualImageNameLen = 36
 
 // MaxVirtualMachineNameLen determines the max len of vm.
-// The name of the VirtualMachine can be valid with a length of up to 63 characters, as exceeding this limit may cause a failure in creating internal resources.
+// The limitation is reportedly associated with the PodDisruptionBudget resource, which has a label containing the virtual machine's name, and the label's value cannot exceed 63 characters.
 const MaxVirtualMachineNameLen = 63

--- a/images/virtualization-artifact/pkg/common/validate/validate.go
+++ b/images/virtualization-artifact/pkg/common/validate/validate.go
@@ -21,10 +21,14 @@ package validate
 // We add prefix "vd-" for the vd name, so max len reduced to 60.
 const MaxDiskNameLen = 60
 
-// MaxVirtualImageNameLen determines the max len of vi.
+// MaxVirtualImageOnDVCRNameLen determines the max len of vi on dvcr.
+// This limit ensures compatibility with hotplug operations
+const MaxVirtualImageOnDVCRNameLen = 37
+
+// MaxVirtualImageOnPVCNameLen determines the max len of vi on pvc.
 // Disk and volume name in kubevirt can be a valid container name (len 63) since disk name can become a container name which will fail to schedule if invalid.
 // We and kubevirt add prefixes "vi-", "volume" and suffix "-init", so max len reduced to 49.
-const MaxVirtualImageNameLen = 37
+const MaxVirtualImageOnPVCNameLen = 49
 
 // MaxClusterVirtualImageNameLen determines the max len of cvi.
 // Disk and volume name in kubevirt can be a valid container name (len 63) since disk name can become a container name which will fail to schedule if invalid.

--- a/images/virtualization-artifact/pkg/controller/cvi/cvi_webhook.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/cvi_webhook.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
-	"github.com/deckhouse/virtualization-controller/pkg/common/blockdevice"
+	"github.com/deckhouse/virtualization-controller/pkg/common/validate"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/cvicondition"
@@ -52,8 +52,8 @@ func (v *Validator) ValidateCreate(_ context.Context, obj runtime.Object) (admis
 		return nil, fmt.Errorf("the ClusterVirtualImage name %q is invalid: '.' is forbidden, allowed name symbols are [0-9a-zA-Z-]", cvi.Name)
 	}
 
-	if len(cvi.Name) > blockdevice.MaxClusterVirtualImageNameLen {
-		return nil, fmt.Errorf("the ClusterVirtualImage name %q is too long: it must be no more than %d characters", cvi.Name, blockdevice.MaxClusterVirtualImageNameLen)
+	if len(cvi.Name) > validate.MaxClusterVirtualImageNameLen {
+		return nil, fmt.Errorf("the ClusterVirtualImage name %q is too long: it must be no more than %d characters", cvi.Name, validate.MaxClusterVirtualImageNameLen)
 	}
 
 	return nil, nil
@@ -87,8 +87,8 @@ func (v *Validator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Obj
 		warnings = append(warnings, fmt.Sprintf("the ClusterVirtualImage name %q is invalid as it contains now forbidden symbol '.', allowed symbols for name are [0-9a-zA-Z-]. Create another image with valid name to avoid problems with future updates.", newCVI.Name))
 	}
 
-	if len(newCVI.Name) > blockdevice.MaxClusterVirtualImageNameLen {
-		warnings = append(warnings, fmt.Sprintf("the ClusterVirtualImage name %q is too long: it must be no more than %d characters", newCVI.Name, blockdevice.MaxClusterVirtualImageNameLen))
+	if len(newCVI.Name) > validate.MaxClusterVirtualImageNameLen {
+		warnings = append(warnings, fmt.Sprintf("the ClusterVirtualImage name %q is too long: it must be no more than %d characters", newCVI.Name, validate.MaxClusterVirtualImageNameLen))
 	}
 
 	return warnings, nil

--- a/images/virtualization-artifact/pkg/controller/vd/internal/validator/name_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/validator/name_validator.go
@@ -23,7 +23,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	"github.com/deckhouse/virtualization-controller/pkg/common/blockdevice"
+	"github.com/deckhouse/virtualization-controller/pkg/common/validate"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
@@ -38,8 +38,8 @@ func (v *NameValidator) ValidateCreate(_ context.Context, vd *virtv2.VirtualDisk
 		return nil, fmt.Errorf("the VirtualDisk name %q is invalid: '.' is forbidden, allowed name symbols are [0-9a-zA-Z-]", vd.Name)
 	}
 
-	if len(vd.Name) > blockdevice.MaxDiskNameLen {
-		return nil, fmt.Errorf("the VirtualDisk name %q is too long: it must be no more than %d characters", vd.Name, blockdevice.MaxDiskNameLen)
+	if len(vd.Name) > validate.MaxDiskNameLen {
+		return nil, fmt.Errorf("the VirtualDisk name %q is too long: it must be no more than %d characters", vd.Name, validate.MaxDiskNameLen)
 	}
 
 	return nil, nil
@@ -52,8 +52,8 @@ func (v *NameValidator) ValidateUpdate(_ context.Context, _, newVD *virtv2.Virtu
 		warnings = append(warnings, fmt.Sprintf("the VirtualDisk name %q is invalid as it contains now forbidden symbol '.', allowed symbols for name are [0-9a-zA-Z-]. Create another disk with valid name to avoid problems with future updates.", newVD.Name))
 	}
 
-	if len(newVD.Name) > blockdevice.MaxDiskNameLen {
-		warnings = append(warnings, fmt.Sprintf("the VirtualDisk name %q is too long: it must be no more than %d characters", newVD.Name, blockdevice.MaxDiskNameLen))
+	if len(newVD.Name) > validate.MaxDiskNameLen {
+		warnings = append(warnings, fmt.Sprintf("the VirtualDisk name %q is too long: it must be no more than %d characters", newVD.Name, validate.MaxDiskNameLen))
 	}
 
 	return warnings, nil

--- a/images/virtualization-artifact/pkg/controller/vi/vi_webhook.go
+++ b/images/virtualization-artifact/pkg/controller/vi/vi_webhook.go
@@ -28,7 +28,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
-
 	"github.com/deckhouse/virtualization-controller/pkg/common/validate"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"

--- a/images/virtualization-artifact/pkg/controller/vi/vi_webhook.go
+++ b/images/virtualization-artifact/pkg/controller/vi/vi_webhook.go
@@ -54,8 +54,14 @@ func (v *Validator) ValidateCreate(_ context.Context, obj runtime.Object) (admis
 		return nil, fmt.Errorf("the VirtualImage name %q is invalid: '.' is forbidden, allowed name symbols are [0-9a-zA-Z-]", vi.Name)
 	}
 
-	if len(vi.Name) > validate.MaxVirtualImageNameLen {
-		return nil, fmt.Errorf("the VirtualImage name %q is too long: it must be no more than %d characters", vi.Name, validate.MaxVirtualImageNameLen)
+	if vi.Spec.Storage == virtv2.StorageContainerRegistry {
+		if len(vi.Name) > validate.MaxVirtualImageOnDVCRNameLen {
+			return nil, fmt.Errorf("the VirtualImage name %q is too long: it must be no more than %d characters", vi.Name, validate.MaxVirtualImageOnDVCRNameLen)
+		}
+	} else {
+		if len(vi.Name) > validate.MaxVirtualImageOnPVCNameLen {
+			return nil, fmt.Errorf("the VirtualImage name %q is too long: it must be no more than %d characters", vi.Name, validate.MaxVirtualImageOnPVCNameLen)
+		}
 	}
 
 	if vi.Spec.Storage == virtv2.StorageKubernetes {
@@ -108,8 +114,14 @@ func (v *Validator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Obj
 		warnings = append(warnings, fmt.Sprintf(" the VirtualImage name %q is invalid as it contains now forbidden symbol '.', allowed symbols for name are [0-9a-zA-Z-]. Create another image with valid name to avoid problems with future updates.", newVI.Name))
 	}
 
-	if len(newVI.Name) > validate.MaxVirtualImageNameLen {
-		warnings = append(warnings, fmt.Sprintf("the VirtualImage name %q is too long: it must be no more than %d characters", newVI.Name, validate.MaxVirtualImageNameLen))
+	if newVI.Spec.Storage == virtv2.StorageContainerRegistry {
+		if len(newVI.Name) > validate.MaxVirtualImageOnDVCRNameLen {
+			warnings = append(warnings, fmt.Sprintf("the VirtualImage name %q is too long: it must be no more than %d characters", newVI.Name, validate.MaxVirtualImageOnDVCRNameLen))
+		}
+	} else {
+		if len(newVI.Name) > validate.MaxVirtualImageOnPVCNameLen {
+			warnings = append(warnings, fmt.Sprintf("the VirtualImage name %q is too long: it must be no more than %d characters", newVI.Name, validate.MaxVirtualImageOnPVCNameLen))
+		}
 	}
 
 	return warnings, nil

--- a/images/virtualization-artifact/pkg/controller/vi/vi_webhook.go
+++ b/images/virtualization-artifact/pkg/controller/vi/vi_webhook.go
@@ -54,14 +54,8 @@ func (v *Validator) ValidateCreate(_ context.Context, obj runtime.Object) (admis
 		return nil, fmt.Errorf("the VirtualImage name %q is invalid: '.' is forbidden, allowed name symbols are [0-9a-zA-Z-]", vi.Name)
 	}
 
-	if vi.Spec.Storage == virtv2.StorageContainerRegistry {
-		if len(vi.Name) > validate.MaxVirtualImageOnDVCRNameLen {
-			return nil, fmt.Errorf("the VirtualImage name %q is too long: it must be no more than %d characters", vi.Name, validate.MaxVirtualImageOnDVCRNameLen)
-		}
-	} else {
-		if len(vi.Name) > validate.MaxVirtualImageOnPVCNameLen {
-			return nil, fmt.Errorf("the VirtualImage name %q is too long: it must be no more than %d characters", vi.Name, validate.MaxVirtualImageOnPVCNameLen)
-		}
+	if len(vi.Name) > validate.MaxVirtualImageNameLen {
+		return nil, fmt.Errorf("the VirtualImage name %q is too long: it must be no more than %d characters", vi.Name, validate.MaxVirtualImageNameLen)
 	}
 
 	if vi.Spec.Storage == virtv2.StorageKubernetes {
@@ -114,14 +108,8 @@ func (v *Validator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Obj
 		warnings = append(warnings, fmt.Sprintf(" the VirtualImage name %q is invalid as it contains now forbidden symbol '.', allowed symbols for name are [0-9a-zA-Z-]. Create another image with valid name to avoid problems with future updates.", newVI.Name))
 	}
 
-	if newVI.Spec.Storage == virtv2.StorageContainerRegistry {
-		if len(newVI.Name) > validate.MaxVirtualImageOnDVCRNameLen {
-			warnings = append(warnings, fmt.Sprintf("the VirtualImage name %q is too long: it must be no more than %d characters", newVI.Name, validate.MaxVirtualImageOnDVCRNameLen))
-		}
-	} else {
-		if len(newVI.Name) > validate.MaxVirtualImageOnPVCNameLen {
-			warnings = append(warnings, fmt.Sprintf("the VirtualImage name %q is too long: it must be no more than %d characters", newVI.Name, validate.MaxVirtualImageOnPVCNameLen))
-		}
+	if len(newVI.Name) > validate.MaxVirtualImageNameLen {
+		warnings = append(warnings, fmt.Sprintf("the VirtualImage name %q is too long: it must be no more than %d characters", newVI.Name, validate.MaxVirtualImageNameLen))
 	}
 
 	return warnings, nil

--- a/images/virtualization-artifact/pkg/controller/vi/vi_webhook.go
+++ b/images/virtualization-artifact/pkg/controller/vi/vi_webhook.go
@@ -28,7 +28,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
-	"github.com/deckhouse/virtualization-controller/pkg/common/blockdevice"
+
+	"github.com/deckhouse/virtualization-controller/pkg/common/validate"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vicondition"
@@ -54,8 +55,8 @@ func (v *Validator) ValidateCreate(_ context.Context, obj runtime.Object) (admis
 		return nil, fmt.Errorf("the VirtualImage name %q is invalid: '.' is forbidden, allowed name symbols are [0-9a-zA-Z-]", vi.Name)
 	}
 
-	if len(vi.Name) > blockdevice.MaxVirtualImageNameLen {
-		return nil, fmt.Errorf("the VirtualImage name %q is too long: it must be no more than %d characters", vi.Name, blockdevice.MaxVirtualImageNameLen)
+	if len(vi.Name) > validate.MaxVirtualImageNameLen {
+		return nil, fmt.Errorf("the VirtualImage name %q is too long: it must be no more than %d characters", vi.Name, validate.MaxVirtualImageNameLen)
 	}
 
 	if vi.Spec.Storage == virtv2.StorageKubernetes {
@@ -108,8 +109,8 @@ func (v *Validator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Obj
 		warnings = append(warnings, fmt.Sprintf(" the VirtualImage name %q is invalid as it contains now forbidden symbol '.', allowed symbols for name are [0-9a-zA-Z-]. Create another image with valid name to avoid problems with future updates.", newVI.Name))
 	}
 
-	if len(newVI.Name) > blockdevice.MaxVirtualImageNameLen {
-		warnings = append(warnings, fmt.Sprintf("the VirtualImage name %q is too long: it must be no more than %d characters", newVI.Name, blockdevice.MaxVirtualImageNameLen))
+	if len(newVI.Name) > validate.MaxVirtualImageNameLen {
+		warnings = append(warnings, fmt.Sprintf("the VirtualImage name %q is too long: it must be no more than %d characters", newVI.Name, validate.MaxVirtualImageNameLen))
 	}
 
 	return warnings, nil

--- a/images/virtualization-artifact/pkg/controller/vm/internal/validators/meta_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/validators/meta_validator.go
@@ -58,12 +58,6 @@ func (v *MetaValidator) ValidateCreate(_ context.Context, vm *v1alpha2.VirtualMa
 }
 
 func (v *MetaValidator) ValidateUpdate(_ context.Context, _, newVM *v1alpha2.VirtualMachine) (admission.Warnings, error) {
-	if newVM.DeletionTimestamp == nil {
-		if len(newVM.Name) > validate.MaxVirtualMachineNameLen {
-			return nil, fmt.Errorf("the VirtualMachine name %q is too long: it must be no more than %d characters", newVM.Name, validate.MaxVirtualMachineNameLen)
-		}
-	}
-
 	for key := range newVM.Annotations {
 		if strings.Contains(key, core.GroupName) {
 			return nil, fmt.Errorf("using the %s group's name in the annotation is prohibited", core.GroupName)

--- a/images/virtualization-artifact/pkg/controller/vm/internal/validators/meta_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/validators/meta_validator.go
@@ -58,8 +58,10 @@ func (v *MetaValidator) ValidateCreate(_ context.Context, vm *v1alpha2.VirtualMa
 }
 
 func (v *MetaValidator) ValidateUpdate(_ context.Context, _, newVM *v1alpha2.VirtualMachine) (admission.Warnings, error) {
-	if len(newVM.Name) > validate.MaxVirtualMachineNameLen {
-		return nil, fmt.Errorf("the VirtualMachine name %q is too long: it must be no more than %d characters", newVM.Name, validate.MaxVirtualMachineNameLen)
+	if newVM.DeletionTimestamp == nil {
+		if len(newVM.Name) > validate.MaxVirtualMachineNameLen {
+			return nil, fmt.Errorf("the VirtualMachine name %q is too long: it must be no more than %d characters", newVM.Name, validate.MaxVirtualMachineNameLen)
+		}
 	}
 
 	for key := range newVM.Annotations {

--- a/images/virtualization-artifact/pkg/controller/vm/internal/validators/meta_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/validators/meta_validator.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	"github.com/deckhouse/virtualization-controller/pkg/common/validate"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
@@ -37,6 +38,10 @@ func NewMetaValidator(client client.Client) *MetaValidator {
 }
 
 func (v *MetaValidator) ValidateCreate(_ context.Context, vm *v1alpha2.VirtualMachine) (admission.Warnings, error) {
+	if len(vm.Name) > validate.MaxVirtualMachineNameLen {
+		return nil, fmt.Errorf("the VirtualMachine name %q is too long: it must be no more than %d characters", vm.Name, validate.MaxVirtualMachineNameLen)
+	}
+
 	for key := range vm.Annotations {
 		if strings.Contains(key, core.GroupName) {
 			return nil, fmt.Errorf("using the %s group's name in the annotation is prohibited", core.GroupName)
@@ -53,6 +58,10 @@ func (v *MetaValidator) ValidateCreate(_ context.Context, vm *v1alpha2.VirtualMa
 }
 
 func (v *MetaValidator) ValidateUpdate(_ context.Context, _, newVM *v1alpha2.VirtualMachine) (admission.Warnings, error) {
+	if len(newVM.Name) > validate.MaxVirtualMachineNameLen {
+		return nil, fmt.Errorf("the VirtualMachine name %q is too long: it must be no more than %d characters", newVM.Name, validate.MaxVirtualMachineNameLen)
+	}
+
 	for key := range newVM.Annotations {
 		if strings.Contains(key, core.GroupName) {
 			return nil, fmt.Errorf("using the %s group's name in the annotation is prohibited", core.GroupName)

--- a/tests/e2e/testdata/complex-test/cvi/cvi-from-cvi-ubuntu-http.yaml
+++ b/tests/e2e/testdata/complex-test/cvi/cvi-from-cvi-ubuntu-http.yaml
@@ -2,7 +2,7 @@
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: ClusterVirtualImage
 metadata:
-  name: cvi-from-cvi-ubuntu-http
+  name: cvi-from-cvi-ubu-http
 spec:
   dataSource:
     type: ObjectRef

--- a/tests/e2e/testdata/complex-test/cvi/cvi-from-vi-ubuntu-http.yaml
+++ b/tests/e2e/testdata/complex-test/cvi/cvi-from-vi-ubuntu-http.yaml
@@ -2,7 +2,7 @@
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: ClusterVirtualImage
 metadata:
-  name: cvi-from-vi-ubuntu-http
+  name: cvi-from-vi-ubu-http
 spec:
   dataSource:
     type: ObjectRef

--- a/tests/e2e/testdata/connectivity/resources/vi.yaml
+++ b/tests/e2e/testdata/connectivity/resources/vi.yaml
@@ -1,7 +1,7 @@
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: noble-server-cloudimg-amd64
+  name: noble-srv-cloud-amd64
 spec:
   storage: ContainerRegistry
   dataSource:

--- a/tests/e2e/testdata/connectivity/resources/vm-connectivity-a.yaml
+++ b/tests/e2e/testdata/connectivity/resources/vm-connectivity-a.yaml
@@ -10,7 +10,7 @@ spec:
     type: ObjectRef
     objectRef:
       kind: VirtualImage
-      name: noble-server-cloudimg-amd64
+      name: noble-srv-cloud-amd64
 ---
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualMachine

--- a/tests/e2e/testdata/connectivity/resources/vm-connectivity-b.yaml
+++ b/tests/e2e/testdata/connectivity/resources/vm-connectivity-b.yaml
@@ -10,7 +10,7 @@ spec:
     type: ObjectRef
     objectRef:
       kind: VirtualImage
-      name: noble-server-cloudimg-amd64
+      name: noble-srv-cloud-amd64
 ---
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualMachine

--- a/tests/e2e/testdata/cvi/cvi_containerimage.yaml
+++ b/tests/e2e/testdata/cvi/cvi_containerimage.yaml
@@ -1,7 +1,7 @@
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: ClusterVirtualImage
 metadata:
-  name: test-cvi-containerimage
+  name: test-cvi-containerimg
 spec:
   dataSource:
     type: ContainerImage

--- a/tests/e2e/testdata/images-creation/cvi/cvi_objectref_vi.yaml
+++ b/tests/e2e/testdata/images-creation/cvi/cvi_objectref_vi.yaml
@@ -14,7 +14,7 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: ClusterVirtualImage
 metadata:
-  name: cvi-oref-vi-containerimage
+  name: cvi-oref-vi-conimg
 spec:
   dataSource:
     type: "ObjectRef"
@@ -50,7 +50,7 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: ClusterVirtualImage
 metadata:
-  name: cvi-oref-vi-oref-vdsnapshot
+  name: cvi-oref-vi-oref-vdsnp
 spec:
   dataSource:
     type: "ObjectRef"
@@ -76,7 +76,7 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: ClusterVirtualImage
 metadata:
-  name: cvi-oref-vi-containerimage-pvc
+  name: cvi-oref-vi-conimg-pvc
 spec:
   dataSource:
     type: "ObjectRef"
@@ -88,7 +88,7 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: ClusterVirtualImage
 metadata:
-  name: cvi-oref-vi-oref-cvi-pvc
+  name: cvi-ref-vi-ref-cvi-pvc
 spec:
   dataSource:
     type: "ObjectRef"
@@ -100,7 +100,7 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: ClusterVirtualImage
 metadata:
-  name: cvi-oref-vi-oref-vd-pvc
+  name: cvi-ref-vi-ref-vd-pvc
 spec:
   dataSource:
     type: "ObjectRef"
@@ -112,7 +112,7 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: ClusterVirtualImage
 metadata:
-  name: cvi-oref-vi-oref-vdsnapshot-pvc
+  name: cvi-rf-vi-rf-vdsnp-pvc
 spec:
   dataSource:
     type: "ObjectRef"

--- a/tests/e2e/testdata/images-creation/vi/vi_objectref_vi.yaml
+++ b/tests/e2e/testdata/images-creation/vi/vi_objectref_vi.yaml
@@ -15,7 +15,7 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-oref-vi-containerimage
+  name: vi-oref-vi-conimg
   namespace: test-d8-virtualization
 spec:
   storage: ContainerRegistry
@@ -54,7 +54,7 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-oref-vi-oref-vdsnapshot
+  name: vi-oref-vi-oref-vdsnp
   namespace: test-d8-virtualization
 spec:
   storage: ContainerRegistry
@@ -82,7 +82,7 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-oref-vi-containerimage-pvc
+  name: vi-oref-vi-con-img-pvc
   namespace: test-d8-virtualization
 spec:
   storage: ContainerRegistry
@@ -121,7 +121,7 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-oref-vi-oref-vdsnapshot-pvc
+  name: vi-ref-vi-ref-vdsnp-pvc
   namespace: test-d8-virtualization
 spec:
   storage: ContainerRegistry

--- a/tests/e2e/testdata/images-creation/vi/vi_pvc_objectref_vi.yaml
+++ b/tests/e2e/testdata/images-creation/vi/vi_pvc_objectref_vi.yaml
@@ -15,7 +15,7 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-pvc-oref-vi-containerimage
+  name: vi-pvc-oref-vi-con-img
   namespace: test-d8-virtualization
 spec:
   storage: PersistentVolumeClaim
@@ -54,7 +54,7 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-pvc-oref-vi-oref-vdsnapshot
+  name: vi-pvc-ref-vi-ref-vdsnp
   namespace: test-d8-virtualization
 spec:
   storage: PersistentVolumeClaim
@@ -82,7 +82,7 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-pvc-oref-vi-containerimage-pvc
+  name: vi-pvc-rf-vi-conimg-pvc
   namespace: test-d8-virtualization
 spec:
   storage: PersistentVolumeClaim
@@ -95,7 +95,7 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-pvc-oref-vi-oref-vd-pvc
+  name: vi-pvc-rf-vi-rf-vd-pvc
   namespace: test-d8-virtualization
 spec:
   storage: PersistentVolumeClaim
@@ -108,7 +108,7 @@ spec:
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
 metadata:
-  name: vi-pvc-oref-vi-oref-vdsnapshot-pvc
+  name: vi-pvc-rf-vi-rf-vds-pvc
   namespace: test-d8-virtualization
 spec:
   storage: PersistentVolumeClaim


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Update name validation for VirtualImage, VirtualDisk, VirtualMachine, and ClusterVirtualImage to the actual length limit.

Actual length limits:
- VirtualMachine: 128 -> 63
- ClusterVirtualImage: 48 -> 36
- VirtualImage: 49 -> 37

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
Fixed inconsistency of name validations at the hook and crd levels.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: api
type: fix 
summary: Update name validation for VirtualImage, VirtualDisk, VirtualMachine, and ClusterVirtualImage to the actual length limit.
```
