### PR TITLE
test: create namespace before apply operation

### DIFF
--- a/tests/e2e/affinity_toleration_test.go
+++ b/tests/e2e/affinity_toleration_test.go
@@ -65,6 +65,8 @@ var _ = Describe("VirtualMachineAffinityAndToleration", ginkgoutil.CommonE2ETest
 		var err error
 		ns, err = kustomize.GetNamespace(kustomization)
 		Expect(err).NotTo(HaveOccurred(), "%w", err)
+
+		CreateNamespace(ns)
 	})
 
 	AfterEach(func() {

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -45,14 +45,13 @@ var _ = Describe("ComplexTest", Serial, ginkgoutil.CommonE2ETestDecorators(), fu
 		}
 	})
 
-	Context("Preparing the environment", func() {
-		It("sets the namespace", func() {
-			kustomization := fmt.Sprintf("%s/%s", conf.TestData.ComplexTest, "kustomization.yaml")
-			var err error
-			ns, err = kustomize.GetNamespace(kustomization)
-			Expect(err).NotTo(HaveOccurred(), "%w", err)
-			Expect(ns).NotTo(BeEmpty())
-		})
+	BeforeAll(func() {
+		kustomization := fmt.Sprintf("%s/%s", conf.TestData.ComplexTest, "kustomization.yaml")
+		var err error
+		ns, err = kustomize.GetNamespace(kustomization)
+		Expect(err).NotTo(HaveOccurred(), "%w", err)
+
+		CreateNamespace(ns)
 	})
 
 	Context("When virtualization resources are applied", func() {

--- a/tests/e2e/default_config.yaml
+++ b/tests/e2e/default_config.yaml
@@ -1,4 +1,4 @@
-namespaceSuffix: "testcases"
+namespaceSuffix: "end-to-end"
 
 clusterTransport:
   kubeConfig: ""

--- a/tests/e2e/image_hotplug_test.go
+++ b/tests/e2e/image_hotplug_test.go
@@ -51,12 +51,6 @@ var _ = Describe("ImageHotplug", ginkgoutil.CommonE2ETestDecorators(), func() {
 		ns            string
 	)
 
-	AfterEach(func() {
-		if CurrentSpecReport().Failed() {
-			SaveTestResources(testCaseLabel, CurrentSpecReport().LeafNodeText)
-		}
-	})
-
 	BeforeAll(func() {
 		kustomization := fmt.Sprintf("%s/%s", conf.TestData.ImageHotplug, "kustomization.yaml")
 		var err error
@@ -69,6 +63,14 @@ var _ = Describe("ImageHotplug", ginkgoutil.CommonE2ETestDecorators(), func() {
 			Resource:       kc.ResourceCVI,
 		})
 		Expect(res.Error()).NotTo(HaveOccurred())
+
+		CreateNamespace(ns)
+	})
+
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			SaveTestResources(testCaseLabel, CurrentSpecReport().LeafNodeText)
+		}
 	})
 
 	Context("When the virtualization resources are applied", func() {

--- a/tests/e2e/images_creation_test.go
+++ b/tests/e2e/images_creation_test.go
@@ -45,6 +45,8 @@ var _ = Describe("VirtualImageCreation", ginkgoutil.CommonE2ETestDecorators(), f
 		ns, err = kustomize.GetNamespace(kustomization)
 		Expect(err).NotTo(HaveOccurred(), "%w", err)
 
+		CreateNamespace(ns)
+
 		Expect(conf.StorageClass.ImmediateStorageClass).NotTo(BeNil(), "immediate storage class cannot be nil; please set up the immediate storage class in the cluster")
 
 		virtualDisk := virtv2.VirtualDisk{}

--- a/tests/e2e/importer_network_policy_test.go
+++ b/tests/e2e/importer_network_policy_test.go
@@ -32,9 +32,11 @@ var _ = Describe("ImporterNetworkPolicy", ginkgoutil.CommonE2ETestDecorators(), 
 	testCaseLabel := map[string]string{"testcase": "importer-network-policy"}
 	var ns string
 
-	AfterAll(func() {
-		By("Delete manifests")
-		DeleteTestCaseResources(ns, ResourcesToDelete{KustomizationDir: conf.TestData.ImporterNetworkPolicy})
+	BeforeAll(func() {
+		kustomization := fmt.Sprintf("%s/%s", conf.TestData.ImporterNetworkPolicy, "kustomization.yaml")
+		var err error
+		ns, err = kustomize.GetNamespace(kustomization)
+		Expect(err).NotTo(HaveOccurred(), "%w", err)
 	})
 
 	BeforeEach(func() {
@@ -43,21 +45,19 @@ var _ = Describe("ImporterNetworkPolicy", ginkgoutil.CommonE2ETestDecorators(), 
 		}
 	})
 
+	AfterAll(func() {
+		By("Delete manifests")
+		DeleteTestCaseResources(ns, ResourcesToDelete{KustomizationDir: conf.TestData.ImporterNetworkPolicy})
+	})
+
 	AfterEach(func() {
 		if CurrentSpecReport().Failed() {
 			SaveTestResources(testCaseLabel, CurrentSpecReport().LeafNodeText)
 		}
 	})
 
-	Context("Preparing the environment", func() {
-		It("sets the namespace", func() {
-			kustomization := fmt.Sprintf("%s/%s", conf.TestData.ImporterNetworkPolicy, "kustomization.yaml")
-			var err error
-			ns, err = kustomize.GetNamespace(kustomization)
-			Expect(err).NotTo(HaveOccurred(), "%w", err)
-		})
-
-		It("project apply", func() {
+	Context("Project", func() {
+		It("creates project", func() {
 			config.PrepareProject(conf.TestData.ImporterNetworkPolicy)
 
 			res := kubectl.Apply(kc.ApplyOptions{

--- a/tests/e2e/ipam_test.go
+++ b/tests/e2e/ipam_test.go
@@ -51,6 +51,8 @@ var _ = Describe("IPAM", ginkgoutil.CommonE2ETestDecorators(), func() {
 		ns, err = kustomize.GetNamespace(kustomization)
 		Expect(err).NotTo(HaveOccurred())
 
+		CreateNamespace(ns)
+
 		res := kubectl.Apply(kc.ApplyOptions{
 			Filename:       []string{conf.TestData.IPAM},
 			FilenameOption: kc.Kustomize,

--- a/tests/e2e/sizing_policy_test.go
+++ b/tests/e2e/sizing_policy_test.go
@@ -35,12 +35,6 @@ import (
 )
 
 var _ = Describe("SizingPolicy", ginkgoutil.CommonE2ETestDecorators(), func() {
-	BeforeEach(func() {
-		if config.IsReusable() {
-			Skip("Test not available in REUSABLE mode: not supported yet.")
-		}
-	})
-
 	var (
 		vmNotValidSizingPolicyChanging string
 		vmNotValidSizingPolicyCreating string
@@ -54,25 +48,31 @@ var _ = Describe("SizingPolicy", ginkgoutil.CommonE2ETestDecorators(), func() {
 		ns                             string
 	)
 
-	AfterEach(func() {
-		if CurrentSpecReport().Failed() {
-			SaveTestResources(testCaseLabel, CurrentSpecReport().LeafNodeText)
-		}
-	})
-
-	Context("Preparing the environment", func() {
+	BeforeAll(func() {
 		vmNotValidSizingPolicyChanging = fmt.Sprintf("%s-vm-%s", namePrefix, notExistingVMClassChanging["vm"])
 		vmNotValidSizingPolicyCreating = fmt.Sprintf("%s-vm-%s", namePrefix, notExistingVMClassCreating["vm"])
 		vmClassDiscovery = fmt.Sprintf("%s-sizing-policy-discovery", namePrefix)
 		vmClassDiscoveryCopy = fmt.Sprintf("%s-sizing-policy-discovery-copy", namePrefix)
 		newVMClassFilePath = fmt.Sprintf("%s/vmc-copy.yaml", conf.TestData.SizingPolicy)
 
-		It("sets the namespace", func() {
-			kustomization := fmt.Sprintf("%s/%s", conf.TestData.SizingPolicy, "kustomization.yaml")
-			var err error
-			ns, err = kustomize.GetNamespace(kustomization)
-			Expect(err).NotTo(HaveOccurred(), "%w", err)
-		})
+		kustomization := fmt.Sprintf("%s/%s", conf.TestData.SizingPolicy, "kustomization.yaml")
+		var err error
+		ns, err = kustomize.GetNamespace(kustomization)
+		Expect(err).NotTo(HaveOccurred(), "%w", err)
+
+		CreateNamespace(ns)
+	})
+
+	BeforeEach(func() {
+		if config.IsReusable() {
+			Skip("Test not available in REUSABLE mode: not supported yet.")
+		}
+	})
+
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			SaveTestResources(testCaseLabel, CurrentSpecReport().LeafNodeText)
+		}
 	})
 
 	Context("When resources are applied", func() {

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -760,3 +760,19 @@ func DeleteResource(ctx context.Context, obj client.Object) {
 	err := crClient.Delete(ctx, obj)
 	Expect(err).NotTo(HaveOccurred())
 }
+
+func CreateNamespace(name string) {
+	GinkgoHelper()
+
+	result := kubectl.RawCommand(fmt.Sprintf("create namespace %s", name), ShortTimeout)
+	Expect(result.Error()).NotTo(HaveOccurred(), result.GetCmd())
+
+	WaitResourcesByPhase(
+		[]string{name},
+		kc.ResourceNamespace,
+		string(corev1.NamespaceActive),
+		kc.WaitOptions{
+			Timeout: ShortTimeout,
+		},
+	)
+}

--- a/tests/e2e/vd_snapshots_test.go
+++ b/tests/e2e/vd_snapshots_test.go
@@ -60,6 +60,8 @@ var _ = Describe("VirtualDiskSnapshots", ginkgoutil.CommonE2ETestDecorators(), f
 		ns, err = kustomize.GetNamespace(kustomization)
 		Expect(err).NotTo(HaveOccurred(), "%w", err)
 
+		CreateNamespace(ns)
+
 		Expect(conf.StorageClass.ImmediateStorageClass).NotTo(BeNil(), "immediate storage class cannot be nil; please set up the immediate storage class in the cluster")
 
 		virtualDiskWithoutConsumer := virtv2.VirtualDisk{}

--- a/tests/e2e/vm_configuration_test.go
+++ b/tests/e2e/vm_configuration_test.go
@@ -46,20 +46,19 @@ var _ = Describe(fmt.Sprintf("VirtualMachineConfiguration %d", GinkgoParallelPro
 		ns             string
 	)
 
+	BeforeAll(func() {
+		kustomization := fmt.Sprintf("%s/%s", conf.TestData.VMConfiguration, "kustomization.yaml")
+		var err error
+		ns, err = kustomize.GetNamespace(kustomization)
+		Expect(err).NotTo(HaveOccurred(), "%w", err)
+
+		CreateNamespace(ns)
+	})
+
 	AfterEach(func() {
 		if CurrentSpecReport().Failed() {
 			SaveTestResources(testCaseLabel, CurrentSpecReport().LeafNodeText)
 		}
-	})
-
-	Context("Preparing the environment", func() {
-		It("sets the namespace", func() {
-			kustomization := fmt.Sprintf("%s/%s", conf.TestData.VMConfiguration, "kustomization.yaml")
-			var err error
-			ns, err = kustomize.GetNamespace(kustomization)
-			Expect(err).NotTo(HaveOccurred(), "%w", err)
-			Expect(ns).NotTo(BeEmpty())
-		})
 	})
 
 	Context("When resources are applied", func() {

--- a/tests/e2e/vm_connectivity_test.go
+++ b/tests/e2e/vm_connectivity_test.go
@@ -54,20 +54,19 @@ var _ = Describe("VirtualMachineConnectivity", ginkgoutil.CommonE2ETestDecorator
 		selectorB string
 	)
 
+	BeforeAll(func() {
+		kustomization := fmt.Sprintf("%s/%s", conf.TestData.Connectivity, "kustomization.yaml")
+		var err error
+		ns, err = kustomize.GetNamespace(kustomization)
+		Expect(err).NotTo(HaveOccurred(), "%w", err)
+
+		CreateNamespace(ns)
+	})
+
 	AfterEach(func() {
 		if CurrentSpecReport().Failed() {
 			SaveTestResources(testCaseLabel, CurrentSpecReport().LeafNodeText)
 		}
-	})
-
-	Context("Preparing the environment", func() {
-		It("sets the namespace", func() {
-			kustomization := fmt.Sprintf("%s/%s", conf.TestData.Connectivity, "kustomization.yaml")
-			var err error
-			ns, err = kustomize.GetNamespace(kustomization)
-			Expect(err).NotTo(HaveOccurred(), "%w", err)
-			Expect(ns).NotTo(BeEmpty())
-		})
 	})
 
 	Context("When resources are applied", func() {

--- a/tests/e2e/vm_disk_attachment_test.go
+++ b/tests/e2e/vm_disk_attachment_test.go
@@ -37,12 +37,6 @@ const unacceptableCount = -1000
 var APIVersion = virtv2.SchemeGroupVersion.String()
 
 var _ = Describe("VirtualDiskAttachment", ginkgoutil.CommonE2ETestDecorators(), func() {
-	BeforeEach(func() {
-		if config.IsReusable() {
-			Skip("Test not available in REUSABLE mode: not supported yet.")
-		}
-	})
-
 	var (
 		testCaseLabel      = map[string]string{"testcase": "vm-disk-attachment"}
 		hasNoConsumerLabel = map[string]string{"hasNoConsumer": "vm-disk-attachment"}
@@ -54,22 +48,28 @@ var _ = Describe("VirtualDiskAttachment", ginkgoutil.CommonE2ETestDecorators(), 
 		ns                 string
 	)
 
+	BeforeAll(func() {
+		vdAttach = fmt.Sprintf("%s-vd-attach-%s", namePrefix, nameSuffix)
+		vmName = fmt.Sprintf("%s-vm-%s", namePrefix, nameSuffix)
+
+		kustomization := fmt.Sprintf("%s/%s", conf.TestData.VMDiskAttachment, "kustomization.yaml")
+		var err error
+		ns, err = kustomize.GetNamespace(kustomization)
+		Expect(err).NotTo(HaveOccurred(), "%w", err)
+
+		CreateNamespace(ns)
+	})
+
+	BeforeEach(func() {
+		if config.IsReusable() {
+			Skip("Test not available in REUSABLE mode: not supported yet.")
+		}
+	})
+
 	AfterEach(func() {
 		if CurrentSpecReport().Failed() {
 			SaveTestResources(testCaseLabel, CurrentSpecReport().LeafNodeText)
 		}
-	})
-
-	Context("Preparing the environment", func() {
-		vdAttach = fmt.Sprintf("%s-vd-attach-%s", namePrefix, nameSuffix)
-		vmName = fmt.Sprintf("%s-vm-%s", namePrefix, nameSuffix)
-
-		It("sets the namespace", func() {
-			kustomization := fmt.Sprintf("%s/%s", conf.TestData.VMDiskAttachment, "kustomization.yaml")
-			var err error
-			ns, err = kustomize.GetNamespace(kustomization)
-			Expect(err).NotTo(HaveOccurred(), "%w", err)
-		})
 	})
 
 	Context("When resources are applied", func() {

--- a/tests/e2e/vm_disk_resizing_test.go
+++ b/tests/e2e/vm_disk_resizing_test.go
@@ -53,6 +53,8 @@ var _ = Describe("VirtualDiskResizing", ginkgoutil.CommonE2ETestDecorators(), fu
 		var err error
 		ns, err = kustomize.GetNamespace(kustomization)
 		Expect(err).NotTo(HaveOccurred(), "%w", err)
+
+		CreateNamespace(ns)
 	})
 
 	AfterEach(func() {

--- a/tests/e2e/vm_evacuation_test.go
+++ b/tests/e2e/vm_evacuation_test.go
@@ -38,12 +38,16 @@ var _ = Describe("VirtualMachineEvacuation", SIGMigration(), ginkgoutil.CommonE2
 	testCaseLabel := map[string]string{"testcase": "vm-evacuation"}
 	var ns string
 
-	BeforeEach(func() {
+	BeforeAll(func() {
 		kustomization := fmt.Sprintf("%s/%s", conf.TestData.VMEvacuation, "kustomization.yaml")
 		var err error
 		ns, err = kustomize.GetNamespace(kustomization)
 		Expect(err).NotTo(HaveOccurred(), "%w", err)
 
+		CreateNamespace(ns)
+	})
+
+	BeforeEach(func() {
 		res := kubectl.Apply(kc.ApplyOptions{
 			Filename:       []string{conf.TestData.VMEvacuation},
 			FilenameOption: kc.Kustomize,

--- a/tests/e2e/vm_label_annotation_test.go
+++ b/tests/e2e/vm_label_annotation_test.go
@@ -31,12 +31,6 @@ import (
 )
 
 var _ = Describe("VirtualMachineLabelAndAnnotation", ginkgoutil.CommonE2ETestDecorators(), func() {
-	BeforeEach(func() {
-		if config.IsReusable() {
-			Skip("Test not available in REUSABLE mode: not supported yet.")
-		}
-	})
-
 	const (
 		specialKey   = "specialKey"
 		specialValue = "specialValue"
@@ -45,19 +39,25 @@ var _ = Describe("VirtualMachineLabelAndAnnotation", ginkgoutil.CommonE2ETestDec
 	specialKeyValue := map[string]string{specialKey: specialValue}
 	var ns string
 
+	BeforeAll(func() {
+		kustomization := fmt.Sprintf("%s/%s", conf.TestData.VMLabelAnnotation, "kustomization.yaml")
+		var err error
+		ns, err = kustomize.GetNamespace(kustomization)
+		Expect(err).NotTo(HaveOccurred(), "%w", err)
+
+		CreateNamespace(ns)
+	})
+
+	BeforeEach(func() {
+		if config.IsReusable() {
+			Skip("Test not available in REUSABLE mode: not supported yet.")
+		}
+	})
+
 	AfterEach(func() {
 		if CurrentSpecReport().Failed() {
 			SaveTestResources(testCaseLabel, CurrentSpecReport().LeafNodeText)
 		}
-	})
-
-	Context("Preparing the environment", func() {
-		It("sets the namespace", func() {
-			kustomization := fmt.Sprintf("%s/%s", conf.TestData.VMLabelAnnotation, "kustomization.yaml")
-			var err error
-			ns, err = kustomize.GetNamespace(kustomization)
-			Expect(err).NotTo(HaveOccurred(), "%w", err)
-		})
 	})
 
 	Context("When resources are applied", func() {

--- a/tests/e2e/vm_migration_cancel_test.go
+++ b/tests/e2e/vm_migration_cancel_test.go
@@ -36,12 +36,16 @@ var _ = Describe("VirtualMachineCancelMigration", SIGMigration(), ginkgoutil.Com
 	testCaseLabel := map[string]string{"testcase": "vm-migration-cancel"}
 	var ns string
 
-	BeforeEach(func() {
+	BeforeAll(func() {
 		kustomization := fmt.Sprintf("%s/%s", conf.TestData.VMMigrationCancel, "kustomization.yaml")
 		var err error
 		ns, err = kustomize.GetNamespace(kustomization)
 		Expect(err).NotTo(HaveOccurred(), "%w", err)
 
+		CreateNamespace(ns)
+	})
+
+	BeforeEach(func() {
 		res := kubectl.Apply(kc.ApplyOptions{
 			Filename:       []string{conf.TestData.VMMigrationCancel},
 			FilenameOption: kc.Kustomize,

--- a/tests/e2e/vm_migration_test.go
+++ b/tests/e2e/vm_migration_test.go
@@ -33,20 +33,19 @@ var _ = Describe("VirtualMachineMigration", SIGMigration(), ginkgoutil.CommonE2E
 	testCaseLabel := map[string]string{"testcase": "vm-migration"}
 	var ns string
 
+	BeforeAll(func() {
+		kustomization := fmt.Sprintf("%s/%s", conf.TestData.VMMigration, "kustomization.yaml")
+		var err error
+		ns, err = kustomize.GetNamespace(kustomization)
+		Expect(err).NotTo(HaveOccurred(), "%w", err)
+
+		CreateNamespace(ns)
+	})
+
 	AfterEach(func() {
 		if CurrentSpecReport().Failed() {
 			SaveTestResources(testCaseLabel, CurrentSpecReport().LeafNodeText)
 		}
-	})
-
-	Context("Preparing the environment", func() {
-		It("sets the namespace", func() {
-			kustomization := fmt.Sprintf("%s/%s", conf.TestData.VMMigration, "kustomization.yaml")
-			var err error
-			ns, err = kustomize.GetNamespace(kustomization)
-			Expect(err).NotTo(HaveOccurred(), "%w", err)
-			Expect(ns).NotTo(BeEmpty())
-		})
 	})
 
 	Context("When resources are applied", func() {

--- a/tests/e2e/vm_version_test.go
+++ b/tests/e2e/vm_version_test.go
@@ -29,28 +29,28 @@ import (
 )
 
 var _ = Describe("VirtualMachineVersions", ginkgoutil.CommonE2ETestDecorators(), func() {
+	testCaseLabel := map[string]string{"testcase": "vm-versions"}
+	var ns string
+
+	BeforeAll(func() {
+		kustomization := fmt.Sprintf("%s/%s", conf.TestData.VMVersions, "kustomization.yaml")
+		var err error
+		ns, err = kustomize.GetNamespace(kustomization)
+		Expect(err).NotTo(HaveOccurred(), "%w", err)
+
+		CreateNamespace(ns)
+	})
+
 	BeforeEach(func() {
 		if config.IsReusable() {
 			Skip("Test not available in REUSABLE mode: not supported yet.")
 		}
 	})
 
-	testCaseLabel := map[string]string{"testcase": "vm-versions"}
-	var ns string
-
 	AfterEach(func() {
 		if CurrentSpecReport().Failed() {
 			SaveTestResources(testCaseLabel, CurrentSpecReport().LeafNodeText)
 		}
-	})
-
-	Context("Preparing the environment", func() {
-		It("sets the namespace", func() {
-			kustomization := fmt.Sprintf("%s/%s", conf.TestData.VMVersions, "kustomization.yaml")
-			var err error
-			ns, err = kustomize.GetNamespace(kustomization)
-			Expect(err).NotTo(HaveOccurred(), "%w", err)
-		})
 	})
 
 	Context("When virtualization resources are applied:", func() {

--- a/tests/e2e/vm_vpc_test.go
+++ b/tests/e2e/vm_vpc_test.go
@@ -41,14 +41,16 @@ var _ = Describe("VirtualMachineAdditionalNetworkInterfaces", SIGMigration(), gi
 	var ns string
 
 	BeforeAll(func() {
-		sbdEnabled, err := isSdnModuleEnabled()
-		if err != nil || !sbdEnabled {
+		sdnEnabled, err := isSdnModuleEnabled()
+		if err != nil || !sdnEnabled {
 			Skip("Module SDN is disabled. Skipping all tests for module SDN.")
 		}
 
 		kustomization := fmt.Sprintf("%s/%s", conf.TestData.VMVpc, "kustomization.yaml")
 		ns, err = kustomize.GetNamespace(kustomization)
 		Expect(err).NotTo(HaveOccurred(), "%w", err)
+
+		CreateNamespace(ns)
 	})
 
 	AfterAll(func() {


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
Sometimes, the 'namespaces not found' error occurs in the end-to-end tests when Kustomize is used. To avoid this, a namespace will be created before the Apply operation.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
There is no 'namespaces not found' error in the end-to-end tests.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: test 
type: fix
summary: "Create a namespace before the Apply operation."
impact_level: low
```
