### PR TITLE
chore(ci): change release tag for dev registry images

### DIFF
--- a/.github/workflows/dev_module_build-and-registration.yml
+++ b/.github/workflows/dev_module_build-and-registration.yml
@@ -35,7 +35,10 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Input existing tag, example v0.16.1. Image module tag in dev-registry will have suffix -dev. For example: v0.16.1-dev"
+        description: |
+          Allow input tag vX.Y.Z (release tag) or vX.Y.Z-rc.N (release candidate tag).
+
+          Example: v1.0.0 or v1.0.0-rc.1
         type: string
         required: true
 
@@ -75,7 +78,7 @@ jobs:
           # Check if tag matches vX.Y.Z pattern (release)
           if echo "$TAG" | grep -P '^v\d+\.\d+\.\d+$' > /dev/null; then
             echo "Release tag detected"
-            echo "MODULES_MODULE_TAG=${TAG}-dev" >> $GITHUB_OUTPUT
+            echo "MODULES_MODULE_TAG=${TAG}" >> $GITHUB_OUTPUT
           # Check if tag matches vX.Y.Z-rc.N pattern (release candidate)
           elif echo "$TAG" | grep -P '^v\d+\.\d+\.\d+-rc\.\d+$' > /dev/null; then
             echo "Release candidate tag detected"


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Change release tag for dev registry images

Allow input tag `vX.Y.Z` (release tag) or `vX.Y.Z-rc.N` (release candidate tag).
Example: `v1.0.0` or `v1.0.0-rc.1`


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: ci
type: chore
summary: change release tag for dev registry images 'vX.Y.Z' (release tag) or 'vX.Y.Z-rc.N' (release candidate tag).
```
