### PR TITLE
fix(ci): add wait condition to E2E error messages

### DIFF
--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -347,7 +347,7 @@ func WaitResources(resources []string, resource kc.Resource, opts kc.WaitOptions
 		}()
 	}
 	wg.Wait()
-	Expect(waitErr).To(BeEmpty())
+	Expect(waitErr).To(BeEmpty(), "should observe resources in '%s' state before %s timeout", opts.For, opts.Timeout.String())
 }
 
 func GetStorageClassFromEnv(envName string) (*storagev1.StorageClass, error) {


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Added the wait condition information to E2E test timeout error messages in the `WaitResources` function. When a `kubectl wait` command times out, the error message now includes the condition that was being waited for (e.g., `condition=AgentReady=True`).

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: ci
type: fix
summary: E2E test timeout errors now include the condition that was being waited for.
```
