### PR TITLE
chore(ci): e2e fixes for more stable tests

### DIFF
--- a/.github/workflows/dev_module_build.yml
+++ b/.github/workflows/dev_module_build.yml
@@ -625,7 +625,7 @@ jobs:
         with:
           name: resources_from_failed_tests
           retention-days: 2
-          path: /tmp/e2e_failed__*
+          path: ${{ runner.temp }}/e2e_failed__*
           if-no-files-found: ignore
 
       - name: Cleanup E2E resources on cancel

--- a/tests/e2e/default_config.yaml
+++ b/tests/e2e/default_config.yaml
@@ -51,12 +51,18 @@ logFilter:
   - "lastTransitionTime: Required value" # Err.
   - "virtualmachineipaddressleases.virtualization.deckhouse.io "
   - "Forbidden: no new finalizers can be added if the object is being deleted, found new finalizers"
+  - "Failed to watch" # error if virtualization-controller restarts during tests. "msg": "Failed to watch", "err": "Get \"http://127.0.0.1:23915/apis/virtualization.deckhouse.io/v1alpha2/virtualmachinerestores?allowWatchBookmarks=true\u0026resourceVersion=709816257\u0026timeoutSeconds=310\u0026watch=true\": context canceled"
+  - "leader election lost"
 regexpLogFilter:
   - "failed to detach: .* not found" # "err" "failed to detach: virtualmachine.kubevirt.io \"head-497d17b-vm-automatic-with-hotplug\" not found",
   - "error patching .* not found" # "err" "error patching *** virtualimages.virtualization.deckhouse.io \"head-497d17b-vi-pvc-oref-vi-oref-vd\" not found",
   - "IP address .* is not among addresses assigned to 'default' network interface .*" # "msg": "IP address (10.66.10.61) is not among addresses assigned to 'default' network interface (10.66.10.60)"
   - "failed to get vmSnapshot: VirtualMachineSnapshot\\.virtualization\\.deckhouse.io .* not found" # "msg": "failed to get vmSnapshot: VirtualMachineSnapshot.virtualization.deckhouse.io \"main-to-pr14969-ynv-0-ef17ba-20250908-142437\" not found"
   - "failed to sync virtual disk data source objectref: start immediate: internalvirtualizationdatavolumes.cdi.internal.virtualization.deckhouse.io .* is forbidden: unable to create new content in namespace .* because it is being terminated" # "err": "failed to sync virtual disk data source objectref: start immediate: internalvirtualizationdatavolumes.cdi.internal.virtualization.deckhouse.io \"vd-head-b3d8865-vd-root-migration-bios-d77ea313-f469-463d-a71b-00c89ca542ab\" is forbidden: unable to create new content in namespace head-b3d8865-end-to-end-vm-migration because it is being terminated"
+  - "Failed to update lock optimistically:.*leases.*leader-election-helper.*" # error during virtualization-controller lifecycle: attempt to reacquire leader election. "msg": "Failed to update lock optimistically: Put \"http://127.0.0.1:23915/apis/coordination.k8s.io/v1/namespaces/d8-virtualization/leases/d8-virt-operator-leader-election-helper?timeout=5s\": context deadline exceeded (Client.Timeout exceeded while awaiting headers), falling back to slow path"
+  - "Failed to update lock: .* leases.*leader-election-helper.*" # "msg": "ock: Operation cannot be fulfilled on leases.coordination.k8s.io \"d8-virt-operator-leader-election-helper\": the object has been modified; please apply your changes to the latest version and try again",
+  - "failed to create VirtualMachineIPAddress .* the specified IP address .* has already been allocated and has not been released" #     "err": "failed to create VirtualMachineIPAddress \"head-5d2c558-vm-restore-safe-tfv4w\": admission webhook \"vmip.virtualization-controller.validate.d8-virtualization\" denied the request: the VirtualMachineIPAddress cannot be created: the specified IP address 10.66.10.4 has already been allocated and has not been released"
+  - "error retrieving resource lock .*leader-election-helper" #  "msg": "error retrieving resource lock d8-virtualization/d8-virt-operator-leader-election-helper: context deadline exceeded",
 
 cleanupResources:
   - clustervirtualimages.virtualization.deckhouse.io

--- a/tests/e2e/network/cilium_agents.go
+++ b/tests/e2e/network/cilium_agents.go
@@ -62,7 +62,7 @@ func CheckCilliumAgents(ctx context.Context, kubectl kc.Kubectl, vmName, vmNames
 			}
 
 			if !found {
-				return fmt.Errorf("failed: cilium agent %s for VM's node %s", pod.Name, nodeName)
+				return fmt.Errorf("failed: not found cilium agent %s for VM's node %s", pod.Name, nodeName)
 			}
 		} else {
 			// For pods on different nodes
@@ -72,7 +72,7 @@ func CheckCilliumAgents(ctx context.Context, kubectl kc.Kubectl, vmName, vmNames
 			}
 
 			if !found {
-				return fmt.Errorf("failed: cilium agent %s for node %s", pod.Name, pod.Spec.NodeName)
+				return fmt.Errorf("failed: not found cilium agent %s for node %s", pod.Name, pod.Spec.NodeName)
 			}
 		}
 	}

