### PR TITLE
chore(core): Add static mount points

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 **/*.git
 **/.svn
 **/.hg
+images/**/mount-points.yaml
 **/werf*.yaml
 **/werf*.yml
 .werf/**

--- a/.werf/defines/image-mountpoints.tmpl
+++ b/.werf/defines/image-mountpoints.tmpl
@@ -1,0 +1,32 @@
+{{/*
+
+Template to bake mount points in the image. These static mount points
+are required so containerd can start a container with image integrity check.
+
+Problem: each directory specified in volumeMounts items should exist
+in image, containerd is unable to create mount point for us when
+integrity check is enabled.
+
+Solution: define all possible mount points in mount-points.yaml file and
+include this template in git section of the werf.inc.yaml.
+
+*/}}
+{{/* NOTE: Keep in sync with version in Deckhouse CSE */}}
+{{- define "image mount points" }}
+{{-   $mountPoints := ($.Files.Get (printf "images/%s/mount-points.yaml" $.ImageName) | fromYaml) }}
+{{-   $context := . }}
+{{-   range $v := $mountPoints.dirs }}
+- add: /tools/mounts/mountdir
+  to: {{ $v | trimSuffix "/" }}
+  stageDependencies:
+    install:
+    - "**/*"
+{{-   end }}
+{{-   range $v := $mountPoints.files }}
+- add: /tools/mounts/mountfile
+  to: {{ $v }}
+  stageDependencies:
+    install:
+    - "**/*"
+{{-   end }}
+{{- end }}

--- a/images/cdi-apiserver/mount-points.yaml
+++ b/images/cdi-apiserver/mount-points.yaml
@@ -1,0 +1,7 @@
+# A list of pre-created mount points for containerd strict mode.
+
+dirs:
+  # Create dirs in /run, as /var/run is a symlink to /run.
+  - /run/certs/cdi-apiserver-signer-bundle
+  - /run/certs/cdi-apiserver-server-cert
+  - /kubeconfig.local

--- a/images/cdi-apiserver/werf.inc.yaml
+++ b/images/cdi-apiserver/werf.inc.yaml
@@ -1,6 +1,8 @@
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 fromImage: {{ .ModuleNamePrefix }}distroless
+git:
+  {{- include "image mount points" . }}
 import:
 - image: {{ .ModuleNamePrefix }}cdi-artifact
   add: /cdi-binaries

--- a/images/cdi-cloner/mount-points.yaml
+++ b/images/cdi-cloner/mount-points.yaml
@@ -1,0 +1,7 @@
+# A list of pre-created mount points for containerd strict mode.
+#
+# See https://github.com/deckhouse/3p-containerized-data-importer/blob/80d763d788e06b3decaf22e4762076cec64582b3/pkg/controller/clone-controller.go#L699
+
+dirs:
+  # Create dirs in /run, as /var/run is a symlink to /run.
+  - /run/cdi/clone/source

--- a/images/cdi-cloner/werf.inc.yaml
+++ b/images/cdi-cloner/werf.inc.yaml
@@ -1,6 +1,8 @@
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 fromImage: {{ .ModuleNamePrefix }}distroless
+git:
+  {{- include "image mount points" . }}
 import:
 - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-bins
   add: /relocate

--- a/images/cdi-controller/mount-points.yaml
+++ b/images/cdi-controller/mount-points.yaml
@@ -1,0 +1,13 @@
+# A list of pre-created mount points for containerd strict mode.
+#
+# Some volume mounts are ignored:
+# - /tmp - already in the 'distroless' base image.
+
+dirs:
+  # Create dirs in /run, as /var/run is a symlink to /run.
+  - /run/cdi/token/keys
+  - /run/certs/cdi-uploadserver-signer
+  - /run/certs/cdi-uploadserver-client-signer
+  - /run/ca-bundle/cdi-uploadserver-signer-bundle
+  - /run/ca-bundle/cdi-uploadserver-client-signer-bundle
+  - /kubeconfig.local

