### PR TITLE
chore(ci): change path of e2e artifacts

### DIFF
--- a/.github/workflows/nightly_e2e_tests_ceph.yaml
+++ b/.github/workflows/nightly_e2e_tests_ceph.yaml
@@ -80,7 +80,7 @@ jobs:
         if: always()
         with:
           name: resources_from_failed_tests
-          path: /tmp/e2e_failed__*
+          path: ${{ runner.temp }}/e2e_failed__*
           if-no-files-found: ignore
 
       - name: Save results

--- a/.github/workflows/nightly_e2e_tests_replicated.yaml
+++ b/.github/workflows/nightly_e2e_tests_replicated.yaml
@@ -80,7 +80,7 @@ jobs:
         if: always()
         with:
           name: resources_from_failed_tests
-          path: /tmp/e2e_failed__*
+          path: ${{ runner.temp }}/e2e_failed__*
           if-no-files-found: ignore
 
       - name: Save results


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
- Change path in upload-artifact to use runner temp directory.


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->

e2e artifacts are now created in the runner temp dir after PR #1470

## What is the expected result?

Artifacts are uploaded on failed e2e tests.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: ci
type: chore
summary: Change path in upload artifact for nightly e2e tests.
```
