### PR TITLE
chore(core): fix run with ro rootfs

### DIFF
--- a/images/packages/p11-kit/werf.inc.yaml
+++ b/images/packages/p11-kit/werf.inc.yaml
@@ -20,14 +20,28 @@ secrets:
   value: {{ $.SOURCE_REPO_GIT }}
 shell:
   install:
-  - git clone --depth=1 $(cat /run/secrets/SOURCE_REPO)/{{ $gitRepoUrl }} --branch {{ $version }} /src
+  - |
+    git clone --depth=1 $(cat /run/secrets/SOURCE_REPO)/{{ $gitRepoUrl }} --branch {{ $version }} /src
+
+    # Download subprojects/pkcs11-json
+    cd /src
+    if [[ "$(cat /run/secrets/SOURCE_REPO)" =~ "github.com" ]] ; then
+      echo "Checkout submodules"
+      git submodule update --init --recursive --depth=1
+    else
+      echo "Checkout submodules with URL rewrite"
+      git \
+        -c url."$(cat /run/secrets/SOURCE_REPO)/".insteadOf=https://github.com/  \
+        submodule update --init --recursive --depth=1
+    fi
+
 ---
 
 {{- $name := print $.ImageName "-dependencies" -}}
 {{- define "$name" -}}
 altPackages:
-- git gcc gcc-c++ make meson ninja-build pkg-config 
-- glib2-devel libffi-devel libtasn1-devel gettext-devel 
+- git gcc gcc-c++ make meson ninja-build pkg-config
+- glib2-devel libffi-devel libtasn1-devel gettext-devel
 - openssl-devel ca-certificates
 - tree
 # packages:

--- a/images/virt-launcher/mount-points.yaml
+++ b/images/virt-launcher/mount-points.yaml
@@ -43,6 +43,6 @@ dirs:
   - /var/lib/libvirt/qemu/nvram
   - /var/lib/kubevirt-node-labeller
   - /var/lib/swtpm-localca
-  - /var/log
+  - /var/log/libvirt
   - /path # For hot-plugged disks, used in "hp Pods".
   - /init/usr/bin # For attaching images as "container disks".


### PR DESCRIPTION

## Description
<!---
  Describe your changes with technical details.
-->

- Fix /var/log/libvirt mount point in virt-launcher image to run it as node-labeller.
- Fix build for p11-kit: rewrite for submodule.


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->

```
kubectl describe po virt-handler-...

  Warning  Failed     28m (x5 over 29m)   kubelet            Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: 
unable to start container process: error during container init: 
error mounting "/var/lib/kubelet/pods/9d576643-8f00-4d97-9d17-af45c5c0bdca/volumes/kubernetes.io~empty-dir/var-log-node-labeller" to rootfs at "/var/log/libvirt": create mountpoint for /var/log/libvirt mount:
mkdir at /run/containerd/io.containerd.runtime.v2.task/k8s.io/virt-launcher/rootfs/var/log/libvirt: read-only file system
```

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
Module works in the strict environment.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->
