### PR TITLE
fix(vmmaclease): fix the typo in VirtualMachineMACAddressLease struct

### DIFF
--- a/api/core/v1alpha2/virtual_machine_mac_address_lease.go
+++ b/api/core/v1alpha2/virtual_machine_mac_address_lease.go
@@ -32,7 +32,7 @@ type VirtualMachineMACAddressLease struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   VirtualMachineMACAddressLeaseSpec   `json:"spec,omitempty"`
-	Status VirtualMachineMACAddressLeaseStatus `json:"status,omiMACmpty"`
+	Status VirtualMachineMACAddressLeaseStatus `json:"status,omitempty"`
 }
 
 // VirtualMachineMACAddressLeaseList contains a list of VirtualMachineMACAddressLease

--- a/images/virtualization-artifact/pkg/apiserver/api/generated/openapi/zz_generated.openapi.go
+++ b/images/virtualization-artifact/pkg/apiserver/api/generated/openapi/zz_generated.openapi.go
@@ -4476,7 +4476,6 @@ func schema_virtualization_api_core_v1alpha2_VirtualMachineMACAddressLease(ref c
 						},
 					},
 				},
-				Required: []string{"status"},
 			},
 		},
 		Dependencies: []string{


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Fix the typo in VirtualMachineMACAddressLease struct.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
