### PR TITLE
fix(vm): watch for kvvm volume snapshot statuses

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm/internal/watcher/kvvm_watcher.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/watcher/kvvm_watcher.go
@@ -19,6 +19,7 @@ package watcher
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	virtv1 "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -61,7 +62,8 @@ func (w *KVVMWatcher) Watch(mgr manager.Manager, ctr controller.Controller) erro
 						oldSynchronizedCondition.Reason != newSynchronizedCondition.Reason ||
 						oldVM.Status.Ready != newVM.Status.Ready ||
 						oldVM.Annotations[annotations.AnnVMStartRequested] != newVM.Annotations[annotations.AnnVMStartRequested] ||
-						oldVM.Annotations[annotations.AnnVMRestartRequested] != newVM.Annotations[annotations.AnnVMRestartRequested]
+						oldVM.Annotations[annotations.AnnVMRestartRequested] != newVM.Annotations[annotations.AnnVMRestartRequested] ||
+						!equality.Semantic.DeepEqual(oldVM.Status.VolumeSnapshotStatuses, newVM.Status.VolumeSnapshotStatuses)
 				},
 			},
 		),


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
Without this, when VMBDA is in the deletion process, it gets stuck in the terminating phase because a stopped VM cannot update block device references during this phase.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
A VMBDA should be correctly deleted when a VM is in the stopped phase.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: vm
type: fix
summary: "A VMBDA should be correctly deleted when a VM is in the stopped phase."
```
