### PR TITLE
fix(core): fix discovery crd descheduler

### DIFF
--- a/templates/descheduler/descheduler.yaml
+++ b/templates/descheduler/descheduler.yaml
@@ -1,4 +1,3 @@
-{{ if has "descheduler" .Values.global.enabledModules }}
 {{ if has "deckhouse.io/v1alpha2/Descheduler" .Values.global.discovery.apiVersions }}
 apiVersion: deckhouse.io/v1alpha2
 kind: Descheduler
@@ -24,5 +23,4 @@ spec:
       enabled: true
       nodeAffinityType:
         - requiredDuringSchedulingIgnoredDuringExecution
-{{- end }}
 {{- end }}

--- a/templates/descheduler/descheduler.yaml
+++ b/templates/descheduler/descheduler.yaml
@@ -1,4 +1,5 @@
-{{- if (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "deschedulers.deckhouse.io") }}
+{{ if has "descheduler" .Values.global.enabledModules }}
+{{ if has "deckhouse.io/v1alpha2/Descheduler" .Values.global.discovery.apiVersions }}
 apiVersion: deckhouse.io/v1alpha2
 kind: Descheduler
 metadata:
@@ -23,4 +24,5 @@ spec:
       enabled: true
       nodeAffinityType:
         - requiredDuringSchedulingIgnoredDuringExecution
+{{- end }}
 {{- end }}

--- a/tools/kubeconform/fixtures/module-values.yaml
+++ b/tools/kubeconform/fixtures/module-values.yaml
@@ -207,6 +207,7 @@ global:
       - autoscaling.k8s.io/v1/VerticalPodAutoscalerCheckpoint
       - config.gatekeeper.sh/v1alpha1/Config
       - virtualization.deckhouse.io/v1alpha2/VirtualDiskSnapshot
+      - deckhouse.io/v1alpha2/Descheduler
     clusterControlPlaneIsHighlyAvailable: false
     clusterDNSAddress: 10.222.0.10
     clusterDomain: cluster.local
@@ -277,6 +278,7 @@ global:
     - virtualization
     - sds-replicated-volume-crd
     - sds-replicated-volume
+    - descheduler
   internal:
     modules:
       kubeRBACProxyCA:


### PR DESCRIPTION
## Description

Use global values to check if descheduler CRD is known to deckhouse. lookup may be not reliable on transitional processes, i.e. deckhouse install, deckhouse restarts or module enabling.

Also add fixes to kubeconform script: delete unexpected metadata properties in descheduler CRDs before running kubeconform.

## Why do we need it, and what problem does it solve?

`lookup` checking leads to Deckhouse queue stuck on descheduler enabling.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->

We can enable and disable descheduler module without errors in the queue.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: fix
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: module
type: fix
summary:  Fix descheduler CRD checking in templates.
impact_level: low
```