--- a/images/cdi-controller/werf.inc.yaml
+++ b/images/cdi-controller/werf.inc.yaml
@@ -1,6 +1,8 @@
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 fromImage: {{ .ModuleNamePrefix }}distroless
+git:
+  {{- include "image mount points" . }}
 import:
 - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-bins
   add: /relocate

--- a/images/cdi-importer/mount-points.yaml
+++ b/images/cdi-importer/mount-points.yaml
@@ -1,0 +1,17 @@
+# A list of pre-created mount points for containerd strict mode.
+#
+# See https://github.com/deckhouse/3p-containerized-data-importer/blob/d5fa5124b8a645521843814fffecdf385b74b379/pkg/controller/import-controller.go#L962
+#
+# Some volume mounts are ignored:
+# - /extraheaders - Etra headers not implemented in virtualization-controller.
+# - /google - No support for GCS data source in VirtualImage.
+# - /tmp - already in the 'distroless' base image.
+
+dirs:
+  - /certs
+  - /data
+  - /opt
+  - /proxycerts
+  - /scratch
+  - /shared
+

--- a/images/cdi-importer/werf.inc.yaml
+++ b/images/cdi-importer/werf.inc.yaml
@@ -1,6 +1,8 @@
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 fromImage: {{ .ModuleNamePrefix }}distroless
+git:
+  {{- include "image mount points" . }}
 import:
 - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-bins
   add: /relocate

--- a/images/cdi-operator/mount-points.yaml
+++ b/images/cdi-operator/mount-points.yaml
@@ -1,0 +1,4 @@
+# A list of pre-created mount points for containerd strict mode.
+
+dirs:
+  - /kubeconfig.local

--- a/images/cdi-operator/werf.inc.yaml
+++ b/images/cdi-operator/werf.inc.yaml
@@ -1,6 +1,8 @@
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 fromImage: {{ .ModuleNamePrefix }}distroless
+git:
+  {{- include "image mount points" . }}
 import:
 - image: {{ .ModuleNamePrefix }}cdi-artifact
   add: /cdi-binaries

--- a/images/distroless/werf.inc.yaml
+++ b/images/distroless/werf.inc.yaml
@@ -27,13 +27,18 @@ shell:
   install:
   - |
     mkdir -p /relocate/etc/{pki,ssl} /relocate/usr/{bin,sbin,share,lib,lib64}
-    
+
     cd /relocate
     for dir in {bin,sbin,lib,lib64};do
       ln -s usr/$dir $dir
     done
+    # /var/run -> ../run symlink to prevent making /var/run a directory during the build.
+    # It is needed for better compatibility with containerd default top layer.
+    mkdir -p run
+    mkdir -p var
+    ln -s var/run ../run
     cd /
-    
+
     cp -pr /tmp /relocate
     cp -pr /etc/passwd /etc/group /etc/hostname /etc/hosts /etc/shadow /etc/protocols /etc/services /etc/nsswitch.conf /relocate/etc
     cp -pr /usr/share/ca-certificates /relocate/usr/share
@@ -41,6 +46,7 @@ shell:
     cp -pr /etc/pki/tls/cert.pem /relocate/etc/ssl
     cp -pr /etc/pki/tls/certs /relocate/etc/ssl
     cp -pr /etc/pki/ca-trust/ /relocate/etc/
+    # Create 'deckhouse' user to run without root.
     echo "deckhouse:x:64535:64535:deckhouse:/:/sbin/nologin" >> /relocate/etc/passwd
     echo "deckhouse:x:64535:" >> /relocate/etc/group
     echo "deckhouse:!::0:::::" >> /relocate/etc/shadow

--- a/images/dvcr-importer/mount-points.yaml
+++ b/images/dvcr-importer/mount-points.yaml
@@ -1,0 +1,7 @@
+# A list of pre-created mount points for containerd strict mode.
+
+dirs:
+  - /dvcr-src-auth
+  - /dvcr-auth
+  - /certs
+  - /proxycerts

