### PR TITLE
chore(ci): ignore specific error on e2e tests

### DIFF
--- a/tests/e2e/default_config.yaml
+++ b/tests/e2e/default_config.yaml
@@ -55,7 +55,7 @@ logFilter:
   - "leader election lost"
   - "a virtual machine cannot be restored from the pending phase with `Forced` mode" # "err": "a virtual machine cannot be restored from the pending phase with `Forced` mode; you can delete the virtual machine and restore it with `Safe` mode"
   - 'virtualMachineSnapshotSecret "" not found' # "msg": "virtualMachineSnapshotSecret \"\" not found"
-  - 'failed to sync migrating volumes: admission webhook "virtualmachine-validator.kubevirt.io" denied the request: spec.template.spec.domain.devices.disks'
+  - 'failed to sync migrating volumes: admission webhook \"virtualmachine-validator.kubevirt.io\" denied the request: spec.template.spec.domain.devices.disks'
 regexpLogFilter:
   - "failed to detach: .* not found" # "err" "failed to detach: virtualmachine.kubevirt.io \"head-497d17b-vm-automatic-with-hotplug\" not found",
   - "error patching .* not found" # "err" "error patching *** virtualimages.virtualization.deckhouse.io \"head-497d17b-vi-pvc-oref-vi-oref-vd\" not found",

--- a/tests/e2e/default_config.yaml
+++ b/tests/e2e/default_config.yaml
@@ -55,6 +55,7 @@ logFilter:
   - "leader election lost"
   - "a virtual machine cannot be restored from the pending phase with `Forced` mode" # "err": "a virtual machine cannot be restored from the pending phase with `Forced` mode; you can delete the virtual machine and restore it with `Safe` mode"
   - 'virtualMachineSnapshotSecret "" not found' # "msg": "virtualMachineSnapshotSecret \"\" not found"
+  - 'failed to sync migrating volumes: admission webhook "virtualmachine-validator.kubevirt.io" denied the request: spec.template.spec.domain.devices.disks'
 regexpLogFilter:
   - "failed to detach: .* not found" # "err" "failed to detach: virtualmachine.kubevirt.io \"head-497d17b-vm-automatic-with-hotplug\" not found",
   - "error patching .* not found" # "err" "error patching *** virtualimages.virtualization.deckhouse.io \"head-497d17b-vi-pvc-oref-vi-oref-vd\" not found",


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Ignore the following error on e2e tests.
`failed to sync migrating volumes: admission webhook "virtualmachine-validator.kubevirt.io" denied the request: spec.template.spec.domain.devices.disks`

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
To remove noise from tests.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
No errors of that kind in Ginkgo output.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->
