### PR TITLE
chore(core): stable flags order for kubevirt components

### DIFF
--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -3,7 +3,7 @@ firmware:
   libvirt: v10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: v1.3.1-v12n.10
+  3p-kubevirt: v1.3.1-v12n.11
   3p-containerized-data-importer: v1.60.3-v12n.9
   distribution: 2.8.3
 package:


### PR DESCRIPTION


## Description

Update 3p-kubevirt to v1.3.1-v12n.11


## Why do we need it, and what problem does it solve?

Add https://github.com/deckhouse/3p-kubevirt/pull/21:
Converting from map to array in flagsToArray may change flags order. This leads to unnecessary restarts of virt-handler, virt-controller, and virt-api.


## What is the expected result?

More stable e2e runs.

No more errors like "tls: x509 unknown entity" during tests.


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

Note: e2e passed as a part of PR #1432.

## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: core
type: chore
summary: Reduce kubevirt components restarts.
```
