### PR TITLE
feat(kubevirt): support vpc and read-only containers, bump kubevirt version to v1.3.1-v12n.7

### DIFF
--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -1,7 +1,7 @@
 ---
 # Source https://github.com/kubevirt/kubevirt/blob/v1.3.1/hack/dockerized#L15
 {{- $version := "v1.3.1" }}
-{{- $tag := print $version "-v12n.6"}}
+{{- $tag := print $version "-v12n.7"}}
 
 {{- $name := print $.ImageName "-dependencies" -}}
 {{- define "$name" -}}

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -120,6 +120,7 @@ packages:
   - policycoreutils
   - psmisc
   - msulogin
+  - iproute2
 binaries:
   # Gnu utils (requared for swtpm)
   - /usr/bin/certtool
@@ -135,6 +136,8 @@ binaries:
   - /usr/sbin/biosdecode /usr/sbin/dmidecode
   # Numactl
   - /usr/bin/memhog /usr/bin/migratepages /usr/bin/migspeed /usr/bin/numactl /usr/bin/numastat
+  # Iproute2
+  - /usr/sbin/tc
 {{- end -}}
 
 {{ $virtLauncherDependencies := include "virt-launcher-dependencies" . | fromYaml }}


### PR DESCRIPTION
## Description
support vpc and read-only containers
bump kubevirt version to v1.3.1-v12n.7 
- https://github.com/deckhouse/3p-kubevirt/pull/10
- https://github.com/deckhouse/3p-kubevirt/pull/9


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: core
type: feature
summary: support vpc and read-only containers, bump kubevirt version to v1.3.1-v12n.7
impact_level: low
```
