### PR TITLE
fix(vmrestore): fix validation in safe mode

### DIFF
--- a/api/core/v1alpha2/virtual_machine_ip_address_lease.go
+++ b/api/core/v1alpha2/virtual_machine_ip_address_lease.go
@@ -20,7 +20,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 const (
 	VirtualMachineIPAddressLeaseKind     = "VirtualMachineIPAddressLease"
-	VirtualMachineIPAddressLeaseResource = "virtualmachineipaddresleases"
+	VirtualMachineIPAddressLeaseResource = "virtualmachineipaddressleases"
 )
 
 // VirtualMachineIPAddressLease defines fact of issued lease for `VirtualMachineIPAddress`.

--- a/images/virtualization-artifact/pkg/controller/vmrestore/internal/restorer/vd_restorer.go
+++ b/images/virtualization-artifact/pkg/controller/vmrestore/internal/restorer/vd_restorer.go
@@ -74,6 +74,9 @@ func (v *VirtualDiskOverrideValidator) Validate(ctx context.Context) error {
 	}
 
 	if existed != nil {
+		if value, ok := existed.Annotations[annotations.AnnVMRestore]; ok && value == v.vmRestoreUID {
+			return nil
+		}
 		return fmt.Errorf("the virtual disk %q %w", vdKey.Name, ErrAlreadyExists)
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vmrestore/internal/restorer/vm_restorer.go
+++ b/images/virtualization-artifact/pkg/controller/vmrestore/internal/restorer/vm_restorer.go
@@ -47,8 +47,6 @@ func NewVirtualMachineOverrideValidator(vmTmpl *virtv2.VirtualMachine, client cl
 		vmTmpl.Annotations[annotations.AnnVMRestore] = vmRestoreUID
 	}
 
-	vmTmpl.Spec.RunPolicy = virtv2.AlwaysOffPolicy
-
 	return &VirtualMachineOverrideValidator{
 		vm: &virtv2.VirtualMachine{
 			TypeMeta: metav1.TypeMeta{
@@ -101,6 +99,9 @@ func (v *VirtualMachineOverrideValidator) Validate(ctx context.Context) error {
 	}
 
 	if existed != nil {
+		if value, ok := existed.Annotations[annotations.AnnVMRestore]; ok && value == v.vmRestoreUID {
+			return nil
+		}
 		return fmt.Errorf("the virtual machine %q %w", vmKey.Name, ErrAlreadyExists)
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vmrestore/internal/restorer/vmbda_restorer.go
+++ b/images/virtualization-artifact/pkg/controller/vmrestore/internal/restorer/vmbda_restorer.go
@@ -83,6 +83,9 @@ func (v *VirtualMachineBlockDeviceAttachmentsOverrideValidator) Validate(ctx con
 	}
 
 	if existed != nil {
+		if value, ok := existed.Annotations[annotations.AnnVMRestore]; ok && value == v.vmRestoreUID {
+			return nil
+		}
 		return fmt.Errorf("the virtual machine block device attachment %q %w", vmbdaKey.Name, ErrAlreadyExists)
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vmrestore/internal/restorer/vmip_restorer.go
+++ b/images/virtualization-artifact/pkg/controller/vmrestore/internal/restorer/vmip_restorer.go
@@ -99,6 +99,10 @@ func (v *VirtualMachineIPAddressOverrideValidator) Validate(ctx context.Context)
 		return nil
 	}
 
+	if value, ok := existed.Annotations[annotations.AnnVMRestore]; ok && value == v.vmRestoreUID {
+		return nil
+	}
+
 	if existed.Status.Phase == virtv2.VirtualMachineIPAddressPhaseAttached || existed.Status.VirtualMachine != "" {
 		return fmt.Errorf("the virtual machine ip address %q is %w and cannot be used for the restored virtual machine", vmipKey.Name, ErrAlreadyInUse)
 	}

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -88,6 +88,7 @@ task run
 - Use the FOCUS environment variable to run a specific test.
 - Set CONTINUE_ON_FAILURE=yes to continue running tests despite any failures.
 - Set POST_CLEANUP=no to disable cleanup after tests.
+- Set LABELS to run tests with specific label(https://onsi.github.io/ginkgo/#spec-labels).
      
 
 For example, to run only the "ComplexTest" ignoring failed suites and leave all created resources in the cluster, use the following command: 

--- a/tests/e2e/Taskfile.yaml
+++ b/tests/e2e/Taskfile.yaml
@@ -86,6 +86,9 @@ tasks:
         go tool ginkgo -v \
           -p --procs=12 \
           --race \
+          {{if .LABELS -}}
+          --label-filter="{{ .LABELS }}" \
+          {{end -}}
           {{if .TIMEOUT -}}
           --timeout={{ .TIMEOUT }} \
           {{else -}}
@@ -105,6 +108,9 @@ tasks:
       - |
         go tool ginkgo -v \
           --race \
+          {{if .LABELS -}}
+          --label-filter="{{ .LABELS }}" \
+          {{end -}}
           {{if .TIMEOUT -}}
           --timeout={{ .TIMEOUT }} \
           {{else -}}

--- a/tests/e2e/config/config.go
+++ b/tests/e2e/config/config.go
@@ -152,6 +152,7 @@ type TestData struct {
 	VMEvacuation          string `yaml:"vmEvacuation"`
 	VMDiskAttachment      string `yaml:"vmDiskAttachment"`
 	VMRestoreForce        string `yaml:"vmRestoreForce"`
+	VMRestoreSafe         string `yaml:"vmRestoreSafe"`
 	VMVersions            string `yaml:"vmVersions"`
 	VdSnapshots           string `yaml:"vdSnapshots"`
 	Sshkey                string `yaml:"sshKey"`

--- a/tests/e2e/default_config.yaml
+++ b/tests/e2e/default_config.yaml
@@ -34,6 +34,7 @@ testData:
   vmEvacuation: "/tmp/testdata/vm-evacuation"
   vmDiskAttachment: "/tmp/testdata/vm-disk-attachment"
   vmRestoreForce: "/tmp/testdata/vm-restore-force"
+  vmRestoreSafe: "/tmp/testdata/vm-restore-safe"
   vmVersions: "/tmp/testdata/vm-versions"
   vdSnapshots: "/tmp/testdata/vd-snapshots"
   ipam: "/tmp/testdata/ipam"

--- a/tests/e2e/kubectl/kubectl.go
+++ b/tests/e2e/kubectl/kubectl.go
@@ -80,6 +80,7 @@ type CreateOptions struct {
 }
 
 type DeleteOptions struct {
+	AllFlag        bool
 	ExcludedLabels []string
 	Filename       []string
 	FilenameOption FilenameOption
@@ -290,6 +291,13 @@ func (k KubectlCMD) PatchResource(resource Resource, name string, opts PatchOpti
 	return k.ExecContext(ctx, cmd)
 }
 
+func (k KubectlCMD) addAllFlag(cmd string, allFlag bool) string {
+	if allFlag {
+		return fmt.Sprintf("%s --all=true", cmd)
+	}
+	return cmd
+}
+
 func (k KubectlCMD) addNamespace(cmd, ns string) string {
 	if ns != "" {
 		return fmt.Sprintf("%s --namespace %s", cmd, ns)
@@ -387,6 +395,7 @@ func (k KubectlCMD) deleteOptions(cmd string, opts DeleteOptions) string {
 	cmd = k.addNamespace(cmd, opts.Namespace)
 	cmd = k.addLabels(cmd, opts.Labels, opts.ExcludedLabels)
 	cmd = k.addIgnoreNotFound(cmd, opts.IgnoreNotFound)
+	cmd = k.addAllFlag(cmd, opts.AllFlag)
 	if opts.Name != "" {
 		cmd += fmt.Sprintf(" %s", opts.Name)
 	}

--- a/tests/e2e/testdata/vm-restore-safe/kustomization.yaml
+++ b/tests/e2e/testdata/vm-restore-safe/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: test-vm-restore-safe
+namePrefix: vm-restore-safe-
+resources:
+  - ns.yaml
+  - vi
+  - vm
+configurations:
+  - transformer.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      id: pr-number-or-commit-hash
+      testcase: vm-restore-safe

--- a/tests/e2e/testdata/vm-restore-safe/ns.yaml
+++ b/tests/e2e/testdata/vm-restore-safe/ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default

--- a/tests/e2e/testdata/vm-restore-safe/transformer.yaml
+++ b/tests/e2e/testdata/vm-restore-safe/transformer.yaml
@@ -1,0 +1,52 @@
+namespace:
+  - kind: ClusterVirtualImage
+    path: spec/dataSource/objectRef/namespace
+nameReference:
+  - kind: VirtualImage
+    version: v1alpha2 # optional
+    fieldSpecs:
+      - path: spec/dataSource/objectRef/name
+        kind: ClusterVirtualImage
+      - path: spec/dataSource/objectRef/name
+        kind: VirtualImage
+      - path: spec/dataSource/objectRef/name
+        kind: VirtualDisk
+      - path: spec/blockDeviceRefs/name
+        kind: VirtualMachine
+  - kind: ClusterVirtualImage
+    version: v1alpha2 # optional
+    fieldSpecs:
+      - path: spec/dataSource/objectRef/name
+        kind: ClusterVirtualImage
+      - path: spec/dataSource/objectRef/name
+        kind: VirtualImage
+      - path: spec/dataSource/objectRef/name
+        kind: VirtualDisk
+      - path: spec/blockDeviceRefs/name
+        kind: VirtualMachine
+  - kind: VirtualDisk
+    version: v1alpha2 # optional
+    fieldSpecs:
+      - path: spec/blockDeviceRefs/name
+        kind: VirtualMachine
+      - path: spec/blockDeviceRef/name
+        kind: VirtualMachineBlockDeviceAttachment
+  - kind: Secret
+    fieldSpecs:
+      - path: spec/provisioning/userDataRef/name
+        kind: VirtualMachine
+  - kind: VirtualMachineIPAddress
+    version: v1alpha2
+    fieldSpecs:
+      - path: spec/virtualMachineIPAddressName
+        kind: VirtualMachine
+  - kind: VirtualMachine
+    version: v1alpha2
+    fieldSpecs:
+      - path: spec/virtualMachineName
+        kind: VirtualMachineBlockDeviceAttachment
+  - kind: VirtualMachineClass
+    version: v1alpha2
+    fieldSpecs:
+      - path: spec/virtualMachineClassName
+        kind: VirtualMachine

--- a/tests/e2e/testdata/vm-restore-safe/vi/kustomization.yaml
+++ b/tests/e2e/testdata/vm-restore-safe/vi/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - vi-alpine-http.yaml
+  - vi-ubuntu-http.yaml

--- a/tests/e2e/testdata/vm-restore-safe/vi/vi-alpine-http.yaml
+++ b/tests/e2e/testdata/vm-restore-safe/vi/vi-alpine-http.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-alpine-http
+spec:
+  storage: ContainerRegistry
+  dataSource:
+    type: HTTP
+    http:
+      url: https://89d64382-20df-4581-8cc7-80df331f67fa.selstorage.ru/alpine/alpine-3-21-bios-perf.qcow2

--- a/tests/e2e/testdata/vm-restore-safe/vi/vi-ubuntu-http.yaml
+++ b/tests/e2e/testdata/vm-restore-safe/vi/vi-ubuntu-http.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualImage
+metadata:
+  name: vi-ubuntu-http
+spec:
+  storage: ContainerRegistry
+  dataSource:
+    type: HTTP
+    http:
+      url: https://89d64382-20df-4581-8cc7-80df331f67fa.selstorage.ru/ubuntu/ubuntu-24.04-minimal-cloudimg-amd64.qcow2

--- a/tests/e2e/testdata/vm-restore-safe/vm/base/cfg/cloudinit.yaml
+++ b/tests/e2e/testdata/vm-restore-safe/vm/base/cfg/cloudinit.yaml
@@ -1,0 +1,11 @@
+#cloud-config
+users:
+  - name: cloud
+    # passwd: cloud
+    passwd: $6$rounds=4096$vln/.aPHBOI7BMYR$bBMkqQvuGs5Gyd/1H5DP4m9HjQSy.kgrxpaGEHwkX7KEFV8BS.HZWPitAtZ2Vd8ZqIZRqmlykRCagTgPejt1i.
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    lock_passwd: false
+    ssh_authorized_keys:
+      # testcases
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFxcXHmwaGnJ8scJaEN5RzklBPZpVSic4GdaAsKjQoeA your_email@example.com

--- a/tests/e2e/testdata/vm-restore-safe/vm/base/kustomization.yaml
+++ b/tests/e2e/testdata/vm-restore-safe/vm/base/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./vm.yaml
+  - ./vd-root.yaml
+  - ./vd-blank.yaml
+  - ./vmbda-vd.yaml
+  - ./vmbda-vi.yaml
+configurations:
+  - transformer.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+secretGenerator:
+  - files:
+      - userData=cfg/cloudinit.yaml
+    name: cloud-init
+    type: provisioning.virtualization.deckhouse.io/cloud-init

--- a/tests/e2e/testdata/vm-restore-safe/vm/base/transformer.yaml
+++ b/tests/e2e/testdata/vm-restore-safe/vm/base/transformer.yaml
@@ -1,0 +1,59 @@
+# https://github.com/kubernetes-sigs/kustomize/blob/master/examples/transformerconfigs/README.md#transformer-configurations
+
+namespace:
+  - kind: ClusterVirtualImage
+    path: spec/dataSource/objectRef/namespace
+nameReference:
+  - kind: VirtualImage
+    version: v1alpha2 # optional
+    fieldSpecs:
+      - path: spec/dataSource/objectRef/name
+        kind: ClusterVirtualImage
+      - path: spec/dataSource/objectRef/name
+        kind: VirtualImage
+      - path: spec/dataSource/objectRef/name
+        kind: VirtualDisk
+      - path: spec/blockDeviceRefs/name
+        kind: VirtualMachine
+  - kind: ClusterVirtualImage
+    version: v1alpha2 # optional
+    fieldSpecs:
+      - path: spec/dataSource/objectRef/name
+        kind: ClusterVirtualImage
+      - path: spec/dataSource/objectRef/name
+        kind: VirtualImage
+      - path: spec/dataSource/objectRef/name
+        kind: VirtualDisk
+      - path: spec/blockDeviceRefs/name
+        kind: VirtualMachine
+  - kind: VirtualDisk
+    version: v1alpha2 # optional
+    fieldSpecs:
+      - path: spec/blockDeviceRefs/name
+        kind: VirtualMachine
+      - path: spec/blockDeviceRef/name
+        kind: VirtualMachineBlockDeviceAttachment
+  - kind: Secret
+    fieldSpecs:
+      - path: spec/provisioning/userDataRef/name
+        kind: VirtualMachine
+  - kind: VirtualMachineIPAddress
+    version: v1alpha2
+    fieldSpecs:
+      - path: spec/virtualMachineIPAddressName
+        kind: VirtualMachine
+  - kind: VirtualMachine
+    version: v1alpha2
+    fieldSpecs:
+      - path: spec/virtualMachineName
+        kind: VirtualMachineBlockDeviceAttachment
+  - kind: VirtualMachineClass
+    version: v1alpha2
+    fieldSpecs:
+      - path: spec/virtualMachineClassName
+        kind: VirtualMachine
+  - kind: VirtualImage
+    version: v1alpha2
+    fieldSpecs:
+      - path: spec/blockDeviceRef/name
+        kind: VirtualMachineBlockDeviceAttachment

--- a/tests/e2e/testdata/vm-restore-safe/vm/base/vd-blank.yaml
+++ b/tests/e2e/testdata/vm-restore-safe/vm/base/vd-blank.yaml
@@ -1,0 +1,7 @@
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualDisk
+metadata:
+  name: vd-blank
+spec:
+  persistentVolumeClaim:
+    size: 512Mi

--- a/tests/e2e/testdata/vm-restore-safe/vm/base/vd-root.yaml
+++ b/tests/e2e/testdata/vm-restore-safe/vm/base/vd-root.yaml
@@ -1,0 +1,12 @@
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualDisk
+metadata:
+  name: vd-root
+spec:
+  persistentVolumeClaim:
+    size: 512Mi
+  dataSource:
+    type: ObjectRef
+    objectRef:
+      kind: VirtualImage
+      name: vi-alpine-http

--- a/tests/e2e/testdata/vm-restore-safe/vm/base/vm.yaml
+++ b/tests/e2e/testdata/vm-restore-safe/vm/base/vm.yaml
@@ -1,0 +1,22 @@
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualMachine
+metadata:
+  name: vm
+spec:
+  bootloader: BIOS
+  virtualMachineClassName: generic
+  cpu:
+    cores: 1
+    coreFraction: 5%
+  memory:
+    size: 256Mi
+  disruptions:
+    restartApprovalMode: Manual
+  provisioning:
+    type: UserDataRef
+    userDataRef:
+      kind: Secret
+      name: cloud-init
+  blockDeviceRefs:
+    - kind: VirtualDisk
+      name: vd-root

--- a/tests/e2e/testdata/vm-restore-safe/vm/base/vmbda-vd.yaml
+++ b/tests/e2e/testdata/vm-restore-safe/vm/base/vmbda-vd.yaml
@@ -1,0 +1,9 @@
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualMachineBlockDeviceAttachment
+metadata:
+  name: blank-disk-attachment
+spec:
+  virtualMachineName: vm
+  blockDeviceRef:
+    kind: VirtualDisk
+    name: vd-blank

--- a/tests/e2e/testdata/vm-restore-safe/vm/base/vmbda-vi.yaml
+++ b/tests/e2e/testdata/vm-restore-safe/vm/base/vmbda-vi.yaml
@@ -1,0 +1,9 @@
+apiVersion: virtualization.deckhouse.io/v1alpha2
+kind: VirtualMachineBlockDeviceAttachment
+metadata:
+  name: vi-attachment
+spec:
+  virtualMachineName: vm
+  blockDeviceRef:
+    kind: VirtualImage
+    name: vi-ubuntu-http

--- a/tests/e2e/testdata/vm-restore-safe/vm/kustomization.yaml
+++ b/tests/e2e/testdata/vm-restore-safe/vm/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - overlays/vm

--- a/tests/e2e/testdata/vm-restore-safe/vm/overlays/vm/kustomization.yaml
+++ b/tests/e2e/testdata/vm-restore-safe/vm/overlays/vm/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+nameSuffix: -restore-safe
+resources:
+  - ../../base
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/disruptions/restartApprovalMode
+        value: Automatic
+    target:
+      kind: VirtualMachine
+      name: vm


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
Resource validation works properly when a virtual machine is restored in Safe mode.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: vmrestore
type: fix
summary: "Resource validation works properly when a virtual machine is restored in Safe mode."
```
