### PR TITLE
fix(vm): remove vmip protection

### DIFF
--- a/api/core/v1alpha2/finalizers.go
+++ b/api/core/v1alpha2/finalizers.go
@@ -21,7 +21,6 @@ const (
 	FinalizerVIProtection                         = "virtualization.deckhouse.io/vi-protection"
 	FinalizerVDProtection                         = "virtualization.deckhouse.io/vd-protection"
 	FinalizerKVVMProtection                       = "virtualization.deckhouse.io/kvvm-protection"
-	FinalizerIPAddressProtection                  = "virtualization.deckhouse.io/vmip-protection"
 	FinalizerPodProtection                        = "virtualization.deckhouse.io/pod-protection"
 	FinalizerVDSnapshotProtection                 = "virtualization.deckhouse.io/vdsnapshot-protection"
 	FinalizerVMSnapshotProtection                 = "virtualization.deckhouse.io/vmsnapshot-protection"

--- a/images/virtualization-artifact/pkg/controller/vm/internal/ipam.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/ipam.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/kvbuilder"
-	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vm/internal/state"
 	"github.com/deckhouse/virtualization-controller/pkg/eventrecord"
 	"github.com/deckhouse/virtualization-controller/pkg/logger"
@@ -48,18 +47,16 @@ type IPAM interface {
 
 func NewIPAMHandler(ipam IPAM, cl client.Client, recorder eventrecord.EventRecorderLogger) *IPAMHandler {
 	return &IPAMHandler{
-		ipam:       ipam,
-		client:     cl,
-		recorder:   recorder,
-		protection: service.NewProtectionService(cl, virtv2.FinalizerIPAddressProtection),
+		ipam:     ipam,
+		client:   cl,
+		recorder: recorder,
 	}
 }
 
 type IPAMHandler struct {
-	ipam       IPAM
-	client     client.Client
-	recorder   eventrecord.EventRecorderLogger
-	protection *service.ProtectionService
+	ipam     IPAM
+	client   client.Client
+	recorder eventrecord.EventRecorderLogger
 }
 
 func (h *IPAMHandler) Handle(ctx context.Context, s state.VirtualMachineState) (reconcile.Result, error) {
@@ -86,11 +83,7 @@ func (h *IPAMHandler) Handle(ctx context.Context, s state.VirtualMachineState) (
 	}
 
 	if isDeletion(current) {
-		return reconcile.Result{}, h.protection.RemoveProtection(ctx, ipAddress)
-	}
-	err = h.protection.AddProtection(ctx, ipAddress)
-	if err != nil {
-		return reconcile.Result{}, err
+		return reconcile.Result{}, nil
 	}
 
 	// 1. OK: already bound.


### PR DESCRIPTION
## Description

When deleting a virtual machine, the finalizer `vmip-protection` was not always removed from the vmip by vm controller in time. The vmip has its own finalizer `vmip-cleanup`, which prevents its deletion. 

To avoid refactoring the virtual machine's controller, finalizer `vmip-protection` has been deleted.


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries

```changes
section: vmip
type: fix
summary: Fix the removal of the finalizer from VirtualMachineIPAddress when deleting a virtual machine.
```
