### PR TITLE
fix(module): change servicemonitor and scrapeconfig namespace

### DIFF
--- a/monitoring/prometheus-rules/virtualization-controller.yaml
+++ b/monitoring/prometheus-rules/virtualization-controller.yaml
@@ -1,7 +1,7 @@
 - name: kubernetes.virtualization.controller_state
   rules:
     - alert: D8VirtualizationControllerTargetDown
-      expr: max by (job) (up{job="scrapeconfig/d8-monitoring/virtualization-controller"}) == 0
+      expr: max by (job) (up{job="scrapeconfig/d8-virtualization/virtualization-controller"}) == 0
       for: 1m
       labels:
         severity_level: "6"
@@ -19,7 +19,7 @@
           2. Or check the Pod logs: `kubectl -n d8-virtualization logs deploy/virtualization-controller`
 
     - alert: D8VirtualizationControllerTargetAbsent
-      expr: absent(up{job="scrapeconfig/d8-monitoring/virtualization-controller"}) == 1
+      expr: absent(up{job="scrapeconfig/d8-virtualization/virtualization-controller"}) == 1
       labels:
         severity_level: "6"
         tier: cluster

--- a/templates/cdi/service-monitor.yaml
+++ b/templates/cdi/service-monitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ .Chart.Name }}-cdi
-  namespace: d8-monitoring
+  namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list $ (dict "prometheus" "main")) | nindent 2 }}
 spec:
   endpoints:
@@ -13,19 +13,6 @@ spec:
       name: prometheus-token
     path: /metrics
     port: metrics
-    # relabelings:
-    # - action: labeldrop
-    #   regex: endpoint|namespace|pod|container
-    # - action: replace
-    #   replacement: linstor-controller
-    #   targetLabel: job
-    # - action: replace
-    #   replacement: cluster
-    #   targetLabel: tier
-    # - action: keep
-    #   regex: "true"
-    #   sourceLabels:
-    #   - __meta_kubernetes_endpoint_ready
     scheme: https
     tlsConfig:
       insecureSkipVerify: true

--- a/templates/dvcr/service-monitor.yaml
+++ b/templates/dvcr/service-monitor.yaml
@@ -5,7 +5,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: dvcr
-  namespace: d8-monitoring
+  namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "dvcr" "prometheus" "main")) | nindent 2 }}
 spec:
   endpoints:

--- a/templates/kubevirt/service-monitor.yaml
+++ b/templates/kubevirt/service-monitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ .Chart.Name }}-virt-handler
-  namespace: d8-monitoring
+  namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list $ (dict "prometheus" "main")) | nindent 2 }}
 spec:
   endpoints:

--- a/templates/namespace.yaml
+++ b/templates/namespace.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  {{- include "helm_lib_module_labels" (list . (dict "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "prometheus.deckhouse.io/rules-watcher-enabled" "true" "prometheus.deckhouse.io/monitor-watcher-enabled" "true" "prometheus.deckhouse.io/scrape-configs-watcher-enabled" "true")) | nindent 2 }}
   name: d8-{{ .Chart.Name }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}

--- a/templates/virtualization-controller/scrape-config.yaml
+++ b/templates/virtualization-controller/scrape-config.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1alpha1
 kind: ScrapeConfig
 metadata:
   name: virtualization-controller
-  namespace: d8-monitoring
+  namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "virtualization-controller" "prometheus" "main")) | nindent 2 }}
 spec:
   honorLabels: true


### PR DESCRIPTION
## Description
Move ServiceMonitor and ScrapeConfig to d8-virtualization namespace


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: module
type: fix 
summary: Move ServiceMonitor and ScrapeConfig to d8-virtualization namespace
impact_level: low
```
