### PR TITLE
chore(ci): drop transient image base-alt-p11, use builder/alt directly

### DIFF
--- a/images/base-alt-p11/werf.inc.yaml
+++ b/images/base-alt-p11/werf.inc.yaml
@@ -1,8 +1,0 @@
----
-image: {{ .ModuleNamePrefix }}{{ .ImageName }}
-final: false
-fromImage: builder/alt
-shell:
-  setup:
-  # Create nonroot-user group and user.
-  - groupadd --gid 1001 nonroot-user && useradd nonroot-user --uid 1001 --gid 1001 --shell /bin/bash --create-home

--- a/images/edk2/werf.inc.yaml
+++ b/images/edk2/werf.inc.yaml
@@ -65,7 +65,7 @@ shell:
 
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: false
-fromImage: {{ .ModuleNamePrefix }}base-alt-p11
+fromImage: builder/alt
 import:
 - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
   add: /{{ $gitRepoName }}-{{ $version }}

--- a/images/libvirt/werf.inc.yaml
+++ b/images/libvirt/werf.inc.yaml
@@ -99,8 +99,7 @@ libraries:
 {{ $builderDependencies := include "$name" . | fromYaml }}
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: false
-{{- $baseAltP11 := printf "%sbase-alt-p11" .ModuleNamePrefix }}
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary $baseAltP11 "builder/alt-go-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/alt" "builder/alt-go-svace" }}
 import:
 - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
   add: /{{ $gitRepoName }}-{{ $version }}

--- a/images/qemu/werf.inc.yaml
+++ b/images/qemu/werf.inc.yaml
@@ -136,8 +136,7 @@ libraries:
 
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: false
-{{- $baseAltP11 := printf "%sbase-alt-p11" .ModuleNamePrefix }}
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary $baseAltP11 "builder/alt-go-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/alt" "builder/alt-go-svace" }}
 import:
 - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
   add: /{{ $gitRepoName }}-{{ $version }}

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -41,8 +41,7 @@ packages:
 
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: false
-{{- $baseAltP11 := printf "%sbase-alt-p11" .ModuleNamePrefix }}
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary $baseAltP11 "builder/alt-go-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/alt" "builder/alt-go-svace" }}
 import:
 - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
   add: /kubevirt


### PR DESCRIPTION
## Description

- virt-artifact image adds "nonroot" group and user to the passwd file explicitly.
- qemu, libvirt, and edk2 images are not needed "nonroot" group and user.


## Why do we need it, and what problem does it solve?



## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: ci
type: chore
summary: drop transient image base-alt-p11, use builder/alt directly
impact_level: low
```
