### PR TITLE
fix(core): debuger image should not be final

### DIFF
--- a/images/debuger/werf.inc.yaml
+++ b/images/debuger/werf.inc.yaml
@@ -1,6 +1,7 @@
 ---
 image: {{ $.ImageName }}
 fromImage: distroless
+final: false
 import:
 - image: {{ $.ImageName }}-builder
   add: /out


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Set debuger image `final: false`

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: core
type: fix
summary: set debuger image `final: false`
impact_level: low
```
