### PR TITLE
chore(vmbda): add columns with blockdevice kind and name for wide output

### DIFF
--- a/api/core/v1alpha2/virtual_machine_block_device_attachment.go
+++ b/api/core/v1alpha2/virtual_machine_block_device_attachment.go
@@ -30,6 +30,8 @@ const (
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:categories={all,virtualization},scope=Namespaced,shortName={vmbda,vmbdas},singular=virtualmachineblockdeviceattachment
 // +kubebuilder:printcolumn:name="PHASE",type="string",JSONPath=".status.phase",description="VirtualMachineBlockDeviceAttachment phase."
+// +kubebuilder:printcolumn:name="BLOCKDEVICE KIND",type=string,JSONPath=`.spec.blockDeviceRef.kind`,priority=1,description="Attached blockdevice kind."
+// +kubebuilder:printcolumn:name="BLOCKDEVICE NAME",type=string,JSONPath=`.spec.blockDeviceRef.name`,priority=1,description="Attached blockdevice name."
 // +kubebuilder:printcolumn:name="VIRTUAL MACHINE NAME",type="string",JSONPath=".status.virtualMachineName",description="Name of the virtual machine the disk is attached to."
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp",description="Time of resource creation."
 // +genclient

--- a/crds/virtualmachineblockdeviceattachments.yaml
+++ b/crds/virtualmachineblockdeviceattachments.yaml
@@ -28,6 +28,16 @@ spec:
           jsonPath: .status.phase
           name: PHASE
           type: string
+        - description: Attached blockdevice kind.
+          jsonPath: .spec.blockDeviceRef.kind
+          name: BLOCKDEVICE KIND
+          priority: 1
+          type: string
+        - description: Attached blockdevice name.
+          jsonPath: .spec.blockDeviceRef.name
+          name: BLOCKDEVICE NAME
+          priority: 1
+          type: string
         - description: Name of the virtual machine the disk is attached to.
           jsonPath: .status.virtualMachineName
           name: VIRTUAL MACHINE NAME


### PR DESCRIPTION
## Description
add columns whit blockdevice kind and name for wide output


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: vmbda
type: chore
summary: add columns whit blockdevice kind and name for wide output
```
