### PR TITLE
chore(ci): add self-written components to svace

### DIFF
--- a/images/cdi-artifact/werf.inc.yaml
+++ b/images/cdi-artifact/werf.inc.yaml
@@ -124,7 +124,7 @@ shell:
   {{- include "debian packages clean" . | nindent 2 }}
 {{- else }}
   {{- include "alt packages proxy" . | nindent 2 }}
-  - apt-get -qq install -y musl-devel
+  - apt-get -qq install -y musl-devel musl-devel-static
   {{- include "alt packages clean" . | nindent 2 }}
 {{- end }}
   - |

--- a/images/cdi-artifact/werf.inc.yaml
+++ b/images/cdi-artifact/werf.inc.yaml
@@ -109,7 +109,7 @@ shell:
 ---
 image: {{ $.ImageName }}-cbuilder
 final: false
-fromImage: builder/golang-bookworm-1.23
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-bookworm-1.23" "builder/alt-go-svace" }}
 git:
   - add: /images/{{ $.ImageName }}/static_binaries
     to: /
@@ -118,14 +118,21 @@ git:
         - '*.c'
 shell:
   install:
+{{- if eq $.SVACE_ENABLED "false" }}
   {{- include "debian packages proxy" . | nindent 2 }}
-  - |
-    apt-get install --yes musl-dev musl-tools
+  - apt-get install --yes musl-dev musl-tools
   {{- include "debian packages clean" . | nindent 2 }}
+{{- else }}
+  {{- include "alt packages proxy" . | nindent 2 }}
+  - apt-get -qq install -y musl-devel
+  {{- include "alt packages clean" . | nindent 2 }}
+{{- end }}
   - |
     echo "Building simple app that prints hello cdi"
     mkdir -p /bins
-    musl-gcc -static -Os -o /bins/hello hello.c
-    musl-gcc -static -Os -o /bins/printFile print_file_context.c
+    {{- $_ := set $ "ProjectName" (list $.ImageName "hello" | join "/") }}
+    {{- include "image-build.build" (set $ "BuildCommand" `musl-gcc -static -Os -o /bins/hello hello.c`) | nindent 6 }}
+    {{- $_ := set $ "ProjectName" (list $.ImageName "printFile" | join "/") }}
+    {{- include "image-build.build" (set $ "BuildCommand" `musl-gcc -static -Os -o /bins/printFile print_file_context.c`) | nindent 6 }}
     strip /bins/hello
     strip /bins/printFile

--- a/images/cdi-cloner/werf.inc.yaml
+++ b/images/cdi-cloner/werf.inc.yaml
@@ -51,7 +51,7 @@ shell:
 ---
 image: {{ $.ImageName }}-gobuild
 final: false
-fromImage: builder/golang-bookworm-1.23
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-bookworm-1.23" "builder/alt-go-svace" }}
 git:
   - add: /images/{{ $.ImageName }}/cloner-startup
     to: /app
@@ -63,4 +63,5 @@ shell:
   - |
     mkdir -p /cdi-binaries
     cd /app
-    go build -ldflags="-s -w" -o /cdi-binaries/cloner-startup ./cmd/cloner-startup
+    {{- $_ := set $ "ProjectName" (list $.ImageName "cdi-cloner" | join "/") }}
+    {{- include "image-build.build" (set $ "BuildCommand" `go build -ldflags="-s -w" -o /cdi-binaries/cloner-startup ./cmd/cloner-startup`) | nindent 6 }}

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -461,7 +461,7 @@ shell:
 ---
 image: {{ $.ImageName }}-cbuilder
 final: false
-fromImage: builder/golang-bookworm-1.23
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-bookworm-1.23" "builder/alt-go-svace" }}
 git:
   - add: /images/{{ $.ImageName }}/static_binaries
     to: /
@@ -470,12 +470,20 @@ git:
         - '*.c'
 shell:
   beforeInstall:
+{{- if eq $.SVACE_ENABLED "false" }}
   {{- include "debian packages proxy" . | nindent 2 }}
   - apt-get install --yes musl-dev musl-tools
   {{- include "debian packages clean" . | nindent 2 }}
+{{- else }}
+  {{- include "alt packages proxy" . | nindent 2 }}
+  - apt-get -qq install -y musl-devel
+  {{- include "alt packages clean" . | nindent 2 }}
+{{- end }}
   install:
   - |
     echo "Building simple app that prints I'am temp pod"
     mkdir -p /bins
-    musl-gcc -static -Os -o /bins/temp_pod temp_pod.c
+
+    {{- $_ := set $ "ProjectName" (list $.ImageName "temp_pod" | join "/") }}
+    {{- include "image-build.build" (set $ "BuildCommand" `musl-gcc -static -Os -o /bins/temp_pod temp_pod.c`) | nindent 6 }}
     strip /bins/temp_pod

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -476,7 +476,7 @@ shell:
   {{- include "debian packages clean" . | nindent 2 }}
 {{- else }}
   {{- include "alt packages proxy" . | nindent 2 }}
-  - apt-get -qq install -y musl-devel
+  - apt-get -qq install -y musl-devel musl-devel-static
   {{- include "alt packages clean" . | nindent 2 }}
 {{- end }}
   install:


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Add self-written components (cloner-startup, hello, temp_pod) to svace.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: ci
type: chore 
summary: add self-written components to svace
```
