### PR TITLE
fix(kubevirt): fix hotplug volumes in filesystem mode, bump kubevirt version to v1.3.1-v12n.6

### DIFF
--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -1,7 +1,7 @@
 ---
 # Source https://github.com/kubevirt/kubevirt/blob/v1.3.1/hack/dockerized#L15
 {{- $version := "v1.3.1" }}
-{{- $tag := print $version "-v12n.5"}}
+{{- $tag := print $version "-v12n.6"}}
 
 {{- $name := print $.ImageName "-dependencies" -}}
 {{- define "$name" -}}


### PR DESCRIPTION
## Description
Fix hotplug volumes in filesystem mode

Bump kubevirt version to v1.3.1-v12n.6
- https://github.com/deckhouse/3p-kubevirt/pull/8
<!---
  Describe your changes with technical details.
-->


## Why do we need it, and what problem does it solve?
To reduce the number of dependencies in the container by removing unnecessary binaries like findmnt.
Using the github.com/moby/sys/mountinfo library achieves the same functionality without external commands.


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: vm
type: fix
summary: Fix hotplug volumes in filesystem mode
```
