### PR TITLE
fix(vd): improve Ready condition for missing VirtualImage references

### DIFF
--- a/api/core/v1alpha2/vdcondition/condition.go
+++ b/api/core/v1alpha2/vdcondition/condition.go
@@ -88,6 +88,10 @@ const (
 	ClusterImageNotReady DatasourceReadyReason = "ClusterImageNotReady"
 	// VirtualDiskSnapshotNotReady indicates that the `VirtualDiskSnapshot` datasource is not ready, which prevents the import process from starting.
 	VirtualDiskSnapshotNotReady DatasourceReadyReason = "VirtualDiskSnapshot"
+	// ImageNotFound indicates that the `VirtualImage` datasource is not found, which prevents the import process from starting.
+	ImageNotFound DatasourceReadyReason = "ImageNotFound"
+	// ClusterImageNotFound indicates that the `ClusterVirtualImage` datasource is not found, which prevents the import process from starting.
+	ClusterImageNotFound DatasourceReadyReason = "ClusterImageNotFound"
 
 	// WaitForUserUpload indicates that the `VirtualDisk` is waiting for the user to upload a datasource for the import process to continue.
 	WaitForUserUpload ReadyReason = "WaitForUserUpload"
@@ -109,6 +113,8 @@ const (
 	ImagePullFailed ReadyReason = "ImagePullFailed"
 	// DatasourceIsNotReady indicates that Datasource is not ready for provisioning.
 	DatasourceIsNotReady ReadyReason = "DatasourceIsNotReady"
+	// DatasourceIsNotFound indicates that Datasource is not found.
+	DatasourceIsNotFound ReadyReason = "DatasourceIsNotFound"
 	// StorageClassIsNotReady indicates that Storage class is not ready.
 	StorageClassIsNotReady ReadyReason = "StorageClassIsNotReady"
 

--- a/images/virtualization-artifact/pkg/controller/vd/internal/datasource_ready.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/datasource_ready.go
@@ -113,6 +113,18 @@ func (h DatasourceReadyHandler) Handle(ctx context.Context, vd *virtv2.VirtualDi
 			Reason(vdcondition.VirtualDiskSnapshotNotReady).
 			Message(service.CapitalizeFirstLetter(err.Error()) + ".")
 		return reconcile.Result{}, nil
+	case errors.As(err, &source.ImageNotFoundError{}):
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(vdcondition.ImageNotFound).
+			Message(service.CapitalizeFirstLetter(err.Error()) + ".")
+		return reconcile.Result{}, nil
+	case errors.As(err, &source.ClusterImageNotFoundError{}):
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(vdcondition.ClusterImageNotFound).
+			Message(service.CapitalizeFirstLetter(err.Error()) + ".")
+		return reconcile.Result{}, nil
 	default:
 		return reconcile.Result{}, fmt.Errorf("validation failed for data source %s: %w", ds.Name(), err)
 	}

--- a/images/virtualization-artifact/pkg/controller/vd/internal/datasource_ready_test.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/datasource_ready_test.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vd/internal/source"
 	"github.com/deckhouse/virtualization-controller/pkg/eventrecord"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
@@ -88,5 +89,49 @@ func TestDatasourceReadyHandler_Handle(t *testing.T) {
 		require.Equal(t, vdcondition.DatasourceReadyType.String(), condition.Type)
 		require.Equal(t, metav1.ConditionTrue, condition.Status)
 		require.Equal(t, vdcondition.DatasourceReady.String(), condition.Reason)
+	})
+
+	t.Run("VirtualDisk with missing VI reference", func(t *testing.T) {
+		vd := virtv2.VirtualDisk{
+			Spec: virtv2.VirtualDiskSpec{
+				DataSource: &virtv2.VirtualDiskDataSource{
+					Type: "NonBlank",
+				},
+			},
+		}
+		sources.GetFunc = func(dsType virtv2.DataSourceType) (source.Handler, bool) {
+			return &source.HandlerMock{ValidateFunc: func(_ context.Context, _ *virtv2.VirtualDisk) error {
+				return source.NewImageNotFoundError("missing-vi")
+			}}, true
+		}
+		handler := NewDatasourceReadyHandler(recorder, blank, sources)
+		_, err := handler.Handle(ctx, &vd)
+		require.NoError(t, err)
+		condition, _ := conditions.GetCondition(vdcondition.DatasourceReadyType, vd.Status.Conditions)
+		require.Equal(t, metav1.ConditionFalse, condition.Status)
+		require.Equal(t, vdcondition.ImageNotFound.String(), condition.Reason)
+		require.Equal(t, "VirtualImage \"missing-vi\" not found.", condition.Message)
+	})
+
+	t.Run("VirtualDisk with missing CVI reference", func(t *testing.T) {
+		vd := virtv2.VirtualDisk{
+			Spec: virtv2.VirtualDiskSpec{
+				DataSource: &virtv2.VirtualDiskDataSource{
+					Type: "NonBlank",
+				},
+			},
+		}
+		sources.GetFunc = func(dsType virtv2.DataSourceType) (source.Handler, bool) {
+			return &source.HandlerMock{ValidateFunc: func(_ context.Context, _ *virtv2.VirtualDisk) error {
+				return source.NewClusterImageNotFoundError("missing-cvi")
+			}}, true
+		}
+		handler := NewDatasourceReadyHandler(recorder, blank, sources)
+		_, err := handler.Handle(ctx, &vd)
+		require.NoError(t, err)
+		condition, _ := conditions.GetCondition(vdcondition.DatasourceReadyType, vd.Status.Conditions)
+		require.Equal(t, metav1.ConditionFalse, condition.Status)
+		require.Equal(t, vdcondition.ClusterImageNotFound.String(), condition.Reason)
+		require.Equal(t, "ClusterVirtualImage \"missing-cvi\" not found.", condition.Message)
 	})
 }

