### PR TITLE
fix(vmop): fix restore operation in Strict mode

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm/internal/block_device_condition.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/block_device_condition.go
@@ -311,6 +311,13 @@ func (h *BlockDeviceHandler) countReadyBlockDevices(vm *virtv2.VirtualMachine, s
 				canStartKVVM = false
 				continue
 			}
+
+			if vd.DeletionTimestamp != nil {
+				canStartKVVM = false
+				warnings = append(warnings, fmt.Sprintf("Virtual disk %s is terminating", vd.Name))
+				continue
+			}
+
 			readyCondition, _ := conditions.GetCondition(vdcondition.ReadyType, vd.Status.Conditions)
 			if readyCondition.Status == metav1.ConditionTrue {
 				ready++


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Fix the case when a disk in the "Terminating" phase was being added to volumes during a restore operation in Strict mode.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
During restore, the VM captured the PVC from the old disk, which was in the Terminating phase.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
The VM should wait until the new restored disk becomes available and then capture its restored PVC. 

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: vmop
type: fix
summary: Fix the case when a disk in the "Terminating" phase was being added to volumes during a restore operation in Strict mode.
```
