### PR TITLE
fix(module): base64 encoding for custom certificate Secret template

### DIFF
--- a/templates/custom-certificate.yaml
+++ b/templates/custom-certificate.yaml
@@ -1,1 +1,32 @@
-{{- include "helm_lib_module_https_copy_custom_certificate" (list . "d8-virtualization" "ingress-tls") -}}
+{{- /* Copy from helm-lib to work with custom certificate retrieved by the common hook in module-sdk. }} */ -}}
+{{- /* Values contain non-encoded certificates, we need to base64 them for the Secret data. }} */ -}}
+
+{{- /* Usage: {{ include "helm_lib_module_https_copy_custom_certificate" (list . "namespace" "secret_name_prefix") }} */ -}}
+{{- /* Renders secret with [custom certificate](https://deckhouse.io/products/kubernetes-platform/documentation/v1/deckhouse-configure-global.html#parameters-modules-https-customcertificate) */ -}}
+{{- /* in passed namespace with passed prefix */ -}}
+{{- define "override_until_fixed::helm_lib_module_https_copy_custom_certificate" -}}
+  {{- $context := index . 0 -}} {{- /* Template context with .Values, .Chart, etc */ -}}
+  {{- $namespace := index . 1 -}} {{- /* Namespace */ -}}
+  {{- $secret_name_prefix := index . 2 -}} {{- /* Secret name prefix */ -}}
+  {{- $mode := include "helm_lib_module_https_mode" $context -}}
+  {{- if eq $mode "CustomCertificate" -}}
+    {{- $module_values := (index $context.Values (include "helm_lib_module_camelcase_name" $context)) -}}
+    {{- $secret_name := include "helm_lib_module_https_secret_name" (list $context $secret_name_prefix) -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secret_name }}
+  namespace: {{ $namespace }}
+  {{- include "helm_lib_module_labels" (list $context) | nindent 2 }}
+type: kubernetes.io/tls
+data:
+  ca.crt: {{ index $module_values.internal.customCertificateData "ca.crt" | b64enc }}
+  tls.crt: {{ index $module_values.internal.customCertificateData "tls.crt" | b64enc }}
+  tls.key: {{ index $module_values.internal.customCertificateData "tls.key" | b64enc }}
+  {{- end -}}
+{{- end -}}
+
+
+
+{{- include "override_until_fixed::helm_lib_module_https_copy_custom_certificate" (list . "d8-virtualization" "ingress-tls") -}}

--- a/templates/custom-certificate.yaml
+++ b/templates/custom-certificate.yaml
@@ -21,7 +21,9 @@ metadata:
   {{- include "helm_lib_module_labels" (list $context) | nindent 2 }}
 type: kubernetes.io/tls
 data:
+{{- if (hasKey $module_values.internal.customCertificateData "ca.crt") }}
   ca.crt: {{ index $module_values.internal.customCertificateData "ca.crt" | b64enc }}
+{{- end }}
   tls.crt: {{ index $module_values.internal.customCertificateData "tls.crt" | b64enc }}
   tls.key: {{ index $module_values.internal.customCertificateData "tls.key" | b64enc }}
   {{- end -}}


### PR DESCRIPTION
## Description

Override helm_lib_module_https_copy_custom_certificate template from the helm-lib, add base64 for Secret fields.


## Why do we need it, and what problem does it solve?

Fix of regression after rewrite copy_custom_certificate in Go. helm-lib expects base64 encoded certificates in values, but common hook returns raw strings.

Custom certificate specified in ModuleConfig/global in spec.settings.modules.https.customCertificate.secretName leads to this error:

```
helm upgrade failed: cannot patch "ingress-tls-customcertificate" with kind Secret ... invalid value: "{ ... \"data\":{\"tls.crt\":\"-----BEGIN CERTIFICATE----....
```


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: module
type: fix
summary: Fix helm template to be compatible with CustomCertificate https mode.
```
