### PR TITLE
fix(test): increase buffer size for log parser

### DIFF
--- a/tests/e2e/errlogger/errlogger.go
+++ b/tests/e2e/errlogger/errlogger.go
@@ -37,12 +37,13 @@ import (
 )
 
 const (
-	Red        = "\033[31m"
-	Yellow     = "\033[33m"
-	Green      = "\033[32m"
-	Reset      = "\033[0m"
-	Bold       = "\033[1m"
-	LevelError = "error"
+	Red         = "\033[31m"
+	Yellow      = "\033[33m"
+	Green       = "\033[32m"
+	Reset       = "\033[0m"
+	Bold        = "\033[1m"
+	LevelError  = "error"
+	maxCapacity = 1024 << 10
 )
 
 type warning string
@@ -91,6 +92,9 @@ func (l *LogStream) ParseStderr() {
 	defer l.LogStreamWaitGroup.Done()
 
 	scanner := bufio.NewScanner(l.Stderr)
+	buf := make([]byte, maxCapacity)
+	scanner.Buffer(buf, maxCapacity)
+
 	for scanner.Scan() {
 		_, writeErr := GinkgoWriter.Write([]byte(fmt.Sprintf("%s%s%s\n", Red, scanner.Text(), Reset)))
 		Expect(writeErr).NotTo(HaveOccurred())
@@ -105,6 +109,9 @@ func (l *LogStream) ParseStdout(excludedPatterns []string, excludedRegexpPattens
 
 	errFlag := false
 	scanner := bufio.NewScanner(l.Stdout)
+	buf := make([]byte, maxCapacity)
+	scanner.Buffer(buf, maxCapacity)
+
 	for scanner.Scan() {
 		var entry LogEntry
 		rawEntry := strings.TrimPrefix(scanner.Text(), "0")


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Increase buffer size for log parser.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
A scan error occurs when the virtualization controller log level is set to debug.
```
  [FAILED] in [It] - /username/virtualization/tests/e2e/errlogger/errlogger.go:198 @ 08/26/25 09:45:02.748
• [FAILED] [16.971 seconds]
ComplexTest When virtualization resources are applied [It] result should be succeeded [Serial]
/username/virtualization/tests/e2e/complex_test.go:59

  [FAILED] failed to scan the "STDOUT" stream)
  Unexpected error:
      <*errors.errorString | 0x5d56870>:
      bufio.Scanner: token too long
      {
          s: "bufio.Scanner: token too long",
      }
  occurred
  In [It] at: /username/virtualization/tests/e2e/errlogger/errlogger.go:198 @ 08/26/25 09:45:02.748
  ```

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
No errors.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: test
type: fix
summary: increase buffer size for local e2e run when loglevel is debug
impact_level: low
```
