### PR TITLE
feat(core): set replicas equal to 3 for HA mode

### DIFF
--- a/templates/cdi/config.yaml
+++ b/templates/cdi/config.yaml
@@ -46,7 +46,7 @@ spec:
       # HA settings for deploy/cdi-apiserver.
       - resourceType: Deployment
         resourceName: cdi-apiserver
-        patch: '[{"op":"replace","path":"/spec/replicas","value":2}]'
+        patch: '[{"op":"replace","path":"/spec/replicas","value":3}]'
         type: json
       - resourceType: Deployment
         resourceName: cdi-apiserver
@@ -59,7 +59,7 @@ spec:
       # HA settings for deploy/cdi-deployment.
       - resourceType: Deployment
         resourceName: cdi-deployment
-        patch: '[{"op":"replace","path":"/spec/replicas","value":2}]'
+        patch: '[{"op":"replace","path":"/spec/replicas","value":3}]'
         type: json
       - resourceType: Deployment
         resourceName: cdi-deployment

--- a/templates/cdi/config.yaml
+++ b/templates/cdi/config.yaml
@@ -59,7 +59,7 @@ spec:
       # HA settings for deploy/cdi-deployment.
       - resourceType: Deployment
         resourceName: cdi-deployment
-        patch: '[{"op":"replace","path":"/spec/replicas","value":3}]'
+        patch: '[{"op":"replace","path":"/spec/replicas","value":2}]'
         type: json
       - resourceType: Deployment
         resourceName: cdi-deployment

--- a/templates/kubevirt/kubevirt.yaml
+++ b/templates/kubevirt/kubevirt.yaml
@@ -106,6 +106,14 @@ spec:
       resourceName: virt-api
       patch: {{ include "spec_strategy_rolling_update_patch" . }}
       type: strategic
+    - resourceType: Deployment
+      resourceName: virt-api
+      patch: '[{"op":"replace","path":"/spec/replicas","value":3}]'
+      type: json
+    - resourceType: Deployment
+      resourceName: virt-controller
+      patch: '[{"op":"replace","path":"/spec/replicas","value":2}]'
+      type: json
     # HA settings for deploy/virt-controller.
     - resourceType: Deployment
       resourceName: virt-controller
@@ -286,8 +294,6 @@ env:
   imagePullPolicy: IfNotPresent
   imagePullSecrets:
     - name: virtualization-module-registry
-  infra:
-    replicas: {{ include "helm_lib_is_ha_to_value" (list . 3 1) }}
   workloadUpdateStrategy:
     workloadUpdateMethods:
       - LiveMigrate

--- a/templates/kubevirt/kubevirt.yaml
+++ b/templates/kubevirt/kubevirt.yaml
@@ -110,10 +110,6 @@ spec:
       resourceName: virt-api
       patch: '[{"op":"replace","path":"/spec/replicas","value":3}]'
       type: json
-    - resourceType: Deployment
-      resourceName: virt-controller
-      patch: '[{"op":"replace","path":"/spec/replicas","value":2}]'
-      type: json
     # HA settings for deploy/virt-controller.
     - resourceType: Deployment
       resourceName: virt-controller

--- a/templates/kubevirt/kubevirt.yaml
+++ b/templates/kubevirt/kubevirt.yaml
@@ -104,10 +104,6 @@ spec:
       type: strategic
     - resourceType: Deployment
       resourceName: virt-api
-      patch: '[{"op":"replace","path":"/spec/replicas","value":3}]'
-      type: json
-    - resourceType: Deployment
-      resourceName: virt-api
       patch: {{ include "spec_strategy_rolling_update_patch" . }}
       type: strategic
     # HA settings for deploy/virt-controller.
@@ -291,7 +287,7 @@ env:
   imagePullSecrets:
     - name: virtualization-module-registry
   infra:
-    replicas: {{ include "helm_lib_is_ha_to_value" (list . 2 1) }}
+    replicas: {{ include "helm_lib_is_ha_to_value" (list . 3 1) }}
   workloadUpdateStrategy:
     workloadUpdateMethods:
       - LiveMigrate

--- a/templates/kubevirt/kubevirt.yaml
+++ b/templates/kubevirt/kubevirt.yaml
@@ -104,6 +104,10 @@ spec:
       type: strategic
     - resourceType: Deployment
       resourceName: virt-api
+      patch: '[{"op":"replace","path":"/spec/replicas","value":3}]'
+      type: json
+    - resourceType: Deployment
+      resourceName: virt-api
       patch: {{ include "spec_strategy_rolling_update_patch" . }}
       type: strategic
     # HA settings for deploy/virt-controller.

--- a/templates/virtualization-api/deployment.yaml
+++ b/templates/virtualization-api/deployment.yaml
@@ -49,7 +49,14 @@ metadata:
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "virtualization-api")) | nindent 2 }}
 spec:
-  {{- include "helm_lib_deployment_strategy_and_replicas_for_ha" . | nindent 2 }}
+  replicas: {{ include "helm_lib_is_ha_to_value" (list . 3 1) }}
+  {{- if (include "helm_lib_ha_enabled" .) }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  {{- end }}
   revisionHistoryLimit: 2
   selector:
     matchLabels:

--- a/templates/virtualization-controller/deployment.yaml
+++ b/templates/virtualization-controller/deployment.yaml
@@ -51,7 +51,14 @@ metadata:
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "virtualization-controller")) | nindent 2 }}
 spec:
-  {{- include "helm_lib_deployment_strategy_and_replicas_for_ha" . | nindent 2 }}
+  replicas: {{ include "helm_lib_is_ha_to_value" (list . 3 1) }}
+  {{- if (include "helm_lib_ha_enabled" .) }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  {{- end }}
   revisionHistoryLimit: 2
   selector:
     matchLabels:


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Every component which is run on master nodes should have at least 3 replicas and run on separate masters. Every other component should have 2 replicas.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
This is a useful feature for HA, because, firstly, sometimes masters can be unavailable, and this saves time on deployment of new pods, and secondly, this evens out load on multiple masters, because some replicas of the same deployment can be leaders on non-leader etcd master node.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
In HA mode we should see this picture.
3 replicas of following components:
- cdi-apiserver
- virt-api
- virtualization-api
- virtualization-controller

and 2 replicas of other components.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: core
type: feature
summary: set replicas equal to 3 for HA mode
```
