### PR TITLE
chore: lint cli d8v

### DIFF
--- a/src/cli/.golangci.yaml
+++ b/src/cli/.golangci.yaml
@@ -1,0 +1,79 @@
+run:
+  concurrency: 4
+  timeout: 10m
+issues:
+  # Show all errors.
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  exclude:
+    - "don't use an underscore in package name"
+output:
+  sort-results: true
+
+exclude-files:
+  - "^zz_generated.*"
+
+linters-settings:
+  gofumpt:
+    extra-rules: true
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(github.com/deckhouse/)
+  goimports:
+    local-prefixes: github.com/deckhouse/
+  errcheck:
+    exclude-functions: fmt:.*,[rR]ead|[wW]rite|[cC]lose,io:Copy
+  revive:
+    rules:
+      - name: dot-imports
+        disabled: true
+  nolintlint:
+    # Exclude following linters from requiring an explanation.
+    # Default: []
+    allow-no-explanation: [funlen, gocognit, lll]
+    # Enable to require an explanation of nonzero length after each nolint directive.
+    # Default: false
+    require-explanation: true
+    # Enable to require nolint directives to mention the specific linter being suppressed.
+    # Default: false
+    require-specific: true
+
+linters:
+  disable-all: true
+  enable:
+    - asciicheck # checks that your code does not contain non-ASCII identifiers
+    - bidichk # checks for dangerous unicode character sequences
+    - bodyclose # checks whether HTTP response body is closed successfully
+    - contextcheck # [maby too many false positives] checks the function whether use a non-inherited context
+    - dogsled # checks assignments with too many blank identifiers (e.g. x, _, _, _, := f())
+    - errcheck # checking for unchecked errors, these unchecked errors can be critical bugs in some cases
+    - errname # checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error
+    - errorlint # finds code that will cause problems with the error wrapping scheme introduced in Go 1.13
+    - copyloopvar # detects places where loop variables are copied (Go 1.22+)
+    - gci # controls golang package import order and makes it always deterministic
+    - gocritic # provides diagnostics that check for bugs, performance and style issues
+    - gofmt # [replaced by goimports] checks whether code was gofmt-ed
+    - gofumpt # [replaced by goimports, gofumports is not available yet] checks whether code was gofumpt-ed
+    - goimports # in addition to fixing imports, goimports also formats your code in the same style as gofmt
+    - gosimple # specializes in simplifying a code
+    - govet # reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
+    - ineffassign # detects when assignments to existing variables are not used
+    - misspell # finds commonly misspelled English words in comments
+    - nolintlint # reports ill-formed or insufficient nolint directives
+    - reassign # Checks that package variables are not reassigned.
+    - revive # fast, configurable, extensible, flexible, and beautiful linter for Go, drop-in replacement of golint
+    - stylecheck # is a replacement for golint
+    - staticcheck # is a go vet on steroids, applying a ton of static analysis checks
+    - typecheck # like the front-end of a Go compiler, parses and type-checks Go code
+    - testifylint # checks usage of github.com/stretchr/testify
+    - unconvert # removes unnecessary type conversions
+    - unparam # reports unused function parameters
+    - unused # checks for unused constants, variables, functions and types
+    - usetesting # reports uses of functions with replacement inside the testing package
+    - testableexamples # checks if examples are testable (have an expected output)
+    - thelper # detects golang test helpers without t.Helper() call and checks the consistency of test helpers
+    - tparallel # detects inappropriate usage of t.Parallel() method in your Go test codes
+    - whitespace # detects leading and trailing whitespace
+    - wastedassign # Finds wasted assignment statements.

--- a/src/cli/Taskfile.yaml
+++ b/src/cli/Taskfile.yaml
@@ -7,15 +7,39 @@ silent: true
 tasks:
   build:
     cmds:
-      - go build -o out/d8v cmd/main.go
+      - go build -o .out/d8v cmd/main.go
   install:
     deps: [build]
     cmds:
       - echo "Check that ~/.local/bin in your PATH"
       - echo "Installing d8v to ~/.local/bin"
       - mkdir -p ~/.local/bin
-      - cp out/d8v ~/.local/bin/d8v
+      - cp .out/d8v ~/.local/bin/d8v
       - task: clean
   clean:
     cmds:
