### PR TITLE
test(vmrestore): change restart approval mode

### DIFF
--- a/tests/e2e/testdata/vm-restore-force/vm/overlays/vm-exists-always-on/kustomization.yaml
+++ b/tests/e2e/testdata/vm-restore-force/vm/overlays/vm-exists-always-on/kustomization.yaml
@@ -11,10 +11,3 @@ patches:
     target:
       kind: VirtualMachine
       name: vm
-  - patch: |-
-      - op: replace
-        path: /spec/disruptions/restartApprovalMode
-        value: Automatic
-    target:
-      kind: VirtualMachine
-      name: vm

--- a/tests/e2e/testdata/vm-restore-force/vm/overlays/vm-exists/kustomization.yaml
+++ b/tests/e2e/testdata/vm-restore-force/vm/overlays/vm-exists/kustomization.yaml
@@ -3,11 +3,3 @@ kind: Kustomization
 nameSuffix: -restore-force
 resources:
   - ../../base
-patches:
-  - patch: |-
-      - op: replace
-        path: /spec/disruptions/restartApprovalMode
-        value: Automatic
-    target:
-      kind: VirtualMachine
-      name: vm

--- a/tests/e2e/testdata/vm-restore-safe/vm/overlays/vm/kustomization.yaml
+++ b/tests/e2e/testdata/vm-restore-safe/vm/overlays/vm/kustomization.yaml
@@ -3,11 +3,3 @@ kind: Kustomization
 nameSuffix: -restore-safe
 resources:
   - ../../base
-patches:
-  - patch: |-
-      - op: replace
-        path: /spec/disruptions/restartApprovalMode
-        value: Automatic
-    target:
-      kind: VirtualMachine
-      name: vm


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
This change is required to prevent potential conflicts between Automatic mode and VMOP restart.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: api
type: chore
summary: "This change is required to prevent potential conflicts between Automatic mode and VMOP restart."
impact_level: low
```
