### PR TITLE
fix(core): enable packages for deckhouse embeded build

### DIFF
--- a/images/libvirt/werf.inc.yaml
+++ b/images/libvirt/werf.inc.yaml
@@ -56,7 +56,7 @@ packages:
 - openvswitch ebtables
 - pkgconfig
 - polkit kmod
-- lvm2 parted
+- parted
 - qemu-img open-iscsi
 - xml-utils xsltproc
 - systemd-container polkit
@@ -81,7 +81,6 @@ libraries:
 - libnuma-devel libcap-ng-devel
 - libcurl-devel
 - libfuse-devel libnbd-devel
-- libblkid-devel libgcrypt-devel
 - libgnutls-devel libp11-kit-devel
 - libreadline-devel libtasn1-devel
 - libattr-devel libbsd-devel
@@ -92,7 +91,7 @@ libraries:
 - libtirpc-devel libsasl2-devel
 - wireshark-devel
 - zlib-devel libclocale
-- libfuse3-devel libnuma libslirp-devel
+- libnuma libslirp-devel
 - libyajl-devel libselinux-devel
 {{- end -}}
 

--- a/images/packages/gnutls/werf.inc.yaml
+++ b/images/packages/gnutls/werf.inc.yaml
@@ -51,7 +51,7 @@ packages:
 - libtpm2-tss-devel libtrousers-devel
 - libtasn1-devel libtasn1-utils zlib-devel
 - libunbound-devel bison gtk-doc texinfo texlive
-- libev4 libev-devel libgcrypt-devel libopencdk-devel
+- libev4 libev-devel libopencdk-devel
 - liboqs-devel libzstd-devel libreadline-devel
 - openssl libssl-devel iproute2-devel
 - libnettle-devel

--- a/images/packages/libattr/werf.inc.yaml
+++ b/images/packages/libattr/werf.inc.yaml
@@ -1,3 +1,4 @@
+---
 {{- $name := print $.ImageName "-dependencies" -}}
 {{- define "$name" -}}
 packages:
@@ -9,9 +10,6 @@ packages:
 {{- $version := get .PackageVersion .ImageName }}
 {{- $gitRepoUrl := "attr.git" }}
 
-{{/* Temporarily exclude images from build as submodule. TODO remove 'if' when this image is used in import section.  */}}
-{{- if eq .ModuleNamePrefix "" }}
----
 image: {{ .ModuleNamePrefix }}{{ .PackagePath }}/{{ .ImageName }}
 final: false
 fromImage: builder/scratch
@@ -70,5 +68,3 @@ shell:
       --disable-static
     make -j$(nproc)
     make DESTDIR=$OUTDIR install
-
-{{- end}}

--- a/images/packages/libblkid/werf.inc.yaml
+++ b/images/packages/libblkid/werf.inc.yaml
@@ -1,3 +1,4 @@
+---
 {{- $name := print $.ImageName "-dependencies" -}}
 {{- define "$name" -}}
 packages:
@@ -11,9 +12,6 @@ packages:
 {{- $version := get .PackageVersion .ImageName }}
 {{- $gitRepoUrl := "util-linux/util-linux.git" }}
 
-{{/* Temporarily exclude images from build as submodule. TODO remove 'if' when this image is used in import section.  */}}
-{{- if eq .ModuleNamePrefix "" }}
----
 image: {{ .ModuleNamePrefix }}{{ .PackagePath }}/{{ .ImageName }}
 final: false
 fromImage: builder/scratch
@@ -78,4 +76,4 @@ shell:
     make DESTDIR=$OUTDIR install
 
     rm -rf $OUTDIR/{bin,sbin}
-{{- end }}
+

--- a/images/packages/libbrotli/werf.inc.yaml
+++ b/images/packages/libbrotli/werf.inc.yaml
@@ -1,3 +1,4 @@
+---
 {{- $name := print $.ImageName "-dependencies" -}}
 {{- define "$name" -}}
 packages:
@@ -10,9 +11,6 @@ packages:
 {{- $version := get .PackageVersion .ImageName }}
 {{- $gitRepoUrl := "google/brotli.git" }}
 
-{{/* Temporarily exclude images from build as submodule. TODO remove 'if' when this image is used in import section.  */}}
-{{- if eq .ModuleNamePrefix "" }}
----
 image: {{ .ModuleNamePrefix }}{{ .PackagePath }}/{{ .ImageName }}
 final: false
 fromImage: builder/scratch
@@ -68,4 +66,3 @@ shell:
 
     make -j$(nproc)
     make DESTDIR=$OUTDIR install
-{{- end }}

--- a/images/packages/libbsd/werf.inc.yaml
+++ b/images/packages/libbsd/werf.inc.yaml
@@ -1,3 +1,4 @@
+---
 {{- $name := print $.ImageName "-dependencies" -}}
 {{- define "$name" -}}
 packages:
@@ -10,9 +11,6 @@ packages:
 {{- $version := get .PackageVersion .ImageName }}
 {{- $gitRepoUrl := "libbsd/libbsd.git" }}
 
-{{/* Temporarily exclude images from build as submodule. TODO remove 'if' when this image is used in import section.  */}}
-{{- if eq .ModuleNamePrefix "" }}
----
 image: {{ .ModuleNamePrefix }}{{ .PackagePath }}/{{ .ImageName }}
 final: false
 fromImage: builder/scratch
@@ -72,4 +70,3 @@ shell:
     make -j$(nproc)
     make DESTDIR=$OUTDIR install
 
-{{- end }}

