### PR TITLE
feat(vm): validate cloud-init userdata

### DIFF
--- a/crds/virtualmachines.yaml
+++ b/crds/virtualmachines.yaml
@@ -72,8 +72,6 @@ spec:
 
                         [More information about `cloud-init` and configuration examples](https://cloudinit.readthedocs.io/en/latest/reference/examples.html).
                       type: string
-                      maxLength: 2048
-
                     userDataRef:
                       description: |
                         Link to an existing resource with the `cloud-init` scenario.

--- a/images/virtualization-artifact/pkg/controller/service/provisioning_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/provisioning_service.go
@@ -31,6 +31,11 @@ import (
 
 const cloudInitUserMaxLen = 2048
 
+var (
+	ErrUserDataEmpty   = errors.New("provisioning userdata is defined, but it is empty")
+	ErrUserDataTooLong = fmt.Errorf("userdata exceeds %d byte limit; should use userDataRef for larger data", cloudInitUserMaxLen)
+)
+
 type ProvisioningService struct {
 	reader client.Reader
 }
@@ -103,11 +108,11 @@ func (p *ProvisioningService) hasOneOfKeys(secret *corev1.Secret, checkKeys ...s
 
 func (p *ProvisioningService) ValidateUserDataLen(userData string) error {
 	if userData == "" {
-		return errors.New("provisioning userdata is defined, but it is empty")
+		return ErrUserDataEmpty
 	}
 
 	if len(userData) > cloudInitUserMaxLen {
-		return fmt.Errorf("userdata exceeds %d byte limit; should use userDataRef for larger data", cloudInitUserMaxLen)
+		return ErrUserDataTooLong
 	}
 
 	return nil

--- a/images/virtualization-artifact/pkg/controller/service/provisioning_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/provisioning_service.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+)
+
+const cloudInitUserMaxLen = 2048
+
+type ProvisioningService struct {
+	reader client.Reader
+}
+
+func NewProvisioningService(reader client.Reader) *ProvisioningService {
+	return &ProvisioningService{
+		reader: reader,
+	}
+}
+
+var ErrSecretIsNotValid = errors.New("secret is not valid")
+
+type SecretNotFoundError string
+
+func (e SecretNotFoundError) Error() string {
+	return fmt.Sprintf("secret %s not found", string(e))
+}
+
+type UnexpectedSecretTypeError string
+
+func (e UnexpectedSecretTypeError) Error() string {
+	return fmt.Sprintf("unexpected secret type: %s", string(e))
+}
+
+var cloudInitCheckKeys = []string{
+	"userdata",
+	"userData",
+}
+
+func (p *ProvisioningService) Validate(ctx context.Context, key types.NamespacedName) error {
+	secret := &corev1.Secret{}
+	err := p.reader.Get(ctx, key, secret)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return SecretNotFoundError(key.String())
+		}
+		return err
+	}
+	switch secret.Type {
+	case v1alpha2.SecretTypeCloudInit:
+		return p.validateCloudInitSecret(secret)
+	case v1alpha2.SecretTypeSysprep:
+		return p.validateSysprepSecret(secret)
+	default:
+		return UnexpectedSecretTypeError(secret.Type)
+	}
+}
+
+func (p *ProvisioningService) validateCloudInitSecret(secret *corev1.Secret) error {
+	if !p.hasOneOfKeys(secret, cloudInitCheckKeys...) {
+		return fmt.Errorf("the secret should have one of data fields %v: %w", cloudInitCheckKeys, ErrSecretIsNotValid)
+	}
+	return nil
+}
+
+func (p *ProvisioningService) validateSysprepSecret(_ *corev1.Secret) error {
+	return nil
+}
+
+func (p *ProvisioningService) hasOneOfKeys(secret *corev1.Secret, checkKeys ...string) bool {
+	validate := len(checkKeys) == 0
+	for _, key := range checkKeys {
+		if _, ok := secret.Data[key]; ok {
+			validate = true
+			break
+		}
+	}
+	return validate
+}
+
+func (p *ProvisioningService) ValidateUserDataLen(userData string) error {
+	if userData == "" {
+		return errors.New("provisioning userdata is defined, but it is empty")
+	}
+
+	if len(userData) > cloudInitUserMaxLen {
+		return fmt.Errorf("userdata exceeds %d byte limit; should use userDataRef for larger data", cloudInitUserMaxLen)
+	}
+
+	return nil
+}

--- a/images/virtualization-artifact/pkg/controller/service/provisioning_service_test.go
+++ b/images/virtualization-artifact/pkg/controller/service/provisioning_service_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ProvisioningService", func() {
+	var provisioningService *ProvisioningService
+
+	BeforeEach(func() {
+		provisioningService = NewProvisioningService(nil)
+	})
+
+	DescribeTable("ValidateUserDataLen",
+		func(userData string, expectedErr error) {
+			err := provisioningService.ValidateUserDataLen(userData)
+			if expectedErr != nil {
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(expectedErr))
+			} else {
+				Expect(err).ToNot(HaveOccurred())
+			}
+		},
+		Entry(
+			"empty userdata",
+			"",
+			ErrUserDataEmpty,
+		),
+		Entry(
+			"userdata exceeds max limit",
+			string(make([]byte, cloudInitUserMaxLen+1)),
+			ErrUserDataTooLong,
+		),
+		Entry(
+			"userdata is within limit",
+			string(make([]byte, cloudInitUserMaxLen-1)),
+			nil,
+		),
+	)
+})

