### PR TITLE
chore(vm): reduce noise in logs about "namespaces not found"

### DIFF
--- a/images/virtualization-artifact/pkg/controller/reconciler/reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/reconciler/reconciler.go
@@ -125,6 +125,9 @@ handlersLoop:
 	case strings.Contains(err.Error(), "no new finalizers can be added if the object is being deleted"):
 		logger.FromContext(ctx).Warn("Forbidden to add finalizers", logger.SlogErr(err))
 		result.RequeueAfter = 1 * time.Second
+	case k8serrors.IsNotFound(err) && strings.Contains(err.Error(), "namespaces"):
+		// No need to return an explicit requeue or requeue with error if namespace is gone, e.g. in e2e tests.
+		logger.FromContext(ctx).Warn("Namespace is gone while reconcile the object", logger.SlogErr(err))
 	default:
 		logger.FromContext(ctx).Error("Failed to update resource", logger.SlogErr(err))
 		errs = errors.Join(errs, err)


### PR DESCRIPTION


## Description

Do not requeue reconcile if status was not updated with error "namespaces ... not found". Just print Warning in this situation.

## Why do we need it, and what problem does it solve?

This situation is not an error, but it fails e2e tests with this messages:

```
  this is the `Virtualization-controller` error! not the current `Ginkgo` context error:
  {
    "level": "error",
    "msg": "Failed to update resource",
    "err": "error updating status subresource: namespaces \"dvp-e2e-m-sds-20251008-145944-724\" not found",
    "controller": "vm-controller",
    "handler": "",
    "ds": "",
    "collector": "",
    "name": "x-559ce0-worker-afad0dff-t78m8-hmnl8",
    "namespace": "dvp-e2e-m-sds-20251008-145944-724",
    "reconcileID": "d2587a50-d711-47b6-83a7-ff620e39706f",
    "time": "2025-10-13T02:03:39Z"
  }
  
```

## What is the expected result?

Reduce number of false-negative e2e runs.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: vm
type: chore
summary: Reduce noise in logs about "namespaces not found".
```