--- a/images/dvcr-importer/werf.inc.yaml
+++ b/images/dvcr-importer/werf.inc.yaml
@@ -1,6 +1,8 @@
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 fromImage: {{ .ModuleNamePrefix }}distroless
+git:
+  {{- include "image mount points" . }}
 import:
 - image: {{ .ModuleNamePrefix }}dvcr-artifact-bins
   add: /relocate

--- a/images/dvcr-uploader/mount-points.yaml
+++ b/images/dvcr-uploader/mount-points.yaml
@@ -1,0 +1,4 @@
+# A list of pre-created mount points for containerd strict mode.
+
+dirs:
+  - /dvcr-auth

--- a/images/dvcr-uploader/werf.inc.yaml
+++ b/images/dvcr-uploader/werf.inc.yaml
@@ -1,6 +1,8 @@
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 fromImage: {{ .ModuleNamePrefix }}distroless
+git:
+  {{- include "image mount points" . }}
 import:
 - image: {{ .ModuleNamePrefix }}dvcr-artifact-bins
   add: /relocate

--- a/images/dvcr/mount-points.yaml
+++ b/images/dvcr/mount-points.yaml
@@ -1,0 +1,7 @@
+# A list of pre-created mount points for containerd strict mode.
+
+dirs:
+  - /etc/docker/registry
+  - /etc/ssl/docker
+  - /var/lib/registry
+  - /auth

--- a/images/dvcr/werf.inc.yaml
+++ b/images/dvcr/werf.inc.yaml
@@ -19,6 +19,8 @@ shell:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 fromImage: {{ .ModuleNamePrefix }}distroless
+git:
+  {{- include "image mount points" . }}
 import:
 - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-builder
   add: /container-registry-binary

--- a/images/kube-api-rewriter/mount-points.yaml
+++ b/images/kube-api-rewriter/mount-points.yaml
@@ -1,0 +1,7 @@
+# A list of pre-created mount points for containerd strict mode.
+
+dirs:
+  - /etc/virt-operator/certificates
+  - /etc/virt-api/certificates
+  # Create dirs in /run, as /var/run is a symlink to /run.
+  - /run/certs/cdi-apiserver-server-cert

--- a/images/kube-api-rewriter/werf.inc.yaml
+++ b/images/kube-api-rewriter/werf.inc.yaml
@@ -35,13 +35,22 @@ shell:
 
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 fromImage: builder/scratch
+git:
+  {{- include "image mount points" . }}
 import:
   - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-builder
     add: /src/kube-api-rewriter/kube-api-rewriter
     to: /app/kube-api-rewriter
     after: install
+  # Make containerd compatible directories structure.
+  - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-builder
+    add: /var
+    to: /var
+    includePaths:
+      - run
+    after: install
 imageSpec:
   config:
-    user: "65532:65532"
+    user: "64535:64535"
     workingDir: "/app"
     entrypoint: ["/app/kube-api-rewriter"]

--- a/images/virt-api/mount-points.yaml
+++ b/images/virt-api/mount-points.yaml
@@ -1,0 +1,10 @@
+# A list of pre-created mount points for containerd strict mode.
+#
+# Some volume mounts are ignored:
+# - /tmp - already in the 'distroless' base image.
+
+dirs:
+  - /etc/virt-api/certificates
+  - /etc/virt-handler/clientcertificates
+  - /profile-data
+  - /kubeconfig.local

--- a/images/virt-api/werf.inc.yaml
+++ b/images/virt-api/werf.inc.yaml
@@ -1,6 +1,8 @@
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 fromImage: {{ .ModuleNamePrefix }}distroless
+git:
+  {{- include "image mount points" . }}
 import:
 - image: {{ .ModuleNamePrefix }}virt-artifact
   add: /kubevirt-binaries/

--- a/images/virt-controller/mount-points.yaml
+++ b/images/virt-controller/mount-points.yaml
@@ -1,0 +1,7 @@
+# A list of pre-created mount points for containerd strict mode.
+
+dirs:
+  - /etc/virt-controller/certificates
+  - /etc/virt-controller/exportca
+  - /profile-data
+  - /kubeconfig.local

