### PR TITLE
fix(vd): fail with error on insufficient PVC size

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/step/create_dv_from_cvi_step.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/step/create_dv_from_cvi_step.go
@@ -96,6 +96,11 @@ func (s CreateDataVolumeFromClusterVirtualImageStep) Take(ctx context.Context, v
 	size, err := s.getPVCSize(vd, cviRef)
 	if err != nil {
 		if errors.Is(err, service.ErrInsufficientPVCSize) {
+			vd.Status.Phase = virtv2.DiskFailed
+			s.cb.
+				Status(metav1.ConditionFalse).
+				Reason(vdcondition.ProvisioningFailed).
+				Message(service.CapitalizeFirstLetter(err.Error()) + ".")
 			return &reconcile.Result{}, nil
 		}
 

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/step/create_dv_from_vi_step.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/step/create_dv_from_vi_step.go
@@ -99,6 +99,11 @@ func (s CreateDataVolumeFromVirtualImageStep) Take(ctx context.Context, vd *virt
 	size, err := s.getPVCSize(vd, viRef)
 	if err != nil {
 		if errors.Is(err, service.ErrInsufficientPVCSize) {
+			vd.Status.Phase = virtv2.DiskFailed
+			s.cb.
+				Status(metav1.ConditionFalse).
+				Reason(vdcondition.ProvisioningFailed).
+				Message(service.CapitalizeFirstLetter(err.Error()) + ".")
 			return &reconcile.Result{}, nil
 		}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
When importing VirtualDisk from VirtualImage or ClusterVirtualImage, if PVC size is insufficient, set phase to Failed with error message in Ready condition instead of hanging in Pending without errors.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
To provide clear, immediate feedback to users when a VD configuration error occurs during import from a VI or a CVI

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: vd
type: fix
summary: Fail with error on insufficient PVC size
```
