### PR TITLE
 fix: Correct Go tools installation command in nightly E2E workflow

### DIFF
--- a/.github/workflows/nightly_e2e_tests_ceph.yaml
+++ b/.github/workflows/nightly_e2e_tests_ceph.yaml
@@ -49,7 +49,7 @@ jobs:
         working-directory: ./tests/e2e/
         run: |
           echo "Install ginkgo"
-          go tool install
+          go install tool
 
       - name: Install Deckhouse-cli
         run: |

--- a/tests/e2e/framework/client.go
+++ b/tests/e2e/framework/client.go
@@ -21,6 +21,9 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/exec"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/deckhouse/virtualization/api/client/kubeclient"
@@ -30,11 +33,6 @@ import (
 	"github.com/deckhouse/virtualization/tests/e2e/d8"
 	gt "github.com/deckhouse/virtualization/tests/e2e/git"
 	"github.com/deckhouse/virtualization/tests/e2e/kubectl"
-
-	// register auth plugins
-	_ "k8s.io/client-go/plugin/pkg/client/auth/exec"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 )
 
 var clients = Clients{}


### PR DESCRIPTION
## Description
This PR fixes a typo in the Go tools installation command within the nightly E2E workflow.
### Change
**Before:** `go tool install` (incorrect, this command does not exist)

**After:** `go install tool` (correct command for installing tools)

The previous command (`go tool install`) was invalid and likely caused the tool installation step to fail. The correct command is `go install tool`.

This ensures that the necessary dependencies are properly installed for the nightly end-to-end tests.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