--- a/images/virtualization-artifact/pkg/controller/vm/internal/validators/provisioning_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/validators/provisioning_validator.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validators
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+)
+
+type ProvisioningValidator struct {
+	provisioningService *service.ProvisioningService
+}
+
+func NewProvisioningValidator(provisioningService *service.ProvisioningService) *ProvisioningValidator {
+	return &ProvisioningValidator{provisioningService: provisioningService}
+}
+
+func (p *ProvisioningValidator) ValidateCreate(_ context.Context, vm *v1alpha2.VirtualMachine) (admission.Warnings, error) {
+	err := p.validateUserDataLen(vm)
+	if err != nil {
+		return admission.Warnings{}, err
+	}
+
+	return nil, nil
+}
+
+func (p *ProvisioningValidator) ValidateUpdate(_ context.Context, _, newVM *v1alpha2.VirtualMachine) (admission.Warnings, error) {
+	err := p.validateUserDataLen(newVM)
+	if err != nil {
+		return admission.Warnings{}, err
+	}
+
+	return nil, nil
+}
+
+func (p *ProvisioningValidator) validateUserDataLen(vm *v1alpha2.VirtualMachine) error {
+	if vm.Spec.Provisioning != nil && vm.Spec.Provisioning.Type == v1alpha2.ProvisioningTypeUserData {
+		err := p.provisioningService.ValidateUserDataLen(vm.Spec.Provisioning.UserData)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/images/virtualization-artifact/pkg/controller/vm/vm_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vm/vm_controller.go
@@ -54,6 +54,7 @@ func SetupController(
 	mgrCache := mgr.GetCache()
 	client := mgr.GetClient()
 	blockDeviceService := service.NewBlockDeviceService(client)
+	provisioningService := service.NewProvisioningService(client)
 	vmClassService := service.NewVirtualMachineClassService(client)
 
 	migrateVolumesService := vmservice.NewMigrationVolumesService(client, internal.MakeKVVMFromVMSpec, 10*time.Second)
@@ -100,7 +101,7 @@ func SetupController(
 
 	if err = builder.WebhookManagedBy(mgr).
 		For(&v1alpha2.VirtualMachine{}).
-		WithValidator(NewValidator(client, blockDeviceService, featuregates.Default(), log)).
+		WithValidator(NewValidator(client, blockDeviceService, provisioningService, featuregates.Default(), log)).
 		WithDefaulter(NewDefaulter(client, vmClassService, log)).
 		Complete(); err != nil {
 		return err

--- a/images/virtualization-artifact/pkg/controller/vm/vm_webhook.go
+++ b/images/virtualization-artifact/pkg/controller/vm/vm_webhook.go
@@ -42,19 +42,20 @@ type Validator struct {
 	log        *log.Logger
 }
 
-func NewValidator(client client.Client, service *service.BlockDeviceService, featureGate featuregate.FeatureGate, log *log.Logger) *Validator {
+func NewValidator(client client.Client, blockDeviceservice *service.BlockDeviceService, provisioningService *service.ProvisioningService, featureGate featuregate.FeatureGate, log *log.Logger) *Validator {
 	return &Validator{
 		validators: []VirtualMachineValidator{
 			validators.NewMetaValidator(client),
 			validators.NewIPAMValidator(client),
 			validators.NewBlockDeviceSpecRefsValidator(),
 			validators.NewSizingPolicyValidator(client),
-			validators.NewBlockDeviceLimiterValidator(service, log),
+			validators.NewBlockDeviceLimiterValidator(blockDeviceservice, log),
 			validators.NewAffinityValidator(),
 			validators.NewTopologySpreadConstraintValidator(),
 			validators.NewCPUCountValidator(),
 			validators.NewNetworksValidator(featureGate),
 			validators.NewFirstDiskValidator(client),
+			validators.NewProvisioningValidator(provisioningService),
 		},
 		log: log.With("webhook", "validation"),
 	}


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Cloud-init userdata in the virtual machine specification should not be empty or exceed 2048 KB.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
These changes are required to prevent the virtual machine from entering a pending status due to incorrect cloud-init userdata.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
Webhook prevents virtual machine creation or update with incorrect cloud-init userdata and Provisioning Handler return an error if resource was created with invalidated data.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: vm
type: feature
summary: "Cloud-init userdata is now validated during virtual machine creation and updates."
```
