### PR TITLE
chore(api): remove not used error filter

### DIFF
--- a/tests/e2e/default_config.yaml
+++ b/tests/e2e/default_config.yaml
@@ -47,7 +47,6 @@ logFilter:
   - "the server rejected our request due to an error in our request" # Err.
   - "failed to sync powerstate" # Msg.
   - "does not have a pvc reference" # "err": "kvvm head-345e7b6a-testcases-image-hotplug/head-345e7b6a-vm-image-hotplug spec volume vi-head-345e7b6a-vi-alpine-http does not have a pvc reference"
-  - "get storage class specified in spec: storage class not found" # Err.
   - "lastTransitionTime: Required value" # Err.
   - "virtualmachineipaddressleases.virtualization.deckhouse.io "
 regexpLogFilter:


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Remove unused error filter from e2e logs filter.


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
impact_level: low
```
