### PR TITLE
feat(api): deprecate the local-path-provisioner

### DIFF
--- a/images/virtualization-artifact/pkg/controller/service/base_storage_class_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/base_storage_class_service.go
@@ -18,6 +18,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"sort"
 
 	corev1 "k8s.io/api/core/v1"
@@ -74,4 +75,19 @@ func (s BaseStorageClassService) GetStorageClass(ctx context.Context, scName str
 
 func (s BaseStorageClassService) GetPersistentVolumeClaim(ctx context.Context, sup *supplements.Generator) (*corev1.PersistentVolumeClaim, error) {
 	return object.FetchObject(ctx, sup.PersistentVolumeClaim(), s.client, &corev1.PersistentVolumeClaim{})
+}
+
+func (s BaseStorageClassService) IsStorageClassDeprecated(ctx context.Context, scName string) (bool, error) {
+	sc, err := s.GetStorageClass(ctx, scName)
+	if err != nil {
+		return false, fmt.Errorf("failed to fetch the %q storage class: %w", scName, err)
+	}
+
+	if sc != nil {
+		if sc.Labels["module"] == "local-path-provisioner" {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }

--- a/images/virtualization-artifact/pkg/controller/vd/internal/interfaces.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/interfaces.go
@@ -49,4 +49,5 @@ type StorageClassService interface {
 	GetDefaultStorageClass(ctx context.Context) (*storagev1.StorageClass, error)
 	GetStorageClass(ctx context.Context, sc string) (*storagev1.StorageClass, error)
 	GetPersistentVolumeClaim(ctx context.Context, sup *supplements.Generator) (*corev1.PersistentVolumeClaim, error)
+	IsStorageClassDeprecated(ctx context.Context, scName string) (bool, error)
 }

--- a/images/virtualization-artifact/pkg/controller/vd/internal/mock.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/mock.go
@@ -543,6 +543,9 @@ var _ StorageClassService = &StorageClassServiceMock{}
 //			IsStorageClassAllowedFunc: func(sc string) bool {
 //				panic("mock out the IsStorageClassAllowed method")
 //			},
+//			IsStorageClassDeprecatedFunc: func(ctx context.Context, scName string) (bool, error) {
+//				panic("mock out the IsStorageClassDeprecated method")
+//			},
 //		}
 //
 //		// use mockedStorageClassService in code that requires StorageClassService
@@ -564,6 +567,9 @@ type StorageClassServiceMock struct {
 
 	// IsStorageClassAllowedFunc mocks the IsStorageClassAllowed method.
 	IsStorageClassAllowedFunc func(sc string) bool
+
+	// IsStorageClassDeprecatedFunc mocks the IsStorageClassDeprecated method.
+	IsStorageClassDeprecatedFunc func(ctx context.Context, scName string) (bool, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -596,12 +602,20 @@ type StorageClassServiceMock struct {
 			// Sc is the sc argument value.
 			Sc string
 		}
+		// IsStorageClassDeprecated holds details about calls to the IsStorageClassDeprecated method.
+		IsStorageClassDeprecated []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ScName is the scName argument value.
+			ScName string
+		}
 	}
 	lockGetDefaultStorageClass   sync.RWMutex
 	lockGetModuleStorageClass    sync.RWMutex
 	lockGetPersistentVolumeClaim sync.RWMutex
 	lockGetStorageClass          sync.RWMutex
 	lockIsStorageClassAllowed    sync.RWMutex
+	lockIsStorageClassDeprecated sync.RWMutex
 }
 
 // GetDefaultStorageClass calls GetDefaultStorageClassFunc.
@@ -769,5 +783,41 @@ func (mock *StorageClassServiceMock) IsStorageClassAllowedCalls() []struct {
 	mock.lockIsStorageClassAllowed.RLock()
 	calls = mock.calls.IsStorageClassAllowed
 	mock.lockIsStorageClassAllowed.RUnlock()
+	return calls
+}
+
+// IsStorageClassDeprecated calls IsStorageClassDeprecatedFunc.
+func (mock *StorageClassServiceMock) IsStorageClassDeprecated(ctx context.Context, scName string) (bool, error) {
+	if mock.IsStorageClassDeprecatedFunc == nil {
+		panic("StorageClassServiceMock.IsStorageClassDeprecatedFunc: method is nil but StorageClassService.IsStorageClassDeprecated was just called")
+	}
+	callInfo := struct {
+		Ctx    context.Context
+		ScName string
+	}{
+		Ctx:    ctx,
+		ScName: scName,
+	}
+	mock.lockIsStorageClassDeprecated.Lock()
+	mock.calls.IsStorageClassDeprecated = append(mock.calls.IsStorageClassDeprecated, callInfo)
+	mock.lockIsStorageClassDeprecated.Unlock()
+	return mock.IsStorageClassDeprecatedFunc(ctx, scName)
+}
+
+// IsStorageClassDeprecatedCalls gets all the calls that were made to IsStorageClassDeprecated.
+// Check the length with:
+//
+//	len(mockedStorageClassService.IsStorageClassDeprecatedCalls())
+func (mock *StorageClassServiceMock) IsStorageClassDeprecatedCalls() []struct {
+	Ctx    context.Context
+	ScName string
+} {
+	var calls []struct {
+		Ctx    context.Context
+		ScName string
+	}
+	mock.lockIsStorageClassDeprecated.RLock()
+	calls = mock.calls.IsStorageClassDeprecated
+	mock.lockIsStorageClassDeprecated.RUnlock()
 	return calls
 }

--- a/images/virtualization-artifact/pkg/controller/vd/internal/storageclass_ready_test.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/storageclass_ready_test.go
@@ -140,6 +140,9 @@ var _ = Describe("StorageClassReadyHandler Run", func() {
 			svc.GetStorageClassFunc = func(_ context.Context, _ string) (*storagev1.StorageClass, error) {
 				return sc, nil
 			}
+			svc.IsStorageClassDeprecatedFunc = func(_ context.Context, _ string) (bool, error) {
+				return false, nil
+			}
 
 			h := NewStorageClassReadyHandler(svc)
 			res, err := h.Handle(ctx, vd)
@@ -152,6 +155,9 @@ var _ = Describe("StorageClassReadyHandler Run", func() {
 		It("has not allowed StorageClass", func() {
 			svc.IsStorageClassAllowedFunc = func(_ string) bool {
 				return false
+			}
+			svc.IsStorageClassDeprecatedFunc = func(_ context.Context, _ string) (bool, error) {
+				return false, nil
 			}
 
 			h := NewStorageClassReadyHandler(svc)
@@ -169,6 +175,9 @@ var _ = Describe("StorageClassReadyHandler Run", func() {
 			svc.GetStorageClassFunc = func(_ context.Context, _ string) (*storagev1.StorageClass, error) {
 				sc.DeletionTimestamp = ptr.To(metav1.Now())
 				return sc, nil
+			}
+			svc.IsStorageClassDeprecatedFunc = func(_ context.Context, _ string) (bool, error) {
+				return false, nil
 			}
 
 			h := NewStorageClassReadyHandler(svc)
@@ -186,6 +195,9 @@ var _ = Describe("StorageClassReadyHandler Run", func() {
 			svc.GetStorageClassFunc = func(_ context.Context, _ string) (*storagev1.StorageClass, error) {
 				return nil, nil
 			}
+			svc.IsStorageClassDeprecatedFunc = func(_ context.Context, _ string) (bool, error) {
+				return false, nil
+			}
 
 			h := NewStorageClassReadyHandler(svc)
 			res, err := h.Handle(ctx, vd)
@@ -201,6 +213,10 @@ var _ = Describe("StorageClassReadyHandler Run", func() {
 			svc.GetModuleStorageClassFunc = func(_ context.Context) (*storagev1.StorageClass, error) {
 				return sc, nil
 			}
+			svc.IsStorageClassDeprecatedFunc = func(_ context.Context, _ string) (bool, error) {
+				return false, nil
+			}
+
 			h := NewStorageClassReadyHandler(svc)
 			res, err := h.Handle(ctx, vd)
 			Expect(err).To(BeNil())
@@ -213,6 +229,9 @@ var _ = Describe("StorageClassReadyHandler Run", func() {
 			svc.GetModuleStorageClassFunc = func(_ context.Context) (*storagev1.StorageClass, error) {
 				sc.DeletionTimestamp = ptr.To(metav1.Now())
 				return sc, nil
+			}
+			svc.IsStorageClassDeprecatedFunc = func(_ context.Context, _ string) (bool, error) {
+				return false, nil
 			}
 
 			h := NewStorageClassReadyHandler(svc)
@@ -235,6 +254,10 @@ var _ = Describe("StorageClassReadyHandler Run", func() {
 			svc.GetDefaultStorageClassFunc = func(_ context.Context) (*storagev1.StorageClass, error) {
 				return sc, nil
 			}
+			svc.IsStorageClassDeprecatedFunc = func(_ context.Context, _ string) (bool, error) {
+				return false, nil
+			}
+
 			h := NewStorageClassReadyHandler(svc)
 			res, err := h.Handle(ctx, vd)
 			Expect(err).To(BeNil())
@@ -247,6 +270,9 @@ var _ = Describe("StorageClassReadyHandler Run", func() {
 			svc.GetDefaultStorageClassFunc = func(_ context.Context) (*storagev1.StorageClass, error) {
 				sc.DeletionTimestamp = ptr.To(metav1.Now())
 				return sc, nil
+			}
+			svc.IsStorageClassDeprecatedFunc = func(_ context.Context, _ string) (bool, error) {
+				return false, nil
 			}
 
 			h := NewStorageClassReadyHandler(svc)

--- a/images/virtualization-artifact/pkg/controller/vd/vd_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vd/vd_controller.go
@@ -107,7 +107,7 @@ func NewController(
 
 	if err = builder.WebhookManagedBy(mgr).
 		For(&virtv2.VirtualDisk{}).
-		WithValidator(NewValidator(mgr.GetClient())).
+		WithValidator(NewValidator(mgr.GetClient(), scService)).
 		Complete(); err != nil {
 		return nil, err
 	}

--- a/images/virtualization-artifact/pkg/controller/vd/vd_webhook.go
+++ b/images/virtualization-artifact/pkg/controller/vd/vd_webhook.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	intsvc "github.com/deckhouse/virtualization-controller/pkg/controller/vd/internal/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vd/internal/validator"
 	"github.com/deckhouse/virtualization-controller/pkg/logger"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
@@ -38,11 +39,11 @@ type Validator struct {
 	validators []VirtualDiskValidator
 }
 
-func NewValidator(client client.Client) *Validator {
+func NewValidator(client client.Client, scService *intsvc.VirtualDiskStorageClassService) *Validator {
 	return &Validator{
 		validators: []VirtualDiskValidator{
 			validator.NewPVCSizeValidator(client),
-			validator.NewSpecChangesValidator(),
+			validator.NewSpecChangesValidator(client, scService),
 			validator.NewISOSourceValidator(client),
 			validator.NewNameValidator(),
 		},

--- a/images/virtualization-artifact/pkg/controller/vi/internal/interfaces.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/interfaces.go
@@ -46,4 +46,5 @@ type StorageClassService interface {
 	GetDefaultStorageClass(ctx context.Context) (*storagev1.StorageClass, error)
 	GetStorageClass(ctx context.Context, sc string) (*storagev1.StorageClass, error)
 	GetPersistentVolumeClaim(ctx context.Context, sup *supplements.Generator) (*corev1.PersistentVolumeClaim, error)
+	IsStorageClassDeprecated(ctx context.Context, scName string) (bool, error)
 }

--- a/images/virtualization-artifact/pkg/controller/vi/internal/mock.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/mock.go
@@ -326,6 +326,9 @@ var _ StorageClassService = &StorageClassServiceMock{}
 //			IsStorageClassAllowedFunc: func(sc string) bool {
 //				panic("mock out the IsStorageClassAllowed method")
 //			},
+//			IsStorageClassDeprecatedFunc: func(ctx context.Context, scName string) (bool, error) {
+//				panic("mock out the IsStorageClassDeprecated method")
+//			},
 //		}
 //
 //		// use mockedStorageClassService in code that requires StorageClassService
@@ -347,6 +350,9 @@ type StorageClassServiceMock struct {
 
 	// IsStorageClassAllowedFunc mocks the IsStorageClassAllowed method.
 	IsStorageClassAllowedFunc func(sc string) bool
+
+	// IsStorageClassDeprecatedFunc mocks the IsStorageClassDeprecated method.
+	IsStorageClassDeprecatedFunc func(ctx context.Context, scName string) (bool, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -379,12 +385,20 @@ type StorageClassServiceMock struct {
 			// Sc is the sc argument value.
 			Sc string
 		}
+		// IsStorageClassDeprecated holds details about calls to the IsStorageClassDeprecated method.
+		IsStorageClassDeprecated []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ScName is the scName argument value.
+			ScName string
+		}
 	}
 	lockGetDefaultStorageClass   sync.RWMutex
 	lockGetModuleStorageClass    sync.RWMutex
 	lockGetPersistentVolumeClaim sync.RWMutex
 	lockGetStorageClass          sync.RWMutex
 	lockIsStorageClassAllowed    sync.RWMutex
+	lockIsStorageClassDeprecated sync.RWMutex
 }
 
 // GetDefaultStorageClass calls GetDefaultStorageClassFunc.
@@ -552,5 +566,41 @@ func (mock *StorageClassServiceMock) IsStorageClassAllowedCalls() []struct {
 	mock.lockIsStorageClassAllowed.RLock()
 	calls = mock.calls.IsStorageClassAllowed
 	mock.lockIsStorageClassAllowed.RUnlock()
+	return calls
+}
+
+// IsStorageClassDeprecated calls IsStorageClassDeprecatedFunc.
+func (mock *StorageClassServiceMock) IsStorageClassDeprecated(ctx context.Context, scName string) (bool, error) {
+	if mock.IsStorageClassDeprecatedFunc == nil {
+		panic("StorageClassServiceMock.IsStorageClassDeprecatedFunc: method is nil but StorageClassService.IsStorageClassDeprecated was just called")
+	}
+	callInfo := struct {
+		Ctx    context.Context
+		ScName string
+	}{
+		Ctx:    ctx,
+		ScName: scName,
+	}
+	mock.lockIsStorageClassDeprecated.Lock()
+	mock.calls.IsStorageClassDeprecated = append(mock.calls.IsStorageClassDeprecated, callInfo)
+	mock.lockIsStorageClassDeprecated.Unlock()
+	return mock.IsStorageClassDeprecatedFunc(ctx, scName)
+}
+
+// IsStorageClassDeprecatedCalls gets all the calls that were made to IsStorageClassDeprecated.
+// Check the length with:
+//
+//	len(mockedStorageClassService.IsStorageClassDeprecatedCalls())
+func (mock *StorageClassServiceMock) IsStorageClassDeprecatedCalls() []struct {
+	Ctx    context.Context
+	ScName string
+} {
+	var calls []struct {
+		Ctx    context.Context
+		ScName string
+	}
+	mock.lockIsStorageClassDeprecated.RLock()
+	calls = mock.calls.IsStorageClassDeprecated
+	mock.lockIsStorageClassDeprecated.RUnlock()
 	return calls
 }

--- a/images/virtualization-artifact/pkg/controller/vi/internal/storageclass_ready_test.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/storageclass_ready_test.go
@@ -119,6 +119,10 @@ func newStorageClassServiceMock(existedStorageClass *string) *StorageClassServic
 		return nil, nil
 	}
 
+	storageClassServiceMock.IsStorageClassDeprecatedFunc = func(_ context.Context, _ string) (bool, error) {
+		return false, nil
+	}
+
 	storageClassServiceMock.GetStorageClassFunc = func(ctx context.Context, storageClassName string) (*storagev1.StorageClass, error) {
 		switch {
 		case existedStorageClass == nil:

--- a/images/virtualization-artifact/pkg/controller/vi/vi_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vi/vi_controller.go
@@ -101,7 +101,7 @@ func NewController(
 
 	if err = builder.WebhookManagedBy(mgr).
 		For(&virtv2.VirtualImage{}).
-		WithValidator(NewValidator(log)).
+		WithValidator(NewValidator(log, mgr.GetClient(), scService)).
 		Complete(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
For `VirtualDisk` and `VirtualImage` creation.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->
Support for storage classes managed by the local-path-provisioner module has been discontinued.
```changes
section: api
type: feature
summary: "The storage classes managed by the `local-path-provisioner` module are now deprecated for VirtualImage and VirtualDisk creation."
```
