### PR TITLE
chore(module): up Deckhouse min. version

### DIFF
--- a/module.yaml
+++ b/module.yaml
@@ -8,7 +8,7 @@ descriptions:
   ru: Модуль виртуализации позволяет запускать и управлять виртуальными машинами в рамках платформы Deckhouse.
 tags: ["virtualization"]
 requirements:
-  deckhouse: ">= 1.69.4"
+  deckhouse: ">= 1.71.0"
   modules:
     cni-cilium: ">= 0.0.0"
 disable:


### PR DESCRIPTION
## Description
Up minimal version of Deckhouse for better compatibility with snapshot-controller. 1.70 required for correct setting volumeSnapshotClassName.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: module
type: chore
summary: Up minimal version of Deckhouse for better compatibility with snapshot-controller. 1.70 required for correct setting volumeSnapshotClassName.
impact_level: low
```
