### PR TITLE
fix(vmip): remove legacy finalizer

### DIFF
--- a/api/core/v1alpha2/finalizers.go
+++ b/api/core/v1alpha2/finalizers.go
@@ -21,6 +21,7 @@ const (
 	FinalizerVIProtection                         = "virtualization.deckhouse.io/vi-protection"
 	FinalizerVDProtection                         = "virtualization.deckhouse.io/vd-protection"
 	FinalizerKVVMProtection                       = "virtualization.deckhouse.io/kvvm-protection"
+	FinalizerIPAddressProtection                  = "virtualization.deckhouse.io/vmip-protection"
 	FinalizerPodProtection                        = "virtualization.deckhouse.io/pod-protection"
 	FinalizerVDSnapshotProtection                 = "virtualization.deckhouse.io/vdsnapshot-protection"
 	FinalizerVMSnapshotProtection                 = "virtualization.deckhouse.io/vmsnapshot-protection"

--- a/images/virtualization-artifact/pkg/controller/vmip/internal/protection_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vmip/internal/protection_handler.go
@@ -50,5 +50,9 @@ func (h *ProtectionHandler) Handle(_ context.Context, vmip *virtv2.VirtualMachin
 
 	// 3. All checks have passed, the resource can be deleted.
 	controllerutil.RemoveFinalizer(vmip, virtv2.FinalizerIPAddressCleanup)
+
+	// 4. Remove legacy finalizer as well. It no longer attaches to new resources, but must be removed from old ones.
+	controllerutil.RemoveFinalizer(vmip, virtv2.FinalizerIPAddressProtection)
+
 	return reconcile.Result{}, nil
 }


### PR DESCRIPTION
## Description

Remove legacy finalizer `virtualization.deckhouse.io/vmip-protection` from `VirtualMachineIPAddress` resources. It no longer attaches to new resources, but must be removed from old ones.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
```changes
section: vmip
type: fix
summary: Fix the deletion of old VirtualMachineIPAddress resources that may have had a legacy finalizer blocking deletion.
```