--- a/images/packages/libburn/werf.inc.yaml
+++ b/images/packages/libburn/werf.inc.yaml
@@ -1,3 +1,4 @@
+---
 {{- $name := print $.ImageName "-dependencies" -}}
 {{- define "$name" -}}
 packages:
@@ -10,9 +11,6 @@ packages:
 {{- $version := get .PackageVersion .ImageName }}
 {{- $gitRepoUrl := "libburnia/libburn.git" }}
 
-{{/* Temporarily exclude images from build as submodule. TODO remove 'if' when this image is used in import section.  */}}
-{{- if eq .ModuleNamePrefix "" }}
----
 image: {{ .ModuleNamePrefix }}{{ .PackagePath }}/{{ .ImageName }}
 final: false
 fromImage: builder/scratch
@@ -70,4 +68,3 @@ shell:
       --disable-static
     make -j$(nproc)
     make DESTDIR=$OUTDIR install
-{{- end}}

--- a/images/packages/libfuse3/werf.inc.yaml
+++ b/images/packages/libfuse3/werf.inc.yaml
@@ -1,3 +1,4 @@
+---
 {{- $name := print $.ImageName "-dependencies" -}}
 {{- define "$name" -}}
 packages:
@@ -11,9 +12,6 @@ packages:
 {{- $version := get .PackageVersion .ImageName }}
 {{- $gitRepoUrl := "libfuse/libfuse.git" }}
 
-{{/* Temporarily exclude images from build as submodule. TODO remove 'if' when this image is used in import section.  */}}
-{{- if eq .ModuleNamePrefix "" }}
----
 image: {{ .ModuleNamePrefix }}{{ .PackagePath }}/{{ .ImageName }}
 final: false
 fromImage: builder/scratch
@@ -67,4 +65,3 @@ shell:
     meson setup build -Duseroot=false -Dprefix=$OUTDIR/usr
     meson compile -C build
     meson install -C build
-{{- end }}

--- a/images/packages/libgcrypt/werf.inc.yaml
+++ b/images/packages/libgcrypt/werf.inc.yaml
@@ -1,3 +1,4 @@
+---
 {{- $name := print $.ImageName "-dependencies" -}}
 {{- define "$name" -}}
 packages:
@@ -11,9 +12,6 @@ packages:
 {{- $version := get .PackageVersion .ImageName }}
 {{- $gitRepoUrl := "gpg/libgcrypt" }}
 
-{{/* Temporarily exclude images from build as submodule. TODO remove 'if' when this image is used in import section.  */}}
-{{- if eq .ModuleNamePrefix "" }}
----
 image: {{ .ModuleNamePrefix }}{{ .PackagePath }}/{{ .ImageName }}
 final: false
 fromImage: builder/scratch
@@ -79,4 +77,3 @@ shell:
     make -j$(nproc)
     make DESTDIR=$OUTDIR install
     libtool --finish /usr/lib64
-{{- end}}

--- a/images/packages/libgmp/werf.inc.yaml
+++ b/images/packages/libgmp/werf.inc.yaml
@@ -1,3 +1,4 @@
+---
 {{- $name := print $.ImageName "-dependencies" -}}
 {{- define "$name" -}}
 packages:
@@ -11,9 +12,6 @@ packages:
 {{- $version := get .PackageVersion .ImageName }}
 {{- $gitRepoUrl := "gmp/gmp" }}
 
-{{/* Temporarily exclude images from build as submodule. TODO remove 'if' when this image is used in import section.  */}}
-{{- if eq .ModuleNamePrefix "" }}
----
 image: {{ .ModuleNamePrefix }}{{ .PackagePath }}/{{ .ImageName }}
 final: false
 fromImage: builder/scratch
@@ -188,4 +186,3 @@ shell:
 
     make -j$(nproc)
     make DESTDIR=$OUTDIR install
-{{- end}}

--- a/images/packages/lvm2/werf.inc.yaml
+++ b/images/packages/lvm2/werf.inc.yaml
@@ -1,3 +1,4 @@
+---
 {{- $name := print $.ImageName "-dependencies" -}}
 {{- define "$name" -}}
 packages:
@@ -12,9 +13,6 @@ packages:
 {{- $version := get .PackageVersion .ImageName }}
 {{- $gitRepoUrl := "lvmteam/lvm2.git" }}
 
-{{/* Temporarily exclude images from build as submodule. TODO remove 'if' when this image is used in import section.  */}}
-{{- if eq .ModuleNamePrefix "" }}
----
 image: {{ .ModuleNamePrefix }}{{ .PackagePath }}/{{ .ImageName }}
 final: false
 fromImage: builder/scratch
@@ -83,4 +81,3 @@ shell:
     make -j$(nproc)
 
     make DESTDIR=$OUTDIR install
-{{- end }}

--- a/images/qemu/werf.inc.yaml
+++ b/images/qemu/werf.inc.yaml
@@ -122,7 +122,7 @@ libraries:
 - libnfs-devel libzstd-devel libseccomp-devel
 - libgnutls-devel
 - libudev-devel libmultipath-devel libblkio-devel libpmem-devel
-- libdaxctl-devel libfuse3-devel rdma-core-devel libnuma-devel
+- libdaxctl-devel rdma-core-devel libnuma-devel
 - bzlib-devel liblzo2-devel libsnappy-devel
 - libcacard-devel libusbredir-devel libepoxy-devel libgbm-devel
 - libvitastor-devel libiscsi-devel glusterfs-coreutils


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Enable packages for deckhouse embeded build 

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: core
type: fix
summary: enable packages for deckhouse embeded build
impact_level: low
```
