### PR TITLE
fix(vm): prevent "Starting" hang when quota is exceeded

### DIFF
--- a/images/virtualization-artifact/pkg/controller/conditions/getter.go
+++ b/images/virtualization-artifact/pkg/controller/conditions/getter.go
@@ -48,6 +48,15 @@ func GetDataVolumeCondition(condType cdiv1.DataVolumeConditionType, conds []cdiv
 	return cdiv1.DataVolumeCondition{}, false
 }
 
+func GetKVVMCondition(condType virtv1.VirtualMachineConditionType, conds []virtv1.VirtualMachineCondition) (virtv1.VirtualMachineCondition, bool) {
+	for _, cond := range conds {
+		if cond.Type == condType {
+			return cond, true
+		}
+	}
+	return virtv1.VirtualMachineCondition{}, false
+}
+
 func GetKVVMICondition(condType virtv1.VirtualMachineInstanceConditionType, conds []virtv1.VirtualMachineInstanceCondition) (virtv1.VirtualMachineInstanceCondition, bool) {
 	for _, cond := range conds {
 		if cond.Type == condType {
@@ -59,4 +68,5 @@ func GetKVVMICondition(condType virtv1.VirtualMachineInstanceConditionType, cond
 
 const (
 	VirtualMachineInstanceNodePlacementNotMatched virtv1.VirtualMachineInstanceConditionType = "NodePlacementNotMatched"
+	VirtualMachineSynchronized                    virtv1.VirtualMachineConditionType         = "Synchronized"
 )

--- a/images/virtualization-artifact/pkg/controller/vm/internal/lifecycle.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/lifecycle.go
@@ -136,7 +136,7 @@ func (h *LifeCycleHandler) syncRunning(vm *virtv2.VirtualMachine, kvvm *virtv1.V
 		}
 
 		// Try to extract error from kvvm Synchronized condition.
-		if IsPodStartedError(kvvm) {
+		if isPodStartedError(kvvm) {
 			vm.Status.Phase = virtv2.MachinePending
 			msg := fmt.Sprintf("Failed to start pod: %s", kvvm.Status.PrintableStatus)
 			if kvvmi != nil {

--- a/images/virtualization-artifact/pkg/controller/vm/internal/lifecycle.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/lifecycle.go
@@ -113,6 +113,7 @@ func (h *LifeCycleHandler) syncRunning(vm *virtv2.VirtualMachine, kvvm *virtv1.V
 	cb := conditions.NewConditionBuilder(vmcondition.TypeRunning).Generation(vm.GetGeneration())
 
 	if pod != nil && pod.Status.Message != "" {
+		vm.Status.Phase = virtv2.MachinePending
 		cb.Status(metav1.ConditionFalse).
 			Reason(vmcondition.ReasonPodNotStarted).
 			Message(fmt.Sprintf("%s: %s", pod.Status.Reason, pod.Status.Message))
@@ -135,7 +136,8 @@ func (h *LifeCycleHandler) syncRunning(vm *virtv2.VirtualMachine, kvvm *virtv1.V
 		}
 
 		// Try to extract error from kvvm Synchronized condition.
-		if isPodStartedError(kvvm) {
+		if IsPodStartedError(kvvm) {
+			vm.Status.Phase = virtv2.MachinePending
 			msg := fmt.Sprintf("Failed to start pod: %s", kvvm.Status.PrintableStatus)
 			if kvvmi != nil {
 				msg = fmt.Sprintf("%s, %s", msg, kvvmi.Status.Phase)

--- a/images/virtualization-artifact/pkg/controller/vm/internal/lifecycle.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/lifecycle.go
@@ -113,7 +113,6 @@ func (h *LifeCycleHandler) syncRunning(vm *virtv2.VirtualMachine, kvvm *virtv1.V
 	cb := conditions.NewConditionBuilder(vmcondition.TypeRunning).Generation(vm.GetGeneration())
 
 	if pod != nil && pod.Status.Message != "" {
-		vm.Status.Phase = virtv2.MachinePending
 		cb.Status(metav1.ConditionFalse).
 			Reason(vmcondition.ReasonPodNotStarted).
 			Message(fmt.Sprintf("%s: %s", pod.Status.Reason, pod.Status.Message))
@@ -137,7 +136,6 @@ func (h *LifeCycleHandler) syncRunning(vm *virtv2.VirtualMachine, kvvm *virtv1.V
 
 		// Try to extract error from kvvm Synchronized condition.
 		if isPodStartedError(kvvm) {
-			vm.Status.Phase = virtv2.MachinePending
 			msg := fmt.Sprintf("Failed to start pod: %s", kvvm.Status.PrintableStatus)
 			if kvvmi != nil {
 				msg = fmt.Sprintf("%s, %s", msg, kvvmi.Status.Phase)

--- a/images/virtualization-artifact/pkg/controller/vm/internal/util.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/util.go
@@ -212,7 +212,7 @@ var mapReasons = map[string]vmcondition.Reason{
 	virtv1.GuestNotRunningReason: vmcondition.ReasonGuestNotRunning,
 }
 
-func isPodStartedError(vm *virtv1.VirtualMachine) bool {
+func IsPodStartedError(vm *virtv1.VirtualMachine) bool {
 	synchronized := service.GetKVVMCondition(string(virtv1.VirtualMachineInstanceSynchronized), vm.Status.Conditions)
 	if synchronized != nil &&
 		synchronized.Status == corev1.ConditionFalse &&

--- a/images/virtualization-artifact/pkg/controller/vm/internal/util.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/util.go
@@ -115,7 +115,13 @@ var mapPhases = map[virtv1.VirtualMachinePrintableStatus]PhaseGetter{
 		return virtv2.MachineStarting
 	},
 	// VirtualMachineStatusStarting indicates that the virtual machine is being prepared for running.
-	virtv1.VirtualMachineStatusStarting: func(_ *virtv2.VirtualMachine, _ *virtv1.VirtualMachine) virtv2.MachinePhase {
+	virtv1.VirtualMachineStatusStarting: func(_ *virtv2.VirtualMachine, kvvm *virtv1.VirtualMachine) virtv2.MachinePhase {
+		synchronizedCondition, _ := conditions.GetKVVMCondition(conditions.VirtualMachineSynchronized, kvvm.Status.Conditions)
+
+		if synchronizedCondition.Reason == failedCreatePodReason {
+			return virtv2.MachinePending
+		}
+
 		return virtv2.MachineStarting
 	},
 	// VirtualMachineStatusRunning indicates that the virtual machine is running.

--- a/images/virtualization-artifact/pkg/controller/vm/internal/util.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/util.go
@@ -212,7 +212,7 @@ var mapReasons = map[string]vmcondition.Reason{
 	virtv1.GuestNotRunningReason: vmcondition.ReasonGuestNotRunning,
 }
 
-func IsPodStartedError(vm *virtv1.VirtualMachine) bool {
+func isPodStartedError(vm *virtv1.VirtualMachine) bool {
 	synchronized := service.GetKVVMCondition(string(virtv1.VirtualMachineInstanceSynchronized), vm.Status.Conditions)
 	if synchronized != nil &&
 		synchronized.Status == corev1.ConditionFalse &&

--- a/images/virtualization-artifact/pkg/controller/vm/internal/watcher/kvvm_watcher.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/watcher/kvvm_watcher.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/deckhouse/virtualization-controller/pkg/common/annotations"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/vm/internal"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
@@ -54,6 +55,8 @@ func (w *KVVMWatcher) Watch(mgr manager.Manager, ctr controller.Controller) erro
 				newVM := e.ObjectNew.(*virtv1.VirtualMachine)
 				return oldVM.Status.PrintableStatus != newVM.Status.PrintableStatus ||
 					oldVM.Status.Ready != newVM.Status.Ready ||
+					internal.IsPodStartedError(oldVM) ||
+					internal.IsPodStartedError(newVM) ||
 					oldVM.Annotations[annotations.AnnVMStartRequested] != newVM.Annotations[annotations.AnnVMStartRequested] ||
 					oldVM.Annotations[annotations.AnnVMRestartRequested] != newVM.Annotations[annotations.AnnVMRestartRequested]
 			},


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Prevent "Starting" hang when quota is exceeded.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: vm
type: fix
summary: Prevent "Starting" hang when quota is exceeded.
```
