### PR TITLE
feat(core): add dvcr config for containerd v2

### DIFF
--- a/images/dvcr-artifact/pkg/registry/registry.go
+++ b/images/dvcr-artifact/pkg/registry/registry.go
@@ -31,6 +31,7 @@ import (
 	"os/exec"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -171,16 +172,40 @@ func (p DataProcessor) inspectAndStreamSourceImage(
 ) error {
 	var tarWriter *tar.Writer
 	{
+		now := time.Now()
+
 		tarWriter = tar.NewWriter(pipeWriter)
+		dirHeader := &tar.Header{
+			Name:       "disk",
+			Mode:       0o755,
+			Uid:        107,
+			Gid:        107,
+			ModTime:    now,
+			AccessTime: now,
+			ChangeTime: now,
+			Typeflag:   tar.TypeDir,
+			Format:     tar.FormatPAX,
+		}
+		if err := tarWriter.WriteHeader(dirHeader); err != nil {
+			return fmt.Errorf("error writing tar header [disk]: %w", err)
+		}
+
+		imagePath := path.Join("disk", sourceImageFilename)
 		header := &tar.Header{
-			Name:     path.Join("disk", sourceImageFilename),
-			Size:     int64(sourceImageSize),
-			Mode:     0o644,
-			Typeflag: tar.TypeReg,
+			Name:       imagePath,
+			Size:       int64(sourceImageSize),
+			Mode:       0o644,
+			Uid:        107,
+			Gid:        107,
+			ModTime:    now,
+			AccessTime: now,
+			ChangeTime: now,
+			Typeflag:   tar.TypeReg,
+			Format:     tar.FormatPAX,
 		}
 
 		if err := tarWriter.WriteHeader(header); err != nil {
-			return fmt.Errorf("error writing tar header: %w", err)
+			return fmt.Errorf("error writing tar header [%s]: %w", imagePath, err)
 		}
 	}
 

--- a/images/dvcr-artifact/pkg/registry/registry.go
+++ b/images/dvcr-artifact/pkg/registry/registry.go
@@ -362,6 +362,8 @@ func (p DataProcessor) uploadLayersAndImage(
 	return nil
 }
 
+// populateCommonConfigFields adds some required fields according to the document:
+// https://github.com/opencontainers/image-spec/blob/main/config.md
 func populateCommonConfigFields(cnf *v1.ConfigFile) {
 	cnf.Created = v1.Time{Time: time.Now().UTC()}
 	cnf.Architecture = imageArchitecture

--- a/images/dvcr-artifact/pkg/registry/registry.go
+++ b/images/dvcr-artifact/pkg/registry/registry.go
@@ -365,7 +365,8 @@ func (p DataProcessor) uploadLayersAndImage(
 // populateCommonConfigFields adds some required fields according to the document:
 // https://github.com/opencontainers/image-spec/blob/main/config.md
 func populateCommonConfigFields(cnf *v1.ConfigFile) {
-	cnf.Created = v1.Time{Time: time.Now().UTC()}
+	now := time.Now().UTC()
+	cnf.Created = v1.Time{Time: now}
 	cnf.Architecture = imageArchitecture
 	cnf.OS = imageOS
 	cnf.Author = imageAuthor
@@ -375,6 +376,13 @@ func populateCommonConfigFields(cnf *v1.ConfigFile) {
 	cnf.Config.Labels[imageLabelEROFSCompatible] = "true"
 
 	cnf.Config.WorkingDir = imageWorkingDir
+
+	cnf.History = append(cnf.History, v1.History{
+		Author:     imageAuthor,
+		Created:    v1.Time{Time: now},
+		Comment:    "streamed from the datasource",
+		EmptyLayer: false,
+	})
 }
 
 func getImageInfo(ctx context.Context, sourceReader io.ReadCloser) (ImageInfo, error) {

--- a/images/dvcr-artifact/pkg/registry/tar.go
+++ b/images/dvcr-artifact/pkg/registry/tar.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"fmt"
+	"io"
+)
+
+const (
+	tarRecordSize     = 512
+	tarEOFMarkerCount = 2
+)
+
+var zero = []byte{0x00}
+
+// writeTarEOFMarker writes EOF marker into Writer.
+// The EOF marker for tar is simply two 512-byte blocks of zeros.
+func writeTarEOFMarker(w io.Writer) error {
+	for i := 0; i < tarRecordSize*tarEOFMarkerCount; i++ {
+		n, err := w.Write(zero)
+		if n != 1 {
+			return fmt.Errorf("error writing zero byte to writer")
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/templates/dvcr/ nodegroupconfiguration.yaml
+++ b/templates/dvcr/ nodegroupconfiguration.yaml
@@ -16,25 +16,46 @@ spec:
   bundles: ["*"]
   content: |
     # Copyright 2023 Flant JSC
-        # Licensed under the Apache License, Version 2.0 (the "License");
+    # Licensed under the Apache License, Version 2.0 (the "License");
     # you may not use this file except in compliance with the License.
     # You may obtain a copy of the License at
-        #     http://www.apache.org/licenses/LICENSE-2.0
-        # Unless required by applicable law or agreed to in writing, software
+    #      http://www.apache.org/licenses/LICENSE-2.0
+    # Unless required by applicable law or agreed to in writing, software
     # distributed under the License is distributed on an "AS IS" BASIS,
     # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     # See the License for the specific language governing permissions and
     # limitations under the License.
 
-    mkdir -p /etc/containerd/conf.d
     bb-event-on 'registry-ca-changed' '_restart_containerd'
     bb-event-on 'containerd-config-changed' '_restart_containerd'
     _restart_containerd() {
         bb-flag-set containerd-need-restart
     }
+
+    {{ "{{- if eq .cri \"ContainerdV2\" }}" }}
+
+    mkdir -p "/etc/containerd/registry.d/{{ $registry }}"
+    mkdir -p "/etc/containerd/certs.d/{{ $registry }}"
+    bb-sync-file "/etc/containerd/certs.d/{{ $registry }}/ca.crt" - registry-ca-changed << "EOF"
+    {{- $ca | nindent 4 }}
+    EOF
+
+    bb-sync-file "/etc/containerd/registry.d/{{ $registry }}/hosts.toml" - containerd-config-changed << "EOF"
+    server = "https://{{ $registry }}"
+    [host."https://{{ $endpoint }}"]
+      capabilities = ["pull", "resolve"]
+      ca = "/etc/containerd/certs.d/{{ $registry }}/ca.crt"
+    [host."https://{{ $endpoint }}".auth]
+      auth = {{  $password | quote }}
+    EOF
+
+    {{ "{{- else }}" }}
+
+    mkdir -p /etc/containerd/conf.d
     bb-sync-file /etc/containerd/conf.d/dvcr-ca.crt - registry-ca-changed << "EOF"
     {{- $ca | nindent 4 }}
     EOF
+
     bb-sync-file /etc/containerd/conf.d/dvcr.toml - containerd-config-changed << "EOF"
     [plugins]
       [plugins."io.containerd.grpc.v1.cri"]
@@ -50,4 +71,7 @@ spec:
             [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ $registry }}"]
               endpoint = ["https://{{ $endpoint }}"]
     EOF
+
+    {{ "{{- end }}" }}
+
 {{- end }}


### PR DESCRIPTION
## Description

- Support containerd v2 config layout: change NGC with dvcr registry.
- Support erofs tar unpacking: erofs strictly requires end-of-file tar marker.
- Fix creation time and add common fields in generated DVCR images manifests.

## Why do we need it, and what problem does it solve?

CVI/VI attaching to VM not working properly with containerd v2 and erofs:

```
# kubectl get vm,po
NAME                                                                 PHASE     NODE           IPADDRESS    AGE
virtualmachine.virtualization.deckhouse.io/cloud-alpine-eros-fail    Pending                  10.66.10.3   16m

NAME                                              READY   STATUS                  RESTARTS   AGE
pod/virt-launcher-cloud-alpine-eros-fail-7h5z4    0/2     Init:ImagePullBackOff   0          49s

Event from kubectl describe:

  Warning    Failed   12s                kubelet  Failed to pull image "dvcr.d8-virtualization.svc/cvi/cloud-alpine-3-21-bios:3d007848-d0b6-41ac-bf46-2ea36bd23276":
failed to pull and unpack image "dvcr.d8-virtualization.svc/cvi/cloud-alpine-3-21-bios:3d007848-d0b6-41ac-bf46-2ea36bd23276":
failed to extract layer (application/vnd.docker.image.rootfs.diff.tar.gzip sha256:4d52a98290b3546b5533d93bbfac7202141460a1237cef955e64b45f7650faa5)
to erofs as "extract-416858418-wjtQ sha256:b47179c4ec93af01cf96c67ebe6c730bf01d85420ab9e10a90dbf296c470f1bc":
failed to convert erofs: erofs apply failed: <E> erofs: failed to read header block @ 111072256
<E> erofs:   Could not format the device : [Error 5] I/O error
```


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->

CVI/VI attaching works in containerd v2.

```
# kubectl get vm,po
NAME                                                                 PHASE     NODE           IPADDRESS    AGE
virtualmachine.virtualization.deckhouse.io/cloud-alpine-eros-debug   Running   virtlab-mi-1   10.66.10.2   19m

NAME                                              READY   STATUS                  RESTARTS   AGE
pod/virt-launcher-cloud-alpine-eros-debug-wjw96   2/2     Running                 0          5m18s
```


#### Image config changes

Before:

```console
$ crane --insecure config localhost:5001/cvi/cloud-alpine-3-21-bios:3d007848-d0b6-41ac-bf46-2ea36bd23276 | jq
{
  "architecture": "",
  "created": "0001-01-01T00:00:00Z",
  "history": [
    {
      "created": "0001-01-01T00:00:00Z"
    }
  ],
  "os": "",
  "rootfs": {
    "type": "layers",
    "diff_ids": [
      "sha256:b47179c4ec93af01cf96c67ebe6c730bf01d85420ab9e10a90dbf296c470f1bc"
    ]
  },
  "config": {
    "Labels": {
      "source-image-format": "qcow2",
      "source-image-size": "111071744",
      "source-image-virtual-size": "367001600"
    }
  }
}
```

After:

```console
$ crane --insecure config localhost:5001/cvi/cloud-alpine-3-21-eros-debug:d0a33a0b-0a14-48b1-b7a6-bacf838598a2 | jq
{
  "architecture": "amd64",
  "author": "DVCR client",
  "created": "2025-08-28T17:50:17.23562222Z",
  "os": "linux",
  "rootfs": {
    "type": "layers",
    "diff_ids": [
      "sha256:8538a78394561ac6b9208a7a8f23986302f48bb78a50218443ceda83135d81b4"
    ]
  },
  "config": {
    "Labels": {
      "erofs-compatible-layers": "true",
      "source-image-format": "qcow2",
      "source-image-size": "111071744",
      "source-image-virtual-size": "367001600"
    },
    "WorkingDir": "/"
  }
}
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: core
type: feature
summary: Support for containerd v2
```
