### PR TITLE
fix(vi): validate storage class

### DIFF
--- a/images/virtualization-artifact/pkg/controller/moduleconfig/moduleconfig_webhook.go
+++ b/images/virtualization-artifact/pkg/controller/moduleconfig/moduleconfig_webhook.go
@@ -46,6 +46,7 @@ func NewModuleConfigValidator(client client.Client) *validator.Validator[*mcapi.
 
 	cidrs := newCIDRsValidator(client)
 	reduceCIDRs := newRemoveCIDRsValidator(client)
+	viStorageClasses := newViStorageClassValidator(client)
 
 	return validator.NewValidator[*mcapi.ModuleConfig](logger).
 		WithPredicate(&validator.Predicate[*mcapi.ModuleConfig]{
@@ -54,5 +55,5 @@ func NewModuleConfigValidator(client client.Client) *validator.Validator[*mcapi.
 					oldMC.GetGeneration() != newMC.GetGeneration()
 			},
 		}).
-		WithUpdateValidators(cidrs, reduceCIDRs)
+		WithUpdateValidators(cidrs, reduceCIDRs, viStorageClasses)
 }

--- a/images/virtualization-artifact/pkg/controller/moduleconfig/vi_storageclass_validator.go
+++ b/images/virtualization-artifact/pkg/controller/moduleconfig/vi_storageclass_validator.go
@@ -84,7 +84,10 @@ func (v viStorageClassValidator) validateStorageClass(ctx context.Context, scNam
 		}
 	}
 
-	return admission.Warnings{}, fmt.Errorf("the storage class %q is not supported in the current version due to known compatibility issues with virtual images; please choose a different storage class", scName)
+	return admission.Warnings{}, fmt.Errorf(
+		"the storage class %q lacks of capabilities to support 'Virtual Images on PVC' function; use StorageClass that supports volume mode 'Block' and access mode 'ReadWriteMany'",
+		scName,
+	)
 }
 
 type viStorageClassSettings struct {

--- a/images/virtualization-artifact/pkg/controller/moduleconfig/vi_storageclass_validator.go
+++ b/images/virtualization-artifact/pkg/controller/moduleconfig/vi_storageclass_validator.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package moduleconfig
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	corev1 "k8s.io/api/core/v1"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	mcapi "github.com/deckhouse/virtualization-controller/pkg/controller/moduleconfig/api"
+)
+
+type viStorageClassValidator struct {
+	client client.Client
+}
+
+func newViStorageClassValidator(client client.Client) *viStorageClassValidator {
+	return &viStorageClassValidator{
+		client: client,
+	}
+}
+
+func (v viStorageClassValidator) ValidateUpdate(ctx context.Context, _, newMC *mcapi.ModuleConfig) (admission.Warnings, error) {
+	warnings := make([]string, 0)
+
+	viScSettings := parseViStorageClass(newMC.Spec.Settings)
+	if viScSettings.DefaultStorageClassName != "" {
+		scWarnings, err := v.validateStorageClass(ctx, viScSettings.DefaultStorageClassName)
+		if err != nil {
+			return warnings, err
+		}
+		if len(scWarnings) != 0 {
+			warnings = append(warnings, scWarnings...)
+		}
+	}
+
+	if len(viScSettings.AllowedStorageClassSelector.MatchNames) != 0 {
+		for _, sc := range viScSettings.AllowedStorageClassSelector.MatchNames {
+			scWarnings, err := v.validateStorageClass(ctx, sc)
+			if err != nil {
+				return warnings, err
+			}
+			if len(scWarnings) != 0 {
+				warnings = append(warnings, scWarnings...)
+			}
+		}
+	}
+
+	return admission.Warnings{}, nil
+}
+
+func (v viStorageClassValidator) validateStorageClass(ctx context.Context, scName string) (admission.Warnings, error) {
+	scProfile := &cdiv1.StorageProfile{}
+	err := v.client.Get(ctx, client.ObjectKey{Name: scName}, scProfile, &client.GetOptions{})
+	if err != nil {
+		return admission.Warnings{}, fmt.Errorf("failed to fetch the storage profile %s: %w", scName, err)
+	}
+	if len(scProfile.Status.ClaimPropertySets) == 0 {
+		return admission.Warnings{}, fmt.Errorf("failed to validate claim property sets of the storage profile`: %s", scName)
+	}
+
+	for _, cps := range scProfile.Status.ClaimPropertySets {
+		if slices.Contains(cps.AccessModes, corev1.ReadWriteMany) && *cps.VolumeMode == corev1.PersistentVolumeBlock {
+			return admission.Warnings{}, nil
+		}
+	}
+
+	return admission.Warnings{}, fmt.Errorf("the storage class %q is not supported in the current version due to known compatibility issues with virtual images; please choose a different storage class", scName)
+}
+
+type viStorageClassSettings struct {
+	DefaultStorageClassName     string
+	AllowedStorageClassSelector AllowedStorageClassSelector
+}
+
+type AllowedStorageClassSelector struct {
+	MatchNames []string
+}
+
+func parseViStorageClass(settings mcapi.SettingsValues) *viStorageClassSettings {
+	viScSettings := &viStorageClassSettings{}
+	if virtualImages, ok := settings["virtualImages"].(map[string]interface{}); ok {
+		if defaultClass, ok := virtualImages["defaultStorageClassName"].(string); ok {
+			viScSettings.DefaultStorageClassName = defaultClass
+		}
+
+		if allowedSelector, ok := virtualImages["allowedStorageClassSelector"].(map[string]interface{}); ok {
+			if matchNames, ok := allowedSelector["matchNames"].([]interface{}); ok {
+				var matchNameStrings []string
+				for _, name := range matchNames {
+					if strName, ok := name.(string); ok {
+						matchNameStrings = append(matchNameStrings, strName)
+					}
+				}
+				viScSettings.AllowedStorageClassSelector.MatchNames = matchNameStrings
+			}
+		}
+	}
+
+	return viScSettings
+}

