### PR TITLE
fix(vmclass): use qemu64 CPU model for Discovery and Features types to improve AMD compatibility

### DIFF
--- a/docs/internal/cpu_model_type_discovery.md
+++ b/docs/internal/cpu_model_type_discovery.md
@@ -11,10 +11,10 @@ Other combinations lead to migration problems. These combinations are unpredicta
 The error might be a bug in libvirt when it compares features after resolving the target CPU model (still
 need to investigate).
 
-The current approach is to use kvm64 model for Discovery and Features types. This model contains a small
-set of features and migration works well.
+The current approach is to use qemu64 model for Discovery and Features types. This model contains a small
+set of features and migration works well. Changed from kvm64 to qemu64 to improve compatibility with AMD CPUs.
 
 ## Solution
 
-1. Use kvm64 model for Discovery and Features vmclass types.
-2. Add patch for kubevirt to prevent adding nodeSelector for cpu model "kvm64".
+1. Use qemu64 model for Discovery and Features vmclass types.
+2. Add patch for kubevirt to prevent adding nodeSelector for cpu model "qemu64".

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
@@ -45,7 +45,7 @@ const (
 	SysprepDiskName   = "sysprep"
 
 	// GenericCPUModel specifies the base CPU model for Features and Discovery CPU model types.
-	GenericCPUModel = "kvm64"
+	GenericCPUModel = "qemu64"
 )
 
 type KVVMOptions struct {


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section:
type:
summary:
```
