### PR TITLE
fix(core) migrate-delete-renamed-validation-admission-policy

### DIFF
--- a/images/hooks/pkg/hooks/migrate-delete-renamed-validation-admission-policy/hook_test.go
+++ b/images/hooks/pkg/hooks/migrate-delete-renamed-validation-admission-policy/hook_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/deckhouse/deckhouse/pkg/log"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/deckhouse/module-sdk/pkg"
 	"github.com/deckhouse/module-sdk/testing/mock"
@@ -47,17 +48,12 @@ var _ = Describe("MigrateDeleteRenamedValidationAdmissionPolicy", func() {
 	newSnapshotPolicy := func(labels map[string]string) pkg.Snapshot {
 		snap := mock.NewSnapshotMock(GinkgoT())
 		snap.UnmarshalToMock.Set(func(v any) (err error) {
-			data, ok := v.(*vap)
-			// data, ok := v.(*unstructured.Unstructured)
+			data, ok := v.(*unstructured.Unstructured)
 			Expect(ok).To(BeTrue())
-			data.Name = policySnapshotName
-			data.Kind = "ValidatingAdmissionPolicy"
-			data.ApiVersion = "admissionregistration.k8s.io/v1"
-			data.Labels = labels
-			// data.SetName(policySnapshotName)
-			// data.SetKind("ValidatingAdmissionPolicy")
-			// data.SetAPIVersion("admissionregistration.k8s.io/v1")
-			// data.SetLabels(labels)
+			data.SetName(policySnapshotName)
+			data.SetKind("ValidatingAdmissionPolicy")
+			data.SetAPIVersion("admissionregistration.k8s.io/v1")
+			data.SetLabels(labels)
 			return nil
 		})
 		return snap
@@ -66,17 +62,12 @@ var _ = Describe("MigrateDeleteRenamedValidationAdmissionPolicy", func() {
 	newSnapshotBinding := func(labels map[string]string) pkg.Snapshot {
 		snap := mock.NewSnapshotMock(GinkgoT())
 		snap.UnmarshalToMock.Set(func(v any) (err error) {
-			data, ok := v.(*vap)
-			// data, ok := v.(*unstructured.Unstructured)
+			data, ok := v.(*unstructured.Unstructured)
 			Expect(ok).To(BeTrue())
-			data.Name = bindingSnapshotName
-			data.Kind = "ValidatingAdmissionPolicyBinding"
-			data.ApiVersion = "admissionregistration.k8s.io/v1"
-			data.Labels = labels
-			// data.SetName(bindingSnapshotName)
-			// data.SetKind("ValidatingAdmissionPolicyBinding")
-			// data.SetAPIVersion("admissionregistration.k8s.io/v1")
-			// data.SetLabels(labels)
+			data.SetName(bindingSnapshotName)
+			data.SetKind("ValidatingAdmissionPolicyBinding")
+			data.SetAPIVersion("admissionregistration.k8s.io/v1")
+			data.SetLabels(labels)
 			return nil
 		})
 		return snap


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Fixed jqfilter to get correct JSON and in subsequent processing (PR #1142 )

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: core
type: fix
summary: Fixed jqfilter to get correct JSON and in subsequent processing (PR #1142 )
impact_level: low
```
