### PR TITLE
fix(vd,vi): enforce storage class restrictions in webhook validators

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vi/vi_webhook.go
+++ b/images/virtualization-artifact/pkg/controller/vi/vi_webhook.go
@@ -86,6 +86,13 @@ func (v *Validator) ValidateCreate(ctx context.Context, obj runtime.Object) (adm
 				)
 			}
 
+			if !v.scService.IsStorageClassAllowed(*vi.Spec.PersistentVolumeClaim.StorageClass) {
+				return nil, fmt.Errorf(
+					"the storage class %q is not allowed; please check the module settings",
+					*vi.Spec.PersistentVolumeClaim.StorageClass,
+				)
+			}
+
 			if sc != nil {
 				sp, err := v.scService.GetStorageProfile(ctx, sc.Name)
 				if err != nil {
@@ -157,6 +164,13 @@ func (v *Validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.O
 					)
 				}
 
+				if !v.scService.IsStorageClassAllowed(*newVI.Spec.PersistentVolumeClaim.StorageClass) {
+					return nil, fmt.Errorf(
+						"the storage class %q is not allowed; please check the module settings",
+						*newVI.Spec.PersistentVolumeClaim.StorageClass,
+					)
+				}
+
 				if sc != nil {
 					sp, err := v.scService.GetStorageProfile(ctx, sc.Name)
 					if err != nil {
@@ -213,6 +227,12 @@ func (v *Validator) validateDefaultStorageClass(ctx context.Context) error {
 
 		if defaultStorageClass != nil {
 			sc = defaultStorageClass
+			if !v.scService.IsStorageClassAllowed(sc.Name) {
+				return fmt.Errorf(
+					"the default storage class %q is not allowed; please check the module settings or specify a storage class name explicitly in the spec",
+					sc.Name,
+				)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section:
type:
summary:
```
