### PR TITLE
chore(core): add cluster dns in cert for audit controller

### DIFF
--- a/images/hooks/pkg/hooks/tls-certificates-audit/hook.go
+++ b/images/hooks/pkg/hooks/tls-certificates-audit/hook.go
@@ -11,7 +11,6 @@ package tls_certificates_audit
 import (
 	"context"
 	"fmt"
-
 	"hooks/pkg/settings"
 
 	tlscertificate "github.com/deckhouse/module-sdk/common-hooks/tls-certificate"
@@ -32,6 +31,8 @@ var conf = tlscertificate.GenSelfSignedTLSHookConf{
 		fmt.Sprintf("%s.%s", settings.AuditCertCN, settings.ModuleNamespace),
 		// virtualization-audit.d8-virtualization.svc
 		fmt.Sprintf("%s.%s.svc", settings.AuditCertCN, settings.ModuleNamespace),
+		// virtualization-audit.d8-virtualization.svc.cluster.local
+		tlscertificate.ClusterDomainSAN(fmt.Sprintf("%s.%s.svc", settings.AuditCertCN, settings.ModuleNamespace)),
 	}),
 
 	FullValuesPathPrefix: fmt.Sprintf("%s.internal.audit.cert", settings.ModuleName),


### PR DESCRIPTION
## Description
After some time, ClientHello from vector receives a record from cluster.local, even though the domain is specified without it. It is necessary to have a cluster.local DNS record in the certificate. Updated the creation of a hook for correct DNS records in the certificate.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: core
type: chore
summary: Add cluster dns in cert for audit controller.
impact_level: low
```
