### PR TITLE
fix(docs): english documentation remove cyrillic characters cdi_kubevirt_patching

### DIFF
--- a/docs/internal/cdi_kubevirt_patching.md
+++ b/docs/internal/cdi_kubevirt_patching.md
@@ -62,7 +62,7 @@ cp 000-bundle-images.patch ../../images/cdi-artifact/patches/000-bundle-images.p
 cp 003-apiserver-node-selector-and-tolerations.patch ../../images/cdi-artifact/patches/003-apiserver-node-selector-and-tolerations.patch
 ```
 
-#### Сlean
+#### Clean
 ```bash
 cd ../../
 rm -rf tmp/cdi
@@ -94,7 +94,7 @@ git diff --patch "<TAG COMMIT>" HEAD > 004-replicas.patch
 cp 004-replicas.patch ../../images/cdi-artifact/patches/004-replicas.patch
 git add ../../images/cdi-artifact/patches/004-replicas.patch
 ```
-#### Сlean
+#### Clean
 ```bash
 cd ../../
 rm -rf tmp/cdi


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Remove from english documentation cyrillic characters

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
English documentation should not contains cyrillic characters
```
[cyrillic-in-english (#documentation)]
     Message:      English documentation contains cyrillic characters
     Module:       virtualization
     Value:        Line 65: #### Сlean
                   -----^
                   Line 97: #### Сlean
                   -----^
     FilePath:     docs/internal/cdi_kubevirt_patching.md
```

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: docs
type: fix
summary: english documentation remove cyrillic characters cdi_kubevirt_patching
impact_level: low
```
