### PR TITLE
fix(vmop): fix the validation of VirtualDisk names during VirtualMachine cloning

### DIFF
--- a/images/virtualization-artifact/pkg/controller/service/restorer/restorers/provisioner_restorer.go
+++ b/images/virtualization-artifact/pkg/controller/service/restorer/restorers/provisioner_restorer.go
@@ -97,7 +97,7 @@ func (v *ProvisionerHandler) ValidateRestore(ctx context.Context) error {
 }
 
 func (v *ProvisionerHandler) ValidateClone(ctx context.Context) error {
-	if err := common.ValidateResourceNameLength(v.secret.Name); err != nil {
+	if err := common.ValidateResourceNameLength(v.secret.Name, v.secret.Kind); err != nil {
 		return err
 	}
 

--- a/images/virtualization-artifact/pkg/controller/service/restorer/restorers/vd_restorer.go
+++ b/images/virtualization-artifact/pkg/controller/service/restorer/restorers/vd_restorer.go
@@ -97,7 +97,7 @@ func (v *VirtualDiskHandler) ValidateRestore(ctx context.Context) error {
 }
 
 func (v *VirtualDiskHandler) ValidateClone(ctx context.Context) error {
-	if err := common.ValidateResourceNameLength(v.vd.Name); err != nil {
+	if err := common.ValidateResourceNameLength(v.vd.Name, v.vd.Kind); err != nil {
 		return err
 	}
 

--- a/images/virtualization-artifact/pkg/controller/service/restorer/restorers/vm_restorer.go
+++ b/images/virtualization-artifact/pkg/controller/service/restorer/restorers/vm_restorer.go
@@ -138,7 +138,7 @@ func (v *VirtualMachineHandler) ValidateRestore(ctx context.Context) error {
 }
 
 func (v *VirtualMachineHandler) ValidateClone(ctx context.Context) error {
-	if err := common.ValidateResourceNameLength(v.vm.Name); err != nil {
+	if err := common.ValidateResourceNameLength(v.vm.Name, v.vm.Kind); err != nil {
 		return err
 	}
 

--- a/images/virtualization-artifact/pkg/controller/service/restorer/restorers/vmbda_restorer.go
+++ b/images/virtualization-artifact/pkg/controller/service/restorer/restorers/vmbda_restorer.go
@@ -112,7 +112,7 @@ func (v *VMBlockDeviceAttachmentHandler) ValidateRestore(ctx context.Context) er
 }
 
 func (v *VMBlockDeviceAttachmentHandler) ValidateClone(ctx context.Context) error {
-	if err := common.ValidateResourceNameLength(v.vmbda.Name); err != nil {
+	if err := common.ValidateResourceNameLength(v.vmbda.Name, v.vmbda.Kind); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Fix the validation of VirtualDisk names during the cloning process of a VirtualMachine.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