-      - rm -rf out
+      - rm -rf .out
+
+  lint:
+    desc: "Run linters locally"
+    cmds:
+      - task: lint:go
+
+  lint:go:
+    desc: "Run golangci-lint"
+    deps:
+      - _ensure:golangci-lint
+    cmds:
+      - |
+        golangci-lint run
+
+  _ensure:golangci-lint:
+    desc: "Ensure golangci-lint is available"
+    internal: true
+    cmds:
+      - |
+        echo -e >&2 "Please install golangci-lint https://golangci-lint.run/usage/install/"
+        exit 1
+    status:
+      - |
+        [ -f ./golangci-lint ] || which golangci-lint

--- a/src/cli/internal/cmd/lifecycle/lifecycle.go
+++ b/src/cli/internal/cmd/lifecycle/lifecycle.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/deckhouse/virtualization/api/client/kubeclient"
-
 	"github.com/deckhouse/virtualization/src/cli/internal/clientconfig"
 	"github.com/deckhouse/virtualization/src/cli/internal/cmd/lifecycle/vmop"
 	"github.com/deckhouse/virtualization/src/cli/internal/templates"
@@ -111,7 +110,7 @@ func (l *Lifecycle) Run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid command %q", l.cmd)
 	}
 	if msg != "" {
-		cmd.Printf(msg)
+		cmd.Printf("%s", msg)
 	}
 	return err
 }
