### PR TITLE
chore(tests): remove personal github account links from e2e tests

### DIFF
--- a/tests/e2e/default_config.yaml
+++ b/tests/e2e/default_config.yaml
@@ -8,7 +8,7 @@ clusterTransport:
   certificateAuthority: ""
 
 disks:
-  uploadHelperImage: "yaroslavborbat/curl-alpine-image"
+  uploadHelperImage: "cr.yandex/crpvs5j3nh1mi2tpithr/e2e/alpine/curl-alpine-image"
   cviTestDataDir: "./testdata/cvi"
   viTestDataDir: "./testdata/vi"
   vdTestDataDir: "./testdata/vd"

--- a/tests/e2e/testdata/complex-test/cvi/cvi-alpine-registry.yaml
+++ b/tests/e2e/testdata/complex-test/cvi/cvi-alpine-registry.yaml
@@ -7,4 +7,4 @@ spec:
   dataSource:
     type: ContainerImage
     containerImage:
-      image: docker.io/fl64/alpine-3.20:latest
+      image: cr.yandex/crpvs5j3nh1mi2tpithr/e2e/alpine/alpine-3-20:latest

--- a/tests/e2e/testdata/complex-test/vd/vd-alpine-registry.yaml
+++ b/tests/e2e/testdata/complex-test/vd/vd-alpine-registry.yaml
@@ -7,6 +7,6 @@ spec:
   dataSource:
     type: ContainerImage
     containerImage:
-      image: docker.io/fl64/alpine-3-20:latest
+      image: cr.yandex/crpvs5j3nh1mi2tpithr/e2e/alpine/alpine-3-20:latest
   persistentVolumeClaim:
     size: 3600Mi

--- a/tests/e2e/testdata/complex-test/vi/vi-alpine-registry.yaml
+++ b/tests/e2e/testdata/complex-test/vi/vi-alpine-registry.yaml
@@ -8,4 +8,4 @@ spec:
   dataSource:
     type: ContainerImage
     containerImage:
-      image: docker.io/fl64/alpine-3-20:latest
+      image: cr.yandex/crpvs5j3nh1mi2tpithr/e2e/alpine/alpine-3-20:latest

--- a/tests/e2e/testdata/cvi/cvi_containerimage.yaml
+++ b/tests/e2e/testdata/cvi/cvi_containerimage.yaml
@@ -6,7 +6,7 @@ spec:
   dataSource:
     type: ContainerImage
     containerImage:
-      image: "registry.hub.docker.com/yaroslavborbat/alpine-image:latest"
+      image: "cr.yandex/crpvs5j3nh1mi2tpithr/e2e/alpine/alpine-image:latest"
 
       # imagePullSecret:
       #   namespace: some-ns

--- a/tests/e2e/testdata/images-creation/cvi/cvi_containerimage.yaml
+++ b/tests/e2e/testdata/images-creation/cvi/cvi_containerimage.yaml
@@ -6,4 +6,4 @@ spec:
   dataSource:
     type: ContainerImage
     containerImage:
-      image: "registry.hub.docker.com/yaroslavborbat/alpine-image:latest"
+      image: "cr.yandex/crpvs5j3nh1mi2tpithr/e2e/alpine/alpine-image:latest"

--- a/tests/e2e/testdata/images-creation/vi/vi_containerimage.yaml
+++ b/tests/e2e/testdata/images-creation/vi/vi_containerimage.yaml
@@ -10,7 +10,7 @@ spec:
   dataSource:
     type: ContainerImage
     containerImage:
-      image: "registry.hub.docker.com/yaroslavborbat/alpine-image:latest"
+      image: "cr.yandex/crpvs5j3nh1mi2tpithr/e2e/alpine/alpine-image:latest"
 ---
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualImage
@@ -24,4 +24,4 @@ spec:
   dataSource:
     type: ContainerImage
     containerImage:
-      image: "registry.hub.docker.com/yaroslavborbat/alpine-image:latest"
+      image: "cr.yandex/crpvs5j3nh1mi2tpithr/e2e/alpine/alpine-image:latest"

--- a/tests/e2e/testdata/vd/vd_containerimage.yaml
+++ b/tests/e2e/testdata/vd/vd_containerimage.yaml
@@ -11,4 +11,4 @@ spec:
   dataSource:
     type: ContainerImage
     containerImage:
-      image: "registry.hub.docker.com/yaroslavborbat/alpine-image:latest"
+      image: "cr.yandex/crpvs5j3nh1mi2tpithr/e2e/alpine/alpine-image:latest"

--- a/tests/e2e/testdata/vi/vi_containerimage.yaml
+++ b/tests/e2e/testdata/vi/vi_containerimage.yaml
@@ -10,7 +10,7 @@ spec:
   dataSource:
     type: ContainerImage
     containerImage:
-      image: "registry.hub.docker.com/yaroslavborbat/alpine-image:latest"
+      image: "cr.yandex/crpvs5j3nh1mi2tpithr/e2e/alpine/alpine-image:latest"
 #      imagePullSecret:
 #        namespace: some-ns
 #        caBundle: secret with ca bandle


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Remove personal github account links from e2e tests

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: images
type: chore
summary: remove personal github account links from e2e tests
impact_level: low
```
