### PR TITLE
fix(vmop): fix deleting vmops when virtualization controller restarted

### DIFF
--- a/images/virtualization-artifact/pkg/controller/gc/gc_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/gc/gc_reconciler.go
@@ -72,6 +72,7 @@ func (r *Reconciler) SetupWithManager(controllerName string, mgr ctrl.Manager, l
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(controllerName).
 		For(r.mgr.New(), builder.WithPredicates(predicate.Funcs{
+			CreateFunc: func(ce event.CreateEvent) bool { return false },
 			UpdateFunc: func(ue event.UpdateEvent) bool {
 				return false
 			},


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Fix the garbage collector: previously, when restarting the virtualization controller, all VMOP were deleted, ignoring the cleaning rules.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries

```changes
section: vmop
type: fix 
summary: "Fixed garbage collector behavior: previously, all VMOP objects were deleted after restarting the virtualization controller, ignoring cleanup rules."
```
