### PR TITLE
feat: bump kubevirt to tag v1.3.1-v12n.8

### DIFF
--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -1,7 +1,7 @@
 ---
 # Source https://github.com/kubevirt/kubevirt/blob/v1.3.1/hack/dockerized#L15
 {{- $version := "v1.3.1" }}
-{{- $tag := print $version "-v12n.7"}}
+{{- $tag := print $version "-v12n.8"}}
 
 {{- $name := print $.ImageName "-dependencies" -}}
 {{- define "$name" -}}


### PR DESCRIPTION
## Description
bump kubevirt to tag v1.3.1-v12n.8
- Set mac address for non default pod network
https://github.com/deckhouse/3p-kubevirt/pull/12
- Improve reason when live-migration failed
https://github.com/deckhouse/3p-kubevirt/pull/11

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: core
type: feature
summary: bump kubevirt to tag v1.3.1-v12n.8. Set mac address for non default pod network and improve reason when live-migration failed
```
