### PR TITLE
fix(core): fix kubevirt HA replicas

### DIFF
--- a/templates/kubevirt/kubevirt.yaml
+++ b/templates/kubevirt/kubevirt.yaml
@@ -96,6 +96,16 @@ spec:
       resourceName: virt-handler
       patch: {{ include "kubevirt.virthandler_nodeseletor_strategic_patch_json" . }}
       type: strategic
+
+    # Set replicas based on HA settings
+    - resourceType: Deployment
+      resourceName: virt-api
+      patch: '[{"op":"replace","path":"/spec/replicas","value": {{ include "helm_lib_is_ha_to_value" (list . 3 1) }}}]'
+      type: json
+    - resourceType: Deployment
+      resourceName: virt-controller
+      patch: '[{"op":"replace","path":"/spec/replicas","value": {{ include "helm_lib_is_ha_to_value" (list . 2 1) }}}]'
+      type: json
     {{- if (include "helm_lib_ha_enabled" .) }}
     # HA settings for deploy/virt-api.
     - resourceType: Deployment
@@ -106,10 +116,6 @@ spec:
       resourceName: virt-api
       patch: {{ include "spec_strategy_rolling_update_patch" . }}
       type: strategic
-    - resourceType: Deployment
-      resourceName: virt-api
-      patch: '[{"op":"replace","path":"/spec/replicas","value":3}]'
-      type: json
     # HA settings for deploy/virt-controller.
     - resourceType: Deployment
       resourceName: virt-controller


### PR DESCRIPTION
Signed-off-by: Maksim Fedotov <maksim.fedotov@flant.com>

## Description
<!---
  Describe your changes with technical details.
-->


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: core
type: fix
summary: fix number of replicas for virt-api and virt-controller in disabled highAvailability mode
```
