### PR TITLE
chore: bump kubevirt to v1.3.1-v12n.5

### DIFF
--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -1,7 +1,7 @@
 ---
 # Source https://github.com/kubevirt/kubevirt/blob/v1.3.1/hack/dockerized#L15
 {{- $version := "v1.3.1" }}
-{{- $tag := print $version "-v12n.4"}}
+{{- $tag := print $version "-v12n.5"}}
 
 {{- $name := print $.ImageName "-dependencies" -}}
 {{- define "$name" -}}


### PR DESCRIPTION
## Description
bump kubevirt to "v1.3.1-v12n.5" 
- increase max length for hotplug containerDisk volumes
https://github.com/deckhouse/3p-kubevirt/pull/7
- drop openshift labels from controller namespace
https://github.com/deckhouse/3p-kubevirt/pull/5
<!---
  Describe your changes with technical details.
-->


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: core
type: fix
summary: Increase max length for hotplug containerDisk volumes. Drop openshift labels from controller namespace
impact_level: low
```
