### PR TITLE
fix(vm): fix metric awaitingRestartToApplyConfiguration

### DIFF
--- a/images/virtualization-artifact/pkg/monitoring/metrics/virtualmachine/data_metric.go
+++ b/images/virtualization-artifact/pkg/monitoring/metrics/virtualmachine/data_metric.go
@@ -68,24 +68,16 @@ func newDataMetric(vm *virtv2.VirtualMachine) *dataMetric {
 	)
 
 	awaitingRestartToApplyConfigurationCondition, _ := conditions.GetCondition(vmcondition.TypeAwaitingRestartToApplyConfiguration, vm.Status.Conditions)
-	if awaitingRestartToApplyConfigurationCondition.Status == metav1.ConditionFalse {
-		awaitingRestartToApplyConfiguration = true
-	}
+	awaitingRestartToApplyConfiguration = awaitingRestartToApplyConfigurationCondition.Status == metav1.ConditionTrue
 
 	configurationAppliedCondition, _ := conditions.GetCondition(vmcondition.TypeConfigurationApplied, vm.Status.Conditions)
-	if configurationAppliedCondition.Status != metav1.ConditionFalse {
-		configurationApplied = true
-	}
+	configurationApplied = configurationAppliedCondition.Status != metav1.ConditionFalse
 
 	agentReadyCondition, _ := conditions.GetCondition(vmcondition.TypeAgentReady, vm.Status.Conditions)
-	if agentReadyCondition.Status == metav1.ConditionTrue {
-		agentReady = true
-	}
+	agentReady = agentReadyCondition.Status == metav1.ConditionTrue
 
 	firmwareUpToDateCondition, _ := conditions.GetCondition(vmcondition.TypeFirmwareUpToDate, vm.Status.Conditions)
-	if firmwareUpToDateCondition.Status != metav1.ConditionFalse {
-		firmwareUpToDate = true
-	}
+	firmwareUpToDate = firmwareUpToDateCondition.Status != metav1.ConditionFalse
 
 	pods := make([]virtv2.VirtualMachinePod, len(vm.Status.VirtualMachinePods))
 	for i, pod := range vm.Status.VirtualMachinePods {


### PR DESCRIPTION
## Description
fix metric awaitingRestartToApplyConfiguration


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: vm
type: fix
summary: fix metric awaitingRestartToApplyConfiguration
impact_level: low
```
