### PR TITLE
fix(vm): fix issue with deleting vmbda from a stopped VM

### DIFF
--- a/images/virtualization-artifact/go.mod
+++ b/images/virtualization-artifact/go.mod
@@ -145,7 +145,10 @@ require (
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 )
 
-replace github.com/deckhouse/virtualization/api => ./../../api
+replace (
+	github.com/deckhouse/virtualization/api => ./../../api
+	kubevirt.io/api => github.com/deckhouse/3p-kubevirt-api v1.3.1-v12n.0
+)
 
 replace (
 	k8s.io/api => k8s.io/api v0.33.3

--- a/images/virtualization-artifact/go.sum
+++ b/images/virtualization-artifact/go.sum
@@ -45,6 +45,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckhouse/3p-kubevirt-api v1.3.1-v12n.0 h1:Tygrxudb159/H4ozBY+jvVhNWWGP6GYNYz8Hg8k2Sok=
+github.com/deckhouse/3p-kubevirt-api v1.3.1-v12n.0/go.mod h1:tCn7VAZktEvymk490iPSMPCmKM9UjbbfH2OsFR/IOLU=
 github.com/deckhouse/deckhouse/pkg/log v0.0.0-20250226105106-176cd3afcdd5 h1:PsN1E0oxC/+4zdA977txrqUCuObFL3HAuu5Xnud8m8c=
 github.com/deckhouse/deckhouse/pkg/log v0.0.0-20250226105106-176cd3afcdd5/go.mod h1:Mk5HRzkc5pIcDIZ2JJ6DPuuqnwhXVkb3you8M8Mg+4w=
 github.com/distribution/reference v0.5.0 h1:/FUIFXtfc/x2gpa5/VGfiGLuOIdYa1t65IKK2OFGvA0=

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
@@ -373,7 +373,8 @@ func (b *KVVM) SetDisk(name string, opts SetDiskOptions) error {
 
 	case opts.ContainerDisk != nil:
 		vs.ContainerDisk = &virtv1.ContainerDiskSource{
-			Image: *opts.ContainerDisk,
+			Image:        *opts.ContainerDisk,
+			Hotpluggable: opts.IsHotplugged,
 		}
 
 	case opts.Provisioning != nil:


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Fixed an issue where VMBDA connected to a VM from VI or CVI disappears from the VM status when it is stopped.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
Status running VirtualMachine: 
```
blockDeviceRefs:
  - attached: true
    kind: VirtualDisk
    name: vd-root-alpine
    size: 200Mi
    target: sda
  - attached: true
    hotplugged: true
    kind: VirtualImage
    name: vi-root-alpine
    size: 200Mi
    target: sdb
    virtualMachineBlockDeviceAttachmentName: vmbda-vi
```

Status stopped VirtualMachine:
```
blockDeviceRefs:
  - attached: false
    kind: VirtualDisk
    name: vd-root-alpine
    size: 200Mi
    target: sda
```


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
Status running VirtualMachine: 
```
blockDeviceRefs:
  - attached: true
    kind: VirtualDisk
    name: vd-root-alpine
    size: 200Mi
    target: sda
  - attached: true
    hotplugged: true
    kind: VirtualImage
    name: vi-root-alpine
    size: 200Mi
    target: sdb
    virtualMachineBlockDeviceAttachmentName: vmbda-vi
```

Status stopped VirtualMachine:
```
blockDeviceRefs:
  - attached: false
    kind: VirtualDisk
    name: vd-root-alpine
    size: 200Mi
    target: sda
  - attached: false
    hotplugged: true
    kind: VirtualImage
    name: vi-root-alpine
    size: 200Mi
    target: sdb
    virtualMachineBlockDeviceAttachmentName: vmbda-vi
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: vm
type: fix
summary: fix issue with deleting vmbda from a stopped VM
```
