### PR TITLE
fix(vm): make provisioning type spec field required

### DIFF
--- a/crds/virtualmachines.yaml
+++ b/crds/virtualmachines.yaml
@@ -52,6 +52,8 @@ spec:
                   description: |
                     Section describing a VM initial provisioning scenario.
                   type: object
+                  required:
+                    - type
                   properties:
                     type:
                       description: |


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Make provisioning type spec field required.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
Unspecified type leads to an error.


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: vm
type: fix
summary: Make provisioning type spec field required.
impact_level: low
```
