### PR TITLE
fix(vd): use requested size for PVC generated from snapshot when available

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/step/create_pvc_from_vdsnapshot_step.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/step/create_pvc_from_vdsnapshot_step.go
@@ -182,7 +182,13 @@ func (s CreatePVCFromVDSnapshotStep) buildPVC(vd *v1alpha2.VirtualDisk, vs *vsv1
 		spec.VolumeMode = ptr.To(corev1.PersistentVolumeMode(volumeMode))
 	}
 
-	if vs.Status != nil && vs.Status.RestoreSize != nil {
+	if vd.Spec.PersistentVolumeClaim.Size != nil {
+		spec.Resources = corev1.VolumeResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceStorage: *vd.Spec.PersistentVolumeClaim.Size,
+			},
+		}
+	} else if vs.Status != nil && vs.Status.RestoreSize != nil {
 		spec.Resources = corev1.VolumeResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceStorage: *vs.Status.RestoreSize,


### PR DESCRIPTION
Fixes an issue when restoring a snapshot on NFS CSI results in tiny PVC instead of original size.

## Description
When restoring a VirtualDisk from a VDSnapshot on NFS CSI, the PVC was created with an incorrect (tiny) size instead of the requested size from `vd.Spec.PersistentVolumeClaim.Size`.

The fix checks for `vd.Spec.PersistentVolumeClaim.Size` first and uses it for PVC creation. Falls back to `vs.Status.RestoreSize` only if size is not explicitly specified in the VirtualDisk spec.

## Why do we need it, and what problem does it solve?
On NFS CSI, restoring a snapshot resulted in a PVC with an incorrect size (likely 0 or minimal size), causing VM boot failures. This fix ensures the PVC is created with the explicitly requested size when available.

## What is the expected result?
1. Create a VirtualDisk with explicit `persistentVolumeClaim.size`
2. Create a VDSnapshot from that disk
3. Restore a new VirtualDisk from the snapshot
4. Verify the restored PVC has the requested size, not the tiny restore size

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: core
type: fix
summary: "Use requested size for PVC generated from VDSnapshot when available."
```