--- a/tests/e2e/vd_snapshots_test.go
+++ b/tests/e2e/vd_snapshots_test.go
@@ -264,7 +264,7 @@ var _ = Describe("VirtualDiskSnapshots", ginkgoutil.CommonE2ETestDecorators(), f
 							}(i)
 						}
 						wg.Wait()
-						Expect(errs).To(BeEmpty(), "concurrent snapshotting error")
+						Expect(errs).To(BeEmpty(), "should not face concurrent snapshotting error")
 
 						Eventually(func() error {
 							frozen, err := CheckFileSystemFrozen(vm.Name, ns)
@@ -280,6 +280,28 @@ var _ = Describe("VirtualDiskSnapshots", ginkgoutil.CommonE2ETestDecorators(), f
 					}
 				}
 			}
+		})
+
+		It("checks snapshots", func() {
+			By("Snapshots should be `Ready`")
+			labels := make(map[string]string)
+			maps.Copy(labels, attachedVirtualDiskLabel)
+			maps.Copy(labels, testCaseLabel)
+
+			Eventually(func() error {
+				vdSnapshots := GetVirtualDiskSnapshots(ns, labels)
+				for _, snapshot := range vdSnapshots.Items {
+					if snapshot.Status.Phase == virtv2.VirtualDiskSnapshotPhaseReady || snapshot.DeletionTimestamp != nil {
+						continue
+					}
+					return errors.New("still wait for all snapshots either in ready or in deletion state")
+				}
+				return nil
+			}).WithTimeout(
+				LongWaitDuration,
+			).WithPolling(
+				Interval,
+			).Should(Succeed(), "all snapshots should be in ready state after creation")
 		})
 
 		// TODO: It is a known issue that disk snapshots are not always created consistently. To prevent this error from causing noise during testing, we disabled this check. It will need to be re-enabled once the consistency issue is fixed.
@@ -319,7 +341,7 @@ var _ = Describe("VirtualDiskSnapshots", ginkgoutil.CommonE2ETestDecorators(), f
 						return nil
 					}
 					if frozen {
-						return fmt.Errorf("the filesystem of the virtual machine %s/%s is frozen", vm.Namespace, vm.Name)
+						return fmt.Errorf("the filesystem of the virtual machine %s/%s is still frozen", vm.Namespace, vm.Name)
 					}
 					return nil
 				}).WithTimeout(
@@ -382,6 +404,18 @@ func CreateVirtualDiskSnapshot(vdName, snapshotName, namespace string, requiredC
 		return fmt.Errorf("cannot create virtual disk snapshot: %s\nstderr: %s", snapshotName, res.StdErr())
 	}
 	return nil
+}
+
+func GetVirtualDiskSnapshots(namespace string, labels map[string]string) virtv2.VirtualDiskSnapshotList {
+	GinkgoHelper()
+	vdSnapshots := virtv2.VirtualDiskSnapshotList{}
+	err := GetObjects(kc.ResourceVDSnapshot, &vdSnapshots, kc.GetOptions{
+		ExcludedLabels: []string{"hasNoConsumer"},
+		Namespace:      namespace,
+		Labels:         labels,
+	})
+	Expect(err).NotTo(HaveOccurred(), "cannot get `vdSnapshots`\nstderr: %s", err)
+	return vdSnapshots
 }
 
 func CheckFileSystemFrozen(vmName, vmNamespace string) (bool, error) {

--- a/tests/e2e/vm_connectivity_test.go
+++ b/tests/e2e/vm_connectivity_test.go
@@ -308,8 +308,12 @@ func CheckCiliumAgents(kubectl kc.Kubectl, namespace string, vms ...string) {
 	GinkgoHelper()
 	for _, vm := range vms {
 		By(fmt.Sprintf("Cilium agent should be OK's for VM: %s", vm))
-		err := network.CheckCilliumAgents(context.Background(), kubectl, vm, namespace)
-		Expect(err).NotTo(HaveOccurred())
+		Eventually(func() error {
+			return network.CheckCilliumAgents(context.Background(), kubectl, vm, namespace)
+		}).
+			WithTimeout(Timeout).
+			WithPolling(Interval).
+			Should(Succeed())
 	}
 }
 


### PR DESCRIPTION
## Description

- Ignore failed to watch, fail to elect, fail to create vmip errors in virtualization-controller log.
- Use Eventually to test IP in cilium agents.
- Fix handling kubectl errors in SaveResourcesForTest.



## Why do we need it, and what problem does it solve?

- More stable e2e tests, ignore some false-positives.
- See errors occurred in AfterEach handler.


## What is the expected result?

- Reduce number of failed e2e runs.
- Upload artifact with resources



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

Note: tested in e2e runs for #1432 :
https://github.com/deckhouse/virtualization/actions/runs/17849395047/job/50754944907
https://github.com/deckhouse/virtualization/actions/runs/17837555108/job/50718609496

## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: ci
type: chore
summary: Fix creating artifact for failed e2e test, ignore more false-positive errors.
```
