### PR TITLE
fix(vd): validate storage class volume mode compatibility on change

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vd/internal/validator/spec_changes_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/validator/spec_changes_validator.go
@@ -22,14 +22,11 @@ import (
 	"fmt"
 	"reflect"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	intsvc "github.com/deckhouse/virtualization-controller/pkg/controller/vd/internal/service"
 	virtv2 "github.com/deckhouse/virtualization/api/core/v1alpha2"
-	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
 )
 
 type SpecChangesValidator struct {


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->

Add validation to prevent storage class changes when the volume modes (Filesystem vs Block) are incompatible. The validator now checks if a storage class change would result in a different volume mode for the PVC and blocks such changes.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
This fix prevents the problematic change at validation time with a error message explaining the incompatibility.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: vd
type: fix
summary: Prevent storage class changes that would result in incompatible volume modes
```
