### PR TITLE
fix(images): fix names validation for images

### DIFF
--- a/images/virtualization-artifact/pkg/common/validate/validate.go
+++ b/images/virtualization-artifact/pkg/common/validate/validate.go
@@ -21,15 +21,15 @@ package validate
 // We add prefix "vd-" for the vd name, so max len reduced to 60.
 const MaxDiskNameLen = 60
 
-// MaxVirtualImageNameLen determines the max len of vi on dvcr.
+// MaxVirtualImageNameLen determines the max len of vi.
 // Disk and volume name in kubevirt can be a valid container name (len 63) since disk name can become a container name which will fail to schedule if invalid.
-// We add prefixes "vi-", so max len reduced to 60.
-const MaxVirtualImageNameLen = 60
+// We and kubevirt add prefixes "vi-", "volume" and suffix "-init", so max len reduced to 49.
+const MaxVirtualImageNameLen = 49
 
 // MaxClusterVirtualImageNameLen determines the max len of cvi.
 // Disk and volume name in kubevirt can be a valid container name (len 63) since disk name can become a container name which will fail to schedule if invalid.
-// We add prefixes "cvi-", so max len reduced to 59.
-const MaxClusterVirtualImageNameLen = 59
+// We and kubevirt add prefixes "cvi-", "volume" and suffix "-init", so max len reduced to 48.
+const MaxClusterVirtualImageNameLen = 48
 
 // MaxVirtualMachineNameLen determines the max len of vm.
 // The limitation is reportedly associated with the PodDisruptionBudget resource, which has a label containing the virtual machine's name, and the label's value cannot exceed 63 characters.

--- a/images/virtualization-artifact/pkg/common/validate/validate.go
+++ b/images/virtualization-artifact/pkg/common/validate/validate.go
@@ -22,13 +22,14 @@ package validate
 const MaxDiskNameLen = 60
 
 // MaxVirtualImageNameLen determines the max len of vi on dvcr.
-// This limitation is reportedly associated with mounting image to virtual machine as hotplug.
-const MaxVirtualImageNameLen = 37
+// Disk and volume name in kubevirt can be a valid container name (len 63) since disk name can become a container name which will fail to schedule if invalid.
+// We add prefixes "vi-", so max len reduced to 60.
+const MaxVirtualImageNameLen = 60
 
 // MaxClusterVirtualImageNameLen determines the max len of cvi.
 // Disk and volume name in kubevirt can be a valid container name (len 63) since disk name can become a container name which will fail to schedule if invalid.
-// We and kubevirt add prefixes "cvi-", "volume" and suffix "-init", so max len reduced to 48.
-const MaxClusterVirtualImageNameLen = 36
+// We add prefixes "cvi-", so max len reduced to 59.
+const MaxClusterVirtualImageNameLen = 59
 
 // MaxVirtualMachineNameLen determines the max len of vm.
 // The limitation is reportedly associated with the PodDisruptionBudget resource, which has a label containing the virtual machine's name, and the label's value cannot exceed 63 characters.


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Fix name validation for VirtualImage and ClusterVirtualImage to the actual length limit.

Actual length limits:

ClusterVirtualImage: 36 -> 48
VirtualImage: 37 -> 49

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: images
type: fix 
summary: |
   The allowed name lengths for resources have been adjusted and the corresponding validation has been added:
   - VirtualMachine: 63 characters
   - ClusterVirtualImage: 48 characters
   - VirtualImage: 49 characters
   - VirtualDisk: 60 characters
```
