### PR TITLE
fix(vdsnapshot): fix multiple vm attachment check

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/life_cycle.go
+++ b/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/life_cycle.go
@@ -76,12 +76,6 @@ func (h LifeCycleHandler) Handle(ctx context.Context, vdSnapshot *virtv2.Virtual
 		return reconcile.Result{}, err
 	}
 
-	vm, err := getVirtualMachine(ctx, vd, h.snapshotter)
-	if err != nil {
-		setPhaseConditionToFailed(cb, &vdSnapshot.Status.Phase, err)
-		return reconcile.Result{}, err
-	}
-
 	if vdSnapshot.DeletionTimestamp != nil {
 		vdSnapshot.Status.Phase = virtv2.VirtualDiskSnapshotPhaseTerminating
 		cb.
@@ -148,6 +142,12 @@ func (h LifeCycleHandler) Handle(ctx context.Context, vdSnapshot *virtv2.Virtual
 			Reason(vdscondition.WaitingForTheVirtualDisk).
 			Message("Waiting for the virtual disk's pvc to be in phase Bound.")
 		return reconcile.Result{}, nil
+	}
+
+	vm, err := getVirtualMachine(ctx, vd, h.snapshotter)
+	if err != nil {
+		setPhaseConditionToFailed(cb, &vdSnapshot.Status.Phase, err)
+		return reconcile.Result{}, err
 	}
 
 	switch {


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
The VirtualDiskSnapshot changes its status to Failed if the VirtualDisk is simultaneously attached to another VirtualMachine after a successful snapshotting process.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
The VirtualDiskSnapshot retains its Ready status even if the VirtualDisk is simultaneously attached to another VirtualMachine after a successful snapshotting process.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: vdsnapshot
type: fix
summary: "The VirtualDiskSnapshot retains its Ready status even if the VirtualDisk is simultaneously attached to another VirtualMachine after a successful snapshotting process."
```
