### PR TITLE
feat(cli): add virtual machine name and namespace flag completions

### DIFF
--- a/api/client/kubeclient/client.go
+++ b/api/client/kubeclient/client.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
 	"github.com/deckhouse/virtualization/api/client/generated/clientset/versioned"
@@ -50,6 +51,7 @@ func init() {
 }
 
 type Client interface {
+	kubernetes.Interface
 	ClusterVirtualImages() virtualizationv1alpha2.ClusterVirtualImageInterface
 	VirtualMachines(namespace string) virtualizationv1alpha2.VirtualMachineInterface
 	VirtualImages(namespace string) virtualizationv1alpha2.VirtualImageInterface
@@ -63,6 +65,7 @@ type Client interface {
 	VirtualMachineMACAddressLeases() virtualizationv1alpha2.VirtualMachineMACAddressLeaseInterface
 }
 type client struct {
+	kubernetes.Interface
 	config      *rest.Config
 	shallowCopy *rest.Config
 	restClient  *rest.RESTClient

--- a/api/client/kubeclient/config.go
+++ b/api/client/kubeclient/config.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -67,11 +68,18 @@ func GetClientFromRESTConfig(config *rest.Config) (Client, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	clientset, err := kubernetes.NewForConfig(&shallowCopy)
+	if err != nil {
+		return nil, err
+	}
+
 	virtClient, err := versioned.NewForConfig(&shallowCopy)
 	if err != nil {
 		return nil, err
 	}
 	return &client{
+		Interface:   clientset,
 		config:      config,
 		shallowCopy: &shallowCopy,
 		restClient:  restClient,

--- a/src/cli/internal/comp/namespace.go
+++ b/src/cli/internal/comp/namespace.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package comp
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/deckhouse/virtualization/src/cli/internal/clientconfig"
+)
+
+func NamespaceFlagCompletionFunc(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	directive := cobra.ShellCompDirectiveNoFileComp
+
+	client, _, _, err := clientconfig.ClientAndNamespaceFromContext(cmd.Context())
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	namespaces, err := client.CoreV1().Namespaces().List(cmd.Context(), metav1.ListOptions{})
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	var comps []string
+	for _, namespace := range namespaces.Items {
+		if strings.HasPrefix(namespace.Name, toComplete) {
+			comps = append(comps, namespace.Name)
+		}
+	}
+
+	return comps, directive
+}

--- a/src/cli/internal/comp/virtualmachine.go
+++ b/src/cli/internal/comp/virtualmachine.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package comp
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/deckhouse/virtualization/src/cli/internal/clientconfig"
+)
+
+func VirtualMachineNameCompletionFunc(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	directive := cobra.ShellCompDirectiveNoFileComp
+
+	if len(args) > 0 {
+		return nil, directive
+	}
+
+	client, namespace, _, err := clientconfig.ClientAndNamespaceFromContext(cmd.Context())
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	vms, err := client.VirtualMachines(namespace).List(cmd.Context(), metav1.ListOptions{})
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	var comps []string
+	for _, vm := range vms.Items {
+		if strings.HasPrefix(vm.Name, toComplete) {
+			comps = append(comps, vm.Name)
+		}
+	}
+
+	return comps, directive
+}

--- a/src/cli/pkg/command/virtualization.go
+++ b/src/cli/pkg/command/virtualization.go
@@ -99,6 +99,8 @@ func NewCommand(programName string) *cobra.Command {
 	ctxWithClient := clientconfig.NewContext(ctx, kubeclient.DefaultClientConfig(virtCmd.PersistentFlags()))
 
 	virtCmd.SetContext(ctxWithClient)
+	_ = virtCmd.RegisterFlagCompletionFunc("namespace", comp.NamespaceFlagCompletionFunc)
+
 	for _, cmd := range virtCmd.Commands() {
 		cmd.SetContext(ctxWithClient)
 		cmd.ValidArgsFunction = comp.VirtualMachineNameCompletionFunc

--- a/src/cli/pkg/command/virtualization.go
+++ b/src/cli/pkg/command/virtualization.go
@@ -37,6 +37,7 @@ import (
 	"github.com/deckhouse/virtualization/src/cli/internal/cmd/scp"
 	"github.com/deckhouse/virtualization/src/cli/internal/cmd/ssh"
 	"github.com/deckhouse/virtualization/src/cli/internal/cmd/vnc"
+	"github.com/deckhouse/virtualization/src/cli/internal/comp"
 	"github.com/deckhouse/virtualization/src/cli/internal/templates"
 )
 
@@ -100,6 +101,7 @@ func NewCommand(programName string) *cobra.Command {
 	virtCmd.SetContext(ctxWithClient)
 	for _, cmd := range virtCmd.Commands() {
 		cmd.SetContext(ctxWithClient)
+		cmd.ValidArgsFunction = comp.VirtualMachineNameCompletionFunc
 	}
 
 	return virtCmd


### PR DESCRIPTION
## Description
add virtual machine name and namespace flag completions

<img width="424" height="106" alt="Screenshot From 2025-08-28 20-57-42" src="https://github.com/user-attachments/assets/9ad98eb3-6d9c-41fb-942d-d621803a3ebc" />


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: core
type: feature
summary: add virtual machine name and namespace flag completions to cli
```