@@ -119,14 +118,14 @@ func (l *Lifecycle) Run(cmd *cobra.Command, args []string) error {
 func (l *Lifecycle) Usage() string {
 	opts := DefaultOptions()
 	usage := fmt.Sprintf(` # %s VirtualMachine 'myvm':`, cases.Title(language.English).String(string(l.cmd)))
-	usage += strings.Replace(fmt.Sprintf(`
+	usage += strings.ReplaceAll(fmt.Sprintf(`
   {{ProgramName}} {{operation}} myvm
   {{ProgramName}} {{operation}} myvm.mynamespace
   {{ProgramName}} {{operation}} myvm -n mynamespace
   # Configure one minute timeout (default: timeout=%v)
   {{ProgramName}} {{operation}} --%s=1m myvm
   # Configure wait vm phase (default: wait=%v)
-  {{ProgramName}} {{operation}} --%s myvm`, opts.Timeout, timeoutFlag, opts.WaitComplete, waitFlag), "{{operation}}", string(l.cmd), -1)
+  {{ProgramName}} {{operation}} --%s myvm`, opts.Timeout, timeoutFlag, opts.WaitComplete, waitFlag), "{{operation}}", string(l.cmd))
 	if l.cmd != Start && l.cmd != Evict {
 		usage += fmt.Sprintf(`
   # Configure shutdown policy (default: force=%v)

--- a/src/cli/internal/cmd/portforward/portforward.go
+++ b/src/cli/internal/cmd/portforward/portforward.go
@@ -26,13 +26,11 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/deckhouse/virtualization/api/client/kubeclient"
+	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
 
-	"github.com/spf13/cobra"
-
+	virtualizationv1alpha2 "github.com/deckhouse/virtualization/api/client/generated/clientset/versioned/typed/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/subresources/v1alpha2"
-
 	"github.com/deckhouse/virtualization/src/cli/internal/clientconfig"
 	"github.com/deckhouse/virtualization/src/cli/internal/templates"
 )
@@ -145,7 +143,7 @@ func (o *PortForward) startStdoutStream(namespace, name string, port forwardedPo
 	}
 
 	klog.V(3).Infof("forwarding to %s/%s:%d", namespace, name, port.remote)
-	if err := streamer.Stream(kubeclient.StreamOptions{
+	if err := streamer.Stream(virtualizationv1alpha2.StreamOptions{
 		In:  os.Stdin,
 		Out: os.Stdout,
 	}); err != nil {

--- a/src/cli/internal/cmd/portforward/portforwarder.go
+++ b/src/cli/internal/cmd/portforward/portforwarder.go
@@ -26,7 +26,7 @@ import (
 
 	"k8s.io/klog/v2"
 
-	"github.com/deckhouse/virtualization/api/client/kubeclient"
+	virtualizationv1alpha2 "github.com/deckhouse/virtualization/api/client/generated/clientset/versioned/typed/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/subresources/v1alpha2"
 )
 
@@ -37,7 +37,7 @@ type portForwarder struct {
 }
 
 type portforwardableResource interface {
-	PortForward(name string, options v1alpha2.VirtualMachinePortForward) (kubeclient.StreamInterface, error)
+	PortForward(name string, options v1alpha2.VirtualMachinePortForward) (virtualizationv1alpha2.StreamInterface, error)
 }
 
 func (p *portForwarder) startForwarding(address *net.IPAddr, port forwardedPort) error {

--- a/src/cli/internal/cmd/scp/native.go
+++ b/src/cli/internal/cmd/scp/native.go
@@ -53,7 +53,7 @@ func (o *SCP) nativeSCP(virtClient kubeclient.Client, local templates.LocalSCPAr
 func (o *SCP) copyToRemote(client *scp.Client, localPath, remotePath string) error {
 	isFile, isDir, exists, err := stat(localPath)
 	if err != nil {
-		return fmt.Errorf("failed reading path %q: %v", localPath, err)
+		return fmt.Errorf("failed reading path %q: %w", localPath, err)
 	}
 
 	if !exists {
@@ -78,7 +78,7 @@ func (o *SCP) copyToRemote(client *scp.Client, localPath, remotePath string) err
 func (o *SCP) copyFromRemote(client *scp.Client, localPath, remotePath string) error {
 	_, isDir, exists, err := stat(localPath)
 	if err != nil {
-		return fmt.Errorf("failed reading path %q: %v", localPath, err)
+		return fmt.Errorf("failed reading path %q: %w", localPath, err)
 	}
 
 	if o.recursive {
@@ -90,7 +90,7 @@ func (o *SCP) copyFromRemote(client *scp.Client, localPath, remotePath string) e
 		}
 
 		if err := os.MkdirAll(localPath, os.ModePerm); err != nil {
-			return fmt.Errorf("failed ensuring the existence of the local target directory %q: %v", localPath, err)
+			return fmt.Errorf("failed ensuring the existence of the local target directory %q: %w", localPath, err)
 		}
 
 		return client.CopyDirFromRemote(remotePath, localPath, &scp.DirTransferOption{PreserveProp: o.preserve})

--- a/src/cli/internal/cmd/ssh/knownhosts.go
+++ b/src/cli/internal/cmd/ssh/knownhosts.go
@@ -37,11 +37,11 @@ func InteractiveHostKeyCallback(knownHostsFilePath string) (ssh.HostKeyCallback,
 	if _, err := os.Stat(knownHostsFilePath); errors.Is(err, os.ErrNotExist) {
 		f, err := os.Create(knownHostsFilePath)
 		if err != nil {
-			return nil, fmt.Errorf("failed creating known hosts file %q: %v", knownHostsFilePath, err)
+			return nil, fmt.Errorf("failed creating known hosts file %q: %w", knownHostsFilePath, err)
 		}
 		_ = f.Close()
 	} else if err != nil {
-		return nil, fmt.Errorf("failed reading known host file %q: %v", knownHostsFilePath, err)
+		return nil, fmt.Errorf("failed reading known host file %q: %w", knownHostsFilePath, err)
 	}
 	validator, err := knownhosts.New(knownHostsFilePath)
 	if err != nil {
@@ -96,7 +96,7 @@ Are you sure you want to continue connecting (yes/no)? `,
 }
 
 func addHostKey(knownHostsFilePath, hostname string, key ssh.PublicKey) error {
-	f, err := os.OpenFile(knownHostsFilePath, os.O_APPEND|os.O_WRONLY, 0600)
+	f, err := os.OpenFile(knownHostsFilePath, os.O_APPEND|os.O_WRONLY, 0o600)
 	if err != nil {
 		return err
 	}

--- a/src/cli/internal/cmd/ssh/native.go
+++ b/src/cli/internal/cmd/ssh/native.go
@@ -30,6 +30,7 @@ import (
 	"golang.org/x/term"
 	"k8s.io/klog/v2"
 
+	virtualizationv1alpha2 "github.com/deckhouse/virtualization/api/client/generated/clientset/versioned/typed/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/client/kubeclient"
 	"github.com/deckhouse/virtualization/api/subresources/v1alpha2"
 )
@@ -206,7 +207,7 @@ func (o *NativeSSHConnection) StartSession(client *ssh.Client, command string) e
 	return nil
 }
 
-func (o *NativeSSHConnection) prepareSSHTunnel(namespace, name string) (kubeclient.StreamInterface, error) {
+func (o *NativeSSHConnection) prepareSSHTunnel(namespace, name string) (virtualizationv1alpha2.StreamInterface, error) {
 	opts := v1alpha2.VirtualMachinePortForward{
 		Port:     o.options.SSHPort,
 		Protocol: "tcp",

--- a/src/cli/internal/cmd/ssh/terminal_unix.go
+++ b/src/cli/internal/cmd/ssh/terminal_unix.go
@@ -39,7 +39,9 @@ func setupTerminal() (func(), error) {
 		return nil, err
 	}
 
-	return func() { term.Restore(fd, state) }, nil
+	return func() {
+		_ = term.Restore(fd, state)
+	}, nil
 }
 
 func requestPty(session *ssh.Session) error {
@@ -67,7 +69,7 @@ func resizeSessionOnWindowChange(session *ssh.Session, _ uintptr) {
 	signal.Notify(sigs, syscall.SIGWINCH)
 
 	for range sigs {
-		session.SendRequest("window-change", false, windowSizePayloadFor())
+		_, _ = session.SendRequest("window-change", false, windowSizePayloadFor())
 	}
 }
 

--- a/src/cli/internal/cmd/ssh/wrapped.go
+++ b/src/cli/internal/cmd/ssh/wrapped.go
@@ -75,7 +75,6 @@ func buildProxyCommandOption(cmd *cobra.Command, namespace, name string, port in
 	for i := 1; i <= len(parents); i++ {
 		pcmd.WriteString(parents[len(parents)-i])
 		pcmd.WriteString(" ")
-
 	}
 
 	proxyCommand := strings.Builder{}

--- a/src/cli/internal/cmd/vnc/vnc.go
+++ b/src/cli/internal/cmd/vnc/vnc.go
@@ -37,8 +37,8 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
 
+	virtualizationv1alpha2 "github.com/deckhouse/virtualization/api/client/generated/clientset/versioned/typed/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/client/kubeclient"
-
 	"github.com/deckhouse/virtualization/src/cli/internal/clientconfig"
 	"github.com/deckhouse/virtualization/src/cli/internal/templates"
 	"github.com/deckhouse/virtualization/src/cli/internal/util"
@@ -185,7 +185,7 @@ func connect(ctx context.Context, ln *net.TCPListener, virtCli kubeclient.Client
 
 	go func() {
 		// transfer data from/to the VM
-		err := vnc.Stream(kubeclient.StreamOptions{
+		err := vnc.Stream(virtualizationv1alpha2.StreamOptions{
 			In:  pipeInReader,
 			Out: pipeOutWriter,
 		})
@@ -213,7 +213,7 @@ func connect(ctx context.Context, ln *net.TCPListener, virtCli kubeclient.Client
 		defer fd.Close()
 
 		klog.V(2).Infof("VNC Client connected in %v", time.Since(start))
-		templates.PrintWarningForPausedVM(virtCli, vmName, namespace)
+		templates.PrintWarningForPausedVM(ctx, virtCli, vmName, namespace)
 
 		// write to FD <- pipeOutReader
 		go func() {

--- a/src/cli/internal/templates/target.go
+++ b/src/cli/internal/templates/target.go
@@ -80,17 +80,18 @@ type RemoteSCPArgument struct {
 	Path      string
 }
 
-func ParseSCPArguments(arg1 string, arg2 string) (local LocalSCPArgument, remote RemoteSCPArgument, toRemote bool, err error) {
+func ParseSCPArguments(arg1, arg2 string) (local LocalSCPArgument, remote RemoteSCPArgument, toRemote bool, err error) {
 	remoteArg := arg1
 	localArg := arg2
 	toRemote = false
-	if strings.Contains(arg1, ":") && strings.Contains(arg2, ":") {
+	switch {
+	case strings.Contains(arg1, ":") && strings.Contains(arg2, ":"):
 		err = fmt.Errorf("copying from a remote location to another remote location is not supported: %q to %q", arg1, arg2)
 		return
-	} else if !strings.Contains(arg1, ":") && !strings.Contains(arg2, ":") {
+	case !strings.Contains(arg1, ":") && !strings.Contains(arg2, ":"):
 		err = fmt.Errorf("none of the two provided locations seems to be a remote location: %q to %q", arg1, arg2)
 		return
-	} else if strings.Contains(localArg, ":") {
+	case strings.Contains(localArg, ":"):
 		remoteArg = arg2
 		localArg = arg1
 		toRemote = true

--- a/src/cli/internal/templates/templates.go
+++ b/src/cli/internal/templates/templates.go
@@ -92,12 +92,12 @@ func ExactArgs(nameOfCommand string, n int) cobra.PositionalArgs {
 }
 
 // PrintWarningForPausedVM prints warning message if VM is paused
-func PrintWarningForPausedVM(virtCli kubeclient.Client, vmName, namespace string) {
-	vm, err := virtCli.VirtualMachines(namespace).Get(context.Background(), vmName, metav1.GetOptions{})
+func PrintWarningForPausedVM(ctx context.Context, virtCli kubeclient.Client, vmName, namespace string) {
+	vm, err := virtCli.VirtualMachines(namespace).Get(ctx, vmName, metav1.GetOptions{})
 	if err != nil {
 		return
 	}
 	if vm.Status.Phase == virtv2.MachinePause {
-		fmt.Fprintf(os.Stderr, "\rWarning: %s is paused. Console will be active after unpause.\n", vmName)
+		_, _ = fmt.Fprintf(os.Stderr, "\rWarning: %s is paused. Console will be active after unpause.\n", vmName)
 	}
 }

--- a/src/cli/internal/util/consts.go
+++ b/src/cli/internal/util/consts.go
@@ -19,12 +19,6 @@ Initially copied from https://github.com/kubevirt/kubevirt/blob/main/pkg/virtctl
 
 package util
 
-import (
-	"errors"
-)
-
-var ErrorInterrupt = errors.New("interrupt")
-
 const (
 	CloseGoingAwayMessage       = "\nYou were disconnected from the console. This has one of the following reasons:\n - another user connected to the console of the target vm\n"
 	CloseAbnormalClosureMessage = "\nYou were disconnected from the console. This has one of the following reasons:\n - network issues\n - machine restart\n"

--- a/src/cli/pkg/command/virtualization.go
+++ b/src/cli/pkg/command/virtualization.go
@@ -29,6 +29,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/component-base/logs"
 
+	"github.com/deckhouse/virtualization/api/client/kubeclient"
 	"github.com/deckhouse/virtualization/src/cli/internal/clientconfig"
 	"github.com/deckhouse/virtualization/src/cli/internal/cmd/console"
 	"github.com/deckhouse/virtualization/src/cli/internal/cmd/lifecycle"
@@ -36,9 +37,6 @@ import (
 	"github.com/deckhouse/virtualization/src/cli/internal/cmd/scp"
 	"github.com/deckhouse/virtualization/src/cli/internal/cmd/ssh"
 	"github.com/deckhouse/virtualization/src/cli/internal/cmd/vnc"
-
-	"github.com/deckhouse/virtualization/api/client/kubeclient"
-
 	"github.com/deckhouse/virtualization/src/cli/internal/templates"
 )
 
@@ -53,7 +51,7 @@ func NewCommand(programName string) *cobra.Command {
 	// used to enable replacement of `ProgramName` placeholder for cobra.Example, which has no template support
 	cobra.AddTemplateFunc(
 		"prepare", func(s string) string {
-			result := strings.Replace(s, "{{ProgramName}}", programName, -1)
+			result := strings.ReplaceAll(s, "{{ProgramName}}", programName)
 			return result
 		},
 	)
@@ -63,8 +61,8 @@ func NewCommand(programName string) *cobra.Command {
 		Short:         programName + " controls virtual machine related operations on your kubernetes cluster.",
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Help()
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
 		},
 	}
 
@@ -77,7 +75,7 @@ func NewCommand(programName string) *cobra.Command {
 		Use:    "options",
 		Hidden: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Printf(cmd.UsageString())
+			cmd.Printf("%s", cmd.UsageString())
 		},
 	}
 


### PR DESCRIPTION
## Description
 lint cli d8v


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: core
type: chore 
summary: lint cli d8v
impact_level: low
```
