### PR TITLE
chore(module): reduce module restarts during installation

### DIFF
--- a/images/hooks/pkg/hooks/discovery-clusterip-service-for-dvcr/hook.go
+++ b/images/hooks/pkg/hooks/discovery-clusterip-service-for-dvcr/hook.go
@@ -39,7 +39,8 @@ const (
 var _ = registry.RegisterFunc(configDiscoveryService, handleDiscoveryService)
 
 var configDiscoveryService = &pkg.HookConfig{
-	OnBeforeHelm: &pkg.OrderedConfig{Order: 5},
+	// Note: this hook should run before TLS certificate generator for DVCR. Order should be lower than 5.
+	OnBeforeHelm: &pkg.OrderedConfig{Order: 3},
 	Kubernetes: []pkg.KubernetesConfig{
 		{
 			Name:       discoveryService,

--- a/images/hooks/pkg/hooks/discovery-workload-nodes/hook.go
+++ b/images/hooks/pkg/hooks/discovery-workload-nodes/hook.go
@@ -64,7 +64,7 @@ var configDiscoveryService = &pkg.HookConfig{
 			Name:       kubevirtConfigSnapshot,
 			APIVersion: "internal.virtualization.deckhouse.io/v1",
 			Kind:       "InternalVirtualizationKubeVirt",
-			JqFilter:   `{ "phase" .status.phase, "parallelMigrationsPerCluster": .spec.configuration.migrations.parallelMigrationsPerCluster }`,
+			JqFilter:   `{ "phase": .status.phase, "parallelMigrationsPerCluster": .spec.configuration.migrations.parallelMigrationsPerCluster }`,
 			NamespaceSelector: &pkg.NamespaceSelector{
 				NameSelector: &pkg.NameSelector{
 					MatchNames: []string{"d8-virtualization"},

--- a/images/hooks/pkg/hooks/discovery-workload-nodes/hook.go
+++ b/images/hooks/pkg/hooks/discovery-workload-nodes/hook.go
@@ -36,6 +36,11 @@ const (
 	nodeLabelValue         = "true"
 
 	virtHandlerNodeCountPath = "virtualization.internal.virtHandler.nodeCount"
+
+	kubevirtConfigSnapshot = "kubevirt-config"
+
+	virtConfigPhasePath                        = "virtualization.internal.virtConfig.phase"
+	virtConfigParallelMigrationsPerClusterPath = "virtualization.internal.virtConfig.parallelMigrationsPerCluster"
 )
 
 var _ = registry.RegisterFunc(configDiscoveryService, handleDiscoveryNodes)
@@ -55,6 +60,21 @@ var configDiscoveryService = &pkg.HookConfig{
 			},
 			ExecuteHookOnSynchronization: ptr.To(false),
 		},
+		{
+			Name:       kubevirtConfigSnapshot,
+			APIVersion: "internal.virtualization.deckhouse.io/v1",
+			Kind:       "InternalVirtualizationKubeVirt",
+			JqFilter:   `{ "phase" .status.phase, "parallelMigrationsPerCluster": .spec.configuration.migrations.parallelMigrationsPerCluster }`,
+			NamespaceSelector: &pkg.NamespaceSelector{
+				NameSelector: &pkg.NameSelector{
+					MatchNames: []string{"d8-virtualization"},
+				},
+			},
+			NameSelector: &pkg.NameSelector{
+				MatchNames: []string{"config"},
+			},
+			ExecuteHookOnSynchronization: ptr.To(false),
+		},
 	},
 
 	Queue: fmt.Sprintf("modules/%s", settings.ModuleName),
@@ -63,5 +83,35 @@ var configDiscoveryService = &pkg.HookConfig{
 func handleDiscoveryNodes(_ context.Context, input *pkg.HookInput) error {
 	nodeCount := len(input.Snapshots.Get(discoveryNodesSnapshot))
 	input.Values.Set(virtHandlerNodeCountPath, nodeCount)
+
+	kvCfgState, err := virtConfigStateFromSnapshot(input)
+	if err != nil {
+		return err
+	}
+	if kvCfgState != nil {
+		input.Values.Set(virtConfigPhasePath, kvCfgState.Phase)
+		input.Values.Set(virtConfigParallelMigrationsPerClusterPath, kvCfgState.ParallelMigrationsPerCluster)
+	}
+
 	return nil
+}
+
+type virtConfigState struct {
+	Phase                        string `json:"phase"`
+	ParallelMigrationsPerCluster int    `json:"parallelMigrationsPerCluster"`
+}
+
+func virtConfigStateFromSnapshot(input *pkg.HookInput) (*virtConfigState, error) {
+	snap := input.Snapshots.Get(kubevirtConfigSnapshot)
+	if len(snap) == 0 {
+		return nil, nil
+	}
+
+	var kvCfgState virtConfigState
+	err := snap[0].UnmarshalTo(&kvCfgState)
+	if err != nil {
+		return nil, err
+	}
+
+	return &kvCfgState, nil
 }

--- a/openapi/values.yaml
+++ b/openapi/values.yaml
@@ -122,6 +122,14 @@ properties:
         properties:
           nodeCount:
             type: integer
+      virtConfig:
+        type: object
+        default: {}
+        properties:
+          phase:
+            type: string
+          parallelMigrationsPerCluster:
+            type: integer
       moduleConfig:
         type: object
         additionalProperties: true

--- a/templates/kubevirt/_kubevirt_helpers.tpl
+++ b/templates/kubevirt/_kubevirt_helpers.tpl
@@ -79,9 +79,9 @@ spec:
 {{-   $default -}}
 {{- else -}}
 {{-   if eq $phase "Deployed" -}}
-{{-     .Values.virtualization.internal |  dig "virtHandler" "nodeCount" $default | min $default -}}
+{{-     max $default ( .Values.virtualization.internal |  dig "virtHandler" "nodeCount" 0 ) -}}
 {{-   else -}}
-{{-     .Values.virtualization.internal |  dig "virtConfig" "parallelMigrationsPerCluster" $default -}}
+{{-     .Values.virtualization.internal | dig "virtConfig" "parallelMigrationsPerCluster" $default -}}
 {{-   end -}}
 {{- end -}}
 {{- end -}}

--- a/templates/kubevirt/_kubevirt_helpers.tpl
+++ b/templates/kubevirt/_kubevirt_helpers.tpl
@@ -62,3 +62,26 @@ spec:
 {{- define "kubevirt.delve_strategic_patch_json" -}}
 '{{ include "kubevirt.delve_strategic_patch" . | fromYaml | toJson }}'
 {{- end }}
+
+{{/* Calculate parallel migrations per cluster.
+ This template returns:
+  - Count of nodes with virt-handler if kubevirt config is in 'Deployed' phase.
+  - Current parallelMigrationsPerCluster if config is not in 'Deployed' phase.
+  - Default migrations count (2) if there is no kubevirt config.
+ This behaviour prevents unnecessary helm installs during installation.
+
+ Values from
+ */}}
+{{- define "kubevirt.parallel_migrations_per_cluster" -}}
+{{- $default := 2 -}}
+{{- $phase := .Values.virtualization.internal | dig "virtConfig" "phase" "<missing>" -}}
+{{- if eq $phase "<missing>" -}}
+{{-   $default -}}
+{{- else -}}
+{{-   if eq $phase "Deployed" -}}
+{{-     .Values.virtualization.internal |  dig "virtHandler" "nodeCount" $default | min $default -}}
+{{-   else -}}
+{{-     .Values.virtualization.internal |  dig "virtConfig" "parallelMigrationsPerCluster" $default -}}
+{{-   end -}}
+{{- end -}}
+{{- end -}}

--- a/templates/kubevirt/kubevirt.yaml
+++ b/templates/kubevirt/kubevirt.yaml
@@ -31,7 +31,7 @@ spec:
     migrations:
       bandwidthPerMigration: 640Mi
       completionTimeoutPerGiB: 800
-      parallelMigrationsPerCluster: {{ .Values.virtualization.internal | dig "virtHandler" "nodeCount" 1 }}
+      parallelMigrationsPerCluster: {{ include "kubevirt.parallel_migrations_per_cluster" . }}
       parallelOutboundMigrationsPerNode: 1
       progressTimeout: 150
     smbios:

--- a/tools/kubeconform/fixtures/module-values.yaml
+++ b/tools/kubeconform/fixtures/module-values.yaml
@@ -394,7 +394,11 @@ virtualization:
         - 10.0.10.0/24
         - 10.0.20.0/24
         - 10.0.30.0/24
-
+    virtConfig:
+      phase: Deployed
+      parallelMigrationsPerCluster: 2
+    virtHandler:
+      nodeCount: 1
   logLevel: debug
   registry:
     base: some-registry.io/sys/deckhouse-oss/modules


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
- Run discover cluster IP hook before TLS certificate generator for DVCR hook.
- Set updated value for parallelMigrationsPerCluster if kubevirt config is Deployed.


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->

1. Running discover hook before certificate generator leads to helm template render error and unnecessary restart:
```
 1. ModuleRun:parallel_queue_1:virtualization:doStartup:OperatorStartup:failures 1:
run helm install: template: virtualization/templates/dvcr/secret.yaml:12:20:
executing "virtualization/templates/dvcr/secret.yaml" at <.Values.virtualization.internal.dvcr.cert.ca>:
nil pointer evaluating interface {}.ca
```

3. Updating `parallelMigrationsPerCluster` to virt-handler nodes adds more restarts during kubevirt deploy process with errors like this:

```
run helm install: helm upgrade failed: cannot patch "config" with kind InternalVirtualizationKubeVirt:
Internal error occurred: failed calling webhook "kubevirt-update-validator.kubevirt.io":
failed to call webhook: Post "https://kubevirt-operator-webhook.d8-virtualization.svc:24192/kubevirt-validate-update?timeout=10s":
remote error: tls: internal error 
```

## What is the expected result?

No errors like that in deckhouse log during module installation.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: module
type: chore
summary: Reduce module restarts during installation.
```
