### PR TITLE
chore: bump kubevirt to v1.3.1-v12n.10

### DIFF
--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -3,7 +3,7 @@ firmware:
   libvirt: 10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: v1.3.1-v12n.9
+  3p-kubevirt: v1.3.1-v12n.10
   3p-containerized-data-importer: v1.60.3-v12n.9
   distribution: 2.8.3
 package:


### PR DESCRIPTION
## Description
bump kubevirt to v1.3.1-v12n.10
https://github.com/deckhouse/3p-kubevirt/pull/18


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: core
type: fix
summary: bump kubevirt to v1.3.1-v12n.10
impact_level: low
```