--- a/images/virtualization-artifact/pkg/controller/service/base_storage_class_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/base_storage_class_service.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/types"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/deckhouse/virtualization-controller/pkg/common/annotations"
@@ -78,4 +79,8 @@ func (s BaseStorageClassService) GetPersistentVolumeClaim(ctx context.Context, s
 
 func (s BaseStorageClassService) IsStorageClassDeprecated(sc *storagev1.StorageClass) bool {
 	return sc != nil && sc.Labels["module"] == "local-path-provisioner"
+}
+
+func (s BaseStorageClassService) GetStorageProfile(ctx context.Context, name string) (*cdiv1.StorageProfile, error) {
+	return object.FetchObject(ctx, types.NamespacedName{Name: name}, s.client, &cdiv1.StorageProfile{})
 }

--- a/images/virtualization-artifact/pkg/controller/vi/internal/interfaces.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/interfaces.go
@@ -21,6 +21,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	"github.com/deckhouse/virtualization-controller/pkg/controller/supplements"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vi/internal/source"
@@ -45,6 +46,8 @@ type StorageClassService interface {
 	GetModuleStorageClass(ctx context.Context) (*storagev1.StorageClass, error)
 	GetDefaultStorageClass(ctx context.Context) (*storagev1.StorageClass, error)
 	GetStorageClass(ctx context.Context, sc string) (*storagev1.StorageClass, error)
+	GetStorageProfile(ctx context.Context, name string) (*cdiv1.StorageProfile, error)
 	GetPersistentVolumeClaim(ctx context.Context, sup *supplements.Generator) (*corev1.PersistentVolumeClaim, error)
 	IsStorageClassDeprecated(sc *storagev1.StorageClass) bool
+	ValidateClaimPropertySets(sp *cdiv1.StorageProfile) error
 }

--- a/images/virtualization-artifact/pkg/controller/vi/internal/service/vi_storage_class_service.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/service/vi_storage_class_service.go
@@ -132,5 +132,8 @@ func (svc *VirtualImageStorageClassService) ValidateClaimPropertySets(sp *cdiv1.
 		}
 	}
 
-	return fmt.Errorf("the storage class %q is not supported in the current version due to known compatibility issues with virtual images; please choose a different storage class", sp.Name)
+	return fmt.Errorf(
+		"the storage class %q lacks of capabilities to support 'Virtual Images on PVC' function; use StorageClass that supports volume mode 'Block' and access mode 'ReadWriteMany'",
+		sp.Name,
+	)
 }

--- a/images/virtualization-artifact/pkg/controller/vi/internal/storageclass_ready_test.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/storageclass_ready_test.go
@@ -176,7 +176,7 @@ func newStorageClassServiceMock(existedStorageClass *string, unsupportedStorageC
 	storageClassServiceMock.ValidateClaimPropertySetsFunc = func(_ *cdiv1.StorageProfile) error {
 		if unsupportedStorageClass {
 			return fmt.Errorf(
-				"the storage class %q is not supported in the current version due to known compatibility issues with virtual images; please choose a different storage class",
+				"the storage class %q lacks of capabilities to support 'Virtual Images on PVC' function; use StorageClass that supports volume mode 'Block' and access mode 'ReadWriteMany'",
 				*existedStorageClass,
 			)
 		}


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Currently, only storage classes with Block volume mode and RWX access mode can be used.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
This is required until the problem with the Filesystem volume mode is resolved.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: vi
type: chore
summary: "Currently, only storage classes with Block volume mode and RWX access mode can be used."
impact_level: low
```
