### PR TITLE
fix(vm): fix networks validator

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm/internal/validators/networks_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/validators/networks_validator.go
@@ -53,8 +53,13 @@ func (v *NetworksValidator) Validate(vm *v1alpha2.VirtualMachine) (admission.War
 		return nil, fmt.Errorf("network with type '%s' should not have a name", v1alpha2.NetworksTypeMain)
 	}
 
+	mainNetworkCount := 0
 	for i, network := range networksSpec {
 		if network.Type == v1alpha2.NetworksTypeMain {
+			mainNetworkCount++
+			if mainNetworkCount > 1 {
+				return nil, fmt.Errorf("only one network of type '%s' is allowed", v1alpha2.NetworksTypeMain)
+			}
 			continue
 		}
 

--- a/images/virtualization-artifact/pkg/controller/vm/internal/validators/networks_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/validators/networks_validator.go
@@ -53,11 +53,9 @@ func (v *NetworksValidator) Validate(vm *v1alpha2.VirtualMachine) (admission.War
 		return nil, fmt.Errorf("network with type '%s' should not have a name", v1alpha2.NetworksTypeMain)
 	}
 
-	mainNetworkCount := 0
 	for i, network := range networksSpec {
 		if network.Type == v1alpha2.NetworksTypeMain {
-			mainNetworkCount++
-			if mainNetworkCount > 1 {
+			if i > 0 {
 				return nil, fmt.Errorf("only one network of type '%s' is allowed", v1alpha2.NetworksTypeMain)
 			}
 			continue

--- a/images/virtualization-artifact/pkg/controller/vm/internal/validators/networks_validator_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/validators/networks_validator_test.go
@@ -30,6 +30,7 @@ func TestNetworksValidate(t *testing.T) {
 	}{
 		{[]v1alpha2.NetworksSpec{}, true},
 		{[]v1alpha2.NetworksSpec{{Type: v1alpha2.NetworksTypeMain}}, true},
+		{[]v1alpha2.NetworksSpec{{Type: v1alpha2.NetworksTypeMain}, {Type: v1alpha2.NetworksTypeMain}}, false},
 		{[]v1alpha2.NetworksSpec{{Type: v1alpha2.NetworksTypeMain, Name: "main"}}, false},
 		{[]v1alpha2.NetworksSpec{{Type: v1alpha2.NetworksTypeNetwork, Name: "test"}, {Type: v1alpha2.NetworksTypeMain}}, false},
 		{[]v1alpha2.NetworksSpec{{Type: v1alpha2.NetworksTypeMain}, {Type: v1alpha2.NetworksTypeNetwork, Name: "test"}}, true},


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
- Fix an issue where multiple networks of type "Main" could be specified in a virtual machine's spec.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: vm
type: fix
summary: Fix an issue where multiple networks of type "Main" could be specified in a virtual machine's spec.
```
