### PR TITLE
ci(chore): update werf cleanup rules

### DIFF
--- a/werf_cleanup.yaml
+++ b/werf_cleanup.yaml
@@ -11,12 +11,8 @@ cleanup:
       limit:
         in: 168h # keep dev images build during last week which not main|pre-alpha
   - references:
-      branch: /release-[0-9]\.[0-9]+.*/
+      branch: /main|release-[0-9]+.*/
       limit:
-        last: 5 # keep 5 images for branches release-*
-    imagesPerReference:
-      last: 1
-  - references:
-      branch: main # keep main
+        last: 5 # keep 5 images for branches release-* and main
     imagesPerReference:
       last: 1


### PR DESCRIPTION
## Description
The cleanup rules have been changed. The old rules led to the dev registry being overloaded with images from release branches.
<!---
  Describe your changes with technical details.
-->


## Why do we need it, and what problem does it solve?
Space in the dev registry is not infinite.
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: ci
type: fix
summary: update werf cleanup rules
impact_level: low
```
