### PR TITLE
test(vdsnapshot): add test labels for vdsnapshots

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm/internal/filesystem.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/filesystem.go
@@ -69,7 +69,6 @@ func (h *FilesystemHandler) Handle(ctx context.Context, s state.VirtualMachineSt
 
 	agentReady, _ := conditions.GetCondition(vmcondition.TypeAgentReady, changed.Status.Conditions)
 	if agentReady.Status != metav1.ConditionTrue {
-		cb.Status(metav1.ConditionUnknown).Reason(conditions.ReasonUnknown)
 		return reconcile.Result{}, nil
 	}
 

--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -748,7 +748,7 @@ func SaveTestResources(labels map[string]string, additional string) {
 
 	str := fmt.Sprintf("/tmp/e2e_failed__%s__%s.yaml", labels["testcase"], additional)
 
-	cmdr := kubectl.Get("virtualization -A", kc.GetOptions{Output: "yaml", Labels: labels})
+	cmdr := kubectl.Get("virtualization,intvirt -A", kc.GetOptions{Output: "yaml", Labels: labels})
 	Expect(cmdr.Error()).NotTo(HaveOccurred(), "cmd: %s\nstderr: %s", cmdr.GetCmd(), cmdr.StdErr())
 
 	err := os.WriteFile(str, cmdr.StdOutBytes(), 0o644)


### PR DESCRIPTION
## Description

Added vd snapshots and kubevirt resources to the artifacts in case the e2e test fails

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
