### PR TITLE
chore(module): fix helm templates after PR#1324

### DIFF
--- a/templates/virtualization-api/_helper.tpl
+++ b/templates/virtualization-api/_helper.tpl
@@ -1,5 +1,5 @@
 {{- define "virtualization-api.isEnabled" -}}
-{{- if eq (include "hasValidModuleConfig" .) "true" }}
+{{- if eq (include "hasValidModuleConfig" .) "true" -}}
 true
 {{- end -}}
 {{- end -}}

--- a/templates/virtualization-controller/_helpers.tpl
+++ b/templates/virtualization-controller/_helpers.tpl
@@ -1,5 +1,5 @@
 {{- define "virtualization-controller.isEnabled" -}}
-{{- if eq (include "hasValidModuleConfig" .) "true" }}
+{{- if eq (include "hasValidModuleConfig" .) "true" -}}
 true
 {{- end -}}
 {{- end -}}

--- a/templates/vm-route-forge/_helper.tpl
+++ b/templates/vm-route-forge/_helper.tpl
@@ -1,6 +1,6 @@
 {{- define "vm-route-forge.isEnabled" -}}
-{{- if eq (include "hasValidModuleConfig" .) "true" }}
-{{- if (.Values.global.enabledModules | has "cni-cilium") }}
+{{- if eq (include "hasValidModuleConfig" .) "true" -}}
+{{- if (.Values.global.enabledModules | has "cni-cilium") -}}
 true
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
## Description

Add dashes to trim whitespaces in template result.


## Why do we need it, and what problem does it solve?

There are no Pods for virtualization-controller, virtualization-api and vm-route-forge after applying PR#1324.


## What is the expected result?

virtualization-controller, virtualization-api and vm-route-forge have running Pods.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: module
type: feature
summary: fix helm templates after PR#1324
```
