### PR TITLE
chore(ci): return docs lint

### DIFF
--- a/.dmtlint.yaml
+++ b/.dmtlint.yaml
@@ -1,7 +1,3 @@
-global:
-  linters-settings:
-    documentation:
-      impact: warn
 linters-settings:
   openapi:
     exclude-rules:

--- a/.dmtlint.yaml
+++ b/.dmtlint.yaml
@@ -1,3 +1,7 @@
+global:
+  linters-settings:
+    documentation:
+      impact: error
 linters-settings:
   openapi:
     exclude-rules:
@@ -44,8 +48,6 @@ linters-settings:
         - kubevirt-internal-virtualization-controller
         - kubevirt-internal-virtualization-handler
   module:
-    oss:
-      disable: true
     exclude-rules:
       license:
         files:

--- a/.dmtlint.yaml
+++ b/.dmtlint.yaml
@@ -48,6 +48,8 @@ linters-settings:
         - kubevirt-internal-virtualization-controller
         - kubevirt-internal-virtualization-handler
   module:
+    oss:
+      disable: true
     exclude-rules:
       license:
         files:


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Return docs linting.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
Revert #1494

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

## Summary by Sourcery

CI:
- Remove global documentation impact setting to restore docs lint rules