### PR TITLE
test: fix cleanup panic

### DIFF
--- a/tests/e2e/tests_suite_test.go
+++ b/tests/e2e/tests_suite_test.go
@@ -349,6 +349,7 @@ func deleteNamespaces() error {
 
 	for _, tc := range testCases {
 		eg.Go(func() error {
+			defer GinkgoRecover()
 			kustomizeFilePath := fmt.Sprintf("%s/kustomization.yaml", tc)
 			namespace, err := kustomize.GetNamespace(kustomizeFilePath)
 			if err != nil {
@@ -371,6 +372,7 @@ func deleteNamespaces() error {
 }
 
 func deleteResources() error {
+	defer GinkgoRecover()
 	var cleanupErr error
 
 	for _, r := range conf.CleanupResources {


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Use GinkgoRecovery with goroutines.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: api
type: chore
summary: "Use GinkgoRecovery with goroutines."
impact_level: low
```
