### PR TITLE
fix(api): fix kubebuilder annotations for CRD categories and short names

### DIFF
--- a/api/Taskfile.dist.yaml
+++ b/api/Taskfile.dist.yaml
@@ -25,8 +25,6 @@ tasks:
 
   generate:crds:
     desc: "Regenerate crds"
-    deps:
-      - _ensure:k8s-controller-gen
     cmds:
       - ./scripts/update-codegen.sh crds
       - task: format:yaml

--- a/api/core/v1alpha2/cluster_virtual_image.go
+++ b/api/core/v1alpha2/cluster_virtual_image.go
@@ -34,7 +34,7 @@ const (
 //
 // +kubebuilder:object:root=true
 // +kubebuilder:metadata:labels={heritage=deckhouse,module=virtualization,backup.deckhouse.io/cluster-config=true}
-// +kubebuilder:resource:categories={virtualization},scope=Cluster,shortName={cvi,cvis},singular=clustervirtualimage
+// +kubebuilder:resource:categories={virtualization-cluster},scope=Cluster,shortName={cvi},singular=clustervirtualimage
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="CDROM",type=boolean,JSONPath=`.status.cdrom`

--- a/api/core/v1alpha2/virtual_disk.go
+++ b/api/core/v1alpha2/virtual_disk.go
@@ -32,7 +32,7 @@ const (
 // Once a VirtualDisk is created, only the disk size field `.spec.persistentVolumeClaim.size` can be changed. All other fields are immutable.
 // +kubebuilder:object:root=true
 // +kubebuilder:metadata:labels={heritage=deckhouse,module=virtualization}
-// +kubebuilder:resource:categories={virtualization,all},scope=Namespaced,shortName={vd,vds},singular=virtualdisk
+// +kubebuilder:resource:categories={virtualization},scope=Namespaced,shortName={vd},singular=virtualdisk
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="Capacity",type=string,JSONPath=`.status.capacity`

--- a/api/core/v1alpha2/virtual_image.go
+++ b/api/core/v1alpha2/virtual_image.go
@@ -34,7 +34,7 @@ const (
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:metadata:labels={heritage=deckhouse,module=virtualization}
-// +kubebuilder:resource:categories={virtualization,all},scope=Namespaced,shortName={vi,vis},singular=virtualimage
+// +kubebuilder:resource:categories={virtualization},scope=Namespaced,shortName={vi},singular=virtualimage
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="CDROM",type=boolean,JSONPath=`.status.cdrom`

--- a/api/core/v1alpha2/virtual_machine.go
+++ b/api/core/v1alpha2/virtual_machine.go
@@ -39,7 +39,7 @@ const (
 // +kubebuilder:object:root=true
 // +kubebuilder:metadata:labels={heritage=deckhouse,module=virtualization}
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:categories={all,virtualization},scope=Namespaced,shortName={vm,vms},singular=virtualmachine
+// +kubebuilder:resource:categories={all,virtualization},scope=Namespaced,shortName={vm},singular=virtualmachine
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="The phase of the virtual machine."
 // +kubebuilder:printcolumn:name="Cores",priority=1,type="string",JSONPath=".spec.cpu.cores",description="The number of cores of the virtual machine."
 // +kubebuilder:printcolumn:name="CoreFraction",priority=1,type="string",JSONPath=".spec.cpu.coreFraction",description="Virtual machine core fraction. The range of available values is set in the `sizePolicy` parameter of the VirtualMachineClass; if it is not set, use values within the 1–100% range."

--- a/api/core/v1alpha2/virtual_machine_block_device_attachment.go
+++ b/api/core/v1alpha2/virtual_machine_block_device_attachment.go
@@ -28,7 +28,7 @@ const (
 // +kubebuilder:object:root=true
 // +kubebuilder:metadata:labels={heritage=deckhouse,module=virtualization}
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:categories={all,virtualization},scope=Namespaced,shortName={vmbda,vmbdas},singular=virtualmachineblockdeviceattachment
+// +kubebuilder:resource:categories={virtualization},scope=Namespaced,shortName={vmbda},singular=virtualmachineblockdeviceattachment
 // +kubebuilder:printcolumn:name="PHASE",type="string",JSONPath=".status.phase",description="VirtualMachineBlockDeviceAttachment phase."
 // +kubebuilder:printcolumn:name="BLOCKDEVICE KIND",type=string,JSONPath=`.spec.blockDeviceRef.kind`,priority=1,description="Attached blockdevice kind."
 // +kubebuilder:printcolumn:name="BLOCKDEVICE NAME",type=string,JSONPath=`.spec.blockDeviceRef.name`,priority=1,description="Attached blockdevice name."

--- a/api/core/v1alpha2/virtual_machine_class.go
+++ b/api/core/v1alpha2/virtual_machine_class.go
@@ -35,7 +35,7 @@ const (
 // +kubebuilder:object:root=true
 // +kubebuilder:metadata:labels={heritage=deckhouse,module=virtualization,backup.deckhouse.io/cluster-config=true}
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:categories={virtualization},scope=Cluster,shortName={vmc,vmcs,vmclass,vmclasses},singular=virtualmachineclass
+// +kubebuilder:resource:categories={virtualization-cluster},scope=Cluster,shortName={vmc,vmclass},singular=virtualmachineclass
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="VirtualMachineClass phase."
 // +kubebuilder:printcolumn:name="IsDefault",type="string",JSONPath=".metadata.annotations.virtualmachineclass\\.virtualization\\.deckhouse\\.io\\/is-default-class",description="Default class for virtual machines without specified class."
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time of resource creation."

--- a/api/core/v1alpha2/virtual_machine_operation.go
+++ b/api/core/v1alpha2/virtual_machine_operation.go
@@ -27,7 +27,7 @@ const (
 // +kubebuilder:object:root=true
 // +kubebuilder:metadata:labels={heritage=deckhouse,module=virtualization}
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:categories={virtualization,all},scope=Namespaced,shortName={vmop,vmops},singular=virtualmachineoperation
+// +kubebuilder:resource:categories={virtualization},scope=Namespaced,shortName={vmop},singular=virtualmachineoperation
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="VirtualMachineOperation phase."
 // +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".spec.type",description="VirtualMachineOperation type."
 // +kubebuilder:printcolumn:name="VirtualMachine",type="string",JSONPath=".spec.virtualMachineName",description="VirtualMachine name."

--- a/api/core/v1alpha2/virtual_machine_restore.go
+++ b/api/core/v1alpha2/virtual_machine_restore.go
@@ -32,7 +32,7 @@ const (
 // +kubebuilder:object:root=true
 // +kubebuilder:metadata:labels={heritage=deckhouse,module=virtualization}
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:categories=virtualization,scope=Namespaced,shortName={vmrestore,vmrestores},singular=virtualmachinerestore
+// +kubebuilder:resource:categories=virtualization,scope=Namespaced,shortName={vmrestore},singular=virtualmachinerestore
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="VirtualMachineRestore phase."
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="VirtualMachineRestore age."
 // +genclient

--- a/api/core/v1alpha2/virtual_machine_snapshot.go
+++ b/api/core/v1alpha2/virtual_machine_snapshot.go
@@ -32,7 +32,7 @@ const (
 // +kubebuilder:object:root=true
 // +kubebuilder:metadata:labels={heritage=deckhouse,module=virtualization}
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:categories={all,virtualization},scope=Namespaced,shortName={vmsnapshot,vmsnapshots},singular=virtualmachinesnapshot
+// +kubebuilder:resource:categories={virtualization},scope=Namespaced,shortName={vmsnapshot,vms},singular=virtualmachinesnapshot
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="VirtualMachineSnapshot phase."
 // +kubebuilder:printcolumn:name="Consistent",type="boolean",JSONPath=".status.consistent",description="VirtualMachineSnapshot consistency."
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="VirtualMachineSnapshot age."


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section:
type:
summary:
```
