### PR TITLE
chore(api): block migration during snapshotting and snapshotting during migration

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/virtual_disk_ready.go
+++ b/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/virtual_disk_ready.go
@@ -18,24 +18,31 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/deckhouse/virtualization-controller/pkg/common/object"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdscondition"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmcondition"
 )
 
 type VirtualDiskReadyHandler struct {
 	snapshotter VirtualDiskReadySnapshotter
+	client      client.Client
 }
 
-func NewVirtualDiskReadyHandler(snapshotter VirtualDiskReadySnapshotter) *VirtualDiskReadyHandler {
+func NewVirtualDiskReadyHandler(snapshotter VirtualDiskReadySnapshotter, client client.Client) *VirtualDiskReadyHandler {
 	return &VirtualDiskReadyHandler{
 		snapshotter: snapshotter,
+		client:      client,
 	}
 }
 
@@ -94,6 +101,14 @@ func (h VirtualDiskReadyHandler) Handle(ctx context.Context, vdSnapshot *v1alpha
 			return reconcile.Result{}, nil
 		}
 
+		attachedToMigratingVM, err := h.checkDiskNotAttachedToMigratingVM(ctx, vd, cb)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		if attachedToMigratingVM {
+			return reconcile.Result{}, nil
+		}
+
 		cb.
 			Status(metav1.ConditionTrue).
 			Reason(vdscondition.VirtualDiskReady).
@@ -106,4 +121,34 @@ func (h VirtualDiskReadyHandler) Handle(ctx context.Context, vdSnapshot *v1alpha
 			Message(fmt.Sprintf("The virtual disk %q is in the %q phase: waiting for it to reach the Ready phase.", vd.Name, vd.Status.Phase))
 		return reconcile.Result{}, nil
 	}
+}
+
+// checkDiskNotAttachedToMigratingVM checks that the disk is not attached to a migrating VM.
+// Returns (true, nil) if the disk is attached to a migrating VM (caller should return immediately).
+// Otherwise returns (false, nil) or (false, err).
+func (h VirtualDiskReadyHandler) checkDiskNotAttachedToMigratingVM(ctx context.Context, vd *v1alpha2.VirtualDisk, cb *conditions.ConditionBuilder) (bool, error) {
+	inUse, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
+	if inUse.Status != metav1.ConditionTrue {
+		return false, nil
+	}
+
+	if len(vd.Status.AttachedToVirtualMachines) != 1 {
+		return false, errors.New("disk is in InUse state but the number of VMs it is attached to is not 1; this should not happen, please report a bug")
+	}
+
+	vmName := vd.Status.AttachedToVirtualMachines[0].Name
+	vm, err := object.FetchObject(ctx, types.NamespacedName{Name: vmName, Namespace: vd.Namespace}, h.client, &v1alpha2.VirtualMachine{})
+	if err != nil {
+		return false, err
+	}
+
+	_, migratingConditionExists := conditions.GetCondition(vmcondition.TypeMigrating, vm.Status.Conditions)
+	if !migratingConditionExists {
+		return false, nil
+	}
+	cb.
+		Status(metav1.ConditionFalse).
+		Reason(vdscondition.VirtualDiskNotReadyForSnapshotting).
+		Message("Snapshot cannot be taken: the virtual machine is currently migrating.")
+	return true, nil
 }

--- a/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/virtual_disk_ready.go
+++ b/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/virtual_disk_ready.go
@@ -101,7 +101,7 @@ func (h VirtualDiskReadyHandler) Handle(ctx context.Context, vdSnapshot *v1alpha
 			return reconcile.Result{}, nil
 		}
 
