### PR TITLE
chore(ci): add vlctl and node-labeller to svace

### DIFF
--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -463,11 +463,15 @@ git:
       - '**/*'
 shell:
   install:
+{{- if eq $.SVACE_ENABLED "false" }}
   {{- include "debian packages proxy" . | nindent 2 }}
-  - |
-    echo "install deps libvirt-dev"
-    apt-get update && apt-get install -y libvirt-dev
+  - apt-get -qq install -y --no-install-recommends libvirt-dev
   {{- include "debian packages clean" . | nindent 2 }}
+{{- else }}
+  {{- include "alt packages proxy" . | nindent 2 }}
+  - apt-get -qq install -y libvirt-devel
+  {{- include "alt packages clean" . | nindent 2 }}
+{{- end }}
   - mkdir -p /binaries
   - |
     echo "Build node-labeller binaries"

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -445,7 +445,7 @@ shell:
 ---
 image: {{ $.ImageName }}-gobuilder
 final: false
-fromImage: builder/golang-bookworm-1.23
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-bookworm-1.23" "builder/alt-go-svace" }}
 git:
   - add: /images/{{ $.ImageName }}/node-labeller
     to: /node-labeller
@@ -473,7 +473,8 @@ shell:
     echo "Build node-labeller binaries"
     cd /node-labeller
     echo '== go build -ldflags="-s -w" -o /binaries/node-labeller ./cmd/node-labeller =='
-    go build -ldflags="-s -w" -o /binaries/node-labeller ./cmd/node-labeller
+    {{- $_ := set $ "ProjectName" (list $.ImageName "node-labeller" | join "/") }}
+    {{- include "image-build.build" (set $ "BuildCommand" `go build -ldflags="-s -w" -o /binaries/node-labeller ./cmd/node-labeller`) | nindent 6 }}
     echo "Done"
   - |
     cd /src-vlctl
@@ -481,7 +482,8 @@ shell:
     export GOARCH=amd64
     export CGO_ENABLED=0
     echo '== go build -ldflags="-s -w" -o /binaries/vlctl ./cmd/vlctl/main.go =='
-    go build -ldflags="-s -w" -o /binaries/vlctl ./cmd/vlctl/main.go
+    {{- $_ := set $ "ProjectName" (list $.ImageName "vlctl" | join "/") }}
+    {{- include "image-build.build" (set $ "BuildCommand" `go build -ldflags="-s -w" -o /binaries/vlctl ./cmd/vlctl/main.go`) | nindent 6 }}
     echo "Done"
 ---
 image: {{ $.ImageName }}-cbuilder


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Add vlctl and node-labeller to svace.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
impact_level: low
```
