### PR TITLE
fix(vm): fix message in `NetworkReady` condition

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm/internal/network.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/network.go
@@ -153,6 +153,10 @@ func (h *NetworkInterfaceHandler) UpdateNetworkStatus(ctx context.Context, s sta
 func extractNetworkStatusFromPods(pods *corev1.PodList) (string, error) {
 	var errorMessages []string
 
+	if len(pods.Items) == 0 {
+		return "Waiting for the pod to be created.", nil
+	}
+
 	for _, pod := range pods.Items {
 		if pod.Status.Phase == corev1.PodSucceeded {
 			continue
@@ -160,7 +164,7 @@ func extractNetworkStatusFromPods(pods *corev1.PodList) (string, error) {
 
 		networkStatusAnnotation, found := pod.Annotations[annotations.AnnNetworksStatus]
 		if !found {
-			errorMessages = append(errorMessages, fmt.Sprintf("Annotation %s is not found", annotations.AnnNetworksStatus))
+			errorMessages = append(errorMessages, "Cannot determine the status of additional interfaces, waiting for a response from the SDN module")
 			continue
 		}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Fix message in NetworkReady condition:
- when module SDN don't set annotation with network status data
- when vm pods not exist

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
Message "Annotation %s is not found" is not clear to the user.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: vm
type: fix
summary: fix message in NetworkReady condition
```
