### PR TITLE
fix(vmop): add validation rules for clone naming

### DIFF
--- a/api/core/v1alpha2/virtual_machine_operation.go
+++ b/api/core/v1alpha2/virtual_machine_operation.go
@@ -69,22 +69,26 @@ type VirtualMachineOperationRestoreSpec struct {
 	VirtualMachineSnapshotName string `json:"virtualMachineSnapshotName"`
 }
 
+// +kubebuilder:validation:XValidation:rule="(has(self.customization) && ((has(self.customization.namePrefix) && size(self.customization.namePrefix) > 0) || (has(self.customization.nameSuffix) && size(self.customization.nameSuffix) > 0))) || (has(self.nameReplacement) && size(self.nameReplacement) > 0)",message="At least one of customization.namePrefix, customization.nameSuffix, or nameReplacement must be set"
 // VirtualMachineOperationCloneSpec defines the clone operation.
 type VirtualMachineOperationCloneSpec struct {
 	Mode VMOPRestoreMode `json:"mode"`
 	// NameReplacement defines rules for renaming resources during cloning.
+	// +kubebuilder:validation:XValidation:rule="self.all(nr, has(nr.to) && size(nr.to) >= 1 && size(nr.to) <= 59)",message="Each nameReplacement.to must be between 1 and 59 characters"
 	NameReplacement []NameReplacement `json:"nameReplacement,omitempty"`
 	// Customization defines customization options for cloning.
 	Customization *VirtualMachineOperationCloneCustomization `json:"customization,omitempty"`
 }
 
+// +kubebuilder:validation:XValidation:rule="!has(self.namePrefix) || (size(self.namePrefix) >= 1 && size(self.namePrefix) <= 59)",message="namePrefix length must be between 1 and 59 characters if set"
+// +kubebuilder:validation:XValidation:rule="!has(self.nameSuffix) || (size(self.nameSuffix) >= 1 && size(self.nameSuffix) <= 59)",message="nameSuffix length must be between 1 and 59 characters if set"
 // VirtualMachineOperationCloneCustomization defines customization options for cloning.
 type VirtualMachineOperationCloneCustomization struct {
 	// NamePrefix adds a prefix to resource names during cloning.
-	// Applied to VirtualDisk, VirtualMachineIPAddress, VirtualMachineMACAddress, and Secret resources.
+	// Applied to VirtualMachine, VirtualDisk, VirtualMachineBlockDeviceAttachment, and Secret resources.
 	NamePrefix string `json:"namePrefix,omitempty"`
 	// NameSuffix adds a suffix to resource names during cloning.
-	// Applied to VirtualDisk, VirtualMachineIPAddress, VirtualMachineMACAddress, and Secret resources.
+	// Applied to VirtualMachine, VirtualDisk, VirtualMachineBlockDeviceAttachment, and Secret resources.
 	NameSuffix string `json:"nameSuffix,omitempty"`
 }
 

--- a/crds/virtualmachineoperations.yaml
+++ b/crds/virtualmachineoperations.yaml
@@ -81,6 +81,19 @@ spec:
                             Applied to VirtualMachine, VirtualDisk, VirtualMachineBlockDeviceAttachment, and Secret resources.
                           type: string
                       type: object
+                      x-kubernetes-validations:
+                        - message:
+                            namePrefix length must be between 1 and 59 characters
+                            if set
+                          rule:
+                            "!has(self.namePrefix) || (size(self.namePrefix) >= 1
+                            && size(self.namePrefix) <= 59)"
+                        - message:
+                            nameSuffix length must be between 1 and 59 characters
+                            if set
+                          rule:
+                            "!has(self.nameSuffix) || (size(self.nameSuffix) >= 1
+                            && size(self.nameSuffix) <= 59)"
                     mode:
                       description: |-
                         VMOPRestoreMode defines the kind of the restore operation.
@@ -121,9 +134,23 @@ spec:
                           - to
                         type: object
                       type: array
+                      x-kubernetes-validations:
+                        - message: Each nameReplacement.to must be between 1 and 59 characters
+                          rule:
+                            self.all(nr, has(nr.to) && size(nr.to) >= 1 && size(nr.to)
+                            <= 59)
                   required:
                     - mode
                   type: object
+                  x-kubernetes-validations:
+                    - message:
+                        At least one of customization.namePrefix, customization.nameSuffix,
+                        or nameReplacement must be set
+                      rule:
+                        (has(self.customization) && ((has(self.customization.namePrefix)
+                        && size(self.customization.namePrefix) > 0) || (has(self.customization.nameSuffix)
+                        && size(self.customization.nameSuffix) > 0))) || (has(self.nameReplacement)
+                        && size(self.nameReplacement) > 0)
                 force:
                   description: |-
                     Force execution of an operation.

--- a/images/virtualization-artifact/pkg/apiserver/api/generated/openapi/zz_generated.openapi.go
+++ b/images/virtualization-artifact/pkg/apiserver/api/generated/openapi/zz_generated.openapi.go
@@ -4912,14 +4912,14 @@ func schema_virtualization_api_core_v1alpha2_VirtualMachineOperationCloneCustomi
 				Properties: map[string]spec.Schema{
 					"namePrefix": {
 						SchemaProps: spec.SchemaProps{
-							Description: "NamePrefix adds a prefix to resource names during cloning. Applied to VirtualDisk, VirtualMachineIPAddress, VirtualMachineMACAddress, and Secret resources.",
+							Description: "NamePrefix adds a prefix to resource names during cloning. Applied to VirtualMachine, VirtualDisk, VirtualMachineBlockDeviceAttachment, and Secret resources.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"nameSuffix": {
 						SchemaProps: spec.SchemaProps{
-							Description: "NameSuffix adds a suffix to resource names during cloning. Applied to VirtualDisk, VirtualMachineIPAddress, VirtualMachineMACAddress, and Secret resources.",
+							Description: "NameSuffix adds a suffix to resource names during cloning. Applied to VirtualMachine, VirtualDisk, VirtualMachineBlockDeviceAttachment, and Secret resources.",
 							Type:        []string{"string"},
 							Format:      "",
 						},


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
### Summary

This PR enhances the `VirtualMachineOperation` CRD by adding validation rules to ensure safe and valid resource naming during clone operations.

### Changes

- Added `x-kubernetes-validations` to the `clone.customization` section:
  - `namePrefix` and `nameSuffix`, if set, must be 1–59 characters long.
- Added validation for `nameReplacement`:
  - Each `to` field must be 1–59 characters long.
- Enforced that at least one renaming mechanism is specified:
  - Either `customization.namePrefix`, `customization.nameSuffix`, or at least one entry in `nameReplacement` must be provided.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

