### PR TITLE
fix(audit): improve VM Access message

### DIFF
--- a/images/virtualization-artifact/pkg/audit/events/vm/vm_access.go
+++ b/images/virtualization-artifact/pkg/audit/events/vm/vm_access.go
@@ -17,6 +17,8 @@ limitations under the License.
 package vm
 
 import (
+	"fmt"
+
 	"k8s.io/apiserver/pkg/apis/audit"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
@@ -80,9 +82,7 @@ func (m *VMAccess) Fill() error {
 		m.eventLog.Name = "Access to VM via portforward"
 	}
 
-	if m.event.Stage == audit.StageRequestReceived {
-		m.eventLog.Name = "Request " + m.eventLog.Name
-	}
+	m.eventLog.Name = fmt.Sprintf("%s: %s", m.eventLog.Name, m.event.Stage)
 
 	vm, err := util.GetVMFromInformer(m.ttlCache, m.informerList.GetVMInformer(), m.event.ObjectRef.Namespace+"/"+m.event.ObjectRef.Name)
 	if err != nil {

--- a/images/virtualization-artifact/pkg/audit/events/vm/vm_access_test.go
+++ b/images/virtualization-artifact/pkg/audit/events/vm/vm_access_test.go
@@ -252,33 +252,33 @@ var _ = Describe("VMOP Events", func() {
 			shouldFailMatch: true,
 		}),
 		Entry("VM Access with ResponseComplete should contain decision and fill without errors", vmAccessTestArgs{
-			expectedName:      "Access to VM via serial console",
+			expectedName:      "Access to VM via serial console: ResponseComplete",
 			customSubresource: "console",
 		}),
 		Entry("VM Access with RequestReceived shouldn't contain decision and fill without errors", vmAccessTestArgs{
-			expectedName:      "Request Access to VM via serial console",
+			expectedName:      "Access to VM via serial console: RequestReceived",
 			customSubresource: "console",
 			isRequestReceived: true,
 		}),
 		Entry("VM Access by Console event should filled without errors", vmAccessTestArgs{
-			expectedName:      "Access to VM via serial console",
+			expectedName:      "Access to VM via serial console: ResponseComplete",
 			customSubresource: "console",
 		}),
 		Entry("VM Access by VNC event should filled without errors", vmAccessTestArgs{
-			expectedName:      "Access to VM via VNC",
+			expectedName:      "Access to VM via VNC: ResponseComplete",
 			customSubresource: "vnc",
 		}),
 		Entry("VM Access by Portforward event should filled without errors", vmAccessTestArgs{
-			expectedName:      "Access to VM via portforward",
+			expectedName:      "Access to VM via portforward: ResponseComplete",
 			customSubresource: "portforward",
 		}),
 		Entry("VM Access with losted VM event should filled without errors", vmAccessTestArgs{
-			expectedName:      "Access to VM via serial console",
+			expectedName:      "Access to VM via serial console: ResponseComplete",
 			customSubresource: "console",
 			shouldLostVM:      true,
 		}),
 		Entry("VM Access with losted VD and Node event should filled without errors", vmAccessTestArgs{
-			expectedName:      "Access to VM via serial console",
+			expectedName:      "Access to VM via serial console: ResponseComplete",
 			customSubresource: "console",
 			shouldLostVD:      true,
 			shouldLostNode:    true,


### PR DESCRIPTION
## Description
Improve VM Access audit messages. Add stage from audit message to eventLog name.


## Why do we need it, and what problem does it solve?
At the moment it is not clear at what stage the request comes when connecting via port-forward, as well as when connecting via console and vnc.


## What is the expected result?
Add stage status of request from event message.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: module
type: fix 
summary: Improve VM Access audit messages. Add stage from audit message to eventLog name.
impact_level: low
```
