### PR TITLE
fix(core): hotplug on sc like nfs

### DIFF
--- a/images/virt-handler/werf.inc.yaml
+++ b/images/virt-handler/werf.inc.yaml
@@ -54,6 +54,7 @@ packages:
 - libnftnl
 - libjansson4
 binaries:
+- /usr/bin/findmnt
 - /usr/bin/getfacl
 - /usr/bin/setfacl
 - /usr/sbin/nft


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Add missing binary findmnt than need for process hotplug in virt-handler

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
findmnt util need in virt-handler for hotplug disks that use storage class like nfs

findmnt getting info about mount point
```
type FindmntInfo struct {
    Target  string json:"target"
    Source  string json:"source"
    Fstype  string json:"fstype"
    Options string json:"options"
}
```

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
Hotplug vmbda should work

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: core
type: fix
summary: add missing binary findmnt than need for process hotplug
```