--- a/images/virt-controller/werf.inc.yaml
+++ b/images/virt-controller/werf.inc.yaml
@@ -1,6 +1,8 @@
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 fromImage: {{ .ModuleNamePrefix }}distroless
+git:
+  {{- include "image mount points" . }}
 import:
 - image: {{ .ModuleNamePrefix }}virt-artifact
   add: /kubevirt-binaries/

--- a/images/virt-handler/mount-points.yaml
+++ b/images/virt-handler/mount-points.yaml
@@ -1,0 +1,21 @@
+# A list of pre-created mount points for containerd strict mode.
+#
+# Some volume mounts are ignored:
+# - /tmp - already in the 'distroless' base image.
+
+dirs:
+  - /etc/virt-handler/clientcertificates
+  - /etc/virt-handler/servercertificates
+  - /kubeconfig.local
+  - /profile-data
+  - /etc/podinfo
+  - /pods
+  - /var/lib/kubevirt
+  - /var/lib/kubelet/device-plugins
+  - /var/lib/kubelet/pods
+  - /var/lib/kubevirt-node-labeller
+  # Create dirs in /run, as /var/run is a symlink to /run.
+  - /run/kubevirt
+  - /run/kubevirt-libvirt-runtimes
+  - /run/kubevirt-private
+

--- a/images/virt-handler/werf.inc.yaml
+++ b/images/virt-handler/werf.inc.yaml
@@ -1,6 +1,8 @@
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 fromImage: {{ .ModuleNamePrefix }}distroless
+git:
+  {{- include "image mount points" . }}
 import:
 - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-bins
   add: /relocate

--- a/images/virt-launcher/mount-points.yaml
+++ b/images/virt-launcher/mount-points.yaml
@@ -1,0 +1,48 @@
+# A list of pre-created mount points for containerd strict mode.
+#
+# See https://github.com/deckhouse/3p-kubevirt/blob/8aed630/pkg/virt-controller/services/rendervolumes.go
+#
+# Some volume mounts are ignored:
+# - /tmp - already in the 'distroless' base image.
+# - /var/run - already in the 'distroless' base image.
+# No need to pre-create a plethora of /var/run descendants,
+# as deckhouse/3p-kubevirt is patched to mount /var/run as emptyDir:
+# - /var/run/libvirt
+# - /var/run/kubevirt-ephemeral-disks
+# - /var/run/kubevirt-hooks
+# - /var/run/kubevirt-private
+# - /var/run/kubevirt-private/sysprep/<volname>
+# - /var/run/kubevirt-private/secret/cloudinit/userdata
+# - /var/run/kubevirt-private/secret/cloudinit/userData
+# - /var/run/kubevirt-private/secret/cloudinit/networkdata
+# - /var/run/kubevirt-private/secret/cloudinit/networkData
+# - /var/run/kubevirt-private/config-map
+# - /var/run/kubevirt-private/downwardapi
+# - /var/run/kubevirt-private/downwardapi-disks
+# - /var/run/kubevirt-private/vmi-disks
+# - /var/run/kubevirt-private/libvirt
+# - /var/run/kubevirt-private/libvirt/qemu
+# - /var/run/kubevirt-private/libvirt/qemu/nvram
+# - /var/run/kubevirt-private/libvirt/qemu/swtpm
+# - /var/run/kubevirt-private/var/lib/swtpm-localca
+# - There are more dirs in /var/run/kubevirt-private/
+# - /var/run/kubevirt
+# - /var/run/kubevirt/container-disks
+# - /var/run/kubevirt/sockets
+# - /var/run/kubevirt/hotplug-disks
+# - /var/run/kubevirt/virtiofs-containers
+# /var/log is mounted as emptyDir too:
+# - /var/log/libvirt
+
+dirs:
+  - /etc/libvirt
+  - /etc/podinfo
+  - /var/cache/libvirt
+  - /var/lib/libvirt
+  - /var/lib/libvirt/swtpm
+  - /var/lib/libvirt/qemu/nvram
+  - /var/lib/kubevirt-node-labeller
+  - /var/lib/swtpm-localca
+  - /var/log
+  - /path # For hot-plugged disks, used in "hp Pods".
+  - /init/usr/bin # For attaching images as "container disks".

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -2,6 +2,8 @@
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: true
 fromImage: {{ .ModuleNamePrefix }}distroless
