### PR TITLE
feat(core): promote vd/vi import error if url is broken

### DIFF
--- a/images/dvcr-artifact/pkg/retry/backoff.go
+++ b/images/dvcr-artifact/pkg/retry/backoff.go
@@ -106,10 +106,11 @@ func (b *Backoff) Step() time.Duration {
 // In all other cases, ErrWaitTimeout is returned.
 func ExponentialBackoff(ctx context.Context, f Fn, backoff Backoff) error {
 	const (
-		dvcrNoSpaceError         = "no space left on device"
-		dvcrInternalErrorPattern = "UNKNOWN: unknown error;"
-		dvcrNoSpaceErrMessage    = "DVCR is overloaded"
-		internalDvcrErrMessage   = "Internal DVCR error (could it be overloaded?)"
+		dvcrNoSpaceError             = "no space left on device"
+		dvcrInternalErrorPattern     = "UNKNOWN: unknown error;"
+		dvcrNoSpaceErrMessage        = "DVCR is overloaded"
+		internalDvcrErrMessage       = "Internal DVCR error (could it be overloaded?)"
+		datasourceCreatingErrMessage = "error creating data source"
 	)
 
 	var err error
@@ -124,6 +125,8 @@ func ExponentialBackoff(ctx context.Context, f Fn, backoff Backoff) error {
 			return fmt.Errorf("%s: %w", dvcrNoSpaceErrMessage, err)
 		case strings.Contains(err.Error(), dvcrInternalErrorPattern):
 			return fmt.Errorf("%s: %w", internalDvcrErrMessage, err)
+		case strings.Contains(err.Error(), datasourceCreatingErrMessage):
+			return err
 		}
 
 		if backoff.Steps == 1 {


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Promote vd/vi import error if url is broken.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
Right now, if the HTTP source returns an error, the VI/VD will hang in the “Provisioning” status, and the only way to tell that something went wrong will be by checking the importer pod logs.


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: core
type: feature
summary: Promote vd/vi import error if url is broken.
```
