### PR TITLE
fix(vm): nil pointer

### DIFF
--- a/images/virtualization-artifact/pkg/controller/service/size_policy_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/size_policy_service.go
@@ -36,7 +36,7 @@ func NewSizePolicyService() *SizePolicyService {
 
 func (s *SizePolicyService) CheckVMMatchedSizePolicy(vm *virtv2.VirtualMachine, vmClass *virtv2.VirtualMachineClass) error {
 	// check if no sizing policy requirements are set
-	if len(vmClass.Spec.SizingPolicies) == 0 {
+	if vmClass == nil || len(vmClass.Spec.SizingPolicies) == 0 {
 		return nil
 	}
 
@@ -63,6 +63,10 @@ func (s *SizePolicyService) CheckVMMatchedSizePolicy(vm *virtv2.VirtualMachine, 
 
 func getVMSizePolicy(vm *virtv2.VirtualMachine, vmClass *virtv2.VirtualMachineClass) *virtv2.SizingPolicy {
 	for _, sp := range vmClass.Spec.SizingPolicies {
+		if sp.Cores == nil {
+			continue
+		}
+
 		if vm.Spec.CPU.Cores >= sp.Cores.Min && vm.Spec.CPU.Cores <= sp.Cores.Max {
 			return sp.DeepCopy()
 		}

--- a/images/virtualization-artifact/pkg/controller/vmclass/internal/validators/sizing_policies_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/internal/validators/sizing_policies_validator.go
@@ -63,6 +63,10 @@ func HasCPUSizePoliciesCrosses(vmclass *v1alpha2.VirtualMachineClassSpec) bool {
 				continue
 			}
 
+			if policy1.Cores == nil || policy2.Cores == nil {
+				continue
+			}
+
 			if policy1.Cores.Min >= policy2.Cores.Min && policy1.Cores.Min <= policy2.Cores.Max {
 				return true
 			}


### PR DESCRIPTION
## Description

Fix panic if Cores were not specified in the vmclass's SizingPolicy.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries

```changes
section: vm 
type: fix
summary: Fix panic if Cores were not specified in the vmclass's SizingPolicy.
```
