### PR TITLE
test: replace log fatal with ginkgo expect

### DIFF
--- a/tests/e2e/tests_suite_test.go
+++ b/tests/e2e/tests_suite_test.go
@@ -225,14 +225,14 @@ var _ = SynchronizedBeforeSuite(func() {
 	for _, filePath := range kustomizationFiles {
 		err := kustomize.SetParams(filePath, ns, namePrefix)
 		if err != nil {
-			log.Fatal(err)
+			Expect(err).NotTo(HaveOccurred())
 		}
 	}
 
 	if !config.IsReusable() {
 		err := Cleanup()
 		if err != nil {
-			log.Fatal(err)
+			Expect(err).NotTo(HaveOccurred())
 		}
 	} else {
 		log.Println("Run test in REUSABLE mode")
@@ -243,7 +243,7 @@ var _ = SynchronizedBeforeSuite(func() {
 		if config.IsCleanUpNeeded() {
 			err := Cleanup()
 			if err != nil {
-				log.Fatal(err)
+				Expect(err).NotTo(HaveOccurred())
 			}
 		}
 	})


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
Errors in test cases should not stop the Ginkgo process.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: api
type: fix
summary: "Errors in test cases should not stop the Ginkgo process."
impact_level: low
```
