### PR TITLE
feat(core): add pvc resources to e2e fail dump

### DIFF
--- a/tests/e2e/util_test.go
+++ b/tests/e2e/util_test.go
@@ -763,7 +763,7 @@ func SaveTestCaseResources(labels map[string]string, additional, namespace, dump
 	errorFileName := fmt.Sprintf("%s/e2e_failed__%s__%s_error.txt", dumpPath, labels["testcase"], additional)
 
 	cmdr := kubectl.Get(
-		"virtualization,cvi,vmc,intvirt,pod,volumesnapshot",
+		"virtualization,cvi,vmc,intvirt,pod,pvc,volumesnapshot",
 		kc.GetOptions{
 			Labels:            labels,
 			Namespace:         namespace,


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Add pvc resources to e2e fail dump.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: core
type: feature
summary: Add pvc resources to e2e fail dump.
impact_level: low
```
