### PR TITLE
test: do not wait agent in label and annotation test

### DIFF
--- a/tests/e2e/vm_label_annotation_test.go
+++ b/tests/e2e/vm_label_annotation_test.go
@@ -95,7 +95,6 @@ var _ = Describe("VirtualMachineLabelAndAnnotation", framework.CommonE2ETestDeco
 	Context("When virtual machines are applied", func() {
 		It("checks VMs phases", func() {
 			By("Virtual machine phase should be Running")
-
 			WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, kc.WaitOptions{
 				Labels:    testCaseLabel,
 				Namespace: ns,

--- a/tests/e2e/vm_label_annotation_test.go
+++ b/tests/e2e/vm_label_annotation_test.go
@@ -32,8 +32,9 @@ import (
 
 var _ = Describe("VirtualMachineLabelAndAnnotation", framework.CommonE2ETestDecorators(), func() {
 	const (
-		specialKey   = "specialKey"
-		specialValue = "specialValue"
+		specialKey       = "specialKey"
+		specialValue     = "specialValue"
+		agentReadyStdErr = "stderr: error: timed out waiting for the condition"
 	)
 
 	var (
@@ -113,7 +114,7 @@ var _ = Describe("VirtualMachineLabelAndAnnotation", framework.CommonE2ETestDeco
 				})
 			})
 
-			if failure != nil {
+			if strings.Contains(failure.Error(), agentReadyStdErr) {
 				criticalError = failure.Error()
 			}
 		})

--- a/tests/e2e/vm_label_annotation_test.go
+++ b/tests/e2e/vm_label_annotation_test.go
@@ -35,11 +35,9 @@ var _ = Describe("VirtualMachineLabelAndAnnotation", framework.CommonE2ETestDeco
 		specialKey   = "specialKey"
 		specialValue = "specialValue"
 	)
-
-	var ns string
-
 	testCaseLabel := map[string]string{"testcase": "vm-label-annotation"}
 	specialKeyValue := map[string]string{specialKey: specialValue}
+	var ns string
 
 	BeforeAll(func() {
 		kustomization := fmt.Sprintf("%s/%s", conf.TestData.VMLabelAnnotation, "kustomization.yaml")

--- a/tests/e2e/vm_label_annotation_test.go
+++ b/tests/e2e/vm_label_annotation_test.go
@@ -32,9 +32,8 @@ import (
 
 var _ = Describe("VirtualMachineLabelAndAnnotation", framework.CommonE2ETestDecorators(), func() {
 	const (
-		specialKey       = "specialKey"
-		specialValue     = "specialValue"
-		agentReadyStdErr = "stderr: error: timed out waiting for the condition"
+		specialKey   = "specialKey"
+		specialValue = "specialValue"
 	)
 
 	var (
@@ -104,23 +103,17 @@ var _ = Describe("VirtualMachineLabelAndAnnotation", framework.CommonE2ETestDeco
 
 	Context("When virtual machines are applied", func() {
 		It("checks VMs phases", func() {
-			By("Virtual machine agents should be ready")
+			By("Virtual machine phase should be Running")
 
-			failure := InterceptGomegaFailure(func() {
-				WaitVMAgentReady(kc.WaitOptions{
-					Labels:    testCaseLabel,
-					Namespace: ns,
-					Timeout:   MaxWaitTimeout,
-				})
+			WaitPhaseByLabel(kc.ResourceVM, PhaseRunning, kc.WaitOptions{
+				Labels:    testCaseLabel,
+				Namespace: ns,
+				Timeout:   MaxWaitTimeout,
 			})
-
-			if strings.Contains(failure.Error(), agentReadyStdErr) {
-				criticalError = failure.Error()
-			}
 		})
 	})
 
-	Context("When virtual machine agents are ready", func() {
+	Context("When virtual machine is running", func() {
 		It(fmt.Sprintf("marks VMs with label %q", specialKeyValue), func() {
 			res := kubectl.List(kc.ResourceVM, kc.GetOptions{
 				Labels:    testCaseLabel,

--- a/tests/e2e/vm_label_annotation_test.go
+++ b/tests/e2e/vm_label_annotation_test.go
@@ -36,10 +36,7 @@ var _ = Describe("VirtualMachineLabelAndAnnotation", framework.CommonE2ETestDeco
 		specialValue = "specialValue"
 	)
 
-	var (
-		ns            string
-		criticalError string
-	)
+	var ns string
 
 	testCaseLabel := map[string]string{"testcase": "vm-label-annotation"}
 	specialKeyValue := map[string]string{specialKey: specialValue}
@@ -56,10 +53,6 @@ var _ = Describe("VirtualMachineLabelAndAnnotation", framework.CommonE2ETestDeco
 	BeforeEach(func() {
 		if config.IsReusable() {
 			Skip("Test not available in REUSABLE mode: not supported yet.")
-		}
-
-		if criticalError != "" {
-			Skip(criticalError)
 		}
 	})
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Do not wait agent in label and annotation test.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: api
type: feature
summary: Do not wait agent in label and annotation test.
impact_level: low
```