--- a/images/virtualization-artifact/pkg/controller/vd/internal/life_cycle.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/life_cycle.go
@@ -99,7 +99,7 @@ func (h LifeCycleHandler) Handle(ctx context.Context, vd *virtv2.VirtualDisk) (r
 				message = datasourceReadyCondition.Message
 			}
 			reason := vdcondition.DatasourceIsNotReady
-			if datasourceReadyCondition.Reason == string(vdcondition.ImageNotFound) || datasourceReadyCondition.Reason == string(vdcondition.ClusterImageNotFound) {
+			if datasourceReadyCondition.Reason == vdcondition.ImageNotFound.String() || datasourceReadyCondition.Reason == vdcondition.ClusterImageNotFound.String() {
 				reason = vdcondition.DatasourceIsNotFound
 			}
 			cb.

--- a/images/virtualization-artifact/pkg/controller/vd/internal/life_cycle_test.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/life_cycle_test.go
@@ -232,6 +232,38 @@ var _ = Describe("LifeCycleHandler Run", func() {
 			},
 		),
 	)
+
+	DescribeTable(
+		"Message propagation and DatasourceIsNotFound reason",
+		func(datasourceReason string, expectedReadyReason string, expectedMessage string) {
+			var sourcesMock SourcesMock
+			recorder := &eventrecord.EventRecorderLoggerMock{
+				EventFunc: func(_ client.Object, _, _, _ string) {},
+			}
+			ctx := logger.ToContext(context.TODO(), slog.Default())
+			vd := virtv2.VirtualDisk{Status: virtv2.VirtualDiskStatus{Conditions: []metav1.Condition{
+				{Type: vdcondition.DatasourceReadyType.String(), Status: metav1.ConditionFalse, Reason: datasourceReason, Message: "Test message"},
+				{Type: vdcondition.StorageClassReadyType.String(), Status: metav1.ConditionTrue},
+			}}}
+
+			sourcesMock.ChangedFunc = func(_ context.Context, _ *virtv2.VirtualDisk) bool {
+				return false
+			}
+			sourcesMock.GetFunc = func(_ virtv2.DataSourceType) (source.Handler, bool) {
+				return &source.HandlerMock{SyncFunc: func(_ context.Context, _ *virtv2.VirtualDisk) (reconcile.Result, error) {
+					return reconcile.Result{}, nil
+				}}, true
+			}
+			handler := NewLifeCycleHandler(recorder, nil, &sourcesMock, nil)
+			_, _ = handler.Handle(ctx, &vd)
+			readyCond, _ := conditions.GetCondition(vdcondition.ReadyType, vd.Status.Conditions)
+			Expect(readyCond.Reason).Should(Equal(expectedReadyReason))
+			Expect(readyCond.Message).Should(Equal(expectedMessage))
+		},
+		Entry("Generic not ready, propagate message", vdcondition.ImageNotReady.String(), vdcondition.DatasourceIsNotReady.String(), "Test message"),
+		Entry("Image not found, use DatasourceIsNotFound and propagate", vdcondition.ImageNotFound.String(), vdcondition.DatasourceIsNotFound.String(), "Test message"),
+		Entry("Cluster image not found, use DatasourceIsNotFound and propagate", vdcondition.ClusterImageNotFound.String(), vdcondition.DatasourceIsNotFound.String(), "Test message"),
+	)
 })
 
 type cleanupAfterSpecChangeTestArgs struct {

--- a/images/virtualization-artifact/pkg/controller/vd/internal/life_cycle_test.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/life_cycle_test.go
@@ -235,7 +235,7 @@ var _ = Describe("LifeCycleHandler Run", func() {
 
 	DescribeTable(
 		"Message propagation and DatasourceIsNotFound reason",
-		func(datasourceReason string, expectedReadyReason string, expectedMessage string) {
+		func(datasourceReason, expectedReadyReason, expectedMessage string) {
 			var sourcesMock SourcesMock
 			recorder := &eventrecord.EventRecorderLoggerMock{
 				EventFunc: func(_ client.Object, _, _, _ string) {},

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/errors.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/errors.go
@@ -42,6 +42,18 @@ func NewImageNotReadyError(name string) error {
 	}
 }
 
+type ImageNotFoundError struct {
+	Name string
+}
+
+func (e ImageNotFoundError) Error() string {
+	return fmt.Sprintf("VirtualImage %q not found", e.Name)
+}
+
+func NewImageNotFoundError(name string) error {
+	return ImageNotFoundError{Name: name}
+}
+
 type ClusterImageNotReadyError struct {
 	name string
 }
@@ -54,6 +66,18 @@ func NewClusterImageNotReadyError(name string) error {
 	return ClusterImageNotReadyError{
 		name: name,
 	}
+}
+
+type ClusterImageNotFoundError struct {
+	Name string
+}
+
+func (e ClusterImageNotFoundError) Error() string {
+	return fmt.Sprintf("ClusterVirtualImage %q not found", e.Name)
+}
+
+func NewClusterImageNotFoundError(name string) error {
+	return ClusterImageNotFoundError{Name: name}
 }
 
 type VirtualDiskSnapshotNotReadyError struct {

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_cvi.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_cvi.go
@@ -93,7 +93,11 @@ func (ds ObjectRefClusterVirtualImage) Validate(ctx context.Context, vd *virtv2.
 		return fmt.Errorf("fetch vi %q: %w", cviRefKey, err)
 	}
 
-	if cviRef == nil || cviRef.Status.Phase != virtv2.ImageReady || cviRef.Status.Target.RegistryURL == "" {
+	if cviRef == nil {
+		return NewClusterImageNotFoundError(vd.Spec.DataSource.ObjectRef.Name)
+	}
+
+	if cviRef.Status.Phase != virtv2.ImageReady || cviRef.Status.Target.RegistryURL == "" {
 		return NewClusterImageNotReadyError(vd.Spec.DataSource.ObjectRef.Name)
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_vi.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_vi.go
@@ -93,7 +93,11 @@ func (ds ObjectRefVirtualImage) Validate(ctx context.Context, vd *virtv2.Virtual
 		return fmt.Errorf("fetch vi %q: %w", viRefKey, err)
 	}
 
-	if viRef == nil || viRef.Status.Phase != virtv2.ImageReady {
+	if viRef == nil {
+		return NewImageNotFoundError(vd.Spec.DataSource.ObjectRef.Name)
+	}
+
+	if viRef.Status.Phase != virtv2.ImageReady {
 		return NewImageNotReadyError(vd.Spec.DataSource.ObjectRef.Name)
 	}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Enhance error handling and condition propagation to clearly indicate in the DatasourceReady and Ready conditions when a referenced VirtualImage or ClusterVirtualImage is not found, distinguishing from "not ready" cases.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
This resolves misleading status where missing images were treated generically as "not ready", providing explicit "not found" messaging.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: vd
type: fix
summary: Set ImageNotReady/ClusterImageNotReady condition when VI/CVI is missing.
```
