### PR TITLE
chore(ci): update version to 2.6.0 for changelog-action

### DIFF
--- a/.github/actions/milestone-changelog/action.yml
+++ b/.github/actions/milestone-changelog/action.yml
@@ -19,7 +19,7 @@ runs:
 
     - name: Collect Changelog
       id: changelog
-      uses: deckhouse/changelog-action@v2
+      uses: deckhouse/changelog-action@v2.6.0
       with:
         token: ${{ inputs.token }}
         repo: ${{ github.repository }}

--- a/.github/workflows/check-changelog-entry.yml
+++ b/.github/workflows/check-changelog-entry.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v3.5.2
       - name: Check Changelog entry
         id: entry-check
-        uses: deckhouse/changelog-action@v2.5.0
+        uses: deckhouse/changelog-action@v2.6.0
         with:
           validate_only: true
           allowed_sections: |


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Update version to 2.6.0 for changelog-action.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
2.6.0 reverts unwanted behavior of ignoring `impact_level: low` entries.
Also, the versions in milestone-changelog and check-changelog-entry were different.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: ci
type: chore
summary: update version to 2.6.0 for changelog-action
```
