### PR TITLE
fix(vmop): remove finalaizer if migration does not exists

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/deletion.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/deletion.go
@@ -66,7 +66,7 @@ func (h DeletionHandler) Handle(ctx context.Context, vmop *virtv2.VirtualMachine
 		return reconcile.Result{}, err
 	}
 
-	if mig == nil {
+	if mig != nil {
 		return reconcile.Result{}, nil
 	}
 


### PR DESCRIPTION
## Description
remove finalaizer if migration does not exists


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: vmop
type: fix
summary: remove finalaizer if migration does not exists
impact_level: low
```
