### PR TITLE
 fix(dra): handle parent watcher channel close in wrapWatcher

### DIFF
--- a/images/virtualization-dra/internal/plugin/wrapresourceslice/watcher.go
+++ b/images/virtualization-dra/internal/plugin/wrapresourceslice/watcher.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 )
 
-func newWrapWatcher(ctx context.Context, w watch.Interface, match func(event watch.Event) bool) watch.Interface {
+func newWrapWatcher(ctx context.Context, w watch.Interface, match func(event watch.Event) bool) *wrapWatcher {
 	ctx, cancel := context.WithCancel(ctx)
 
 	watcher := &wrapWatcher{
@@ -31,6 +31,7 @@ func newWrapWatcher(ctx context.Context, w watch.Interface, match func(event wat
 		ctx:     ctx,
 		cancel:  cancel,
 		result:  make(chan watch.Event),
+		done:    make(chan struct{}),
 	}
 	go watcher.receive(ctx)
 
@@ -44,17 +45,27 @@ type wrapWatcher struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 	result chan watch.Event
+	done   chan struct{}
 }
 
 func (w *wrapWatcher) receive(ctx context.Context) {
+	defer close(w.result)
+	defer close(w.done)
 	resultChan := w.watcher.ResultChan()
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case event := <-resultChan:
+		case event, ok := <-resultChan:
+			if !ok {
+				return
+			}
 			if w.match == nil || w.match(event) {
-				w.result <- event
+				select {
+				case <-ctx.Done():
+					return
+				case w.result <- event:
+				}
 			}
 		}
 	}
@@ -71,4 +82,5 @@ func (w *wrapWatcher) Stop() {
 		w.watcher.Stop()
 		w.cancel()
 	}
+	<-w.done
 }

--- a/images/virtualization-dra/internal/usb/store.go
+++ b/images/virtualization-dra/internal/usb/store.go
@@ -426,10 +426,6 @@ func (s *AllocationStore) Unprepare(_ context.Context, claimUID types.UID) error
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if err := s.cdi.DeleteClaimSpecFile(string(claimUID)); err != nil {
-		return fmt.Errorf("unable to delete CDI spec file for claim: %w", err)
-	}
-
 	usbGatewayEnabled := featuregates.Default().USBGatewayEnabled()
 
 	allocatedDevices := s.resourceClaimAllocations[claimUID]
@@ -447,6 +443,11 @@ func (s *AllocationStore) Unprepare(_ context.Context, claimUID types.UID) error
 
 		s.allocatedDevices.Delete(device)
 	}
+
+	if err := s.cdi.DeleteClaimSpecFile(string(claimUID)); err != nil {
+		return fmt.Errorf("unable to delete CDI spec file for claim: %w", err)
+	}
+
 	delete(s.resourceClaimAllocations, claimUID)
 
 	return nil
@@ -526,7 +527,7 @@ func (s *AllocationStore) makeResources(devicesByName map[string]Device) resourc
 		return resourceslice.DriverResources{}
 	}
 
-	devices := make([]resourcev1.Device, len(devicesByName))
+	devices := make([]resourcev1.Device, 0, len(devicesByName))
 	for _, usbDevice := range devicesByName {
 		devices = append(devices, *usbDevice.ToAPIDevice(s.nodeName))
 	}


### PR DESCRIPTION
## Description

Fix `wrapWatcher` in the virtualization-dra plugin so that it correctly reacts when the parent watcher closes its `ResultChan()`. Previously the wrapper did not check the closed state of the parent channel, so events stopped being delivered and the cache stopped updating.

Changes:
- Check `ok` when reading from the parent's `ResultChan()`; when the channel is closed (`ok == false`), exit the receive loop and close the wrapper's channels.
- Add a `done` channel that is closed when the receive goroutine exits; close both `result` and `done` in `receive()` via defer.
- In `Stop()`, wait for `<-w.done` so that the receive goroutine fully exits before `Stop()` returns.
- When sending to `w.result`, use a select with `ctx.Done()` to avoid blocking if the consumer has stopped reading.
- Change `newWrapWatcher` return type to `*wrapWatcher` so callers can use the concrete type (e.g. for proper `Stop()` semantics).

## Why do we need it, and what problem does it solve?

When the parent watcher closes its result channel (e.g. on reconnect, apiserver disconnect, or explicit stop), the wrapper was not detecting it. The code used `event := <-resultChan` without the second `ok` value, so after the parent closed the channel the wrapper could either receive only zero-value events or block indefinitely. As a result:

- The wrapper's `result` channel was never closed.
- Consumers (including cache/listwatch logic) did not see the stream as finished and did not refresh or resync.
- The cache could become stale and not receive new events after the parent watcher was replaced or closed.

The fix ensures that when the parent closes its channel, the wrapper closes its own channels, so consumers are notified and can react (e.g. relist or re-establish the watch), keeping the cache in sync.

## What is the expected result?

- When the parent watcher closes `ResultChan()`, the wrapper's `ResultChan()` is closed as well.
- Consumers detect the closed channel and can relist or re-watch as needed.
- The cache is updated correctly after reconnects or parent watcher restarts.
- `Stop()` waits for the receive goroutine to finish, so there are no goroutine leaks and cleanup order is predictable.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->