### PR TITLE
refactor(cli): add common clientconfig

### DIFF
--- a/src/cli/cmd/main.go
+++ b/src/cli/cmd/main.go
@@ -19,12 +19,16 @@ package main
 import (
 	"os"
 
+	"github.com/fatih/color"
+
 	"github.com/deckhouse/virtualization/src/cli/pkg/command"
 )
 
 func main() {
-	virtCmd, _ := command.NewCommand(os.Args[0])
+	virtCmd := command.NewCommand(os.Args[0])
 	if err := virtCmd.Execute(); err != nil {
+		red := color.New(color.FgRed)
+		_, _ = red.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/src/cli/go.mod
+++ b/src/cli/go.mod
@@ -5,8 +5,8 @@ go 1.23.6
 toolchain go1.24.0
 
 require (
-	github.com/deckhouse/deckhouse-cli v0.12.1
 	github.com/deckhouse/virtualization/api v0.15.0
+	github.com/fatih/color v1.18.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/povsister/scp v0.0.0-20250504051308-e467f71ea63c
 	github.com/spf13/cobra v1.8.1
@@ -19,6 +19,7 @@ require (
 	k8s.io/client-go v0.32.2
 	k8s.io/component-base v0.29.3
 	k8s.io/klog/v2 v2.130.1
+	k8s.io/utils v0.0.0-20241210054802-24370beab758
 )
 
 require github.com/golang/protobuf v1.5.4 // indirect
@@ -44,6 +45,8 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
@@ -53,7 +56,9 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.60.1 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
+	github.com/stretchr/testify v1.10.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/net v0.35.0 // indirect
 	golang.org/x/oauth2 v0.25.0 // indirect
 	golang.org/x/time v0.9.0 // indirect
@@ -64,7 +69,6 @@ require (
 	k8s.io/api v0.32.2 // indirect
 	k8s.io/apiextensions-apiserver v0.29.3 // indirect
 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect
-	k8s.io/utils v0.0.0-20241210054802-24370beab758 // indirect
 	kubevirt.io/api v1.2.0 // indirect
 	kubevirt.io/containerized-data-importer-api v1.57.0-alpha1 // indirect
 	kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90 // indirect
@@ -72,3 +76,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/deckhouse/virtualization/api => ../../api

--- a/src/cli/go.sum
+++ b/src/cli/go.sum
@@ -21,10 +21,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deckhouse/deckhouse-cli v0.12.1 h1:wKnDwx1oQdMLtJTisKst/gvswQxBPKK+CzY4awdzZt4=
-github.com/deckhouse/deckhouse-cli v0.12.1/go.mod h1:Hhx+Ov3WZCdu+GpBQzg7rplh1IUP+fGyNGCudNYbMjo=
-github.com/deckhouse/virtualization/api v0.15.0 h1:yRX6n18kK9wwO2f+8fc2s2nb1N2vYKxKb3/aSRtc9Kk=
-github.com/deckhouse/virtualization/api v0.15.0/go.mod h1:t+6i4NC43RfNLqcZqkEc5vxY1ypKceqmOOKlVEq0cYA=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
@@ -35,6 +31,8 @@ github.com/emicklei/go-restful/v3 v3.11.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRr
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
+github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
@@ -138,6 +136,11 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
+github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
+github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
+github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -283,6 +286,8 @@ golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
 golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/src/cli/internal/clientconfig/clientconfig.go
+++ b/src/cli/internal/clientconfig/clientconfig.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clientconfig
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/deckhouse/virtualization/api/client/kubeclient"
+)
+
+type key struct{}
+
+var clientConfigKey key
+
+// NewContext returns a new Context that stores a clientConfig as value.
+func NewContext(ctx context.Context, clientConfig clientcmd.ClientConfig) context.Context {
+	return context.WithValue(ctx, clientConfigKey, clientConfig)
+}
+
+func ClientAndNamespaceFromContext(ctx context.Context) (client kubeclient.Client, namespace string, overridden bool, err error) {
+	clientConfig, ok := ctx.Value(clientConfigKey).(clientcmd.ClientConfig)
+	if !ok {
+		return nil, "", false, fmt.Errorf("unable to get client config from context")
+	}
+	client, err = kubeclient.GetClientFromClientConfig(clientConfig)
+	if err != nil {
+		return nil, "", false, err
+	}
+	namespace, overridden, err = clientConfig.Namespace()
+	if err != nil {
+		return nil, "", false, err
+	}
+	return client, namespace, overridden, nil
+}

--- a/src/cli/internal/cmd/console/console.go
+++ b/src/cli/internal/cmd/console/console.go
@@ -21,42 +21,39 @@ package console
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"os"
+	"os/signal"
 	"strings"
 	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/deckhouse/virtualization/api/client/kubeclient"
+
+	"github.com/deckhouse/virtualization/src/cli/internal/clientconfig"
 	"github.com/deckhouse/virtualization/src/cli/internal/templates"
 	"github.com/deckhouse/virtualization/src/cli/internal/util"
 )
 
-var timeout int
-
-func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
+func NewCommand() *cobra.Command {
+	console := &Console{}
 	cmd := &cobra.Command{
 		Use:     "console (VirtualMachine)",
 		Short:   "Connect to a console of a virtual machine.",
 		Example: usage(),
 		Args:    templates.ExactArgs("console", 1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			c := Console{clientConfig: clientConfig}
-			return c.Run(args)
-		},
+		RunE:    console.Run,
 	}
 
-	cmd.Flags().IntVar(&timeout, "timeout", 5, "The number of minutes to wait for the virtual machine to be ready.")
+	cmd.Flags().IntVar(&console.timeout, "timeout", 5, "The number of minutes to wait for the virtual machine to be ready.")
 	cmd.SetUsageTemplate(templates.UsageTemplate())
 	return cmd
 }
 
 type Console struct {
-	clientConfig clientcmd.ClientConfig
+	timeout int
 }
 
 func usage() string {
@@ -70,52 +67,62 @@ func usage() string {
 	return usage
 }
 
-func (c *Console) Run(args []string) error {
+func (c *Console) Run(cmd *cobra.Command, args []string) error {
+	client, defaultNamespace, _, err := clientconfig.ClientAndNamespaceFromContext(cmd.Context())
+	if err != nil {
+		return err
+	}
 	namespace, name, err := templates.ParseTarget(args[0])
 	if err != nil {
 		return err
 	}
 	if namespace == "" {
-		namespace, _, err = c.clientConfig.Namespace()
-		if err != nil {
-			return err
-		}
+		namespace = defaultNamespace
 	}
 
-	virtCli, err := kubeclient.GetClientFromClientConfig(c.clientConfig)
-	if err != nil {
-		return err
-	}
+	interrupt := make(chan os.Signal, 1)
+	go func() {
+		<-interrupt
+		close(interrupt)
+	}()
+	signal.Notify(interrupt, os.Interrupt)
 
 	for {
-		err := connect(name, namespace, virtCli)
-		if err != nil {
-			if errors.Is(err, util.ErrorInterrupt) || strings.Contains(err.Error(), "not found") {
-				return err
-			}
+		err := connect(name, namespace, client, c.timeout)
+		if err == nil {
+			continue
+		}
 
-			var e *websocket.CloseError
-			if errors.As(err, &e) {
-				switch e.Code {
-				case websocket.CloseGoingAway:
-					fmt.Fprint(os.Stderr, "\nYou were disconnected from the console. This has one of the following reasons:"+
-						"\n - another user connected to the console of the target vm\n")
-					return nil
-				case websocket.CloseAbnormalClosure:
-					fmt.Fprint(os.Stderr, "\nYou were disconnected from the console. This has one of the following reasons:"+
-						"\n - network issues"+
-						"\n - machine restart\n")
-				}
-			} else {
-				fmt.Fprintf(os.Stderr, "%s\n", err)
-			}
+		if errors.Is(err, util.ErrorInterrupt) || strings.Contains(err.Error(), "not found") {
+			return err
+		}
 
+		var e *websocket.CloseError
+		if errors.As(err, &e) {
+			switch e.Code {
+			case websocket.CloseGoingAway:
+				cmd.Printf("\nYou were disconnected from the console. This has one of the following reasons:" +
+					"\n - another user connected to the console of the target vm\n")
+				return nil
+			case websocket.CloseAbnormalClosure:
+				cmd.Printf("\nYou were disconnected from the console. This has one of the following reasons:" +
+					"\n - network issues" +
+					"\n - machine restart\n")
+			}
+		} else {
+			cmd.Printf("%s\n", err)
+		}
+
+		select {
+		case <-interrupt:
+			return nil
+		default:
 			time.Sleep(time.Second)
 		}
 	}
 }
 
-func connect(name string, namespace string, virtCli kubeclient.Client) error {
+func connect(name string, namespace string, virtCli kubeclient.Client, timeout int) error {
 	stdinReader, stdinWriter := io.Pipe()
 	stdoutReader, stdoutWriter := io.Pipe()
 

--- a/src/cli/internal/cmd/console/console.go
+++ b/src/cli/internal/cmd/console/console.go
@@ -22,8 +22,6 @@ package console
 import (
 	"errors"
 	"io"
-	"os"
-	"os/signal"
 	"strings"
 	"time"
 
@@ -80,13 +78,6 @@ func (c *Console) Run(cmd *cobra.Command, args []string) error {
 		namespace = defaultNamespace
 	}
 
-	interrupt := make(chan os.Signal, 1)
-	go func() {
-		<-interrupt
-		close(interrupt)
-	}()
-	signal.Notify(interrupt, os.Interrupt)
-
 	for {
 		err := connect(name, namespace, client, c.timeout)
 		if err == nil {
@@ -113,12 +104,7 @@ func (c *Console) Run(cmd *cobra.Command, args []string) error {
 			cmd.Printf("%s\n", err)
 		}
 
-		select {
-		case <-interrupt:
-			return nil
-		default:
-			time.Sleep(time.Second)
-		}
+		time.Sleep(time.Second)
 	}
 }
 

--- a/src/cli/internal/cmd/lifecycle/evict.go
+++ b/src/cli/internal/cmd/lifecycle/evict.go
@@ -18,21 +18,18 @@ package lifecycle
 
 import (
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/deckhouse/virtualization/src/cli/internal/templates"
 )
 
-func NewEvictCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
-	lifecycle := NewLifecycle(Evict, clientConfig)
+func NewEvictCommand() *cobra.Command {
+	lifecycle := NewLifecycle(Evict)
 	cmd := &cobra.Command{
 		Use:     "evict (VirtualMachine)",
 		Short:   "Evict a virtual machine.",
 		Example: lifecycle.Usage(),
 		Args:    templates.ExactArgs("evict", 1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return lifecycle.Run(args)
-		},
+		RunE:    lifecycle.Run,
 	}
 	AddCommandlineArgs(cmd.Flags(), &lifecycle.opts)
 	cmd.SetUsageTemplate(templates.UsageTemplate())

--- a/src/cli/internal/cmd/lifecycle/restart.go
+++ b/src/cli/internal/cmd/lifecycle/restart.go
@@ -18,21 +18,18 @@ package lifecycle
 
 import (
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/deckhouse/virtualization/src/cli/internal/templates"
 )
 
-func NewRestartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
-	lifecycle := NewLifecycle(Restart, clientConfig)
+func NewRestartCommand() *cobra.Command {
+	lifecycle := NewLifecycle(Restart)
 	cmd := &cobra.Command{
 		Use:     "restart (VirtualMachine)",
 		Short:   "Restart a virtual machine.",
 		Example: lifecycle.Usage(),
 		Args:    templates.ExactArgs("restart", 1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return lifecycle.Run(args)
-		},
+		RunE:    lifecycle.Run,
 	}
 	AddCommandlineArgs(cmd.Flags(), &lifecycle.opts)
 	cmd.SetUsageTemplate(templates.UsageTemplate())

--- a/src/cli/internal/cmd/lifecycle/start.go
+++ b/src/cli/internal/cmd/lifecycle/start.go
@@ -18,21 +18,18 @@ package lifecycle
 
 import (
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/deckhouse/virtualization/src/cli/internal/templates"
 )
 
-func NewStartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
-	lifecycle := NewLifecycle(Start, clientConfig)
+func NewStartCommand() *cobra.Command {
+	lifecycle := NewLifecycle(Start)
 	cmd := &cobra.Command{
 		Use:     "start (VirtualMachine)",
 		Short:   "Start a virtual machine.",
 		Example: lifecycle.Usage(),
 		Args:    templates.ExactArgs("start", 1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return lifecycle.Run(args)
-		},
+		RunE:    lifecycle.Run,
 	}
 	AddCommandlineArgs(cmd.Flags(), &lifecycle.opts)
 	cmd.SetUsageTemplate(templates.UsageTemplate())

--- a/src/cli/internal/cmd/lifecycle/stop.go
+++ b/src/cli/internal/cmd/lifecycle/stop.go
@@ -18,21 +18,18 @@ package lifecycle
 
 import (
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/deckhouse/virtualization/src/cli/internal/templates"
 )
 
-func NewStopCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
-	lifecycle := NewLifecycle(Stop, clientConfig)
+func NewStopCommand() *cobra.Command {
+	lifecycle := NewLifecycle(Stop)
 	cmd := &cobra.Command{
 		Use:     "stop (VirtualMachine)",
 		Short:   "Stop a virtual machine.",
 		Example: lifecycle.Usage(),
 		Args:    templates.ExactArgs("stop", 1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return lifecycle.Run(args)
-		},
+		RunE:    lifecycle.Run,
 	}
 	AddCommandlineArgs(cmd.Flags(), &lifecycle.opts)
 	cmd.SetUsageTemplate(templates.UsageTemplate())

--- a/src/cli/internal/cmd/lifecycle/vmop/vmop.go
+++ b/src/cli/internal/cmd/lifecycle/vmop/vmop.go
@@ -21,12 +21,14 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/deckhouse/virtualization/api/client/kubeclient"
-	"github.com/deckhouse/virtualization/api/core/v1alpha2"
-	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmopcondition"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	"github.com/deckhouse/virtualization/api/client/kubeclient"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmopcondition"
 )
 
 type VirtualMachineOperation struct {
@@ -233,7 +235,7 @@ func (v VirtualMachineOperation) newVMOP(vmName, vmNamespace string, t v1alpha2.
 		Spec: v1alpha2.VirtualMachineOperationSpec{
 			Type:           t,
 			VirtualMachine: vmName,
-			Force:          force,
+			Force:          ptr.To(force),
 		},
 	}
 }

--- a/src/cli/internal/cmd/scp/native.go
+++ b/src/cli/internal/cmd/scp/native.go
@@ -27,15 +27,13 @@ import (
 
 	"github.com/povsister/scp"
 
+	"github.com/deckhouse/virtualization/api/client/kubeclient"
 	"github.com/deckhouse/virtualization/src/cli/internal/cmd/ssh"
 	"github.com/deckhouse/virtualization/src/cli/internal/templates"
 )
 
-func (o *SCP) nativeSCP(local templates.LocalSCPArgument, remote templates.RemoteSCPArgument, toRemote bool) error {
-	sshClient := ssh.NativeSSHConnection{
-		ClientConfig: o.clientConfig,
-		Options:      o.options,
-	}
+func (o *SCP) nativeSCP(virtClient kubeclient.Client, local templates.LocalSCPArgument, remote templates.RemoteSCPArgument, toRemote bool) error {
+	sshClient := ssh.NewNativeSSHConnection(virtClient, o.options)
 	client, err := sshClient.PrepareSSHClient(remote.Namespace, remote.Name)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description
add common clientconfig


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: cli
type: refactor
summary: add clientconfig
impact_level: low
```
