### PR TITLE
fix(vmbda): watch for the vm phase

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vmbda/internal/watcher/vm_watcher.go
+++ b/images/virtualization-artifact/pkg/controller/vmbda/internal/watcher/vm_watcher.go
@@ -101,7 +101,7 @@ func (w VirtualMachineWatcher) filterUpdateEvents(e event.UpdateEvent) bool {
 	oldRunningCondition, _ := conditions.GetCondition(vmcondition.TypeRunning, oldVM.Status.Conditions)
 	newRunningCondition, _ := conditions.GetCondition(vmcondition.TypeRunning, newVM.Status.Conditions)
 
-	if newRunningCondition.Status != oldRunningCondition.Status {
+	if oldRunningCondition.Status != newRunningCondition.Status || oldVM.Status.Phase != newVM.Status.Phase {
 		return true
 	}
 


### PR DESCRIPTION
## Description



## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries

```changes
section: vmbda
type: fix
summary: 
impact_level: low
```
