### PR TITLE
chore(module): do not lock main queue on empty publicClusterDomain

### DIFF
--- a/images/virtualization-artifact/pkg/common/annotations/annotations.go
+++ b/images/virtualization-artifact/pkg/common/annotations/annotations.go
@@ -47,8 +47,9 @@ const (
 	// AnnPodRetainAfterCompletion is PVC annotation for retaining transfer pods after completion
 	AnnPodRetainAfterCompletion = AnnAPIGroup + "/storage.pod.retainAfterCompletion"
 
-	// AnnUploadURL provides a const for CVMI/VMI/VMD uploadURL annotation.
-	AnnUploadURL = AnnAPIGroup + "/upload.url"
+	// AnnUploadURLDeprecated provides a const for CVMI/VMI/VMD uploadURL annotation.
+	// TODO remove annotation and its usages after version 1.0 becomes Stable.
+	AnnUploadURLDeprecated = AnnAPIGroup + "/upload.url"
 
 	// AnnTolerationsHash provides a const for annotation with hash of applied tolerations.
 	AnnTolerationsHash = AnnAPIGroup + "/tolerations-hash"
@@ -96,6 +97,11 @@ const (
 	AnnVMRestore = AnnAPIGroupV + "/vmrestore"
 	// AnnVMOPEvacuation is an annotation on vmop that represents a vmop created by evacuation controller
 	AnnVMOPEvacuation = AnnAPIGroupV + "/evacuation"
+
+	// AnnUploadURL is an annotation on Ingress with full URL to upload image from outside the cluster.
+	AnnUploadURL = AnnAPIGroupV + "/upload.url"
+	// AnnUploadPath is an annotation on Ingress with the URL path to upload image.
+	AnnUploadPath = AnnAPIGroupV + "/upload.path"
 
 	// LabelsPrefix is a prefix for virtualization-controller labels.
 	LabelsPrefix = "virtualization.deckhouse.io"

--- a/images/virtualization-artifact/pkg/config/load_dvcr_settings.go
+++ b/images/virtualization-artifact/pkg/config/load_dvcr_settings.go
@@ -66,12 +66,6 @@ func LoadDVCRSettingsFromEnvs(controllerNamespace string) (*dvcr.Settings, error
 	if dvcrSettings.RegistryURL == "" {
 		return nil, fmt.Errorf("environment variable %q undefined, specify DVCR settings", DVCRRegistryURLVar)
 	}
-	if dvcrSettings.UploaderIngressSettings.Host == "" {
-		return nil, fmt.Errorf("environment variable %q undefined, specify DVCR settings", UploaderIngressHostVar)
-	}
-	if dvcrSettings.UploaderIngressSettings.Class == "" {
-		return nil, fmt.Errorf("environment variable %q undefined, specify DVCR settings", UploaderIngressClassVar)
-	}
 
 	if dvcrSettings.AuthSecret != "" && dvcrSettings.AuthSecretNamespace == "" {
 		dvcrSettings.AuthSecretNamespace = controllerNamespace

--- a/images/virtualization-artifact/pkg/controller/service/stat_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/stat_service.go
@@ -248,7 +248,9 @@ func (s StatService) IsUploaderReady(pod *corev1.Pod, svc *corev1.Service, ing *
 		return false
 	}
 
-	return podutil.IsPodRunning(pod) && podutil.IsPodStarted(pod) && ing.Annotations[annotations.AnnUploadURL] != ""
+	ingressIsOK := ing.Annotations[annotations.AnnUploadPath] != "" || ing.Annotations[annotations.AnnUploadURLDeprecated] != ""
+
+	return podutil.IsPodRunning(pod) && podutil.IsPodStarted(pod) && ingressIsOK
 }
 
 func (s StatService) IsUploadStarted(ownerUID types.UID, pod *corev1.Pod) bool {

--- a/images/virtualization-artifact/pkg/controller/service/uploader_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/uploader_service.go
@@ -246,6 +246,10 @@ func (s UploaderService) GetIngress(ctx context.Context, sup *supplements.Genera
 func (s UploaderService) GetExternalURL(ctx context.Context, ing *netv1.Ingress) string {
 	url := ing.Annotations[annotations.AnnUploadURL]
 	if url == "" {
+		// Fallback to deprecated annotation.
+		url = ing.Annotations[annotations.AnnUploadURLDeprecated]
+	}
+	if url == "" {
 		logger.FromContext(ctx).Error("unexpected empty upload url, please report a bug")
 		return ""
 	}

--- a/templates/certificate.yaml
+++ b/templates/certificate.yaml
@@ -1,3 +1,5 @@
+{{/* Certificate is meaningless without specified publicDomainTemplate. */}}
+{{- if ne "<missing>" (dig "modules" "publicDomainTemplate" "<missing>" .Values.global) }}
 {{- if eq (include "helm_lib_module_https_mode" .) "CertManager" }}
 ---
 apiVersion: cert-manager.io/v1
@@ -15,4 +17,5 @@ spec:
   issuerRef:
     name: {{ include "helm_lib_module_https_cert_manager_cluster_issuer_name" . }}
     kind: ClusterIssuer
+{{- end }}
 {{- end }}

--- a/templates/virtualization-controller/_helpers.tpl
+++ b/templates/virtualization-controller/_helpers.tpl
@@ -58,8 +58,10 @@ true
 {{- end }}
 - name: VIRTUAL_MACHINE_IP_LEASES_RETENTION_DURATION
   value: "10m"
+{{- if ne "<missing>" (dig "modules" "publicDomainTemplate" "<missing>" .Values.global) }}
 - name: UPLOADER_INGRESS_HOST
   value: {{ include "helm_lib_module_public_domain" (list . "virtualization") }}
+{{- end }}
 {{- if (include "helm_lib_module_https_ingress_tls_enabled" .) }}
 - name: UPLOADER_INGRESS_TLS_SECRET
   value: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}


### PR DESCRIPTION
## Description

Degrade gracefuly on empty `settings.modules.publicClusterDomain` (`mc/global`):
- Do not create `Certificate` resource for cert-manager if `publicClusterDomain` is empty.
- Do not show "external" URL in CVI/VI status, only "inCluster" URL.

Also, "virt.deckhouse.io" annotation group is deprecated, use "virtualization.deckhouse.io" for external upload url on Ingress resource.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
Prevent main queue locking with cryptic message "<$context.Values.global.modules.publicDomainTemplate>: wrong type for value; expected string; got interface {}".

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


- Module should not lock main queue.
- Module should support "in-cluster" upload when publicDomainTemplate is empty.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: module
type: chore
summary: Support "in-cluster" upload when publicDomainTemplate is empty.
```