### PR TITLE
chore(module): rename scary exe extension

### DIFF
--- a/images/hooks/werf.inc.yaml
+++ b/images/hooks/werf.inc.yaml
@@ -56,5 +56,5 @@ shell:
     export TAGS="{{ printf "-tags %s" .MODULE_EDITION }}"
     {{- $_ := set $ "ProjectName" (list $.ImageName "hooks" | join "/") }}
     {{- include "image-build.build" (set $ "BuildCommand" `go build -ldflags="-s -w" $TAGS -a -o /go-hooks/virtualization-module-hooks ./cmd/virtualization-module-hooks`) | nindent 6 }}
-    # Note: module-config-reporter should have extension to be treated as a classic shell hook (not batch).
-    {{- include "image-build.build" (set $ "BuildCommand" `go build -ldflags="-s -w" $TAGS -a -o /go-hooks/module-config-reporter.exe ./cmd/module-config-reporter`) | nindent 6 }}
+    # Note: module-config-reporter hook binary should have extension to be treated as a classic shell hook (not batch).
+    {{- include "image-build.build" (set $ "BuildCommand" `go build -ldflags="-s -w" $TAGS -a -o /go-hooks/module-config-reporter.classic.hook ./cmd/module-config-reporter`) | nindent 6 }}


### PR DESCRIPTION
## Description

module-config-reporter hook binary should have an extension to be treated as a classic shell hook (not batch). ".exe" extension is for Windows PE binaries, so change it to more descriptive ".classic.hook"


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries


```changes
section: module
type: chore
summary: "Rename module-config-reporter.exe hook extension to more descriptive one: module-config-reporter.classic.hook"
impact_level: low
```
