### PR TITLE
fix(e2e): panic when controller pod is completed

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -293,7 +293,7 @@ func (c *controllerRestartChecker) Check() error {
 	for _, pod := range pods.Items {
 		foundContainer := false
 		for _, containerStatus := range pod.Status.ContainerStatuses {
-			if containerStatus.Name == VirtualizationController {
+			if containerStatus.Name == VirtualizationController && containerStatus.State.Running != nil {
 				foundContainer = true
 				if containerStatus.State.Running.StartedAt.After(c.startedAt.Time) {
 					errs = errors.Join(errs, fmt.Errorf("the container %q was restarted: %s", VirtualizationController, pod.Name))


### PR DESCRIPTION
## Description
Current PR fix panics, which causes when during e2e tests one of pods of virtualization-controller is completed.

## What is the expected result?
No panics during tests.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

