### PR TITLE
chore(ci): hotfix for dmt licences

### DIFF
--- a/.dmtlint.yaml
+++ b/.dmtlint.yaml
@@ -55,6 +55,10 @@ linters-settings:
           - images/hooks/pkg/hooks/tls-certificates-audit/hook.go
         directories:
           - tests/
+          - api/client/generated
+          - hack/
+          - images/
+          - tools/
   images:
     # CDI patches are soon to be phased out by moving them to 3p repo
     patches:


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
hotfix for dmt licences

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