+git:
+  {{- include "image mount points" . }}
 import:
   - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-binaries
     add: /relocate

--- a/images/virt-operator/mount-points.yaml
+++ b/images/virt-operator/mount-points.yaml
@@ -1,0 +1,6 @@
+# A list of pre-created mount points for containerd strict mode.
+
+dirs:
+  - /etc/virt-operator/certificates
+  - /profile-data
+  - /kubeconfig.local

--- a/images/virt-operator/werf.inc.yaml
+++ b/images/virt-operator/werf.inc.yaml
@@ -1,6 +1,8 @@
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 fromImage: {{ .ModuleNamePrefix }}distroless
+git:
+  {{- include "image mount points" . }}
 import:
 - image: {{ .ModuleNamePrefix }}virt-artifact
   add: /kubevirt-binaries/

--- a/images/virtualization-api/mount-points.yaml
+++ b/images/virtualization-api/mount-points.yaml
@@ -1,0 +1,6 @@
+# A list of pre-created mount points for containerd strict mode.
+
+dirs:
+  - /etc/virtualization-api/certificates
+  - /etc/virtualization-api-proxy/certificates
+  - /etc/virt-api/certificates

--- a/images/virtualization-api/werf.inc.yaml
+++ b/images/virtualization-api/werf.inc.yaml
@@ -1,6 +1,8 @@
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 fromImage: {{ .ModuleNamePrefix }}distroless
+git:
+  {{- include "image mount points" . }}
 import:
 - image: {{ .ModuleNamePrefix }}virtualization-artifact
   add: /out/virtualization-api

