### PR TITLE
chore(module): dedup lines on live migration memory graph

### DIFF
--- a/monitoring/grafana-dashboards/main/virtual-machine.json
+++ b/monitoring/grafana-dashboards/main/virtual-machine.json
@@ -1720,7 +1720,7 @@
               }
             ]
           },
-          "unit": "bytes"
+          "unit": "Bps"
         },
         "overrides": []
       },
@@ -1750,7 +1750,7 @@
             "uid": "P0D6E4079E36703EB"
           },
           "editorMode": "code",
-          "expr": "rate(d8_virtualization_virtualmachine_migration_data_processed_bytes{namespace=\"$namespace\", name=\"$name\"}[$__rate_interval])",
+          "expr": "sum(rate(d8_virtualization_virtualmachine_migration_data_processed_bytes{namespace=\"$namespace\", name=\"$name\"}[$__rate_interval])) without (instance,job,node)",
           "instant": false,
           "legendFormat": "Processed memory rate",
           "range": true,
@@ -1762,7 +1762,7 @@
             "uid": "${ds_prometheus}"
           },
           "editorMode": "code",
-          "expr": "rate(d8_virtualization_virtualmachine_migration_data_remaining_bytes{namespace=\"$namespace\", name=\"$name\"}[$__rate_interval])",
+          "expr": "sum(rate(d8_virtualization_virtualmachine_migration_data_remaining_bytes{namespace=\"$namespace\", name=\"$name\"}[$__rate_interval])) without (instance,job,node)",
           "hide": false,
           "instant": false,
           "legendFormat": "Remaining memory rate",
@@ -1775,7 +1775,7 @@
             "uid": "${ds_prometheus}"
           },
           "editorMode": "code",
-          "expr": "d8_virtualization_virtualmachine_migration_dirty_memory_rate_bytes{namespace=\"$namespace\", name=\"$name\"}",
+          "expr": "sum(d8_virtualization_virtualmachine_migration_dirty_memory_rate_bytes{namespace=\"$namespace\", name=\"$name\"}) without (instance,job,node)",
           "hide": false,
           "instant": false,
           "legendFormat": "Dirty memory rate",


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
- Drop some labels to not split  graph lines.
- Use bytes/sec(SI) unit.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->

Before:

<img width="1215" height="388" alt="image" src="https://github.com/user-attachments/assets/e2284a10-d2d5-4396-b77f-a56af5f94b0c" />


After:

<img width="1215" height="388" alt="image" src="https://github.com/user-attachments/assets/e17197be-1c45-4fd9-a7ac-949b958ce2ff" />


## What is the expected result?

Only 3 lines are present on the graph.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: observability
type: fix
summary: Fixed the graph on the virtual machine dashboard that displays memory copy statistics during VM migration.
```
