### PR TITLE
chore(core): add d8v prefix for more containers

### DIFF
--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -3,7 +3,8 @@ firmware:
   libvirt: v10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: v1.3.1-v12n.15
+  #3p-kubevirt: v1.3.1-v12n.15
+  3p-kubevirt: "dvp/chore/job-install-strategy-security-context"
   #3p-containerized-data-importer: v1.60.3-v12n.10
   3p-containerized-data-importer: "dvp/chore/more-d8v-prefixed-containers"
   distribution: 2.8.3


### PR DESCRIPTION

## Description
- Rename more containers for checkings in strict environment.
- Fix container names in recording rules.


## Why do we need it, and what problem does it solve?

These containers should be checked in strict environments.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: core
type: chore
summary: Strict environment should check containers for importer and upload-server pods.
```
