### PR TITLE
ci: use Github token when installing `Task`

### DIFF
--- a/.github/workflows/dev_module_build.yml
+++ b/.github/workflows/dev_module_build.yml
@@ -217,7 +217,8 @@ jobs:
       - name: Install Task
         uses: arduino/setup-task@v2
         with:
-          version: 3.37.2
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v4
         with:
@@ -285,7 +286,8 @@ jobs:
       - name: Install Task
         uses: arduino/setup-task@v2
         with:
-          version: 3.37.2
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v4
         with:
@@ -306,7 +308,8 @@ jobs:
       - name: Install Task
         uses: arduino/setup-task@v2
         with:
-          version: 3.37.2
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v4
         with:
@@ -587,6 +590,9 @@ jobs:
 
       - name: Install Task
         uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install ginkgo
         working-directory: ./tests/e2e/

--- a/.github/workflows/dev_validation.yaml
+++ b/.github/workflows/dev_validation.yaml
@@ -66,7 +66,8 @@ jobs:
       - name: Install Task
         uses: arduino/setup-task@v2
         with:
-          version: 3.37.2
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v4
         with:
@@ -90,7 +91,8 @@ jobs:
       - name: Install Task
         uses: arduino/setup-task@v2
         with:
-          version: 3.37.2
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v4
         with:
@@ -114,7 +116,8 @@ jobs:
       - name: Install Task
         uses: arduino/setup-task@v2
         with:
-          version: 3.37.2
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v4
         with:
@@ -137,7 +140,8 @@ jobs:
       - name: Install Task
         uses: arduino/setup-task@v2
         with:
-          version: 3.37.2
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: azure/setup-helm@v4.3.0
         with:
@@ -182,7 +186,8 @@ jobs:
         if: matrix.components.component != 'vm-route-forge' || env.route_forge_skip != 'true'
         uses: arduino/setup-task@v2
         with:
-          version: 3.37.2
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
         if: matrix.components.component != 'vm-route-forge' || env.route_forge_skip != 'true'

--- a/.github/workflows/nightly_e2e_tests_ceph.yaml
+++ b/.github/workflows/nightly_e2e_tests_ceph.yaml
@@ -44,6 +44,9 @@ jobs:
 
       - name: Install Task
         uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install ginkgo
         working-directory: ./tests/e2e/

--- a/.github/workflows/nightly_e2e_tests_replicated.yaml
+++ b/.github/workflows/nightly_e2e_tests_replicated.yaml
@@ -44,6 +44,9 @@ jobs:
 
       - name: Install Task
         uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install ginkgo
         working-directory: ./tests/e2e/


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
This is required to prevent Github API rate limiting.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: api
type: chore
summary: "Github token is used to prevent API rate limiting."
impact_level: low
```
