### PR TITLE
refactor(api): simplify IsStorageClassDeprecated method signature

### DIFF
--- a/images/virtualization-artifact/pkg/controller/service/base_storage_class_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/base_storage_class_service.go
@@ -18,7 +18,6 @@ package service
 
 import (
 	"context"
-	"fmt"
 	"sort"
 
 	corev1 "k8s.io/api/core/v1"
@@ -77,17 +76,6 @@ func (s BaseStorageClassService) GetPersistentVolumeClaim(ctx context.Context, s
 	return object.FetchObject(ctx, sup.PersistentVolumeClaim(), s.client, &corev1.PersistentVolumeClaim{})
 }
 
-func (s BaseStorageClassService) IsStorageClassDeprecated(ctx context.Context, scName string) (bool, error) {
-	sc, err := s.GetStorageClass(ctx, scName)
-	if err != nil {
-		return false, fmt.Errorf("failed to fetch the %q storage class: %w", scName, err)
-	}
-
-	if sc != nil {
-		if sc.Labels["module"] == "local-path-provisioner" {
-			return true, nil
-		}
-	}
-
-	return false, nil
+func (s BaseStorageClassService) IsStorageClassDeprecated(sc *storagev1.StorageClass) bool {
+	return sc != nil && sc.Labels["module"] == "local-path-provisioner"
 }

--- a/images/virtualization-artifact/pkg/controller/vd/internal/interfaces.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/interfaces.go
@@ -49,5 +49,5 @@ type StorageClassService interface {
 	GetDefaultStorageClass(ctx context.Context) (*storagev1.StorageClass, error)
 	GetStorageClass(ctx context.Context, sc string) (*storagev1.StorageClass, error)
 	GetPersistentVolumeClaim(ctx context.Context, sup *supplements.Generator) (*corev1.PersistentVolumeClaim, error)
-	IsStorageClassDeprecated(ctx context.Context, scName string) (bool, error)
+	IsStorageClassDeprecated(sc *storagev1.StorageClass) bool
 }

--- a/images/virtualization-artifact/pkg/controller/vd/internal/mock.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/mock.go
@@ -543,7 +543,7 @@ var _ StorageClassService = &StorageClassServiceMock{}
 //			IsStorageClassAllowedFunc: func(sc string) bool {
 //				panic("mock out the IsStorageClassAllowed method")
 //			},
-//			IsStorageClassDeprecatedFunc: func(ctx context.Context, scName string) (bool, error) {
+//			IsStorageClassDeprecatedFunc: func(sc *storagev1.StorageClass) bool {
 //				panic("mock out the IsStorageClassDeprecated method")
 //			},
 //		}
@@ -569,7 +569,7 @@ type StorageClassServiceMock struct {
 	IsStorageClassAllowedFunc func(sc string) bool
 
 	// IsStorageClassDeprecatedFunc mocks the IsStorageClassDeprecated method.
-	IsStorageClassDeprecatedFunc func(ctx context.Context, scName string) (bool, error)
+	IsStorageClassDeprecatedFunc func(sc *storagev1.StorageClass) bool
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -604,10 +604,8 @@ type StorageClassServiceMock struct {
 		}
 		// IsStorageClassDeprecated holds details about calls to the IsStorageClassDeprecated method.
 		IsStorageClassDeprecated []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// ScName is the scName argument value.
-			ScName string
+			// Sc is the sc argument value.
+			Sc *storagev1.StorageClass
 		}
 	}
 	lockGetDefaultStorageClass   sync.RWMutex
@@ -787,21 +785,19 @@ func (mock *StorageClassServiceMock) IsStorageClassAllowedCalls() []struct {
 }
 
 // IsStorageClassDeprecated calls IsStorageClassDeprecatedFunc.
-func (mock *StorageClassServiceMock) IsStorageClassDeprecated(ctx context.Context, scName string) (bool, error) {
+func (mock *StorageClassServiceMock) IsStorageClassDeprecated(sc *storagev1.StorageClass) bool {
 	if mock.IsStorageClassDeprecatedFunc == nil {
 		panic("StorageClassServiceMock.IsStorageClassDeprecatedFunc: method is nil but StorageClassService.IsStorageClassDeprecated was just called")
 	}
 	callInfo := struct {
-		Ctx    context.Context
-		ScName string
+		Sc *storagev1.StorageClass
 	}{
-		Ctx:    ctx,
-		ScName: scName,
+		Sc: sc,
 	}
 	mock.lockIsStorageClassDeprecated.Lock()
 	mock.calls.IsStorageClassDeprecated = append(mock.calls.IsStorageClassDeprecated, callInfo)
 	mock.lockIsStorageClassDeprecated.Unlock()
-	return mock.IsStorageClassDeprecatedFunc(ctx, scName)
+	return mock.IsStorageClassDeprecatedFunc(sc)
 }
 
 // IsStorageClassDeprecatedCalls gets all the calls that were made to IsStorageClassDeprecated.
@@ -809,12 +805,10 @@ func (mock *StorageClassServiceMock) IsStorageClassDeprecated(ctx context.Contex
 //
 //	len(mockedStorageClassService.IsStorageClassDeprecatedCalls())
 func (mock *StorageClassServiceMock) IsStorageClassDeprecatedCalls() []struct {
-	Ctx    context.Context
-	ScName string
+	Sc *storagev1.StorageClass
 } {
 	var calls []struct {
-		Ctx    context.Context
-		ScName string
+		Sc *storagev1.StorageClass
 	}
 	mock.lockIsStorageClassDeprecated.RLock()
 	calls = mock.calls.IsStorageClassDeprecated

--- a/images/virtualization-artifact/pkg/controller/vd/internal/storageclass_ready_test.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/storageclass_ready_test.go
@@ -140,8 +140,8 @@ var _ = Describe("StorageClassReadyHandler Run", func() {
 			svc.GetStorageClassFunc = func(_ context.Context, _ string) (*storagev1.StorageClass, error) {
 				return sc, nil
 			}
-			svc.IsStorageClassDeprecatedFunc = func(_ context.Context, _ string) (bool, error) {
-				return false, nil
+			svc.IsStorageClassDeprecatedFunc = func(_ *storagev1.StorageClass) bool {
+				return false
 			}
 
 			h := NewStorageClassReadyHandler(svc)
@@ -156,8 +156,11 @@ var _ = Describe("StorageClassReadyHandler Run", func() {
 			svc.IsStorageClassAllowedFunc = func(_ string) bool {
 				return false
 			}
-			svc.IsStorageClassDeprecatedFunc = func(_ context.Context, _ string) (bool, error) {
-				return false, nil
+			svc.IsStorageClassDeprecatedFunc = func(_ *storagev1.StorageClass) bool {
+				return false
+			}
+			svc.GetStorageClassFunc = func(_ context.Context, _ string) (*storagev1.StorageClass, error) {
+				return nil, nil
 			}
 
 			h := NewStorageClassReadyHandler(svc)
@@ -176,8 +179,8 @@ var _ = Describe("StorageClassReadyHandler Run", func() {
 				sc.DeletionTimestamp = ptr.To(metav1.Now())
 				return sc, nil
 			}
-			svc.IsStorageClassDeprecatedFunc = func(_ context.Context, _ string) (bool, error) {
-				return false, nil
+			svc.IsStorageClassDeprecatedFunc = func(_ *storagev1.StorageClass) bool {
+				return false
 			}
 
 			h := NewStorageClassReadyHandler(svc)
@@ -195,8 +198,8 @@ var _ = Describe("StorageClassReadyHandler Run", func() {
 			svc.GetStorageClassFunc = func(_ context.Context, _ string) (*storagev1.StorageClass, error) {
 				return nil, nil
 			}
-			svc.IsStorageClassDeprecatedFunc = func(_ context.Context, _ string) (bool, error) {
-				return false, nil
+			svc.IsStorageClassDeprecatedFunc = func(_ *storagev1.StorageClass) bool {
+				return false
 			}
 
 			h := NewStorageClassReadyHandler(svc)
@@ -213,8 +216,8 @@ var _ = Describe("StorageClassReadyHandler Run", func() {
 			svc.GetModuleStorageClassFunc = func(_ context.Context) (*storagev1.StorageClass, error) {
 				return sc, nil
 			}
-			svc.IsStorageClassDeprecatedFunc = func(_ context.Context, _ string) (bool, error) {
-				return false, nil
+			svc.IsStorageClassDeprecatedFunc = func(_ *storagev1.StorageClass) bool {
+				return false
 			}
 
 			h := NewStorageClassReadyHandler(svc)
@@ -230,8 +233,8 @@ var _ = Describe("StorageClassReadyHandler Run", func() {
 				sc.DeletionTimestamp = ptr.To(metav1.Now())
 				return sc, nil
 			}
-			svc.IsStorageClassDeprecatedFunc = func(_ context.Context, _ string) (bool, error) {
-				return false, nil
+			svc.IsStorageClassDeprecatedFunc = func(_ *storagev1.StorageClass) bool {
+				return false
 			}
 
 			h := NewStorageClassReadyHandler(svc)
@@ -254,8 +257,8 @@ var _ = Describe("StorageClassReadyHandler Run", func() {
 			svc.GetDefaultStorageClassFunc = func(_ context.Context) (*storagev1.StorageClass, error) {
 				return sc, nil
 			}
-			svc.IsStorageClassDeprecatedFunc = func(_ context.Context, _ string) (bool, error) {
-				return false, nil
+			svc.IsStorageClassDeprecatedFunc = func(_ *storagev1.StorageClass) bool {
+				return false
 			}
 
 			h := NewStorageClassReadyHandler(svc)
@@ -271,8 +274,8 @@ var _ = Describe("StorageClassReadyHandler Run", func() {
 				sc.DeletionTimestamp = ptr.To(metav1.Now())
 				return sc, nil
 			}
-			svc.IsStorageClassDeprecatedFunc = func(_ context.Context, _ string) (bool, error) {
-				return false, nil
+			svc.IsStorageClassDeprecatedFunc = func(_ *storagev1.StorageClass) bool {
+				return false
 			}
 
 			h := NewStorageClassReadyHandler(svc)

--- a/images/virtualization-artifact/pkg/controller/vd/internal/validator/spec_changes_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/validator/spec_changes_validator.go
@@ -46,11 +46,11 @@ func NewSpecChangesValidator(client client.Client, scService *intsvc.VirtualDisk
 
 func (v *SpecChangesValidator) ValidateCreate(ctx context.Context, newVD *virtv2.VirtualDisk) (admission.Warnings, error) {
 	if newVD.Spec.PersistentVolumeClaim.StorageClass != nil && *newVD.Spec.PersistentVolumeClaim.StorageClass != "" {
-		deprecated, err := v.scService.IsStorageClassDeprecated(ctx, *newVD.Spec.PersistentVolumeClaim.StorageClass)
+		sc, err := v.scService.GetStorageClass(ctx, *newVD.Spec.PersistentVolumeClaim.StorageClass)
 		if err != nil {
 			return nil, err
 		}
-		if deprecated {
+		if v.scService.IsStorageClassDeprecated(sc) {
 			return nil, fmt.Errorf(
 				"the provisioner of the %q storage class is deprecated; please use a different one",
 				*newVD.Spec.PersistentVolumeClaim.StorageClass,
@@ -82,11 +82,11 @@ func (v *SpecChangesValidator) ValidateUpdate(ctx context.Context, oldVD, newVD 
 		}
 	case newVD.Status.Phase == virtv2.DiskPending:
 		if newVD.Spec.PersistentVolumeClaim.StorageClass != nil && *newVD.Spec.PersistentVolumeClaim.StorageClass != "" {
-			deprecated, err := v.scService.IsStorageClassDeprecated(ctx, *newVD.Spec.PersistentVolumeClaim.StorageClass)
+			sc, err := v.scService.GetStorageClass(ctx, *newVD.Spec.PersistentVolumeClaim.StorageClass)
 			if err != nil {
 				return nil, err
 			}
-			if deprecated {
+			if v.scService.IsStorageClassDeprecated(sc) {
 				return nil, fmt.Errorf(
 					"the provisioner of the %q storage class is deprecated; please use a different one",
 					*newVD.Spec.PersistentVolumeClaim.StorageClass,

--- a/images/virtualization-artifact/pkg/controller/vi/internal/interfaces.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/interfaces.go
@@ -46,5 +46,5 @@ type StorageClassService interface {
 	GetDefaultStorageClass(ctx context.Context) (*storagev1.StorageClass, error)
 	GetStorageClass(ctx context.Context, sc string) (*storagev1.StorageClass, error)
 	GetPersistentVolumeClaim(ctx context.Context, sup *supplements.Generator) (*corev1.PersistentVolumeClaim, error)
-	IsStorageClassDeprecated(ctx context.Context, scName string) (bool, error)
+	IsStorageClassDeprecated(sc *storagev1.StorageClass) bool
 }

--- a/images/virtualization-artifact/pkg/controller/vi/internal/mock.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/mock.go
@@ -326,7 +326,7 @@ var _ StorageClassService = &StorageClassServiceMock{}
 //			IsStorageClassAllowedFunc: func(sc string) bool {
 //				panic("mock out the IsStorageClassAllowed method")
 //			},
-//			IsStorageClassDeprecatedFunc: func(ctx context.Context, scName string) (bool, error) {
+//			IsStorageClassDeprecatedFunc: func(sc *storagev1.StorageClass) bool {
 //				panic("mock out the IsStorageClassDeprecated method")
 //			},
 //		}
@@ -352,7 +352,7 @@ type StorageClassServiceMock struct {
 	IsStorageClassAllowedFunc func(sc string) bool
 
 	// IsStorageClassDeprecatedFunc mocks the IsStorageClassDeprecated method.
-	IsStorageClassDeprecatedFunc func(ctx context.Context, scName string) (bool, error)
+	IsStorageClassDeprecatedFunc func(sc *storagev1.StorageClass) bool
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -387,10 +387,8 @@ type StorageClassServiceMock struct {
 		}
 		// IsStorageClassDeprecated holds details about calls to the IsStorageClassDeprecated method.
 		IsStorageClassDeprecated []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// ScName is the scName argument value.
-			ScName string
+			// Sc is the sc argument value.
+			Sc *storagev1.StorageClass
 		}
 	}
 	lockGetDefaultStorageClass   sync.RWMutex
@@ -570,21 +568,19 @@ func (mock *StorageClassServiceMock) IsStorageClassAllowedCalls() []struct {
 }
 
 // IsStorageClassDeprecated calls IsStorageClassDeprecatedFunc.
-func (mock *StorageClassServiceMock) IsStorageClassDeprecated(ctx context.Context, scName string) (bool, error) {
+func (mock *StorageClassServiceMock) IsStorageClassDeprecated(sc *storagev1.StorageClass) bool {
 	if mock.IsStorageClassDeprecatedFunc == nil {
 		panic("StorageClassServiceMock.IsStorageClassDeprecatedFunc: method is nil but StorageClassService.IsStorageClassDeprecated was just called")
 	}
 	callInfo := struct {
-		Ctx    context.Context
-		ScName string
+		Sc *storagev1.StorageClass
 	}{
-		Ctx:    ctx,
-		ScName: scName,
+		Sc: sc,
 	}
 	mock.lockIsStorageClassDeprecated.Lock()
 	mock.calls.IsStorageClassDeprecated = append(mock.calls.IsStorageClassDeprecated, callInfo)
 	mock.lockIsStorageClassDeprecated.Unlock()
-	return mock.IsStorageClassDeprecatedFunc(ctx, scName)
+	return mock.IsStorageClassDeprecatedFunc(sc)
 }
 
 // IsStorageClassDeprecatedCalls gets all the calls that were made to IsStorageClassDeprecated.
@@ -592,12 +588,10 @@ func (mock *StorageClassServiceMock) IsStorageClassDeprecated(ctx context.Contex
 //
 //	len(mockedStorageClassService.IsStorageClassDeprecatedCalls())
 func (mock *StorageClassServiceMock) IsStorageClassDeprecatedCalls() []struct {
-	Ctx    context.Context
-	ScName string
+	Sc *storagev1.StorageClass
 } {
 	var calls []struct {
-		Ctx    context.Context
-		ScName string
+		Sc *storagev1.StorageClass
 	}
 	mock.lockIsStorageClassDeprecated.RLock()
 	calls = mock.calls.IsStorageClassDeprecated

--- a/images/virtualization-artifact/pkg/controller/vi/internal/storageclass_ready_test.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/storageclass_ready_test.go
@@ -119,8 +119,8 @@ func newStorageClassServiceMock(existedStorageClass *string) *StorageClassServic
 		return nil, nil
 	}
 
-	storageClassServiceMock.IsStorageClassDeprecatedFunc = func(_ context.Context, _ string) (bool, error) {
-		return false, nil
+	storageClassServiceMock.IsStorageClassDeprecatedFunc = func(_ *storagev1.StorageClass) bool {
+		return false
 	}
 
 	storageClassServiceMock.GetStorageClassFunc = func(ctx context.Context, storageClassName string) (*storagev1.StorageClass, error) {

--- a/images/virtualization-artifact/pkg/controller/vi/vi_webhook.go
+++ b/images/virtualization-artifact/pkg/controller/vi/vi_webhook.go
@@ -73,11 +73,11 @@ func (v *Validator) ValidateCreate(ctx context.Context, obj runtime.Object) (adm
 	}
 
 	if vi.Spec.PersistentVolumeClaim.StorageClass != nil && *vi.Spec.PersistentVolumeClaim.StorageClass != "" {
-		deprecated, err := v.scService.IsStorageClassDeprecated(ctx, *vi.Spec.PersistentVolumeClaim.StorageClass)
+		sc, err := v.scService.GetStorageClass(ctx, *vi.Spec.PersistentVolumeClaim.StorageClass)
 		if err != nil {
 			return nil, err
 		}
-		if deprecated {
+		if v.scService.IsStorageClassDeprecated(sc) {
 			return nil, fmt.Errorf(
 				"the provisioner of the %q storage class is deprecated; please use a different one",
 				*vi.Spec.PersistentVolumeClaim.StorageClass,
@@ -123,11 +123,11 @@ func (v *Validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.O
 		}
 	case newVI.Status.Phase == virtv2.ImagePending:
 		if newVI.Spec.PersistentVolumeClaim.StorageClass != nil && *newVI.Spec.PersistentVolumeClaim.StorageClass != "" {
-			deprecated, err := v.scService.IsStorageClassDeprecated(ctx, *newVI.Spec.PersistentVolumeClaim.StorageClass)
+			sc, err := v.scService.GetStorageClass(ctx, *newVI.Spec.PersistentVolumeClaim.StorageClass)
 			if err != nil {
 				return nil, err
 			}
-			if deprecated {
+			if v.scService.IsStorageClassDeprecated(sc) {
 				return nil, fmt.Errorf(
 					"the provisioner of the %q storage class is deprecated; please use a different one",
 					*newVI.Spec.PersistentVolumeClaim.StorageClass,


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Update the IsStorageClassDeprecated method to accept a StorageClass pointer instead of a string.  Adjust related mock implementations and tests accordingly. Fix linter errors.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
This change improves type safety and reduces the need for additional lookups.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: api
type: chore
summary: Update the IsStorageClassDeprecated method to accept a StorageClass pointer instead of a string.
```
