### PR TITLE
fix(ci): ignore kubectl logs exit codes in e2e test teardown

### DIFF
--- a/tests/e2e/tests_suite_test.go
+++ b/tests/e2e/tests_suite_test.go
@@ -292,11 +292,8 @@ func StopV12nControllerLogStream(logStreamByPod map[string]*el.LogStream) []erro
 		go func() {
 			defer GinkgoRecover()
 			defer logStream.LogStreamWaitGroup.Done()
-			warn, err := logStream.WaitCmd()
+			warn, _ := logStream.WaitCmd()
 			mu.Lock()
-			if err != nil {
-				errs = append(errs, err)
-			}
 			if warn != "" {
 				_, err := GinkgoWriter.Write([]byte(warn))
 				if err != nil {


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Modify the StopV12nControllerLogStream function in E2E tests to ignore exit codes from kubectl logs commands during test teardown. The function now only captures warning messages while discarding error returns from the log stream command.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: ci
type: fix
summary: E2E tests no longer fail due to kubectl logs exit codes during teardown.
```