--- a/images/virtualization-artifact/pkg/common/consts.go
+++ b/images/virtualization-artifact/pkg/common/consts.go
@@ -79,10 +79,6 @@ const (
 	ImportProxyNoProxy = "no_proxy"
 	// ImporterProxyCertDirVar provides a constant to capture our env variable "IMPORTER_PROXY_CERT_DIR"
 	ImporterProxyCertDirVar = "IMPORTER_PROXY_CERT_DIR"
-	// ImporterExtraHeader provides a constant to include extra HTTP headers, as the prefix to a format string
-	ImporterExtraHeader = "IMPORTER_EXTRA_HEADER_"
-	// ImporterSecretExtraHeadersDir is where the secrets containing extra HTTP headers will be mounted
-	ImporterSecretExtraHeadersDir = "/extraheaders"
 
 	// ImporterDestinationAuthConfigDir is a mount directory for auth Secret.
 	ImporterDestinationAuthConfigDir = "/dvcr-auth"
@@ -101,10 +97,8 @@ const (
 
 	UploaderDestinationEndpoint       = "UPLOADER_DESTINATION_ENDPOINT"
 	UploaderDestinationAuthConfigVar  = "UPLOADER_DESTINATION_AUTH_CONFIG"
-	UploaderExtraHeader               = "UPLOADER_EXTRA_HEADER_"
 	UploaderDestinationAuthConfigDir  = "/dvcr-auth"
 	UploaderDestinationAuthConfigFile = "/dvcr-auth/.dockerconfigjson"
-	UploaderSecretExtraHeadersDir     = "/extraheaders"
 
 	DockerRegistrySchemePrefix = "docker://"
 

--- a/images/virtualization-artifact/pkg/controller/importer/importer_pod.go
+++ b/images/virtualization-artifact/pkg/controller/importer/importer_pod.go
@@ -18,8 +18,6 @@ package importer
 
 import (
 	"context"
-	"fmt"
-	"path"
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
@@ -51,9 +49,6 @@ const (
 
 	// ProxyCertVolName is the name of the volumecontaining certs
 	proxyCertVolName = "cdi-proxy-cert-vol"
-
-	// secretExtraHeadersVolumeName is the format string that specifies where extra HTTP header secrets will be mounted
-	secretExtraHeadersVolumeName = "import-extra-headers-vol-%d"
 
 	// destinationAuthVol is the name of the volume containing DVCR docker auth config.
 	destinationAuthVol = "dvcr-secret-vol"
@@ -386,21 +381,6 @@ func (imp *Importer) addVolumes(pod *corev1.Pod, container *corev1.Container) {
 			corev1.VolumeDevice{
 				Name:       "volume",
 				DevicePath: "/dev/xvda",
-			},
-		)
-	}
-
-	// Mount extra headers Secrets.
-	for index, header := range imp.EnvSettings.SecretExtraHeaders {
-		volName := fmt.Sprintf(secretExtraHeadersVolumeName, index)
-		mountPath := path.Join(common.ImporterSecretExtraHeadersDir, fmt.Sprint(index))
-		envName := fmt.Sprintf("%s%d", common.ImporterExtraHeader, index)
-		podutil.AddVolume(pod, container,
-			podutil.CreateSecretVolume(volName, header),
-			podutil.CreateVolumeMount(volName, mountPath),
-			corev1.EnvVar{
-				Name:  envName,
-				Value: header,
 			},
 		)
 	}

--- a/images/virtualization-artifact/pkg/controller/importer/settings.go
+++ b/images/virtualization-artifact/pkg/controller/importer/settings.go
@@ -61,7 +61,6 @@ type Settings struct {
 	NoProxy                string
 	CertConfigMapProxy     string
 	ExtraHeaders           []string
-	SecretExtraHeaders     []string
 	DestinationEndpoint    string
 	DestinationInsecureTLS string
 	DestinationAuthSecret  string

--- a/images/virtualization-artifact/pkg/controller/uploader/settings.go
+++ b/images/virtualization-artifact/pkg/controller/uploader/settings.go
@@ -25,7 +25,6 @@ import (
 // Fields from this struct are passed via environment variables.
 type Settings struct {
 	Verbose                string
-	SecretExtraHeaders     []string
 	DestinationEndpoint    string
 	DestinationInsecureTLS string
 	DestinationAuthSecret  string

--- a/images/virtualization-artifact/pkg/controller/uploader/uploader_pod.go
+++ b/images/virtualization-artifact/pkg/controller/uploader/uploader_pod.go
@@ -18,8 +18,6 @@ package uploader
 
 import (
 	"context"
-	"fmt"
-	"path"
 
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -36,9 +34,6 @@ import (
 )
 
 const (
-	// secretExtraHeadersVolumeName is the format string that specifies where extra HTTP header secrets will be mounted
-	secretExtraHeadersVolumeName = "import-extra-headers-vol-%d"
-
 	// destinationAuthVol is the name of the volume containing DVCR docker auth config.
 	destinationAuthVol = "dvcr-secret-vol"
 )
@@ -194,21 +189,6 @@ func (p *Pod) addVolumes(pod *corev1.Pod, container *corev1.Container) {
 			corev1.EnvVar{
 				Name:  common.UploaderDestinationAuthConfigVar,
 				Value: common.UploaderDestinationAuthConfigFile,
-			},
-		)
-	}
-
-	// Mount extra headers Secrets.
-	for index, header := range p.Settings.SecretExtraHeaders {
-		volName := fmt.Sprintf(secretExtraHeadersVolumeName, index)
-		mountPath := path.Join(common.UploaderSecretExtraHeadersDir, fmt.Sprint(index))
-		envName := fmt.Sprintf("%s%d", common.UploaderExtraHeader, index)
-		podutil.AddVolume(pod, container,
-			podutil.CreateSecretVolume(volName, header),
-			podutil.CreateVolumeMount(volName, mountPath),
-			corev1.EnvVar{
-				Name:  envName,
-				Value: header,
 			},
 		)
 	}

--- a/images/virtualization-audit/mount-points.yaml
+++ b/images/virtualization-audit/mount-points.yaml
@@ -1,0 +1,4 @@
+# A list of pre-created mount points for containerd strict mode.
+
+dirs:
+  - /etc/virtualization-audit/certificates

--- a/images/virtualization-audit/werf.inc.yaml
+++ b/images/virtualization-audit/werf.inc.yaml
@@ -2,6 +2,8 @@
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 fromImage: {{ .ModuleNamePrefix }}distroless
+git:
+  {{- include "image mount points" . }}
 import:
 - image: {{ .ModuleNamePrefix }}virtualization-artifact
   add: /out/virtualization-audit

--- a/images/virtualization-controller/mount-points.yaml
+++ b/images/virtualization-controller/mount-points.yaml
@@ -1,0 +1,5 @@
+# A list of pre-created mount points for containerd strict mode.
+
+dirs:
+  - /tmp/k8s-webhook-server/serving-certs
+  - /kubeconfig.local

--- a/images/virtualization-controller/werf.inc.yaml
+++ b/images/virtualization-controller/werf.inc.yaml
@@ -1,6 +1,8 @@
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 fromImage: {{ .ModuleNamePrefix }}distroless
+git:
+  {{- include "image mount points" . }}
 import:
 - image: {{ .ModuleNamePrefix }}virtualization-artifact
   add: /out/virtualization-controller

--- a/templates/virtualization-api/deployment.yaml
+++ b/templates/virtualization-api/deployment.yaml
@@ -85,19 +85,19 @@ spec:
             {{- else }}
             - --v=3
             {{- end }}
-            - --tls-cert-file=/etc/virtualziation-api/certificates/tls.crt
-            - --tls-private-key-file=/etc/virtualziation-api/certificates/tls.key
-            - --proxy-client-cert-file=/etc/virtualziation-api-proxy/certificates/tls.crt
-            - --proxy-client-key-file=/etc/virtualziation-api-proxy/certificates/tls.key
+            - --tls-cert-file=/etc/virtualization-api/certificates/tls.crt
+            - --tls-private-key-file=/etc/virtualization-api/certificates/tls.key
+            - --proxy-client-cert-file=/etc/virtualization-api-proxy/certificates/tls.crt
+            - --proxy-client-key-file=/etc/virtualization-api-proxy/certificates/tls.key
             - --service-account-name=virtualization-api
             - --service-account-namespace=d8-{{ .Chart.Name }}
           image: {{ include "helm_lib_module_image" (list . "virtualizationApi") }}
           imagePullPolicy: IfNotPresent
           volumeMounts:
-            - mountPath: /etc/virtualziation-api/certificates
+            - mountPath: /etc/virtualization-api/certificates
               name:  virtualization-api-tls
               readOnly: true
-            - mountPath: /etc/virtualziation-api-proxy/certificates
+            - mountPath: /etc/virtualization-api-proxy/certificates
               name:  virtualization-api-proxy-tls
               readOnly: true
             - mountPath: /etc/virt-api/certificates

--- a/tools/mounts/README.md
+++ b/tools/mounts/README.md
@@ -1,0 +1,3 @@
+# Mount primitives
+
+This dir contains empty dir and empty file to use as mountpoints in the images.


### PR DESCRIPTION
## Description

Part of https://github.com/deckhouse/deckhouse/pull/14920

- Pre-create all "top" mount points in final images.
- Cleanup: remove unused extraheaders settings.
- Create `/run`, `/var`, and `/var/run -> ../run` in the base 'distroless' image to mimic strict containerd mode if run in regular mode.

**TODO** 
- [ ] Change virt-launcher manifest, add mount /var/run as emptyDir, change location /usr/bin in container-disk containers.


## Why do we need it, and what problem does it solve?

All mountPaths should pre-created during build time to run in the environment with containerd integrity checks.

## What is the expected result?

Module works as usual in the environment with containerd integrity checks.


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

Note: e2e passed as a part of PR #1432 

https://github.com/deckhouse/virtualization/pull/1432#issuecomment-3275606685

## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: core
type: chore
summary: Pre-create mount points in all final images.
```
