### PR TITLE
fix(vm): add display of `.status.network` if `.spec.network` is empty

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm/internal/network.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/network.go
@@ -68,11 +68,6 @@ func (h *NetworkInterfaceHandler) Handle(ctx context.Context, s state.VirtualMac
 		conditions.SetCondition(cb, &vm.Status.Conditions)
 	}()
 
-	if vm.Spec.Networks == nil {
-		vm.Status.Networks = nil
-		return reconcile.Result{}, nil
-	}
-
 	if len(vm.Spec.Networks) > 1 {
 		if !h.featureGate.Enabled(featuregates.SDN) {
 			cb.Status(metav1.ConditionFalse).Reason(vmcondition.ReasonSDNModuleDisable).Message("For additional network interfaces, please enable SDN module")

--- a/images/virtualization-artifact/pkg/controller/vm/internal/network_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/network_test.go
@@ -138,7 +138,7 @@ var _ = Describe("NetworkInterfaceHandler", func() {
 				Expect(exists).To(BeTrue())
 				Expect(cond.Status).To(Equal(metav1.ConditionUnknown))
 				Expect(cond.Reason).To(Equal(conditions.ReasonUnknown.String()))
-				Expect(newVM.Status.Networks).To(BeNil())
+				Expect(newVM.Status.Networks).NotTo(BeNil())
 			})
 		})
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Add display of `.status.network` if `.spec.network` is empty.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: vm
type: fix
summary:  Add display of `.status.network` if `.spec.network` is empty
```
