### PR TITLE
chore(cdi): support more CSI modules

### DIFF
--- a/images/cdi-artifact/werf.inc.yaml
+++ b/images/cdi-artifact/werf.inc.yaml
@@ -1,5 +1,5 @@
 ---
-{{- $version := "v1.60.3-v12n.6" }}
+{{- $version := "v1.60.3-v12n.7" }}
 {{- $gitRepoUrl := "deckhouse/3p-containerized-data-importer" }}
 
 ---


### PR DESCRIPTION
## Description

Switch CDI to version v1.60.3-v12n.7.

## Why do we need it, and what problem does it solve?

Add more CSI modules support in CDI.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: cdi
type: chore
summary: Add more CSI modules support in CDI.
```
