### PR TITLE
chore(module): add network label with network name

### DIFF
--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -3,7 +3,7 @@ firmware:
   libvirt: v10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: v1.3.1-v12n.12
+  3p-kubevirt: v1.3.1-v12n.13
   3p-containerized-data-importer: v1.60.3-v12n.10
   distribution: 2.8.3
 package:

--- a/monitoring/grafana-dashboards/main/virtual-machine.json
+++ b/monitoring/grafana-dashboards/main/virtual-machine.json
@@ -1284,7 +1284,7 @@
             "uid": "${ds_prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(d8_virtualization_virtualmachine_network_receive_bytes_total{namespace=\"$namespace\", name=\"$name\", network=\"$network\"}[$__rate_interval])*8)",
+          "expr": "sum(rate(d8_virtualization_virtualmachine_network_receive_bytes_total{namespace=\"$namespace\", name=\"$name\"}[$__rate_interval])*8)",
           "instant": false,
           "legendFormat": "RX",
           "range": true,
@@ -1296,7 +1296,7 @@
             "uid": "${ds_prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(d8_virtualization_virtualmachine_network_transmit_bytes_total{namespace=\"$namespace\", name=\"$name\", network=\"$network\"}[$__rate_interval])*8)",
+          "expr": "sum(rate(d8_virtualization_virtualmachine_network_transmit_bytes_total{namespace=\"$namespace\", name=\"$name\"}[$__rate_interval])*8)",
           "hide": false,
           "instant": false,
           "legendFormat": "TX",
@@ -4471,8 +4471,8 @@
       {
         "current": {
           "selected": false,
-          "text": "default",
-          "value": "default"
+          "text": "All",
+          "value": "$__all"
         },
         "datasource": {
           "type": "prometheus",
@@ -4480,7 +4480,7 @@
         },
         "definition": "label_values(d8_virtualization_virtualmachine_network_receive_bytes_total{namespace=\"$namespace\", name=\"$name\"},network)",
         "hide": 2,
-        "includeAll": false,
+        "includeAll": true,
         "multi": false,
         "name": "network",
         "options": [],

--- a/templates/kubevirt/service-monitor.yaml
+++ b/templates/kubevirt/service-monitor.yaml
@@ -78,14 +78,6 @@ spec:
             - __name__
             - drive
           targetLabel: type
-        # network ----------------------------------------------------------------------------------
-        # add network=default for all kubevirt_vmi_network_ metrics
-        - action: replace
-          regex: kubevirt_vmi_network_(.*)
-          replacement: default
-          sourceLabels:
-            - __name__
-          targetLabel: network
         # cpu --------------------------------------------------------------------------------------
         # for kubevirt_vmi_vcpu_ add new label core with value from id label
         - action: replace


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
- Remove metric replacement rule to always set network label with "default" value
- Add kubevirt patch to set network name from annotation.

Supporting PR: [3p-kubevirt #22 feat(metrics): add network label with network name](https://github.com/deckhouse/3p-kubevirt/pull/22)

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->

Given this specs:

```
  networks:
  - type: Main
  - name: test-vlan-540
    type: Network
  - name: test-vlan-542
    type: Network
```

Before: only "default" network is shown:

<img width="618" height="344" alt="image" src="https://github.com/user-attachments/assets/cbb4edbf-743b-4a15-b77d-6b174a94c7bb" />

After:

<img width="618" height="431" alt="image" src="https://github.com/user-attachments/assets/cc50e54e-4fa4-4011-943b-76c18a393c3e" />

Network bandwidth is summed for all networks:

<img width="609" height="308" alt="image" src="https://github.com/user-attachments/assets/55f66d78-df78-41c4-9eae-39e439c806ce" />

<img width="609" height="308" alt="image" src="https://github.com/user-attachments/assets/a3942e9c-84c4-4149-8581-8fa1b50922c0" />
<img width="609" height="308" alt="image" src="https://github.com/user-attachments/assets/e7215e0a-7c4b-47ee-84a7-97109b5e042e" />

<img width="609" height="308" alt="image" src="https://github.com/user-attachments/assets/1bb911e0-b5e7-49e9-8ac5-d7de2fa9ec96" />


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->

Graph contains separate lines for each network specified in the VM spec.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: observability
type: feature
summary: Repeat "Network details" graphs for all networks specified in the VM spec.
```
