### PR TITLE
test(ci): extract e2e-run-ci script from taskfile

### DIFF
--- a/tests/e2e/Taskfile.yaml
+++ b/tests/e2e/Taskfile.yaml
@@ -37,57 +37,7 @@ tasks:
       - kubectl
       - d8
     cmds:
-      - |
-        GINKGO_RESULT=$(mktemp)
-        DATE=$(date +"%Y-%m-%d")
-        echo "DATE=$DATE" >> $GITHUB_ENV
-        START_TIME=$(date +"%H:%M:%S")
-        echo "START_TIME=$START_TIME" >> $GITHUB_ENV
-        go tool ginkgo -v --race --timeout=$TIMEOUT | tee $GINKGO_RESULT
-        EXIT_CODE="${PIPESTATUS[0]}"
-        RESULT=$(sed -e "s/\x1b\[[0-9;]*m//g" $GINKGO_RESULT | grep --color=never -E "FAIL!|SUCCESS!")
-        if [[ $RESULT == FAIL!* || $EXIT_CODE -ne "0" ]]; then
-          RESULT_STATUS=":x: FAIL!"
-        elif [[ $RESULT == SUCCESS!* ]]; then
-          RESULT_STATUS=":white_check_mark: SUCCESS!"
-        else
-          RESULT_STATUS=":question: UNKNOWN"
-          EXIT_CODE=1
-        fi
-
-        PASSED=$(echo "$RESULT" | grep -oP "\d+(?= Passed)")
-        FAILED=$(echo "$RESULT" | grep -oP "\d+(?= Failed)")
-        PENDING=$(echo "$RESULT" | grep -oP "\d+(?= Pending)")
-        SKIPPED=$(echo "$RESULT" | grep -oP "\d+(?= Skipped)")
-
-        SUMMARY=$(jq -n \
-          --arg csi "$CSI" \
-          --arg date "$DATE" \
-          --arg startTime "$START_TIME" \
-          --arg branch "$GITHUB_REF_NAME" \
-          --arg status "$RESULT_STATUS" \
-          --argjson passed "$PASSED" \
-          --argjson failed "$FAILED" \
-          --argjson pending "$PENDING" \
-          --argjson skipped "$SKIPPED" \
-          --arg link "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
-          '{
-            CSI: $csi,
-            Date: $date,
-            StartTime: $startTime,
-            Branch: $branch,
-            Status: $status,
-            Passed: $passed,
-            Failed: $failed,
-            Pending: $pending,
-            Skipped: $skipped,
-            Link: $link
-          }'
-        )
-
-        echo "$SUMMARY"
-        echo "SUMMARY=$(echo "$SUMMARY" | jq -c .)" >> $GITHUB_ENV
-        exit $EXIT_CODE
+      - ./task_run_ci.sh
 
   runp:
     desc: "Run e2e tests"

--- a/tests/e2e/task_run_ci.sh
+++ b/tests/e2e/task_run_ci.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 Flant JSC
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+GINKGO_RESULT=$(mktemp)
+
+DATE=$(date +"%Y-%m-%d")
+echo "DATE=$DATE" >> $GITHUB_ENV
+START_TIME=$(date +"%H:%M:%S")
+echo "START_TIME=$START_TIME" >> $GITHUB_ENV
+
+go tool ginkgo -v --race --timeout=$TIMEOUT | tee $GINKGO_RESULT
+EXIT_CODE="${PIPESTATUS[0]}"
+RESULT=$(sed -e "s/\x1b\[[0-9;]*m//g" $GINKGO_RESULT | grep --color=never -E "FAIL!|SUCCESS!")
+if [[ $RESULT == FAIL!* || $EXIT_CODE -ne "0" ]]; then
+    RESULT_STATUS=":x: FAIL!"
+elif [[ $RESULT == SUCCESS!* ]]; then
+    RESULT_STATUS=":white_check_mark: SUCCESS!"
+else
+    RESULT_STATUS=":question: UNKNOWN"
+    EXIT_CODE=1
+fi
+
+PASSED=$(echo "$RESULT" | grep -oP "\d+(?= Passed)")
+FAILED=$(echo "$RESULT" | grep -oP "\d+(?= Failed)")
+PENDING=$(echo "$RESULT" | grep -oP "\d+(?= Pending)")
+SKIPPED=$(echo "$RESULT" | grep -oP "\d+(?= Skipped)")
+
+SUMMARY=$(jq -n \
+    --arg csi "$CSI" \
+    --arg date "$DATE" \
+    --arg startTime "$START_TIME" \
+    --arg branch "$GITHUB_REF_NAME" \
+    --arg status "$RESULT_STATUS" \
+    --argjson passed "$PASSED" \
+    --argjson failed "$FAILED" \
+    --argjson pending "$PENDING" \
+    --argjson skipped "$SKIPPED" \
+    --arg link "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+    '{
+    CSI: $csi,
+    Date: $date,
+    StartTime: $startTime,
+    Branch: $branch,
+    Status: $status,
+    Passed: $passed,
+    Failed: $failed,
+    Pending: $pending,
+    Skipped: $skipped,
+    Link: $link
+    }'
+)
+
+echo "$SUMMARY"
+echo "SUMMARY=$(echo "$SUMMARY" | jq -c .)" >> $GITHUB_ENV
+exit $EXIT_CODE


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
The `run:ci` script should be executed from within the script itself to avoid issues with shell processing on a GitHub runner.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: ci
type: fix
summary: "The `run:ci` script should be executed from within the script itself to avoid issues with shell processing on a GitHub runner."
impact_level: low
```
