### PR TITLE
chore(test): add conditions to make e2e tests less noisy

### DIFF
--- a/tests/e2e/default_config.yaml
+++ b/tests/e2e/default_config.yaml
@@ -50,10 +50,13 @@ logFilter:
   - "does not have a pvc reference" # "err": "kvvm head-345e7b6a-testcases-image-hotplug/head-345e7b6a-vm-image-hotplug spec volume vi-head-345e7b6a-vi-alpine-http does not have a pvc reference"
   - "lastTransitionTime: Required value" # Err.
   - "virtualmachineipaddressleases.virtualization.deckhouse.io "
+  - "Forbidden: no new finalizers can be added if the object is being deleted, found new finalizers"
 regexpLogFilter:
   - "failed to detach: .* not found" # "err" "failed to detach: virtualmachine.kubevirt.io \"head-497d17b-vm-automatic-with-hotplug\" not found",
   - "error patching .* not found" # "err" "error patching *** virtualimages.virtualization.deckhouse.io \"head-497d17b-vi-pvc-oref-vi-oref-vd\" not found",
   - "IP address .* is not among addresses assigned to 'default' network interface .*" # "msg": "IP address (10.66.10.61) is not among addresses assigned to 'default' network interface (10.66.10.60)"
+  - "failed to get vmSnapshot: VirtualMachineSnapshot\\.virtualization\\.deckhouse.io .* not found" # "msg": "failed to get vmSnapshot: VirtualMachineSnapshot.virtualization.deckhouse.io \"main-to-pr14969-ynv-0-ef17ba-20250908-142437\" not found"
+  - "failed to sync virtual disk data source objectref: start immediate: internalvirtualizationdatavolumes.cdi.internal.virtualization.deckhouse.io .* is forbidden: unable to create new content in namespace .* because it is being terminated" # "err": "failed to sync virtual disk data source objectref: start immediate: internalvirtualizationdatavolumes.cdi.internal.virtualization.deckhouse.io \"vd-head-b3d8865-vd-root-migration-bios-d77ea313-f469-463d-a71b-00c89ca542ab\" is forbidden: unable to create new content in namespace head-b3d8865-end-to-end-vm-migration because it is being terminated"
 
 cleanupResources:
   - clustervirtualimages.virtualization.deckhouse.io


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Add conditions to make tests less noisy

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
We only need up-to-date information in the test logs.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: module
type: chore
summary: add conditions to make tests less noisy
impact_level: low
```
