### PR TITLE
fix(vm): fix issues with attaching an nfs disk to a virtual machine and with provisioning a disk on nfs

### DIFF
--- a/images/cdi-artifact/werf.inc.yaml
+++ b/images/cdi-artifact/werf.inc.yaml
@@ -1,5 +1,5 @@
 ---
-{{- $version := "v1.60.3-v12n.5" }}
+{{- $version := "v1.60.3-v12n.6" }}
 {{- $gitRepoUrl := "deckhouse/3p-containerized-data-importer" }}
 
 ---


### PR DESCRIPTION
## Description

Fixed issues with attaching an NFS disk to a virtual machine and with provisioning a disk on NFS.

- the CSI driver creates PVC as `root:qemu` on the NFS server because fsGroup is set to qemu;
- as the PVC is `drwxrwsr-x root:qemu`, the CDI importer running as `qemu:root` cannot create the disk directory on the PVC (mkdir permission denied).

Solution: run the CDI importer with gid qemu (runAsGroup: 107).

test

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: vd
type: fix
summary: Fixed the creation of virtual disks using NFS storage with the `no_root_squash` option.
```
