### PR TITLE
fix: bump go in debug images

### DIFF
--- a/images/virtualization-artifact/hack/dlv-apiserver.Dockerfile
+++ b/images/virtualization-artifact/hack/dlv-apiserver.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.9-bookworm@sha256:26ca07ec0684ebe2154ad45a3a03710edb90b9cfc3769bead74ebcf6644dc759 AS builder
+FROM golang:1.24.5-bookworm@sha256:ef8c5c733079ac219c77edab604c425d748c740d8699530ea6aced9de79aea40 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/images/virtualization-artifact/hack/dlv-audit.Dockerfile
+++ b/images/virtualization-artifact/hack/dlv-audit.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.9-bookworm@sha256:26ca07ec0684ebe2154ad45a3a03710edb90b9cfc3769bead74ebcf6644dc759 AS builder
+FROM golang:1.24.5-bookworm@sha256:ef8c5c733079ac219c77edab604c425d748c740d8699530ea6aced9de79aea40 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/images/virtualization-artifact/hack/dlv-controller.Dockerfile
+++ b/images/virtualization-artifact/hack/dlv-controller.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.9-bookworm@sha256:26ca07ec0684ebe2154ad45a3a03710edb90b9cfc3769bead74ebcf6644dc759 AS builder
+FROM golang:1.24.5-bookworm@sha256:ef8c5c733079ac219c77edab604c425d748c740d8699530ea6aced9de79aea40 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
## Description
bump go in debug images


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: core
type: chore 
summary: bump go in debug images
impact_level: low
```