-		attachedToMigratingVM, err := h.isVDAttachedToMigratingVM(ctx, vd, cb)
+		attachedToMigratingVM, err := h.isVDAttachedToMigratingVM(ctx, vd)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
@@ -130,7 +130,7 @@ func (h VirtualDiskReadyHandler) Handle(ctx context.Context, vdSnapshot *v1alpha
 // isVDAttachedToMigratingVM checks that the disk is not attached to a migrating VM.
 // Returns (true, nil) if the disk is attached to a migrating VM (caller should return immediately).
 // Otherwise returns (false, nil) or (false, err).
-func (h VirtualDiskReadyHandler) isVDAttachedToMigratingVM(ctx context.Context, vd *v1alpha2.VirtualDisk, cb *conditions.ConditionBuilder) (bool, error) {
+func (h VirtualDiskReadyHandler) isVDAttachedToMigratingVM(ctx context.Context, vd *v1alpha2.VirtualDisk) (bool, error) {
 	inUse, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
 	if inUse.Status != metav1.ConditionTrue {
 		return false, nil
@@ -158,9 +158,5 @@ func (h VirtualDiskReadyHandler) isVDAttachedToMigratingVM(ctx context.Context, 
 	if !migratingConditionExists {
 		return false, nil
 	}
-	cb.
-		Status(metav1.ConditionFalse).
-		Reason(vdscondition.VirtualDiskNotReadyForSnapshotting).
-		Message("Snapshot cannot be taken: the virtual machine is currently migrating.")
 	return true, nil
 }

--- a/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/virtual_disk_ready.go
+++ b/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/virtual_disk_ready.go
@@ -101,7 +101,7 @@ func (h VirtualDiskReadyHandler) Handle(ctx context.Context, vdSnapshot *v1alpha
 			return reconcile.Result{}, nil
 		}
 
-		attachedToMigratingVM, err := h.checkDiskNotAttachedToMigratingVM(ctx, vd, cb)
+		attachedToMigratingVM, err := h.isVDAttachedToMigratingVM(ctx, vd, cb)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
@@ -123,20 +123,28 @@ func (h VirtualDiskReadyHandler) Handle(ctx context.Context, vdSnapshot *v1alpha
 	}
 }
 
-// checkDiskNotAttachedToMigratingVM checks that the disk is not attached to a migrating VM.
+// isVDAttachedToMigratingVM checks that the disk is not attached to a migrating VM.
 // Returns (true, nil) if the disk is attached to a migrating VM (caller should return immediately).
 // Otherwise returns (false, nil) or (false, err).
-func (h VirtualDiskReadyHandler) checkDiskNotAttachedToMigratingVM(ctx context.Context, vd *v1alpha2.VirtualDisk, cb *conditions.ConditionBuilder) (bool, error) {
+func (h VirtualDiskReadyHandler) isVDAttachedToMigratingVM(ctx context.Context, vd *v1alpha2.VirtualDisk, cb *conditions.ConditionBuilder) (bool, error) {
 	inUse, _ := conditions.GetCondition(vdcondition.InUseType, vd.Status.Conditions)
 	if inUse.Status != metav1.ConditionTrue {
 		return false, nil
 	}
 
-	if len(vd.Status.AttachedToVirtualMachines) != 1 {
+	var vmNames []string
+
+	for _, attachedVM := range vd.Status.AttachedToVirtualMachines {
+		if attachedVM.Mounted {
+			vmNames = append(vmNames, attachedVM.Name)
+		}
+	}
+
+	if len(vmNames) != 1 {
 		return false, errors.New("disk is in InUse state but the number of VMs it is attached to is not 1; this should not happen, please report a bug")
 	}
 
-	vmName := vd.Status.AttachedToVirtualMachines[0].Name
+	vmName := vmNames[0]
 	vm, err := object.FetchObject(ctx, types.NamespacedName{Name: vmName, Namespace: vd.Namespace}, h.client, &v1alpha2.VirtualMachine{})
 	if err != nil {
 		return false, err

--- a/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/virtual_disk_ready.go
+++ b/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/virtual_disk_ready.go
@@ -23,6 +23,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	virtv1 "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -155,8 +156,20 @@ func (h VirtualDiskReadyHandler) isVDAttachedToMigratingVM(ctx context.Context, 
 	}
 
 	_, migratingConditionExists := conditions.GetCondition(vmcondition.TypeMigrating, vm.Status.Conditions)
-	if !migratingConditionExists {
-		return false, nil
+	if migratingConditionExists {
+		return true, nil
 	}
-	return true, nil
+
+	kvvmi, err := object.FetchObject(ctx, types.NamespacedName{Name: vmName, Namespace: vd.Namespace}, h.client, &virtv1.VirtualMachineInstance{})
+	if err != nil {
+		return false, err
+	}
+
+	if kvvmi != nil && kvvmi.Status.MigrationState != nil &&
+		kvvmi.Status.MigrationState.StartTimestamp != nil &&
+		kvvmi.Status.MigrationState.EndTimestamp == nil {
+		return true, nil
+	}
+
+	return false, nil
 }

--- a/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/virtual_disk_ready.go
+++ b/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/virtual_disk_ready.go
@@ -106,6 +106,10 @@ func (h VirtualDiskReadyHandler) Handle(ctx context.Context, vdSnapshot *v1alpha
 			return reconcile.Result{}, err
 		}
 		if attachedToMigratingVM {
+			cb.
+				Status(metav1.ConditionFalse).
+				Reason(vdscondition.VirtualDiskNotReadyForSnapshotting).
+				Message("Snapshot cannot be taken: the virtual disk is attached to a migrating virtual machine.")
 			return reconcile.Result{}, nil
 		}
 

--- a/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/virtual_disk_ready_test.go
+++ b/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/virtual_disk_ready_test.go
@@ -23,19 +23,27 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/deckhouse/virtualization-controller/pkg/common/testutil"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdscondition"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmcondition"
 )
 
 var _ = Describe("VirtualDiskReady handler", func() {
 	var snapshotter *VirtualDiskReadySnapshotterMock
 	var vd *v1alpha2.VirtualDisk
 	var vdSnapshot *v1alpha2.VirtualDiskSnapshot
+	var fakeClient client.Client
 
 	BeforeEach(func() {
+		var err error
+		fakeClient, err = testutil.NewFakeClientWithObjects()
+		Expect(err).NotTo(HaveOccurred())
+
 		vd = &v1alpha2.VirtualDisk{
 			ObjectMeta: metav1.ObjectMeta{Name: "vd-01"},
 			Status: v1alpha2.VirtualDiskStatus{
@@ -63,7 +71,7 @@ var _ = Describe("VirtualDiskReady handler", func() {
 
 	Context("condition VirtualDiskReady is True", func() {
 		It("The virtual disk is ready for snapshotting", func() {
-			h := NewVirtualDiskReadyHandler(snapshotter)
+			h := NewVirtualDiskReadyHandler(snapshotter, fakeClient)
 
 			_, err := h.Handle(testContext(), vdSnapshot)
 			Expect(err).To(BeNil())
@@ -79,7 +87,7 @@ var _ = Describe("VirtualDiskReady handler", func() {
 			snapshotter.GetVirtualDiskFunc = func(_ context.Context, _, _ string) (*v1alpha2.VirtualDisk, error) {
 				return nil, nil
 			}
-			h := NewVirtualDiskReadyHandler(snapshotter)
+			h := NewVirtualDiskReadyHandler(snapshotter, fakeClient)
 
 			_, err := h.Handle(testContext(), vdSnapshot)
 			Expect(err).To(BeNil())
@@ -94,7 +102,7 @@ var _ = Describe("VirtualDiskReady handler", func() {
 				vd.DeletionTimestamp = ptr.To(metav1.Now())
 				return vd, nil
 			}
-			h := NewVirtualDiskReadyHandler(snapshotter)
+			h := NewVirtualDiskReadyHandler(snapshotter, fakeClient)
 
 			_, err := h.Handle(testContext(), vdSnapshot)
 			Expect(err).To(BeNil())
@@ -109,7 +117,7 @@ var _ = Describe("VirtualDiskReady handler", func() {
 				vd.Status.Phase = v1alpha2.DiskPending
 				return vd, nil
 			}
-			h := NewVirtualDiskReadyHandler(snapshotter)
+			h := NewVirtualDiskReadyHandler(snapshotter, fakeClient)
 
 			_, err := h.Handle(testContext(), vdSnapshot)
 			Expect(err).To(BeNil())
@@ -130,7 +138,7 @@ var _ = Describe("VirtualDiskReady handler", func() {
 				})
 				return vd, nil
 			}
-			h := NewVirtualDiskReadyHandler(snapshotter)
+			h := NewVirtualDiskReadyHandler(snapshotter, fakeClient)
 
 			_, err := h.Handle(testContext(), vdSnapshot)
 			Expect(err).To(BeNil())
@@ -138,6 +146,41 @@ var _ = Describe("VirtualDiskReady handler", func() {
 			Expect(ready.Status).To(Equal(metav1.ConditionFalse))
 			Expect(ready.Reason).To(Equal(vdscondition.VirtualDiskNotReadyForSnapshotting.String()))
 			Expect(ready.Message).ToNot(BeEmpty())
+		})
+
+		It("The virtual disk is attached to a migrating VM", func() {
+			const namespace = "default"
+			vmName := "vm-migrating"
+			vd.Namespace = namespace
+			vd.Status.Conditions = []metav1.Condition{
+				{Type: vdcondition.SnapshottingType.String(), Status: metav1.ConditionTrue},
+				{Type: vdcondition.InUseType.String(), Status: metav1.ConditionTrue},
+			}
+			vd.Status.AttachedToVirtualMachines = []v1alpha2.AttachedVirtualMachine{{Name: vmName}}
+			vdSnapshot.Namespace = namespace
+
+			vm := &v1alpha2.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{Name: vmName, Namespace: namespace},
+				Status: v1alpha2.VirtualMachineStatus{
+					Conditions: []metav1.Condition{
+						{Type: vmcondition.TypeMigrating.String(), Status: metav1.ConditionTrue},
+					},
+				},
+			}
+			fakeClient, err := testutil.NewFakeClientWithObjects(vm)
+			Expect(err).NotTo(HaveOccurred())
+
+			snapshotter.GetVirtualDiskFunc = func(_ context.Context, _, _ string) (*v1alpha2.VirtualDisk, error) {
+				return vd, nil
+			}
+			h := NewVirtualDiskReadyHandler(snapshotter, fakeClient)
+
+			_, err = h.Handle(testContext(), vdSnapshot)
+			Expect(err).To(BeNil())
+			ready, _ := conditions.GetCondition(vdscondition.VirtualDiskReadyType, vdSnapshot.Status.Conditions)
+			Expect(ready.Status).To(Equal(metav1.ConditionFalse))
+			Expect(ready.Reason).To(Equal(vdscondition.VirtualDiskNotReadyForSnapshotting.String()))
+			Expect(ready.Message).To(ContainSubstring("migrating"))
 		})
 	})
 })

--- a/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/virtual_disk_ready_test.go
+++ b/images/virtualization-artifact/pkg/controller/vdsnapshot/internal/virtual_disk_ready_test.go
@@ -69,11 +69,117 @@ var _ = Describe("VirtualDiskReady handler", func() {
 		}
 	})
 
+	Context("condition VirtualDiskReady is Unknown", func() {
+		It("The virtual disk snapshot is being deleted", func() {
+			vdSnapshot.DeletionTimestamp = ptr.To(metav1.Now())
+			h := NewVirtualDiskReadyHandler(snapshotter, fakeClient)
+
+			_, err := h.Handle(testContext(), vdSnapshot)
+			Expect(err).To(BeNil())
+			ready, _ := conditions.GetCondition(vdscondition.VirtualDiskReadyType, vdSnapshot.Status.Conditions)
+			Expect(ready.Status).To(Equal(metav1.ConditionUnknown))
+			Expect(ready.Reason).To(Equal(conditions.ReasonUnknown.String()))
+			Expect(ready.Message).To(BeEmpty())
+		})
+	})
+
 	Context("condition VirtualDiskReady is True", func() {
 		It("The virtual disk is ready for snapshotting", func() {
 			h := NewVirtualDiskReadyHandler(snapshotter, fakeClient)
 
 			_, err := h.Handle(testContext(), vdSnapshot)
+			Expect(err).To(BeNil())
+			ready, _ := conditions.GetCondition(vdscondition.VirtualDiskReadyType, vdSnapshot.Status.Conditions)
+			Expect(ready.Status).To(Equal(metav1.ConditionTrue))
+			Expect(ready.Reason).To(Equal(vdscondition.VirtualDiskReady.String()))
+			Expect(ready.Message).To(BeEmpty())
+		})
+
+		It("The virtual disk snapshot is already in Ready phase", func() {
+			vdSnapshot.Status.Phase = v1alpha2.VirtualDiskSnapshotPhaseReady
+			h := NewVirtualDiskReadyHandler(snapshotter, fakeClient)
+
+			_, err := h.Handle(testContext(), vdSnapshot)
+			Expect(err).To(BeNil())
+			ready, _ := conditions.GetCondition(vdscondition.VirtualDiskReadyType, vdSnapshot.Status.Conditions)
+			Expect(ready.Status).To(Equal(metav1.ConditionTrue))
+			Expect(ready.Reason).To(Equal(vdscondition.VirtualDiskReady.String()))
+			Expect(ready.Message).To(BeEmpty())
+		})
+
+		It("The virtual disk has no snapshotting condition", func() {
+			snapshotter.GetVirtualDiskFunc = func(_ context.Context, _, _ string) (*v1alpha2.VirtualDisk, error) {
+				vd.Status.Conditions = nil
+				return vd, nil
+			}
+			h := NewVirtualDiskReadyHandler(snapshotter, fakeClient)
+
+			_, err := h.Handle(testContext(), vdSnapshot)
+			Expect(err).To(BeNil())
+			ready, _ := conditions.GetCondition(vdscondition.VirtualDiskReadyType, vdSnapshot.Status.Conditions)
+			Expect(ready.Status).To(Equal(metav1.ConditionTrue))
+			Expect(ready.Reason).To(Equal(vdscondition.VirtualDiskReady.String()))
+			Expect(ready.Message).To(BeEmpty())
+		})
+
+		It("The virtual disk is InUse but attached VM is not migrating", func() {
+			const namespace = "default"
+			vmName := "vm-running"
+			vd.Namespace = namespace
+			vd.Status.Conditions = []metav1.Condition{
+				{Type: vdcondition.SnapshottingType.String(), Status: metav1.ConditionTrue},
+				{Type: vdcondition.InUseType.String(), Status: metav1.ConditionTrue},
+			}
+			vd.Status.AttachedToVirtualMachines = []v1alpha2.AttachedVirtualMachine{{Name: vmName, Mounted: true}}
+			vdSnapshot.Namespace = namespace
+
+			vm := &v1alpha2.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{Name: vmName, Namespace: namespace},
+				Status:     v1alpha2.VirtualMachineStatus{},
+			}
+			fakeClient, err := testutil.NewFakeClientWithObjects(vm)
+			Expect(err).NotTo(HaveOccurred())
+
+			snapshotter.GetVirtualDiskFunc = func(_ context.Context, _, _ string) (*v1alpha2.VirtualDisk, error) {
+				return vd, nil
+			}
+			h := NewVirtualDiskReadyHandler(snapshotter, fakeClient)
+
+			_, err = h.Handle(testContext(), vdSnapshot)
+			Expect(err).To(BeNil())
+			ready, _ := conditions.GetCondition(vdscondition.VirtualDiskReadyType, vdSnapshot.Status.Conditions)
+			Expect(ready.Status).To(Equal(metav1.ConditionTrue))
+			Expect(ready.Reason).To(Equal(vdscondition.VirtualDiskReady.String()))
+			Expect(ready.Message).To(BeEmpty())
+		})
+
+		It("The virtual disk has multiple attached VMs but only one is mounted and it is not migrating", func() {
+			const namespace = "default"
+			vmName := "vm-mounted"
+			vd.Namespace = namespace
+			vd.Status.Conditions = []metav1.Condition{
+				{Type: vdcondition.SnapshottingType.String(), Status: metav1.ConditionTrue},
+				{Type: vdcondition.InUseType.String(), Status: metav1.ConditionTrue},
+			}
+			vd.Status.AttachedToVirtualMachines = []v1alpha2.AttachedVirtualMachine{
+				{Name: "vm-unmounted", Mounted: false},
+				{Name: vmName, Mounted: true},
+			}
+			vdSnapshot.Namespace = namespace
+
+			vm := &v1alpha2.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{Name: vmName, Namespace: namespace},
+				Status:     v1alpha2.VirtualMachineStatus{},
+			}
+			fakeClient, err := testutil.NewFakeClientWithObjects(vm)
+			Expect(err).NotTo(HaveOccurred())
+
+			snapshotter.GetVirtualDiskFunc = func(_ context.Context, _, _ string) (*v1alpha2.VirtualDisk, error) {
+				return vd, nil
+			}
+			h := NewVirtualDiskReadyHandler(snapshotter, fakeClient)
+
+			_, err = h.Handle(testContext(), vdSnapshot)
 			Expect(err).To(BeNil())
 			ready, _ := conditions.GetCondition(vdscondition.VirtualDiskReadyType, vdSnapshot.Status.Conditions)
 			Expect(ready.Status).To(Equal(metav1.ConditionTrue))
@@ -148,6 +254,27 @@ var _ = Describe("VirtualDiskReady handler", func() {
 			Expect(ready.Message).ToNot(BeEmpty())
 		})
 
+		It("The virtual disk snapshotting condition is stale", func() {
+			snapshotter.GetVirtualDiskFunc = func(_ context.Context, _, _ string) (*v1alpha2.VirtualDisk, error) {
+				vd.Generation = 2
+				vd.Status.Conditions = []metav1.Condition{
+					{
+						Type:               vdcondition.SnapshottingType.String(),
+						Status:             metav1.ConditionTrue,
+						ObservedGeneration: 1,
+					},
+				}
+				return vd, nil
+			}
+			h := NewVirtualDiskReadyHandler(snapshotter, fakeClient)
+
+			_, err := h.Handle(testContext(), vdSnapshot)
+			Expect(err).To(BeNil())
+			ready, _ := conditions.GetCondition(vdscondition.VirtualDiskReadyType, vdSnapshot.Status.Conditions)
+			Expect(ready.Status).To(Equal(metav1.ConditionFalse))
+			Expect(ready.Reason).To(Equal(vdscondition.VirtualDiskNotReadyForSnapshotting.String()))
+		})
+
 		It("The virtual disk is attached to a migrating VM", func() {
 			const namespace = "default"
 			vmName := "vm-migrating"
@@ -156,7 +283,7 @@ var _ = Describe("VirtualDiskReady handler", func() {
 				{Type: vdcondition.SnapshottingType.String(), Status: metav1.ConditionTrue},
 				{Type: vdcondition.InUseType.String(), Status: metav1.ConditionTrue},
 			}
-			vd.Status.AttachedToVirtualMachines = []v1alpha2.AttachedVirtualMachine{{Name: vmName}}
+			vd.Status.AttachedToVirtualMachines = []v1alpha2.AttachedVirtualMachine{{Name: vmName, Mounted: true}}
 			vdSnapshot.Namespace = namespace
 
 			vm := &v1alpha2.VirtualMachine{
@@ -181,6 +308,53 @@ var _ = Describe("VirtualDiskReady handler", func() {
 			Expect(ready.Status).To(Equal(metav1.ConditionFalse))
 			Expect(ready.Reason).To(Equal(vdscondition.VirtualDiskNotReadyForSnapshotting.String()))
 			Expect(ready.Message).To(ContainSubstring("migrating"))
+		})
+	})
+
+	Context("returns an error", func() {
+		It("The virtual disk is InUse but has no mounted VMs", func() {
+			const namespace = "default"
+			vd.Namespace = namespace
+			vd.Status.Conditions = []metav1.Condition{
+				{Type: vdcondition.SnapshottingType.String(), Status: metav1.ConditionTrue},
+				{Type: vdcondition.InUseType.String(), Status: metav1.ConditionTrue},
+			}
+			vd.Status.AttachedToVirtualMachines = []v1alpha2.AttachedVirtualMachine{
+				{Name: "vm-01", Mounted: false},
+			}
+			vdSnapshot.Namespace = namespace
+
+			snapshotter.GetVirtualDiskFunc = func(_ context.Context, _, _ string) (*v1alpha2.VirtualDisk, error) {
+				return vd, nil
+			}
+			h := NewVirtualDiskReadyHandler(snapshotter, fakeClient)
+
+			_, err := h.Handle(testContext(), vdSnapshot)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("please report a bug"))
+		})
+
+		It("The virtual disk is InUse with multiple mounted VMs", func() {
+			const namespace = "default"
+			vd.Namespace = namespace
+			vd.Status.Conditions = []metav1.Condition{
+				{Type: vdcondition.SnapshottingType.String(), Status: metav1.ConditionTrue},
+				{Type: vdcondition.InUseType.String(), Status: metav1.ConditionTrue},
+			}
+			vd.Status.AttachedToVirtualMachines = []v1alpha2.AttachedVirtualMachine{
+				{Name: "vm-01", Mounted: true},
+				{Name: "vm-02", Mounted: true},
+			}
+			vdSnapshot.Namespace = namespace
+
+			snapshotter.GetVirtualDiskFunc = func(_ context.Context, _, _ string) (*v1alpha2.VirtualDisk, error) {
+				return vd, nil
+			}
+			h := NewVirtualDiskReadyHandler(snapshotter, fakeClient)
+
+			_, err := h.Handle(testContext(), vdSnapshot)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("please report a bug"))
 		})
 	})
 })

--- a/images/virtualization-artifact/pkg/controller/vdsnapshot/vdsnapshot_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vdsnapshot/vdsnapshot_controller.go
@@ -48,7 +48,7 @@ func NewController(
 
 	reconciler := NewReconciler(
 		mgr.GetClient(),
-		internal.NewVirtualDiskReadyHandler(freezer),
+		internal.NewVirtualDiskReadyHandler(freezer, mgr.GetClient()),
 		internal.NewLifeCycleHandler(freezer),
 		internal.NewDeletionHandler(freezer),
 	)

--- a/images/virtualization-artifact/pkg/controller/vm/internal/migrating.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/migrating.go
@@ -280,11 +280,11 @@ func (h *MigratingHandler) getVMOPCandidate(ctx context.Context, s state.Virtual
 func (h *MigratingHandler) syncMigratable(ctx context.Context, s state.VirtualMachineState, vm *v1alpha2.VirtualMachine, kvvm *virtv1.VirtualMachine, kvvmi *virtv1.VirtualMachineInstance) error {
 	cb := conditions.NewConditionBuilder(vmcondition.TypeMigratable).Generation(vm.GetGeneration())
 
-	fsFrozen, _ := conditions.GetCondition(vmcondition.TypeFilesystemFrozen, vm.Status.Conditions)
-	if fsFrozen.Status == metav1.ConditionTrue {
+	snapshotting, _ := conditions.GetCondition(vmcondition.TypeSnapshotting, vm.Status.Conditions)
+	if snapshotting.Status == metav1.ConditionTrue {
 		cb.Status(metav1.ConditionFalse).
 			Reason(vmcondition.ReasonNonMigratable).
-			Message("For the migration to proceed, the file system must be unfrozen.")
+			Message("Cannot migrate the machine while a snapshot is in progress.")
 		conditions.SetCondition(cb, &vm.Status.Conditions)
 		return nil
 	}

--- a/images/virtualization-artifact/pkg/controller/vm/internal/migrating.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/migrating.go
@@ -289,6 +289,15 @@ func (h *MigratingHandler) syncMigratable(ctx context.Context, s state.VirtualMa
 		return nil
 	}
 
+	frozen, _ := conditions.GetCondition(vmcondition.TypeFilesystemFrozen, vm.Status.Conditions)
+	if frozen.Status == metav1.ConditionTrue {
+		cb.Status(metav1.ConditionFalse).
+			Reason(vmcondition.ReasonNonMigratable).
+			Message("Cannot migrate the virtual machine whose file system is frozen.")
+		conditions.SetCondition(cb, &vm.Status.Conditions)
+		return nil
+	}
+
 	if kvvm != nil {
 		liveMigratable := service.GetKVVMCondition(string(virtv1.VirtualMachineInstanceIsMigratable), kvvm.Status.Conditions)
 		switch {

--- a/images/virtualization-artifact/pkg/controller/vm/internal/migrating.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/migrating.go
@@ -290,7 +290,7 @@ func (h *MigratingHandler) syncMigratable(ctx context.Context, s state.VirtualMa
 	if snapshotting.Status == metav1.ConditionTrue {
 		cb.Status(metav1.ConditionFalse).
 			Reason(vmcondition.ReasonNonMigratable).
-			Message("Cannot migrate the machine while a snapshot is in progress.")
+			Message("Cannot migrate the virtual machine while a snapshot is in progress.")
 		conditions.SetCondition(cb, &vm.Status.Conditions)
 		return nil
 	}

--- a/images/virtualization-artifact/pkg/controller/vm/internal/migrating.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/migrating.go
@@ -25,9 +25,12 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	virtv1 "kubevirt.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/deckhouse/virtualization-controller/pkg/common/object"
 	commonvmop "github.com/deckhouse/virtualization-controller/pkg/common/vmop"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
@@ -35,6 +38,7 @@ import (
 	"github.com/deckhouse/virtualization-controller/pkg/featuregates"
 	"github.com/deckhouse/virtualization-controller/pkg/logger"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmcondition"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmopcondition"
 )
@@ -47,11 +51,13 @@ type migratingVolumesService interface {
 }
 type MigratingHandler struct {
 	migratingVolumesService migratingVolumesService
+	client                  client.Client
 }
 
-func NewMigratingHandler(migratingVolumesService migratingVolumesService) *MigratingHandler {
+func NewMigratingHandler(migratingVolumesService migratingVolumesService, client client.Client) *MigratingHandler {
 	return &MigratingHandler{
 		migratingVolumesService: migratingVolumesService,
+		client:                  client,
 	}
 }
 
@@ -287,6 +293,23 @@ func (h *MigratingHandler) syncMigratable(ctx context.Context, s state.VirtualMa
 			Message("Cannot migrate the machine while a snapshot is in progress.")
 		conditions.SetCondition(cb, &vm.Status.Conditions)
 		return nil
+	}
+
+	for _, bd := range vm.Status.BlockDeviceRefs {
+		if bd.Kind == v1alpha2.VirtualDiskKind {
+			vd, err := object.FetchObject(ctx, types.NamespacedName{Name: bd.Name, Namespace: vm.Namespace}, h.client, &v1alpha2.VirtualDisk{})
+			if err != nil {
+				return err
+			}
+			vdSnapshotting, _ := conditions.GetCondition(vdcondition.SnapshottingType, vd.Status.Conditions)
+			if vdSnapshotting.Status == metav1.ConditionTrue {
+				cb.Status(metav1.ConditionFalse).
+					Reason(vmcondition.ReasonNonMigratable).
+					Message(fmt.Sprintf("Cannot migrate the machine while a snapshot is in progress on attached disk %q", vd.Name))
+				conditions.SetCondition(cb, &vm.Status.Conditions)
+				return nil
+			}
+		}
 	}
 
 	frozen, _ := conditions.GetCondition(vmcondition.TypeFilesystemFrozen, vm.Status.Conditions)

--- a/images/virtualization-artifact/pkg/controller/vm/internal/migrating.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/migrating.go
@@ -313,7 +313,7 @@ func (h *MigratingHandler) syncMigratable(ctx context.Context, s state.VirtualMa
 	}
 
 	frozen, _ := conditions.GetCondition(vmcondition.TypeFilesystemFrozen, vm.Status.Conditions)
-	if frozen.Status == metav1.ConditionTrue {
+	if frozen.Status == metav1.ConditionTrue || (kvvmi != nil && kvvmi.Status.FSFreezeStatus == service.FSFrozen) {
 		cb.Status(metav1.ConditionFalse).
 			Reason(vmcondition.ReasonNonMigratable).
 			Message("Cannot migrate the virtual machine whose file system is frozen.")

--- a/images/virtualization-artifact/pkg/controller/vm/internal/migrating_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/migrating_test.go
@@ -34,6 +34,7 @@ import (
 	vmservice "github.com/deckhouse/virtualization-controller/pkg/controller/vm/internal/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vm/internal/state"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmcondition"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmopcondition"
 )
@@ -92,7 +93,7 @@ var _ = Describe("MigratingHandler", func() {
 	}
 
 	reconcile := func() {
-		h := NewMigratingHandler(vmservice.NewMigrationVolumesService(fakeClient, MakeKVVMFromVMSpec, 10*time.Second))
+		h := NewMigratingHandler(vmservice.NewMigrationVolumesService(fakeClient, MakeKVVMFromVMSpec, 10*time.Second), fakeClient)
 		_, err := h.Handle(ctx, vmState)
 		Expect(err).NotTo(HaveOccurred())
 		err = resource.Update(context.Background())
@@ -215,6 +216,36 @@ var _ = Describe("MigratingHandler", func() {
 			Expect(exists).To(BeTrue())
 			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 			Expect(cond.Reason).To(Equal(vmcondition.ReasonMigratingInProgress.String()))
+		})
+
+		It("Should set Migratable False when attached disk has snapshot in progress", func() {
+			vdName := "vd-snapshotting"
+			vd := &v1alpha2.VirtualDisk{
+				ObjectMeta: metav1.ObjectMeta{Name: vdName, Namespace: namespace},
+				Status: v1alpha2.VirtualDiskStatus{
+					Conditions: []metav1.Condition{
+						{Type: vdcondition.SnapshottingType.String(), Status: metav1.ConditionTrue},
+					},
+				},
+			}
+			vm := newVM()
+			vm.Status.BlockDeviceRefs = []v1alpha2.BlockDeviceStatusRef{
+				{Kind: v1alpha2.DiskDevice, Name: vdName},
+			}
+			kvvmi := newKVVMI(nil)
+			fakeClient, resource, vmState = setupEnvironment(vm, kvvmi, vd)
+			reconcile()
+
+			newVM := &v1alpha2.VirtualMachine{}
+			err := fakeClient.Get(ctx, client.ObjectKeyFromObject(vm), newVM)
+			Expect(err).NotTo(HaveOccurred())
+
+			cond, exists := conditions.GetCondition(vmcondition.TypeMigratable, newVM.Status.Conditions)
+			Expect(exists).To(BeTrue())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal(vmcondition.ReasonNonMigratable.String()))
+			Expect(cond.Message).To(ContainSubstring("snapshot is in progress on attached disk"))
+			Expect(cond.Message).To(ContainSubstring(vdName))
 		})
 	})
 })

--- a/images/virtualization-artifact/pkg/controller/vm/vm_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vm/vm_controller.go
@@ -80,7 +80,7 @@ func SetupController(
 		internal.NewSyncPowerStateHandler(client, recorder),
 		internal.NewSyncMetadataHandler(client),
 		internal.NewLifeCycleHandler(client, recorder),
-		internal.NewMigratingHandler(migrateVolumesService),
+		internal.NewMigratingHandler(migrateVolumesService, client),
 		internal.NewFirmwareHandler(firmwareImage),
 		internal.NewEvictHandler(),
 		internal.NewStatisticHandler(client),

--- a/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle.go
@@ -383,7 +383,7 @@ func (h LifecycleHandler) canExecute(vmop *v1alpha2.VirtualMachineOperation, vm 
 			Generation(vmop.GetGeneration()).
 			Reason(vmopcondition.ReasonOperationFailed).
 			Status(metav1.ConditionFalse).
-			Message("VirtualMachine is not migratable, cannot be processed."),
+			Message(fmt.Sprintf("VirtualMachine is not migratable, cannot be processed: %s", migratable.Message)),
 		&vmop.Status.Conditions)
 	return false
 }

--- a/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle.go
@@ -36,6 +36,7 @@ import (
 	"github.com/deckhouse/virtualization-controller/pkg/livemigration"
 	"github.com/deckhouse/virtualization-controller/pkg/logger"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmcondition"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmopcondition"
 )
@@ -135,6 +136,23 @@ func (h LifecycleHandler) Handle(ctx context.Context, vmop *v1alpha2.VirtualMach
 	// Synchronize conditions to the VMOP.
 	if commonvmop.IsOperationInProgress(vmop) {
 		log.Debug("Operation in progress, check if VM is completed", "vm.phase", vm.Status.Phase, "vmop.phase", vmop.Status.Phase)
+
+		if msg, snapshotting := h.isSnapshotInProgress(ctx, vm); snapshotting {
+			log.Info("Snapshot detected during migration, cancelling migration")
+			if err := h.migration.DeleteMigration(ctx, vmop); err != nil {
+				return reconcile.Result{}, fmt.Errorf("failed to cancel migration due to snapshot: %w", err)
+			}
+			vmop.Status.Phase = v1alpha2.VMOPPhaseFailed
+			h.recorder.Event(vmop, corev1.EventTypeWarning, v1alpha2.ReasonErrVMOPFailed, "Migration cancelled due to snapshot")
+			conditions.SetCondition(
+				completedCond.
+					Reason(vmopcondition.ReasonOperationFailed).
+					Status(metav1.ConditionFalse).
+					Message(msg),
+				&vmop.Status.Conditions)
+			return reconcile.Result{}, nil
+		}
+
 		return reconcile.Result{}, h.syncOperationComplete(ctx, vmop)
 	}
 
@@ -386,6 +404,31 @@ func (h LifecycleHandler) canExecute(vmop *v1alpha2.VirtualMachineOperation, vm 
 			Message(fmt.Sprintf("VirtualMachine is not migratable, cannot be processed: %s", migratable.Message)),
 		&vmop.Status.Conditions)
 	return false
+}
+
+// isSnapshotInProgress checks if the VM or any of its attached virtual disks
+// have an active snapshot operation. Returns a descriptive message and true if so.
+func (h LifecycleHandler) isSnapshotInProgress(ctx context.Context, vm *v1alpha2.VirtualMachine) (string, bool) {
+	snapshotting, _ := conditions.GetCondition(vmcondition.TypeSnapshotting, vm.Status.Conditions)
+	if snapshotting.Status == metav1.ConditionTrue {
+		return "Migration was cancelled because a snapshot is in progress on the virtual machine.", true
+	}
+
+	for _, bd := range vm.Status.BlockDeviceRefs {
+		if bd.Kind != v1alpha2.DiskDevice {
+			continue
+		}
+		vd, err := object.FetchObject(ctx, types.NamespacedName{Name: bd.Name, Namespace: vm.Namespace}, h.client, &v1alpha2.VirtualDisk{})
+		if err != nil || vd == nil {
+			continue
+		}
+		vdSnapshotting, _ := conditions.GetCondition(vdcondition.SnapshottingType, vd.Status.Conditions)
+		if vdSnapshotting.Status == metav1.ConditionTrue {
+			return fmt.Sprintf("Migration was cancelled because a snapshot is in progress on attached disk %q.", bd.Name), true
+		}
+	}
+
+	return "", false
 }
 
 func (h LifecycleHandler) execute(ctx context.Context, vmop *v1alpha2.VirtualMachineOperation, vm *v1alpha2.VirtualMachine) error {

--- a/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle_test.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle_test.go
@@ -31,13 +31,16 @@ import (
 	vmbuilder "github.com/deckhouse/virtualization-controller/pkg/builder/vm"
 	vmopbuilder "github.com/deckhouse/virtualization-controller/pkg/builder/vmop"
 	"github.com/deckhouse/virtualization-controller/pkg/common/testutil"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/reconciler"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vmop/migration/internal/service"
 	genericservice "github.com/deckhouse/virtualization-controller/pkg/controller/vmop/service"
 	"github.com/deckhouse/virtualization-controller/pkg/eventrecord"
 	"github.com/deckhouse/virtualization-controller/pkg/featuregates"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmcondition"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmopcondition"
 )
 
 var _ = Describe("LifecycleHandler", func() {
@@ -245,4 +248,113 @@ var _ = Describe("LifecycleHandler", func() {
 			false,                              // targetMigrationEnabled
 		),
 	)
+
+	Context("Cancel in-progress migration due to snapshot", func() {
+		newInProgressVMOP := func() *v1alpha2.VirtualMachineOperation {
+			vmop := vmopbuilder.New(
+				vmopbuilder.WithName(name),
+				vmopbuilder.WithNamespace(namespace),
+				vmopbuilder.WithType(v1alpha2.VMOPTypeMigrate),
+				vmopbuilder.WithVirtualMachine(name),
+			)
+			vmop.Status.Phase = v1alpha2.VMOPPhaseInProgress
+			conditions.SetCondition(
+				conditions.NewConditionBuilder(vmopcondition.TypeSignalSent).
+					Reason(vmopcondition.ReasonSignalSentSuccess).
+					Status(metav1.ConditionTrue),
+				&vmop.Status.Conditions)
+			return vmop
+		}
+
+		It("Should cancel migration when VM has TypeSnapshotting=True", func() {
+			vmop := newInProgressVMOP()
+
+			vm := newVM(v1alpha2.PreferSafeMigrationPolicy)
+			vm.Status.Conditions = append(vm.Status.Conditions, metav1.Condition{
+				Type:   vmcondition.TypeSnapshotting.String(),
+				Status: metav1.ConditionTrue,
+				Reason: vmcondition.ReasonSnapshottingInProgress.String(),
+			})
+
+			migration := newSimpleMigration(fmt.Sprintf("vmop-%s", name), namespace, name)
+			migration.OwnerReferences = []metav1.OwnerReference{
+				{APIVersion: v1alpha2.SchemeGroupVersion.String(), Kind: v1alpha2.VirtualMachineOperationKind, Name: vmop.Name, UID: vmop.UID, Controller: ptr.To(true)},
+			}
+
+			fakeClient, _ = setupEnvironment(vmop, vm, migration)
+			migrationService := service.NewMigrationService(fakeClient, featuregates.Default())
+			base := genericservice.NewBaseVMOPService(fakeClient, recorderMock)
+
+			h := NewLifecycleHandler(fakeClient, migrationService, base, recorderMock)
+			_, err := h.Handle(ctx, vmop)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(vmop.Status.Phase).To(Equal(v1alpha2.VMOPPhaseFailed))
+			completed, exists := conditions.GetCondition(vmopcondition.TypeCompleted, vmop.Status.Conditions)
+			Expect(exists).To(BeTrue())
+			Expect(completed.Status).To(Equal(metav1.ConditionFalse))
+			Expect(completed.Reason).To(Equal(vmopcondition.ReasonOperationFailed.String()))
+			Expect(completed.Message).To(ContainSubstring("snapshot"))
+		})
+
+		It("Should cancel migration when attached VD has SnapshottingType=True", func() {
+			vdName := "vd-snapshotting"
+			vmop := newInProgressVMOP()
+
+			vm := newVM(v1alpha2.PreferSafeMigrationPolicy)
+			vm.Status.BlockDeviceRefs = []v1alpha2.BlockDeviceStatusRef{
+				{Kind: v1alpha2.DiskDevice, Name: vdName},
+			}
+
+			vd := &v1alpha2.VirtualDisk{
+				ObjectMeta: metav1.ObjectMeta{Name: vdName, Namespace: namespace},
+				Status: v1alpha2.VirtualDiskStatus{
+					Conditions: []metav1.Condition{
+						{Type: vdcondition.SnapshottingType.String(), Status: metav1.ConditionTrue},
+					},
+				},
+			}
+
+			migration := newSimpleMigration(fmt.Sprintf("vmop-%s", name), namespace, name)
+			migration.OwnerReferences = []metav1.OwnerReference{
+				{APIVersion: v1alpha2.SchemeGroupVersion.String(), Kind: v1alpha2.VirtualMachineOperationKind, Name: vmop.Name, UID: vmop.UID, Controller: ptr.To(true)},
+			}
+
+			fakeClient, _ = setupEnvironment(vmop, vm, vd, migration)
+			migrationService := service.NewMigrationService(fakeClient, featuregates.Default())
+			base := genericservice.NewBaseVMOPService(fakeClient, recorderMock)
+
+			h := NewLifecycleHandler(fakeClient, migrationService, base, recorderMock)
+			_, err := h.Handle(ctx, vmop)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(vmop.Status.Phase).To(Equal(v1alpha2.VMOPPhaseFailed))
+			completed, exists := conditions.GetCondition(vmopcondition.TypeCompleted, vmop.Status.Conditions)
+			Expect(exists).To(BeTrue())
+			Expect(completed.Status).To(Equal(metav1.ConditionFalse))
+			Expect(completed.Message).To(ContainSubstring(vdName))
+		})
+
+		It("Should not cancel migration when no snapshot is in progress", func() {
+			vmop := newInProgressVMOP()
+
+			vm := newVM(v1alpha2.PreferSafeMigrationPolicy)
+
+			migration := newSimpleMigration(fmt.Sprintf("vmop-%s", name), namespace, name)
+			migration.OwnerReferences = []metav1.OwnerReference{
+				{APIVersion: v1alpha2.SchemeGroupVersion.String(), Kind: v1alpha2.VirtualMachineOperationKind, Name: vmop.Name, UID: vmop.UID, Controller: ptr.To(true)},
+			}
+			migration.Status.Phase = virtv1.MigrationRunning
+
+			fakeClient, _ = setupEnvironment(vmop, vm, migration)
+			migrationService := service.NewMigrationService(fakeClient, featuregates.Default())
+			base := genericservice.NewBaseVMOPService(fakeClient, recorderMock)
+
+			h := NewLifecycleHandler(fakeClient, migrationService, base, recorderMock)
+			_, err := h.Handle(ctx, vmop)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(vmop.Status.Phase).To(Equal(v1alpha2.VMOPPhaseInProgress))
+		})
+	})
 })

--- a/images/virtualization-artifact/pkg/controller/vmop/migration/internal/watcher/vm.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/migration/internal/watcher/vm.go
@@ -78,8 +78,13 @@ func (w VMWatcher) Watch(mgr manager.Manager, ctr controller.Controller) error {
 
 					migratingOld, _ := conditions.GetCondition(vmcondition.TypeMigrating, e.ObjectOld.Status.Conditions)
 					migratingNew, _ := conditions.GetCondition(vmcondition.TypeMigrating, e.ObjectNew.Status.Conditions)
+					if !equality.Semantic.DeepEqual(migratingOld, migratingNew) {
+						return true
+					}
 
-					return !equality.Semantic.DeepEqual(migratingOld, migratingNew)
+					snapshottingOld, _ := conditions.GetCondition(vmcondition.TypeSnapshotting, e.ObjectOld.Status.Conditions)
+					snapshottingNew, _ := conditions.GetCondition(vmcondition.TypeSnapshotting, e.ObjectNew.Status.Conditions)
+					return !equality.Semantic.DeepEqual(snapshottingOld, snapshottingNew)
 				},
 			},
 		),

--- a/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/virtual_machine_ready.go
+++ b/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/virtual_machine_ready.go
@@ -82,6 +82,15 @@ func (h VirtualMachineReadyHandler) Handle(ctx context.Context, vmSnapshot *v1al
 		return reconcile.Result{}, nil
 	}
 
+	_, migratingConditionExists := conditions.GetCondition(vmcondition.TypeMigrating, vm.Status.Conditions)
+	if migratingConditionExists {
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(vmscondition.VirtualMachineNotReadyForSnapshotting).
+			Message("The virtual machine is migrating at the moment, so a snapshot cannot be taken.")
+		return reconcile.Result{}, nil
+	}
+
 	switch vm.Status.Phase {
 	case v1alpha2.MachineRunning, v1alpha2.MachineStopped:
 		// If the snapshotting condition is not found, it means that the vm is ready for snapshotting.

--- a/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/virtual_machine_ready.go
+++ b/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/virtual_machine_ready.go
@@ -21,8 +21,11 @@ import (
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	virtv1 "kubevirt.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/deckhouse/virtualization-controller/pkg/common/object"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmcondition"
@@ -35,11 +38,13 @@ type VirtualMachineReadySnapshotter interface {
 
 type VirtualMachineReadyHandler struct {
 	snapshotter VirtualMachineReadySnapshotter
+	client      client.Client
 }
 
-func NewVirtualMachineReadyHandler(snapshotter VirtualMachineReadySnapshotter) *VirtualMachineReadyHandler {
+func NewVirtualMachineReadyHandler(snapshotter VirtualMachineReadySnapshotter, client client.Client) *VirtualMachineReadyHandler {
 	return &VirtualMachineReadyHandler{
 		snapshotter: snapshotter,
+		client:      client,
 	}
 }
 
@@ -84,6 +89,21 @@ func (h VirtualMachineReadyHandler) Handle(ctx context.Context, vmSnapshot *v1al
 
 	_, migratingConditionExists := conditions.GetCondition(vmcondition.TypeMigrating, vm.Status.Conditions)
 	if migratingConditionExists {
+		cb.
+			Status(metav1.ConditionFalse).
+			Reason(vmscondition.VirtualMachineNotReadyForSnapshotting).
+			Message("Snapshot cannot be taken: the virtual machine is currently migrating.")
+		return reconcile.Result{}, nil
+	}
+
+	kvvmi, err := object.FetchObject(ctx, client.ObjectKeyFromObject(vm), h.client, &virtv1.VirtualMachineInstance{})
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if kvvmi != nil && kvvmi.Status.MigrationState != nil &&
+		kvvmi.Status.MigrationState.StartTimestamp != nil &&
+		kvvmi.Status.MigrationState.EndTimestamp == nil {
 		cb.
 			Status(metav1.ConditionFalse).
 			Reason(vmscondition.VirtualMachineNotReadyForSnapshotting).

--- a/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/virtual_machine_ready.go
+++ b/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/virtual_machine_ready.go
@@ -87,7 +87,7 @@ func (h VirtualMachineReadyHandler) Handle(ctx context.Context, vmSnapshot *v1al
 		cb.
 			Status(metav1.ConditionFalse).
 			Reason(vmscondition.VirtualMachineNotReadyForSnapshotting).
-			Message("The virtual machine is migrating at the moment, so a snapshot cannot be taken.")
+			Message("Snapshot cannot be taken: the virtual machine is currently migrating.")
 		return reconcile.Result{}, nil
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vmsnapshot/vmsnapshot_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vmsnapshot/vmsnapshot_controller.go
@@ -51,7 +51,7 @@ func NewController(
 
 	reconciler := NewReconciler(
 		mgr.GetClient(),
-		internal.NewVirtualMachineReadyHandler(snapshotter),
+		internal.NewVirtualMachineReadyHandler(snapshotter, mgr.GetClient()),
 		internal.NewLifeCycleHandler(recorder, snapshotter, restorer.NewSecretRestorer(mgr.GetClient()), mgr.GetClient()),
 		internal.NewEnsureValidityHandler(),
 	)


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Block migration during snapshotting, and block snapshotting while migration is in progress.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
The combination of migration and snapshot creation caused issues with file system freeze and unfreeze operations.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
Stable working system.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

