### PR TITLE
feat(core): add SELinux type spc_t to InternalVirtualizationKubeVirt

### DIFF
--- a/templates/kubevirt/kubevirt.yaml
+++ b/templates/kubevirt/kubevirt.yaml
@@ -26,7 +26,7 @@ spec:
           tokenBucketRateLimiter:
             qps: 5000
             burst: 6000
-    selinuxLauncherType: container_t
+    selinuxLauncherType: spc_t
     migrations:
       bandwidthPerMigration: 640Mi
       completionTimeoutPerGiB: 800


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Add SELinux type spc_t to InternalVirtualizationKubeVirt

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: core
type: fix
summary: Add SELinux type spc_t to InternalVirtualizationKubeVirt
impact_level: low
```
