### PR TITLE
chore(module): use v1alpha3 to install vmclass/generic

### DIFF
--- a/images/hooks/pkg/hooks/install-vmclass-generic/hook.go
+++ b/images/hooks/pkg/hooks/install-vmclass-generic/hook.go
@@ -25,7 +25,7 @@ import (
 
 	"hooks/pkg/settings"
 
-	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha3"
 
 	"github.com/deckhouse/module-sdk/pkg"
 	"github.com/deckhouse/module-sdk/pkg/registry"
@@ -71,7 +71,7 @@ var config = &pkg.HookConfig{
 		},
 		{
 			Name:     vmClassGenericSnapshot,
-			Kind:     v1alpha2.VirtualMachineClassKind,
+			Kind:     v1alpha3.VirtualMachineClassKind,
 			JqFilter: `{apiVersion, kind, "metadata": ( .metadata | {name, labels, annotations, creationTimestamp} ) }`,
 			NameSelector: &pkg.NameSelector{
 				MatchNames: []string{vmClassGenericName},
@@ -167,13 +167,13 @@ func parseVMClassInstallationStateFromSnapshot(input *pkg.HookInput) (*vmClassIn
 }
 
 // parseVMClassGenericFromSnapshot unmarshal ModuleConfig from jqFilter result.
-func parseVMClassGenericFromSnapshot(input *pkg.HookInput) (*v1alpha2.VirtualMachineClass, error) {
+func parseVMClassGenericFromSnapshot(input *pkg.HookInput) (*v1alpha3.VirtualMachineClass, error) {
 	snap := input.Snapshots.Get(vmClassGenericSnapshot)
 	if len(snap) < 1 {
 		return nil, nil
 	}
 
-	var vmclass v1alpha2.VirtualMachineClass
+	var vmclass v1alpha3.VirtualMachineClass
 	err := snap[0].UnmarshalTo(&vmclass)
 	if err != nil {
 		return nil, err
@@ -183,11 +183,11 @@ func parseVMClassGenericFromSnapshot(input *pkg.HookInput) (*v1alpha2.VirtualMac
 
 // vmClassGenericManifest returns a manifest for 'generic' vmclass
 // that should work for VM on every Node in cluster.
-func vmClassGenericManifest() *v1alpha2.VirtualMachineClass {
-	return &v1alpha2.VirtualMachineClass{
+func vmClassGenericManifest() *v1alpha3.VirtualMachineClass {
+	return &v1alpha3.VirtualMachineClass{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: v1alpha2.SchemeGroupVersion.String(),
-			Kind:       v1alpha2.VirtualMachineClassKind,
+			APIVersion: v1alpha3.SchemeGroupVersion.String(),
+			Kind:       v1alpha3.VirtualMachineClassKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: vmClassGenericName,
@@ -196,43 +196,43 @@ func vmClassGenericManifest() *v1alpha2.VirtualMachineClass {
 				"module": settings.ModuleName,
 			},
 		},
-		Spec: v1alpha2.VirtualMachineClassSpec{
-			CPU: v1alpha2.CPU{
-				Type:  v1alpha2.CPUTypeModel,
+		Spec: v1alpha3.VirtualMachineClassSpec{
+			CPU: v1alpha3.CPU{
+				Type:  v1alpha3.CPUTypeModel,
 				Model: "Nehalem",
 			},
-			SizingPolicies: []v1alpha2.SizingPolicy{
+			SizingPolicies: []v1alpha3.SizingPolicy{
 				{
-					Cores: &v1alpha2.SizingPolicyCores{
+					Cores: &v1alpha3.SizingPolicyCores{
 						Min: 1,
 						Max: 4,
 					},
 					DedicatedCores: []bool{false},
-					CoreFractions:  []v1alpha2.CoreFractionValue{5, 10, 20, 50, 100},
+					CoreFractions:  []v1alpha3.CoreFractionValue{"5%", "10%", "20%", "50%", "100%"},
 				},
 				{
-					Cores: &v1alpha2.SizingPolicyCores{
+					Cores: &v1alpha3.SizingPolicyCores{
 						Min: 5,
 						Max: 8,
 					},
 					DedicatedCores: []bool{false},
-					CoreFractions:  []v1alpha2.CoreFractionValue{20, 50, 100},
+					CoreFractions:  []v1alpha3.CoreFractionValue{"20%", "50%", "100%"},
 				},
 				{
-					Cores: &v1alpha2.SizingPolicyCores{
+					Cores: &v1alpha3.SizingPolicyCores{
 						Min: 9,
 						Max: 16,
 					},
 					DedicatedCores: []bool{true, false},
-					CoreFractions:  []v1alpha2.CoreFractionValue{50, 100},
+					CoreFractions:  []v1alpha3.CoreFractionValue{"50%", "100%"},
 				},
 				{
-					Cores: &v1alpha2.SizingPolicyCores{
+					Cores: &v1alpha3.SizingPolicyCores{
 						Min: 17,
 						Max: 1024,
 					},
 					DedicatedCores: []bool{true, false},
-					CoreFractions:  []v1alpha2.CoreFractionValue{100},
+					CoreFractions:  []v1alpha3.CoreFractionValue{"100%"},
 				},
 			},
 		},
@@ -240,7 +240,7 @@ func vmClassGenericManifest() *v1alpha2.VirtualMachineClass {
 }
 
 // isManagedByModule checks if vmclass has all labels that module set when installing vmclass.
-func isManagedByModule(vmClass *v1alpha2.VirtualMachineClass) bool {
+func isManagedByModule(vmClass *v1alpha3.VirtualMachineClass) bool {
 	if vmClass == nil {
 		return false
 	}
@@ -266,7 +266,7 @@ const (
 
 // addPatchesToCleanupMetadata fills patch collector with patches if vmclass metadata
 // should be cleaned.
-func addPatchesToCleanupMetadata(input *pkg.HookInput, vmClass *v1alpha2.VirtualMachineClass) {
+func addPatchesToCleanupMetadata(input *pkg.HookInput, vmClass *v1alpha3.VirtualMachineClass) {
 	var patches []map[string]interface{}
 
 	labelNames := []string{
@@ -283,20 +283,11 @@ func addPatchesToCleanupMetadata(input *pkg.HookInput, vmClass *v1alpha2.Virtual
 		}
 	}
 
-	// Ensure "keep resource" annotation on vmclass/generic, so Helm will keep it
-	// in the cluster even that we've deleted its manifest from templates.
-	if _, exists := vmClass.Annotations[helmKeepResourceAnno]; !exists {
-		patches = append(patches, map[string]interface{}{
-			"op":    "add",
-			"path":  fmt.Sprintf("/metadata/annotations/%s", jsonPatchEscape(helmKeepResourceAnno)),
-			"value": nil,
-		})
-	}
-
 	annoNames := []string{
 		helmReleaseNameAnno,
 		helmReleaseNamespaceAnno,
 	}
+	hasHelmAnnotations := false
 	for _, annoName := range annoNames {
 		if _, exists := vmClass.Annotations[annoName]; exists {
 			patches = append(patches, map[string]interface{}{
@@ -304,7 +295,19 @@ func addPatchesToCleanupMetadata(input *pkg.HookInput, vmClass *v1alpha2.Virtual
 				"path":  fmt.Sprintf("/metadata/annotations/%s", jsonPatchEscape(annoName)),
 				"value": nil,
 			})
+			hasHelmAnnotations = true
 		}
+	}
+
+	// Ensure "keep resource" annotation on vmclass/generic, so Helm will keep resource
+	// in the cluster even that we've deleted its manifest from templates.
+	_, hasKeepResourceAnno := vmClass.Annotations[helmKeepResourceAnno]
+	if hasHelmAnnotations && !hasKeepResourceAnno {
+		patches = append(patches, map[string]interface{}{
+			"op":    "add",
+			"path":  fmt.Sprintf("/metadata/annotations/%s", jsonPatchEscape(helmKeepResourceAnno)),
+			"value": nil,
+		})
 	}
 
 	if len(patches) == 0 {

--- a/images/hooks/pkg/hooks/install-vmclass-generic/hook_test.go
+++ b/images/hooks/pkg/hooks/install-vmclass-generic/hook_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/deckhouse/deckhouse/pkg/log"
 	"github.com/deckhouse/module-sdk/pkg"
 	"github.com/deckhouse/module-sdk/testing/mock"
-	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha3"
 )
 
 func Test_InstallVMClassGeneric(t *testing.T) {
@@ -121,7 +121,7 @@ var _ = Describe("Install VMClass Generic hook", func() {
 		}
 		snapshots.GetMock.When(vmClassGenericSnapshot).Then([]pkg.Snapshot{
 			mock.NewSnapshotMock(GinkgoT()).UnmarshalToMock.Set(func(v any) error {
-				vmClassInSnapshot, ok := v.(*v1alpha2.VirtualMachineClass)
+				vmClassInSnapshot, ok := v.(*v1alpha3.VirtualMachineClass)
 				Expect(ok).To(BeTrue())
 				*vmClassInSnapshot = *vmClass
 				return nil
@@ -133,7 +133,7 @@ var _ = Describe("Install VMClass Generic hook", func() {
 		vmClass := vmClassGenericManifest().DeepCopy()
 		snapshots.GetMock.When(vmClassGenericSnapshot).Then([]pkg.Snapshot{
 			mock.NewSnapshotMock(GinkgoT()).UnmarshalToMock.Set(func(v any) error {
-				vmClassInSnapshot, ok := v.(*v1alpha2.VirtualMachineClass)
+				vmClassInSnapshot, ok := v.(*v1alpha3.VirtualMachineClass)
 				Expect(ok).To(BeTrue())
 				*vmClassInSnapshot = *vmClass
 				return nil
@@ -149,7 +149,7 @@ var _ = Describe("Install VMClass Generic hook", func() {
 		vmClass.Annotations = nil
 		snapshots.GetMock.When(vmClassGenericSnapshot).Then([]pkg.Snapshot{
 			mock.NewSnapshotMock(GinkgoT()).UnmarshalToMock.Set(func(v any) error {
-				vmClassInSnapshot, ok := v.(*v1alpha2.VirtualMachineClass)
+				vmClassInSnapshot, ok := v.(*v1alpha3.VirtualMachineClass)
 				Expect(ok).To(BeTrue())
 				*vmClassInSnapshot = *vmClass
 				return nil
@@ -167,7 +167,7 @@ var _ = Describe("Install VMClass Generic hook", func() {
 		}
 		snapshots.GetMock.When(vmClassGenericSnapshot).Then([]pkg.Snapshot{
 			mock.NewSnapshotMock(GinkgoT()).UnmarshalToMock.Set(func(v any) error {
-				vmClassInSnapshot, ok := v.(*v1alpha2.VirtualMachineClass)
+				vmClassInSnapshot, ok := v.(*v1alpha3.VirtualMachineClass)
 				Expect(ok).To(BeTrue())
 				*vmClassInSnapshot = *vmClass
 				return nil
@@ -187,7 +187,7 @@ var _ = Describe("Install VMClass Generic hook", func() {
 		}
 		snapshots.GetMock.When(vmClassGenericSnapshot).Then([]pkg.Snapshot{
 			mock.NewSnapshotMock(GinkgoT()).UnmarshalToMock.Set(func(v any) error {
-				vmClassInSnapshot, ok := v.(*v1alpha2.VirtualMachineClass)
+				vmClassInSnapshot, ok := v.(*v1alpha3.VirtualMachineClass)
 				Expect(ok).To(BeTrue())
 				*vmClassInSnapshot = *vmClass
 				return nil
@@ -197,7 +197,7 @@ var _ = Describe("Install VMClass Generic hook", func() {
 
 	expectVMClassGeneric := func(obj interface{}) {
 		GinkgoHelper()
-		vmClass, ok := obj.(*v1alpha2.VirtualMachineClass)
+		vmClass, ok := obj.(*v1alpha3.VirtualMachineClass)
 		Expect(ok).To(BeTrue())
 		Expect(vmClass.Name).To(Equal("generic"))
 		Expect(vmClass.Labels).To(Equal(map[string]string{
@@ -318,17 +318,17 @@ var _ = Describe("Install VMClass Generic hook", func() {
 				})
 			})
 
-			When("vmclass/generic without keep-resource annotation is present", func() {
+			When("vmclass/generic without keep-resource annotation", func() {
 				It("should not change vmclass/generic and set values", func() {
 					prepareVMClassSnapshotGenericWithoutKeepResource()
 
 					values.SetMock.Return()
 					patchCollector.CreateMock.Optional()
-					patchCollector.PatchWithJSONMock.Return()
+					patchCollector.PatchWithJSONMock.Optional()
 
 					Expect(Reconcile(context.Background(), newInput())).To(Succeed())
 					Expect(patchCollector.CreateMock.Calls()).To(HaveLen(0))
-					Expect(patchCollector.PatchWithJSONMock.Calls()).To(HaveLen(1))
+					Expect(patchCollector.PatchWithJSONMock.Calls()).To(HaveLen(0))
 					Expect(values.SetMock.Calls()).To(HaveLen(1))
 				})
 			})


### PR DESCRIPTION

## Description

- Change vmclass generic manifest to use strings for coreFractions.
- Fix error when hook trying to patch vmclass/generic without annotations.



## Why do we need it, and what problem does it solve?

1. Upgrade vmclass version after merging #1601.
2. Fix blocking the main queue when new vmclass generic is created, but module-state secret is not created. E.g. this error may occur during the first installation of the module when ModuleConfig is invalid.

## What is the expected result?

Newly created vmclass/generic has "apiVersion: virtualization.deckhouse.io/v1alpha3".

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: module
type: chore
summary: Upgrade version to v1alpha3 for vmclass/generic, fix blocking main queue in case of unsuccessful module installation.
```
