### PR TITLE
fix(vmsnapshot): fix creating snapshot from vm with awaiting restart changes

### DIFF
--- a/api/core/v1alpha2/vmscondition/condition.go
+++ b/api/core/v1alpha2/vmscondition/condition.go
@@ -41,8 +41,6 @@ const (
 
 	// WaitingForTheVirtualMachine signifies that the snapshot process is waiting for the virtual machine to become ready for snapshotting.
 	WaitingForTheVirtualMachine VirtualMachineSnapshotReadyReason = "WaitingForTheVirtualMachine"
-	// RestartAwaitingChanges signifies that the snapshotting process cannot begin because the virtual machine has awaiting changes.
-	RestartAwaitingChanges VirtualMachineSnapshotReadyReason = "RestartAwaitingChanges"
 	// BlockDevicesNotReady signifies that the snapshotting process cannot begin because the block devices of the virtual machine are not ready.
 	BlockDevicesNotReady VirtualMachineSnapshotReadyReason = "BlockDevicesNotReady"
 	// PotentiallyInconsistent signifies that the snapshotting process cannot begin because creating a snapshot of the running virtual machine might result in an inconsistent snapshot.

--- a/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/life_cycle.go
+++ b/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/life_cycle.go
@@ -190,25 +190,6 @@ func (h LifeCycleHandler) Handle(ctx context.Context, vmSnapshot *virtv2.Virtual
 		return reconcile.Result{}, err
 	}
 
-	// 2. Ensure there are no RestartAwaitingChanges.
-	if len(vm.Status.RestartAwaitingChanges) > 0 {
-		vmSnapshot.Status.Phase = virtv2.VirtualMachineSnapshotPhasePending
-		msg := fmt.Sprintf(
-			"Waiting for the restart and approval of changes to virtual machine %q before taking the snapshot.",
-			vm.Name,
-		)
-		h.recorder.Event(
-			vmSnapshot,
-			corev1.EventTypeNormal,
-			virtv2.ReasonVMSnapshottingPending,
-			msg,
-		)
-		cb.
-			Status(metav1.ConditionFalse).
-			Reason(vmscondition.RestartAwaitingChanges).Message(msg)
-		return reconcile.Result{}, nil
-	}
-
 	needToFreeze := h.needToFreeze(vm, vmSnapshot.Spec.RequiredConsistency)
 
 	isAwaitingConsistency := needToFreeze && !h.snapshotter.CanFreeze(vm) && vmSnapshot.Spec.RequiredConsistency
@@ -260,7 +241,7 @@ func (h LifeCycleHandler) Handle(ctx context.Context, vmSnapshot *virtv2.Virtual
 
 	var hasFrozen bool
 
-	// 3. Ensure the virtual machine is consistent for snapshotting.
+	// 2. Ensure the virtual machine is consistent for snapshotting.
 	if needToFreeze {
 		hasFrozen, err = h.freezeVirtualMachine(ctx, vm, vmSnapshot)
 		if err != nil {
@@ -278,17 +259,17 @@ func (h LifeCycleHandler) Handle(ctx context.Context, vmSnapshot *virtv2.Virtual
 		return reconcile.Result{}, nil
 	}
 
-	// 4. Create secret.
+	// 3. Create secret.
 	err = h.ensureSecret(ctx, vm, vmSnapshot)
 	if err != nil {
 		h.setPhaseConditionToFailed(cb, vmSnapshot, err)
 		return reconcile.Result{}, err
 	}
 
-	// 5. Fill status.VirtualDiskSnapshotNames.
+	// 4. Fill status.VirtualDiskSnapshotNames.
 	h.fillStatusVirtualDiskSnapshotNames(vmSnapshot, vm)
 
-	// 6. Get or Create VirtualDiskSnapshots.
+	// 5. Get or Create VirtualDiskSnapshots.
 	vdSnapshots, err := h.ensureVirtualDiskSnapshots(ctx, vmSnapshot)
 	switch {
 	case err == nil:
@@ -314,7 +295,7 @@ func (h LifeCycleHandler) Handle(ctx context.Context, vmSnapshot *virtv2.Virtual
 		return reconcile.Result{}, err
 	}
 
-	// 7. Wait for VirtualDiskSnapshots to be Ready.
+	// 6. Wait for VirtualDiskSnapshots to be Ready.
 	readyCount := h.countReadyVirtualDiskSnapshots(vdSnapshots)
 	msg := fmt.Sprintf(
 		"Waiting for the virtual disk snapshots to be taken for "+
@@ -351,21 +332,21 @@ func (h LifeCycleHandler) Handle(ctx context.Context, vmSnapshot *virtv2.Virtual
 		vmSnapshot.Status.Consistent = nil
 	}
 
-	// 8. Unfreeze VirtualMachine if can.
+	// 7. Unfreeze VirtualMachine if can.
 	unfrozen, err := h.unfreezeVirtualMachineIfCan(ctx, vmSnapshot, vm)
 	if err != nil {
 		h.setPhaseConditionToFailed(cb, vmSnapshot, err)
 		return reconcile.Result{}, err
 	}
 
-	// 9. Fill status resources.
+	// 8. Fill status resources.
 	err = h.fillStatusResources(ctx, vmSnapshot, vm)
 	if err != nil {
 		h.setPhaseConditionToFailed(cb, vmSnapshot, err)
 		return reconcile.Result{}, err
 	}
 
-	// 10. Move to Ready phase.
+	// 9. Move to Ready phase.
 	log.Debug("The virtual disk snapshots are taken: the virtual machine snapshot is Ready now", "unfrozen", unfrozen)
 
 	vmSnapshot.Status.Phase = virtv2.VirtualMachineSnapshotPhaseReady

--- a/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/life_cycle_test.go
+++ b/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/life_cycle_test.go
@@ -240,11 +240,11 @@ var _ = Describe("LifeCycle handler", func() {
 
 			_, err := h.Handle(testContext(), vmSnapshot)
 			Expect(err).To(BeNil())
-			Expect(vmSnapshot.Status.Phase).To(Equal(virtv2.VirtualMachineSnapshotPhasePending))
+			Expect(vmSnapshot.Status.Phase).To(Equal(virtv2.VirtualMachineSnapshotPhaseInProgress))
 			ready, _ := conditions.GetCondition(vmscondition.VirtualMachineSnapshotReadyType, vmSnapshot.Status.Conditions)
 			Expect(ready.Status).To(Equal(metav1.ConditionFalse))
-			Expect(ready.Reason).To(Equal(vmscondition.RestartAwaitingChanges.String()))
-			Expect(ready.Message).ToNot(BeEmpty())
+			Expect(ready.Reason).To(Equal(vmscondition.FileSystemFreezing.String()))
+			Expect(ready.Message).To(Equal("The snapshotting process has started."))
 		})
 
 		It("The virtual machine is potentially inconsistent", func() {


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Fix creating snapshot from vm with awaiting restart changes

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
When creating a snapshot from a VM with changes requiring a restart, the snapshot remained in `Pending` status.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
The snapshot is now always created based on the configuration defined in the .spec at the moment the snapshot is taken.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

