### PR TITLE
fix(module): fix validating for field https.mode

### DIFF
--- a/images/virtualization-artifact/pkg/config/load_dvcr_settings.go
+++ b/images/virtualization-artifact/pkg/config/load_dvcr_settings.go
@@ -69,9 +69,6 @@ func LoadDVCRSettingsFromEnvs(controllerNamespace string) (*dvcr.Settings, error
 	if dvcrSettings.UploaderIngressSettings.Host == "" {
 		return nil, fmt.Errorf("environment variable %q undefined, specify DVCR settings", UploaderIngressHostVar)
 	}
-	if dvcrSettings.UploaderIngressSettings.TLSSecret == "" {
-		return nil, fmt.Errorf("environment variable %q undefined, specify DVCR settings", UploaderIngressTLSSecretVar)
-	}
 	if dvcrSettings.UploaderIngressSettings.Class == "" {
 		return nil, fmt.Errorf("environment variable %q undefined, specify DVCR settings", UploaderIngressClassVar)
 	}

--- a/images/virtualization-artifact/pkg/controller/uploader/uploader_ingress.go
+++ b/images/virtualization-artifact/pkg/controller/uploader/uploader_ingress.go
@@ -84,7 +84,6 @@ func (i *Ingress) makeSpec() *netv1.Ingress {
 			Namespace: i.Settings.Namespace,
 			Annotations: map[string]string{
 				annotations.AnnUploadURL:                              uploadURL,
-				"nginx.ingress.kubernetes.io/ssl-redirect":            "true",
 				"nginx.ingress.kubernetes.io/proxy-body-size":         "0",
 				"nginx.ingress.kubernetes.io/proxy-request-buffering": "off",
 				"nginx.ingress.kubernetes.io/proxy-buffering":         "off",
@@ -129,6 +128,7 @@ func (i *Ingress) makeSpec() *netv1.Ingress {
 				SecretName: i.Settings.TLSSecretName,
 			},
 		}
+		ingress.Annotations["nginx.ingress.kubernetes.io/ssl-redirect"] = "true"
 	}
 
 	return ingress

--- a/images/virtualization-artifact/pkg/controller/uploader/uploader_ingress.go
+++ b/images/virtualization-artifact/pkg/controller/uploader/uploader_ingress.go
@@ -67,7 +67,14 @@ func (i *Ingress) Create(ctx context.Context, client client.Client) (*netv1.Ingr
 func (i *Ingress) makeSpec() *netv1.Ingress {
 	pathTypeExact := netv1.PathTypeExact
 	path := i.generatePath()
-	return &netv1.Ingress{
+	tlsEnabled := i.Settings.TLSSecretName != ""
+	var uploadURL string
+	if tlsEnabled {
+		uploadURL = fmt.Sprintf("https://%s%s", i.Settings.Host, path)
+	} else {
+		uploadURL = fmt.Sprintf("http://%s%s", i.Settings.Host, path)
+	}
+	ingress := &netv1.Ingress{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Ingress",
 			APIVersion: netv1.SchemeGroupVersion.String(),
@@ -76,7 +83,7 @@ func (i *Ingress) makeSpec() *netv1.Ingress {
 			Name:      i.Settings.Name,
 			Namespace: i.Settings.Namespace,
 			Annotations: map[string]string{
-				annotations.AnnUploadURL:                              fmt.Sprintf("https://%s%s", i.Settings.Host, path),
+				annotations.AnnUploadURL:                              uploadURL,
 				"nginx.ingress.kubernetes.io/ssl-redirect":            "true",
 				"nginx.ingress.kubernetes.io/proxy-body-size":         "0",
 				"nginx.ingress.kubernetes.io/proxy-request-buffering": "off",
@@ -112,14 +119,19 @@ func (i *Ingress) makeSpec() *netv1.Ingress {
 					},
 				},
 			},
-			TLS: []netv1.IngressTLS{
-				{
-					Hosts:      []string{i.Settings.Host},
-					SecretName: i.Settings.TLSSecretName,
-				},
-			},
 		},
 	}
+
+	if tlsEnabled {
+		ingress.Spec.TLS = []netv1.IngressTLS{
+			{
+				Hosts:      []string{i.Settings.Host},
+				SecretName: i.Settings.TLSSecretName,
+			},
+		}
+	}
+
+	return ingress
 }
 
 func (i *Ingress) generatePath() string {

--- a/templates/virtualization-controller/_helpers.tpl
+++ b/templates/virtualization-controller/_helpers.tpl
@@ -54,8 +54,10 @@
   value: "10m"
 - name: UPLOADER_INGRESS_HOST
   value: {{ include "helm_lib_module_public_domain" (list . "virtualization") }}
+{{- if or (eq (include "helm_lib_module_https_mode" .) "CertManager") (eq (include "helm_lib_module_https_mode" .) "CustomCertificate") }}
 - name: UPLOADER_INGRESS_TLS_SECRET
   value: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
+{{- end }}
 - name: UPLOADER_INGRESS_CLASS
   value: {{ include "helm_lib_module_ingress_class" . | quote }}
 - name: PROVISIONING_POD_LIMITS

--- a/templates/virtualization-controller/_helpers.tpl
+++ b/templates/virtualization-controller/_helpers.tpl
@@ -54,7 +54,7 @@
   value: "10m"
 - name: UPLOADER_INGRESS_HOST
   value: {{ include "helm_lib_module_public_domain" (list . "virtualization") }}
-{{- if or (eq (include "helm_lib_module_https_mode" .) "CertManager") (eq (include "helm_lib_module_https_mode" .) "CustomCertificate") }}
+{{- if (include "helm_lib_module_https_ingress_tls_enabled" .) }}
 - name: UPLOADER_INGRESS_TLS_SECRET
   value: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
 {{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Fix validation logic related to the `https.mode` field in the virtualization module settings, ensuring that the UPLOADER_INGRESS_TLS_SECRET is only required when the HTTPS mode is 'CertManager' or 'CustomCertificate'.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
If the `https.mode` field in the module settings is set to `OnlyInURI`, we get an error:
```
  1. ModuleRun:main:virtualization:KubeConfig-Changed-Modules:failures 1:run helm install: execution error at (virtualization/templates/virtualization-controller/deployment.yaml:96:16): https.mode must be CustomCertificate or CertManager
```

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
All work as expected

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: module
type: fix
summary: Fix validation logic related to the https.mode field in the virtualization module settings, ensuring that the UPLOADER_INGRESS_TLS_SECRET is only required when the HTTPS mode is 'CertManager' or 'CustomCertificate'.
```
