### PR TITLE
fix(e2e): fix false positive resource apply error

### DIFF
--- a/tests/e2e/affinity_toleration_test.go
+++ b/tests/e2e/affinity_toleration_test.go
@@ -77,6 +77,13 @@ var _ = Describe("VirtualMachineAffinityAndToleration", ginkgoutil.CommonE2ETest
 
 	Context("When the virtualization resources are applied:", func() {
 		It("result should be succeeded", func() {
+			vmClassFilePath := fmt.Sprintf("%s/vmc.yaml", conf.TestData.AffinityToleration)
+			vmcRes := kubectl.Apply(kc.ApplyOptions{
+				Filename:       []string{vmClassFilePath},
+				FilenameOption: kc.Filename,
+			})
+			Expect(vmcRes.Error()).NotTo(HaveOccurred(), "failed to apply virtual class resource")
+
 			res := kubectl.Apply(kc.ApplyOptions{
 				Filename:       []string{conf.TestData.AffinityToleration},
 				FilenameOption: kc.Kustomize,

--- a/tests/e2e/complex_test.go
+++ b/tests/e2e/complex_test.go
@@ -69,6 +69,13 @@ var _ = Describe("ComplexTest", Serial, ginkgoutil.CommonE2ETestDecorators(), fu
 				}
 			}
 
+			vmClassFilePath := fmt.Sprintf("%s/vmc.yaml", conf.TestData.ComplexTest)
+			vmcRes := kubectl.Apply(kc.ApplyOptions{
+				Filename:       []string{vmClassFilePath},
+				FilenameOption: kc.Filename,
+			})
+			Expect(vmcRes.Error()).NotTo(HaveOccurred(), "failed to apply virtual class resource")
+
 			res := kubectl.Apply(kc.ApplyOptions{
 				Filename:       []string{conf.TestData.ComplexTest},
 				FilenameOption: kc.Kustomize,

--- a/tests/e2e/sizing_policy_test.go
+++ b/tests/e2e/sizing_policy_test.go
@@ -77,6 +77,13 @@ var _ = Describe("SizingPolicy", ginkgoutil.CommonE2ETestDecorators(), func() {
 
 	Context("When resources are applied", func() {
 		It("result should be succeeded", func() {
+			vmClassFilePath := fmt.Sprintf("%s/vmc.yaml", conf.TestData.SizingPolicy)
+			vmcRes := kubectl.Apply(kc.ApplyOptions{
+				Filename:       []string{vmClassFilePath},
+				FilenameOption: kc.Filename,
+			})
+			Expect(vmcRes.Error()).NotTo(HaveOccurred(), "failed to apply virtual class resource")
+
 			res := kubectl.Apply(kc.ApplyOptions{
 				Filename:       []string{conf.TestData.SizingPolicy},
 				FilenameOption: kc.Kustomize,


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
When applying a VirtualMachine whose VirtualMachineClass hasn’t been created, a warning is emitted about it, which the test treats as an error. We create the VirtualMachineClass beforehand to avoid false positives.


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
impact_level: low
```
