### PR TITLE
test(vmrestore): fix labels in the e2e test case

### DIFF
--- a/tests/e2e/vm_restore_force_test.go
+++ b/tests/e2e/vm_restore_force_test.go
@@ -172,7 +172,7 @@ var _ = Describe("VirtualMachineRestoreForce", SIGRestoration(), ginkgoutil.Comm
 						string(virtv2.BlockDeviceAttachmentPhaseAttached),
 						kc.WaitOptions{
 							Namespace: vm.Namespace,
-							Labels:    testCaseLabel,
+							Labels:    additionalDiskLabel,
 							Timeout:   LongWaitDuration,
 						})
 					err := GetObject(virtv2.VirtualMachineKind, vm.Name, &vm, kc.GetOptions{Namespace: vm.Namespace})


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
The `VirtualMachineRestore` end-to-end test case should pass.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: api
type: chore
summary: "Incorrect labels were fixed in the `VirtualMachineRestore` end-to-end test case."
impact_level: low
```
