### PR TITLE
 fix(vi): respect storageClassName when creating from snapshot

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/step/create_pvc_from_vdsnapshot_step.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/step/create_pvc_from_vdsnapshot_step.go
@@ -256,8 +256,9 @@ func (s CreatePVCFromVDSnapshotStep) validateStorageClassCompatibility(ctx conte
 		return fmt.Errorf("cannot fetch target storage class %q: %w", targetSCName, err)
 	}
 
+	log, _ := logger.GetDataSourceContext(ctx, "objectref")
 	if vs.Spec.Source.PersistentVolumeClaimName == nil || *vs.Spec.Source.PersistentVolumeClaimName == "" {
-		// Can't determine original PVC, skip validation
+		log.With("volumeSnapshot.name", vs.Name).Debug("Cannot determine original PVC from VolumeSnapshot, skipping storage class compatibility validation")
 		return nil
 	}
 
@@ -275,7 +276,6 @@ func (s CreatePVCFromVDSnapshotStep) validateStorageClassCompatibility(ctx conte
 	}
 
 	if originalProvisioner == "" {
-		log, _ := logger.GetDataSourceContext(ctx, "objectref")
 		log.With("pvc.name", pvcName).Debug("Cannot determine original provisioner from PVC annotations, skipping storage class compatibility validation")
 		return nil
 	}

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/step/create_pvc_step.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/step/create_pvc_step.go
@@ -220,7 +220,9 @@ func (s CreatePersistentVolumeClaimStep) validateStorageClassCompatibility(ctx c
 		return fmt.Errorf("cannot fetch target storage class %q: %w", targetSCName, err)
 	}
 
+	log, _ := logger.GetDataSourceContext(ctx, "objectref")
 	if vs.Spec.Source.PersistentVolumeClaimName == nil || *vs.Spec.Source.PersistentVolumeClaimName == "" {
+		log.With("volumeSnapshot.name", vs.Name).Debug("Cannot determine original PVC from VolumeSnapshot, skipping storage class compatibility validation")
 		return nil
 	}
 
@@ -238,7 +240,6 @@ func (s CreatePersistentVolumeClaimStep) validateStorageClassCompatibility(ctx c
 	}
 
 	if originalProvisioner == "" {
-		log, _ := logger.GetDataSourceContext(ctx, "objectref")
 		log.With("pvc.name", pvcName).Debug("Cannot determine original provisioner from PVC annotations, skipping storage class compatibility validation")
 		return nil
 	}


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Fix the VirtualImage controller to respect user-specified storageClassName when creating disks from VirtualDiskSnapshot. Previously, the controller was always using the storage class from the original disk (stored in VolumeSnapshot annotations), completely ignoring the user-specified value in spec.persistentVolumeClaim.storageClassName. Also add error message when user tries to perform cross-provider restore.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
When users tried to restore a VirtualImage from a snapshot with a different storage class, the parameter spec.persistentVolumeClaim.storageClassName was silently ignored. The restored disk would always use the same storage class as the original disk.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: vi
type: fix
summary: When creating virtual images from virtual disk snapshots, the `spec.persistentVolumeClaim.storageClassName` parameter is now respected. Previously, it could be ignored.
```
