### PR TITLE
fix(core): audit controller nil pointer

### DIFF
--- a/images/virtualization-artifact/pkg/audit/events/module/module_control.go
+++ b/images/virtualization-artifact/pkg/audit/events/module/module_control.go
@@ -85,7 +85,7 @@ func (m *ModuleControl) Fill() error {
 		return nil
 	}
 
-	if (m.event.Verb == "patch" || m.event.Verb == "update") && !*moduleConfig.Spec.Enabled {
+	if (m.event.Verb == "patch" || m.event.Verb == "update") && (moduleConfig.Spec.Enabled != nil && !*moduleConfig.Spec.Enabled) {
 		m.eventLog.Name = "Module disabled"
 		m.eventLog.Level = "warn"
 	}

--- a/images/virtualization-artifact/pkg/audit/events/module/module_control_test.go
+++ b/images/virtualization-artifact/pkg/audit/events/module/module_control_test.go
@@ -47,6 +47,7 @@ type moduleControlTestArgs struct {
 	customObjectRefNil     bool
 	customStage            audit.Stage
 	customDisabledModule   bool
+	customNilEnabledModule bool
 	shouldFailMatch        bool
 }
 
@@ -78,7 +79,7 @@ var _ = Describe("Module control Events", func() {
 		modConfig = &mcapi.ModuleConfig{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-moduleconfig", Namespace: "test", UID: "0000-0000-4567"},
 			Spec: mcapi.ModuleConfigSpec{
-				Enabled: ptr.To(true),
+				Enabled: nil,
 			},
 		}
 
@@ -149,6 +150,10 @@ var _ = Describe("Module control Events", func() {
 			if args.shouldFailMatch {
 				Expect(eventLog.IsMatched()).To(BeFalse())
 				return
+			}
+
+			if args.customNilEnabledModule {
+				modConfig.Spec.Enabled = nil
 			}
 
 			Expect(eventLog.IsMatched()).To(BeTrue())
@@ -241,6 +246,13 @@ var _ = Describe("Module control Events", func() {
 			expectedLevel:      "warn",
 			expectedActionType: "delete",
 			shouldLostModule:   true,
+		}),
+		Entry("Module Control event shouldn't failed fill with null enabled", moduleControlTestArgs{
+			eventVerb:              "delete",
+			expectedName:           "Module deletion",
+			expectedLevel:          "warn",
+			expectedActionType:     "delete",
+			customNilEnabledModule: true,
 		}),
 	)
 })


### PR DESCRIPTION
## Description
Added nil check for audit controller. This error occurs when one of the moduleconfigs with a missing enabled field is updated.

## Why do we need it, and what problem does it solve?
Fixes nil pointer error.


## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: core
type: fix
summary: Fix nil pointer error that occurs when one of the moduleconfigs with a missing enabled field is updated.
impact_level: low
```
