### PR TITLE
feat(vm): hotplug cpu (phase 1)

### DIFF
--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -3,7 +3,7 @@ firmware:
   libvirt: v10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: dvp/set-memory-limits-while-hotplugging
+  3p-kubevirt: dvp/hotplug-cpu-prefer-cores-over-sockets
   3p-containerized-data-importer: v1.60.3-v12n.17
   distribution: 2.8.3
 package:

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
@@ -433,7 +433,7 @@ func GetCPUFraction(cpuFraction string) (int, error) {
 	fraction := intstr.FromString(cpuFraction)
 	value, _, err := getIntOrPercentValueSafely(&fraction)
 	if err != nil {
-		return 0, fmt.Errorf("invalid value for cpu fraction: %v", err)
+		return 0, fmt.Errorf("invalid value for cpu fraction: %w", err)
 	}
 	return value, nil
 }
@@ -443,19 +443,17 @@ func getIntOrPercentValueSafely(intOrStr *intstr.IntOrString) (int, bool, error)
 	case intstr.Int:
 		return intOrStr.IntValue(), false, nil
 	case intstr.String:
-		isPercent := false
 		s := intOrStr.StrVal
-		if strings.HasSuffix(s, "%") {
-			isPercent = true
-			s = strings.TrimSuffix(intOrStr.StrVal, "%")
-		} else {
+		if !strings.HasSuffix(s, "%") {
 			return 0, false, fmt.Errorf("invalid type: string is not a percentage")
 		}
+		s = strings.TrimSuffix(intOrStr.StrVal, "%")
+
 		v, err := strconv.Atoi(s)
 		if err != nil {
-			return 0, false, fmt.Errorf("invalid value %q: %v", intOrStr.StrVal, err)
+			return 0, false, fmt.Errorf("invalid value %q: %w", intOrStr.StrVal, err)
 		}
-		return int(v), isPercent, nil
+		return v, true, nil
 	}
 	return 0, false, fmt.Errorf("invalid type: neither int nor percentage")
 }

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
@@ -338,7 +338,7 @@ func (b *KVVM) setCPUHotpluggable(cores int, coreFraction string) error {
 func (b *KVVM) SetMemory(memorySize resource.Quantity) {
 	// Support for VMs started with memory size in requests-limits.
 	// TODO delete this in the future (around 3-4 more versions after enabling memory hotplug by default).
-	if b.ResourceExists && isVMRunningWithMemoryResources(b.Resource) {
+	if b.ResourceExists && shouldKeepMemoryNonHotpluggable(b.Resource) {
 		b.setMemoryNonHotpluggable(memorySize)
 		return
 	}
@@ -410,20 +410,23 @@ func isVMRunningWithCPUResources(kvvm *virtv1.VirtualMachine) bool {
 	return hasCPURequests && hasCPULimits
 }
 
-func isVMRunningWithMemoryResources(kvvm *virtv1.VirtualMachine) bool {
+func shouldKeepMemoryNonHotpluggable(kvvm *virtv1.VirtualMachine) bool {
 	if kvvm == nil {
 		return false
 	}
 
-	if kvvm.Status.PrintableStatus != virtv1.VirtualMachineStatusRunning {
-		return false
+	if kvvm.Status.PrintableStatus == virtv1.VirtualMachineStatusRunning || kvvm.Status.PrintableStatus == virtv1.VirtualMachineStatusMigrating {
+		// Running or Migrating machines with memory resources should keep as non-hotpluggable.
+		// Machines without memory resources should proceed as hotpluggable.
+		res := kvvm.Spec.Template.Spec.Domain.Resources
+		_, hasMemoryRequests := res.Requests[corev1.ResourceMemory]
+		_, hasMemoryLimits := res.Limits[corev1.ResourceMemory]
+
+		return hasMemoryRequests && hasMemoryLimits
 	}
 
-	res := kvvm.Spec.Template.Spec.Domain.Resources
-	_, hasMemoryRequests := res.Requests[corev1.ResourceMemory]
-	_, hasMemoryLimits := res.Limits[corev1.ResourceMemory]
-
-	return hasMemoryRequests && hasMemoryLimits
+	// Proceed as hotpluggable if machine is not Running or Migrating.
+	return false
 }
 
 func GetCPUFraction(cpuFraction string) (int, error) {

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
@@ -259,34 +259,52 @@ func (b *KVVM) SetTopologySpreadConstraint(topology []corev1.TopologySpreadConst
 }
 
 func (b *KVVM) SetCPU(cores int, coreFraction string) error {
+	// Support for VMs started with cpu configuration in requests-limits.
+	// TODO delete this in the future (around 3-4 more versions after enabling cpu hotplug by default).
+	if b.ResourceExists && isVMRunningWithCPUResources(b.Resource) {
+		return b.setCPUNonHotpluggable(cores, coreFraction)
+	}
+	return b.setCPUHotpluggable(cores, coreFraction)
+}
+
+// setCPUNonHotpluggable translates cpu configuration to requests and limit in KVVM.
+// Note: this is a first implementation, cpu hotplug is not compatible with this strategy.
+func (b *KVVM) setCPUNonHotpluggable(cores int, coreFraction string) error {
 	domainSpec := &b.Resource.Spec.Template.Spec.Domain
 	if domainSpec.CPU == nil {
 		domainSpec.CPU = &virtv1.CPU{}
 	}
+	cpuRequest, err := GetCPURequest(cores, coreFraction)
+	if err != nil {
+		return err
+	}
 
-	// TODO delete this in the future (around 3-4 more versions after enabling cpu hotplug by default).
-	if b.ResourceExists && isVMRunningWithCPUResources(b.Resource) {
-		cpuRequest, err := GetCPURequest(cores, coreFraction)
-		if err != nil {
-			return err
-		}
+	cpuLimit := GetCPULimit(cores)
+	if domainSpec.Resources.Requests == nil {
+		domainSpec.Resources.Requests = make(map[corev1.ResourceName]resource.Quantity)
+	}
+	if domainSpec.Resources.Limits == nil {
+		domainSpec.Resources.Limits = make(map[corev1.ResourceName]resource.Quantity)
+	}
+	domainSpec.Resources.Requests[corev1.ResourceCPU] = *cpuRequest
+	domainSpec.Resources.Limits[corev1.ResourceCPU] = *cpuLimit
 
-		cpuLimit := GetCPULimit(cores)
-		if domainSpec.Resources.Requests == nil {
-			domainSpec.Resources.Requests = make(map[corev1.ResourceName]resource.Quantity)
-		}
-		if domainSpec.Resources.Limits == nil {
-			domainSpec.Resources.Limits = make(map[corev1.ResourceName]resource.Quantity)
-		}
-		domainSpec.Resources.Requests[corev1.ResourceCPU] = *cpuRequest
-		domainSpec.Resources.Limits[corev1.ResourceCPU] = *cpuLimit
+	socketsNeeded, coresNeeded := vm.CalculateCoresAndSockets(cores)
 
-		socketsNeeded, coresNeeded := vm.CalculateCoresAndSockets(cores)
+	domainSpec.CPU.Cores = uint32(coresNeeded)
+	domainSpec.CPU.Sockets = uint32(socketsNeeded)
+	domainSpec.CPU.MaxSockets = uint32(socketsNeeded)
+	return nil
+}
 
-		domainSpec.CPU.Cores = uint32(coresNeeded)
-		domainSpec.CPU.Sockets = uint32(socketsNeeded)
-		domainSpec.CPU.MaxSockets = uint32(socketsNeeded)
-		return nil
+// setCPUHotpluggable translates cpu configuration to settings in domain.cpu field.
+// This field is compatible with memory hotplug.
+// Also, remove requests-limits for memory if any.
+// Note: we swap cores and sockets to bypass vm-validation webhook.
+func (b *KVVM) setCPUHotpluggable(cores int, coreFraction string) error {
+	domainSpec := &b.Resource.Spec.Template.Spec.Domain
+	if domainSpec.CPU == nil {
+		domainSpec.CPU = &virtv1.CPU{}
 	}
 
 	fraction, err := GetCPUFraction(coreFraction)
@@ -295,10 +313,10 @@ func (b *KVVM) SetCPU(cores int, coreFraction string) error {
 	}
 	b.SetKVVMIAnnotation(CPUResourcesRequestsFractionAnnotation, strconv.Itoa(fraction))
 
+	socketsNeeded, coresPerSocketNeeded := vm.CalculateCoresAndSockets(cores)
 	// Use "dynamic cores" hotplug strategy.
 	// Workaround: swap cores and sockets in domainSpec to bypass vm-validator webhook.
 	b.SetKVVMIAnnotation(VCPUTopologyDynamicCoresAnnotation, "")
-	socketsNeeded, coresPerSocketNeeded := vm.CalculateCoresAndSockets(cores)
 	domainSpec.CPU.Cores = uint32(socketsNeeded)
 	domainSpec.CPU.Sockets = uint32(coresPerSocketNeeded)
 	domainSpec.CPU.MaxSockets = CPUMaxCoresPerSocket

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
@@ -264,34 +264,50 @@ func (b *KVVM) SetCPU(cores int, coreFraction string) error {
 		domainSpec.CPU = &virtv1.CPU{}
 	}
 
+	// TODO delete this in the future (around 3-4 more versions after enabling cpu hotplug by default).
+	if b.ResourceExists && isVMRunningWithCPUResources(b.Resource) {
+		cpuRequest, err := GetCPURequest(cores, coreFraction)
+		if err != nil {
+			return err
+		}
+
+		cpuLimit := GetCPULimit(cores)
+		if domainSpec.Resources.Requests == nil {
+			domainSpec.Resources.Requests = make(map[corev1.ResourceName]resource.Quantity)
+		}
+		if domainSpec.Resources.Limits == nil {
+			domainSpec.Resources.Limits = make(map[corev1.ResourceName]resource.Quantity)
+		}
+		domainSpec.Resources.Requests[corev1.ResourceCPU] = *cpuRequest
+		domainSpec.Resources.Limits[corev1.ResourceCPU] = *cpuLimit
+
+		socketsNeeded, coresNeeded := vm.CalculateCoresAndSockets(cores)
+
+		domainSpec.CPU.Cores = uint32(coresNeeded)
+		domainSpec.CPU.Sockets = uint32(socketsNeeded)
+		domainSpec.CPU.MaxSockets = uint32(socketsNeeded)
+		return nil
+	}
+
 	fraction, err := GetCPUFraction(coreFraction)
 	if err != nil {
 		return err
 	}
 	b.SetKVVMIAnnotation(CPUResourcesRequestsFractionAnnotation, strconv.Itoa(fraction))
 
-	//cpuRequest, err := GetCPURequest(cores, coreFraction)
-	//if err != nil {
-	//	return err
-	//}
-	//cpuLimit := GetCPULimit(cores)
-	//if domainSpec.Resources.Requests == nil {
-	//	domainSpec.Resources.Requests = make(map[corev1.ResourceName]resource.Quantity)
-	//}
-	//if domainSpec.Resources.Limits == nil {
-	//	domainSpec.Resources.Limits = make(map[corev1.ResourceName]resource.Quantity)
-	//}
-	//domainSpec.Resources.Requests[corev1.ResourceCPU] = *cpuRequest
-	//domainSpec.Resources.Limits[corev1.ResourceCPU] = *cpuLimit
-
-	socketsNeeded, coresPerSocketNeeded := vm.CalculateCoresAndSockets(cores)
-
 	// Use "dynamic cores" hotplug strategy.
 	// Workaround: swap cores and sockets in domainSpec to bypass vm-validator webhook.
 	b.SetKVVMIAnnotation(VCPUTopologyDynamicCoresAnnotation, "")
+	socketsNeeded, coresPerSocketNeeded := vm.CalculateCoresAndSockets(cores)
 	domainSpec.CPU.Cores = uint32(socketsNeeded)
 	domainSpec.CPU.Sockets = uint32(coresPerSocketNeeded)
 	domainSpec.CPU.MaxSockets = CPUMaxCoresPerSocket
+
+	// Remove CPU limits and requests if set by previous implementation.
+	res := &b.Resource.Spec.Template.Spec.Domain.Resources
+	delete(res.Requests, corev1.ResourceCPU)
+	delete(res.Limits, corev1.ResourceCPU)
+
 	return nil
 }
 
@@ -358,6 +374,22 @@ func (b *KVVM) setMemoryHotpluggable(memorySize resource.Quantity) {
 	res := &b.Resource.Spec.Template.Spec.Domain.Resources
 	delete(res.Requests, corev1.ResourceMemory)
 	delete(res.Limits, corev1.ResourceMemory)
+}
+
+func isVMRunningWithCPUResources(kvvm *virtv1.VirtualMachine) bool {
+	if kvvm == nil {
+		return false
+	}
+
+	if kvvm.Status.PrintableStatus != virtv1.VirtualMachineStatusRunning {
+		return false
+	}
+
+	res := kvvm.Spec.Template.Spec.Domain.Resources
+	_, hasCPURequests := res.Requests[corev1.ResourceCPU]
+	_, hasCPULimits := res.Limits[corev1.ResourceCPU]
+
+	return hasCPURequests && hasCPULimits
 }
 
 func isVMRunningWithMemoryResources(kvvm *virtv1.VirtualMachine) bool {

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"strconv"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -50,6 +52,16 @@ const (
 
 	MaxMemorySizeForHotplug      = 256 * 1024 * 1024 * 1024 // 256 Gi (safely limit to not overlap somewhat conservative 38 bit physical address space)
 	EnableMemoryHotplugThreshold = 1 * 1024 * 1024 * 1024   // 1 Gi (no hotplug for VMs with less than 1Gi)
+)
+
+const (
+	// VCPUTopologyDynamicCoresAnnotation annotation indicates "distributed by sockets" or "dynamic cores number" VCPU topology.
+	VCPUTopologyDynamicCoresAnnotation = "internal.virtualization.deckhouse.io/vcpu-topology-dynamic-cores"
+
+	CPUResourcesRequestsFractionAnnotation = "internal.virtualization.deckhouse.io/cpu-resources-requests-fraction"
+
+	// CPUMaxCoresPerSocket is a maximum number of cores per socket.
+	CPUMaxCoresPerSocket = 16
 )
 
 type KVVMOptions struct {
@@ -251,25 +263,35 @@ func (b *KVVM) SetCPU(cores int, coreFraction string) error {
 	if domainSpec.CPU == nil {
 		domainSpec.CPU = &virtv1.CPU{}
 	}
-	cpuRequest, err := GetCPURequest(cores, coreFraction)
+
+	fraction, err := GetCPUFraction(coreFraction)
 	if err != nil {
 		return err
 	}
-	cpuLimit := GetCPULimit(cores)
-	if domainSpec.Resources.Requests == nil {
-		domainSpec.Resources.Requests = make(map[corev1.ResourceName]resource.Quantity)
-	}
-	if domainSpec.Resources.Limits == nil {
-		domainSpec.Resources.Limits = make(map[corev1.ResourceName]resource.Quantity)
-	}
-	domainSpec.Resources.Requests[corev1.ResourceCPU] = *cpuRequest
-	domainSpec.Resources.Limits[corev1.ResourceCPU] = *cpuLimit
+	b.SetKVVMIAnnotation(CPUResourcesRequestsFractionAnnotation, strconv.Itoa(fraction))
 
-	socketsNeeded, coresNeeded := vm.CalculateCoresAndSockets(cores)
+	//cpuRequest, err := GetCPURequest(cores, coreFraction)
+	//if err != nil {
+	//	return err
+	//}
+	//cpuLimit := GetCPULimit(cores)
+	//if domainSpec.Resources.Requests == nil {
+	//	domainSpec.Resources.Requests = make(map[corev1.ResourceName]resource.Quantity)
+	//}
+	//if domainSpec.Resources.Limits == nil {
+	//	domainSpec.Resources.Limits = make(map[corev1.ResourceName]resource.Quantity)
+	//}
+	//domainSpec.Resources.Requests[corev1.ResourceCPU] = *cpuRequest
+	//domainSpec.Resources.Limits[corev1.ResourceCPU] = *cpuLimit
 
-	domainSpec.CPU.Cores = uint32(coresNeeded)
-	domainSpec.CPU.Sockets = uint32(socketsNeeded)
-	domainSpec.CPU.MaxSockets = uint32(socketsNeeded)
+	socketsNeeded, coresPerSocketNeeded := vm.CalculateCoresAndSockets(cores)
+
+	// Use "dynamic cores" hotplug strategy.
+	// Workaround: swap cores and sockets in domainSpec to bypass vm-validator webhook.
+	b.SetKVVMIAnnotation(VCPUTopologyDynamicCoresAnnotation, "")
+	domainSpec.CPU.Cores = uint32(socketsNeeded)
+	domainSpec.CPU.Sockets = uint32(coresPerSocketNeeded)
+	domainSpec.CPU.MaxSockets = CPUMaxCoresPerSocket
 	return nil
 }
 
@@ -352,6 +374,40 @@ func isVMRunningWithMemoryResources(kvvm *virtv1.VirtualMachine) bool {
 	_, hasMemoryLimits := res.Limits[corev1.ResourceMemory]
 
 	return hasMemoryRequests && hasMemoryLimits
+}
+
+func GetCPUFraction(cpuFraction string) (int, error) {
+	if cpuFraction == "" {
+		return 100, nil
+	}
+	fraction := intstr.FromString(cpuFraction)
+	value, _, err := getIntOrPercentValueSafely(&fraction)
+	if err != nil {
+		return 0, fmt.Errorf("invalid value for cpu fraction: %v", err)
+	}
+	return value, nil
+}
+
+func getIntOrPercentValueSafely(intOrStr *intstr.IntOrString) (int, bool, error) {
+	switch intOrStr.Type {
+	case intstr.Int:
+		return intOrStr.IntValue(), false, nil
+	case intstr.String:
+		isPercent := false
+		s := intOrStr.StrVal
+		if strings.HasSuffix(s, "%") {
+			isPercent = true
+			s = strings.TrimSuffix(intOrStr.StrVal, "%")
+		} else {
+			return 0, false, fmt.Errorf("invalid type: string is not a percentage")
+		}
+		v, err := strconv.Atoi(s)
+		if err != nil {
+			return 0, false, fmt.Errorf("invalid value %q: %v", intOrStr.StrVal, err)
+		}
+		return int(v), isPercent, nil
+	}
+	return 0, false, fmt.Errorf("invalid type: neither int nor percentage")
 }
 
 func GetCPURequest(cores int, coreFraction string) (*resource.Quantity, error) {

--- a/images/virtualization-artifact/pkg/controller/vm/internal/statistic.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/statistic.go
@@ -18,6 +18,7 @@ package internal
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"strconv"
 	"time"
@@ -30,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/deckhouse/virtualization-controller/pkg/common/vm"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/kvbuilder"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vm/internal/state"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
@@ -68,7 +70,9 @@ func (h *StatisticHandler) Handle(ctx context.Context, s state.VirtualMachineSta
 	}
 	h.syncPods(changed, pod, pods)
 
-	h.syncResources(changed, kvvmi, pod)
+	if err := h.syncResources(changed, kvvmi, pod); err != nil {
+		return reconcile.Result{}, err
+	}
 
 	return reconcile.Result{}, nil
 }
@@ -80,15 +84,15 @@ func (h *StatisticHandler) Name() string {
 func (h *StatisticHandler) syncResources(changed *v1alpha2.VirtualMachine,
 	kvvmi *virtv1.VirtualMachineInstance,
 	pod *corev1.Pod,
-) {
+) error {
 	if changed == nil {
-		return
+		return nil
 	}
 	var resources v1alpha2.ResourcesStatus
 	switch pod {
 	case nil:
 		var (
-			cpuKVVMIRequest resource.Quantity
+			cpuKVVMIRequest *resource.Quantity
 			memorySize      resource.Quantity
 			topology        v1alpha2.Topology
 			coreFraction    string
@@ -99,7 +103,13 @@ func (h *StatisticHandler) syncResources(changed *v1alpha2.VirtualMachine,
 			topology = v1alpha2.Topology{CoresPerSocket: coresPerSocket, Sockets: sockets}
 			coreFraction = changed.Spec.CPU.CoreFraction
 		} else {
-			cpuKVVMIRequest = kvvmi.Spec.Domain.Resources.Requests[corev1.ResourceCPU]
+			//if kvvmi.Annotations[kvbuilder.CPUResourcesRequestsFractionAnnotation]
+			//cpuKVVMIRequest = kvvmi.Spec.Domain.Resources.Requests[corev1.ResourceCPU]
+			var err error
+			cpuKVVMIRequest, err = h.getCoresRequestedByKVVMI(kvvmi)
+			if err != nil {
+				return err
+			}
 			memorySize = kvvmi.Spec.Domain.Resources.Requests[corev1.ResourceMemory]
 
 			coreFraction = h.getCoreFractionByKVVMI(kvvmi)
@@ -107,18 +117,21 @@ func (h *StatisticHandler) syncResources(changed *v1alpha2.VirtualMachine,
 		}
 		resources = v1alpha2.ResourcesStatus{
 			CPU: v1alpha2.CPUStatus{
-				Cores:          topology.CoresPerSocket * topology.Sockets,
-				CoreFraction:   coreFraction,
-				RequestedCores: cpuKVVMIRequest,
-				Topology:       topology,
+				Cores:        topology.CoresPerSocket * topology.Sockets,
+				CoreFraction: coreFraction,
+				Topology:     topology,
 			},
 			Memory: v1alpha2.MemoryStatus{
 				Size: memorySize,
 			},
 		}
+		if cpuKVVMIRequest != nil {
+			resources.CPU.RequestedCores = *cpuKVVMIRequest
+		}
+
 	default:
 		if kvvmi == nil {
-			return
+			return nil
 		}
 		var ctr corev1.Container
 		for _, container := range pod.Spec.Containers {
@@ -127,15 +140,18 @@ func (h *StatisticHandler) syncResources(changed *v1alpha2.VirtualMachine,
 			}
 		}
 
-		cpuKVVMIRequest := kvvmi.Spec.Domain.Resources.Requests[corev1.ResourceCPU]
+		coreFraction := h.getCoreFractionByKVVMI(kvvmi)
+		topology := h.getCurrentTopologyByKVVMI(kvvmi)
+		cores := topology.CoresPerSocket * topology.Sockets
+
+		cpuFractionRequests, err := h.getCoresRequestedByKVVMI(kvvmi)
+		if err != nil {
+			return fmt.Errorf("get core fraction by kvvmi: %w", err)
+		}
 		cpuPODRequest := ctr.Resources.Requests[corev1.ResourceCPU]
 
 		cpuOverhead := cpuPODRequest.DeepCopy()
-		cpuOverhead.Sub(cpuKVVMIRequest)
-
-		cores := h.getCoresByKVVMI(kvvmi)
-		coreFraction := h.getCoreFractionByKVVMI(kvvmi)
-		topology := h.getCurrentTopologyByKVVMI(kvvmi)
+		cpuOverhead.Sub(*cpuFractionRequests)
 
 		memoryKVVMIRequest := kvvmi.Spec.Domain.Resources.Requests[corev1.ResourceMemory]
 		memoryPodRequest := ctr.Resources.Requests[corev1.ResourceMemory]
@@ -149,7 +165,7 @@ func (h *StatisticHandler) syncResources(changed *v1alpha2.VirtualMachine,
 			CPU: v1alpha2.CPUStatus{
 				Cores:           cores,
 				CoreFraction:    coreFraction,
-				RequestedCores:  cpuKVVMIRequest,
+				RequestedCores:  *cpuFractionRequests,
 				RuntimeOverhead: cpuOverhead,
 				Topology:        topology,
 			},
@@ -160,6 +176,7 @@ func (h *StatisticHandler) syncResources(changed *v1alpha2.VirtualMachine,
 		}
 	}
 	changed.Status.Resources = resources
+	return nil
 }
 
 // getCoresByKVVMI
@@ -182,7 +199,7 @@ func (h *StatisticHandler) getCoreFractionByKVVMI(kvvmi *virtv1.VirtualMachineIn
 		return ""
 	}
 	// Fraction is stored in annotation after enabling CPU hotplug.
-	cpuFractionStr, hasAnno := kvvmi.Annotations[""]
+	cpuFractionStr, hasAnno := kvvmi.Annotations[kvbuilder.CPUResourcesRequestsFractionAnnotation]
 	if hasAnno {
 		return cpuFractionStr + "%"
 	}
@@ -191,26 +208,78 @@ func (h *StatisticHandler) getCoreFractionByKVVMI(kvvmi *virtv1.VirtualMachineIn
 	return strconv.Itoa(int(cpuKVVMIRequest.MilliValue())*100/(h.getCoresByKVVMI(kvvmi)*1000)) + "%"
 }
 
+func (h *StatisticHandler) getCoresRequestedByKVVMI(kvvmi *virtv1.VirtualMachineInstance) (*resource.Quantity, error) {
+	if kvvmi == nil {
+		return nil, nil
+	}
+	// Fraction is stored in annotation after enabling CPU hotplug.
+	cpuFractionStr, hasAnno := kvvmi.Annotations[kvbuilder.CPUResourcesRequestsFractionAnnotation]
+	if hasAnno {
+		if kvvmi.Spec.Domain.CPU == nil {
+			return nil, fmt.Errorf("enabled dynamic cores with annotation %s, but missing spec.domain.cpu", kvbuilder.CPUResourcesRequestsFractionAnnotation)
+		}
+		cores := kvvmi.Spec.Domain.CPU.Cores * kvvmi.Spec.Domain.CPU.Sockets
+
+		cpuFraction, err := strconv.Atoi(cpuFractionStr)
+		if err != nil {
+			return nil, err
+		}
+
+		if cpuFraction <= 0 || cpuFraction > 100 {
+			cpuFraction = 100
+		}
+		if cpuFraction == 100 {
+			return resource.NewQuantity(int64(cores), resource.DecimalSI), nil
+		}
+
+		// Use multiplier to calculate fraction of millis.
+		requested := cores * 1000
+		// Round up, to always return integer number of millis.
+		value := int64(math.Ceil(float64(cpuFraction) * (float64(requested)) / 100))
+		return resource.NewMilliQuantity(value, resource.DecimalSI), nil
+	}
+
+	// Also support previous implementation: return cpu requests if set.
+	if reqCPU, hasCPURequests := kvvmi.Spec.Domain.Resources.Requests[corev1.ResourceCPU]; hasCPURequests {
+		return &reqCPU, nil
+	}
+
+	return nil, nil
+}
+
 func (h *StatisticHandler) getCurrentTopologyByKVVMI(kvvmi *virtv1.VirtualMachineInstance) v1alpha2.Topology {
 	if kvvmi == nil {
 		return v1alpha2.Topology{}
 	}
 
+	cores := -1
+	sockets := -1
+
 	if kvvmi.Status.CurrentCPUTopology != nil {
-		return v1alpha2.Topology{
-			CoresPerSocket: int(kvvmi.Status.CurrentCPUTopology.Cores),
-			Sockets:        int(kvvmi.Status.CurrentCPUTopology.Sockets),
-		}
+		cores = int(kvvmi.Status.CurrentCPUTopology.Cores)
+		sockets = int(kvvmi.Status.CurrentCPUTopology.Sockets)
 	}
 
 	if kvvmi.Spec.Domain.CPU != nil {
+		cores = int(kvvmi.Spec.Domain.CPU.Cores)
+		sockets = int(kvvmi.Spec.Domain.CPU.Sockets)
+	}
+
+	if _, isDynamicCores := kvvmi.Annotations[kvbuilder.VCPUTopologyDynamicCoresAnnotation]; isDynamicCores {
+		// Swap cores and sockets.
+		tmp := cores
+		cores = sockets
+		sockets = tmp
+	}
+
+	if cores > 0 && sockets > 0 {
 		return v1alpha2.Topology{
-			CoresPerSocket: int(kvvmi.Spec.Domain.CPU.Cores),
-			Sockets:        int(kvvmi.Spec.Domain.CPU.Sockets),
+			CoresPerSocket: cores,
+			Sockets:        sockets,
 		}
 	}
 
-	cores := h.getCoresByKVVMI(kvvmi)
+	cores = h.getCoresByKVVMI(kvvmi)
 	sockets, coresPerSocket := vm.CalculateCoresAndSockets(cores)
 	return v1alpha2.Topology{CoresPerSocket: coresPerSocket, Sockets: sockets}
 }

--- a/images/virtualization-artifact/pkg/controller/vm/internal/statistic.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/statistic.go
@@ -103,8 +103,6 @@ func (h *StatisticHandler) syncResources(changed *v1alpha2.VirtualMachine,
 			topology = v1alpha2.Topology{CoresPerSocket: coresPerSocket, Sockets: sockets}
 			coreFraction = changed.Spec.CPU.CoreFraction
 		} else {
-			//if kvvmi.Annotations[kvbuilder.CPUResourcesRequestsFractionAnnotation]
-			//cpuKVVMIRequest = kvvmi.Spec.Domain.Resources.Requests[corev1.ResourceCPU]
 			var err error
 			cpuKVVMIRequest, err = h.getCoresRequestedByKVVMI(kvvmi)
 			if err != nil {
@@ -267,9 +265,7 @@ func (h *StatisticHandler) getCurrentTopologyByKVVMI(kvvmi *virtv1.VirtualMachin
 
 	if _, isDynamicCores := kvvmi.Annotations[kvbuilder.VCPUTopologyDynamicCoresAnnotation]; isDynamicCores {
 		// Swap cores and sockets.
-		tmp := cores
-		cores = sockets
-		sockets = tmp
+		cores, sockets = sockets, cores
 	}
 
 	if cores > 0 && sockets > 0 {

--- a/images/virtualization-artifact/pkg/controller/vm/internal/statistic.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/statistic.go
@@ -90,27 +90,24 @@ func (h *StatisticHandler) syncResources(changed *v1alpha2.VirtualMachine,
 		var (
 			cpuKVVMIRequest resource.Quantity
 			memorySize      resource.Quantity
-			cores           int
 			topology        v1alpha2.Topology
 			coreFraction    string
 		)
 		if kvvmi == nil {
 			memorySize = changed.Spec.Memory.Size
-			cores = changed.Spec.CPU.Cores
-			coreFraction = changed.Spec.CPU.CoreFraction
-			sockets, coresPerSocket := vm.CalculateCoresAndSockets(cores)
+			sockets, coresPerSocket := vm.CalculateCoresAndSockets(changed.Spec.CPU.Cores)
 			topology = v1alpha2.Topology{CoresPerSocket: coresPerSocket, Sockets: sockets}
+			coreFraction = changed.Spec.CPU.CoreFraction
 		} else {
 			cpuKVVMIRequest = kvvmi.Spec.Domain.Resources.Requests[corev1.ResourceCPU]
 			memorySize = kvvmi.Spec.Domain.Resources.Requests[corev1.ResourceMemory]
 
-			cores = h.getCoresByKVVMI(kvvmi)
 			coreFraction = h.getCoreFractionByKVVMI(kvvmi)
 			topology = h.getCurrentTopologyByKVVMI(kvvmi)
 		}
 		resources = v1alpha2.ResourcesStatus{
 			CPU: v1alpha2.CPUStatus{
-				Cores:          cores,
+				Cores:          topology.CoresPerSocket * topology.Sockets,
 				CoreFraction:   coreFraction,
 				RequestedCores: cpuKVVMIRequest,
 				Topology:       topology,
@@ -165,18 +162,31 @@ func (h *StatisticHandler) syncResources(changed *v1alpha2.VirtualMachine,
 	changed.Status.Resources = resources
 }
 
+// getCoresByKVVMI
+// TODO refactor: no need to get cores from limits after enabling CPU hotplug, kvvmi.Spec.Domain.CPU should be enough.
 func (h *StatisticHandler) getCoresByKVVMI(kvvmi *virtv1.VirtualMachineInstance) int {
 	if kvvmi == nil {
 		return -1
 	}
-	cpuKVVMILimit := kvvmi.Spec.Domain.Resources.Limits[corev1.ResourceCPU]
-	return int(cpuKVVMILimit.Value())
+
+	cpuKVVMILimit, hasLimits := kvvmi.Spec.Domain.Resources.Limits[corev1.ResourceCPU]
+	if hasLimits {
+		return int(cpuKVVMILimit.Value())
+	}
+
+	return 1
 }
 
 func (h *StatisticHandler) getCoreFractionByKVVMI(kvvmi *virtv1.VirtualMachineInstance) string {
 	if kvvmi == nil {
 		return ""
 	}
+	// Fraction is stored in annotation after enabling CPU hotplug.
+	cpuFractionStr, hasAnno := kvvmi.Annotations[""]
+	if hasAnno {
+		return cpuFractionStr + "%"
+	}
+	// Also support previous implementation: calculate from requests and limits values.
 	cpuKVVMIRequest := kvvmi.Spec.Domain.Resources.Requests[corev1.ResourceCPU]
 	return strconv.Itoa(int(cpuKVVMIRequest.MilliValue())*100/(h.getCoresByKVVMI(kvvmi)*1000)) + "%"
 }

--- a/images/virtualization-artifact/pkg/controller/vm/internal/statistic_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/statistic_test.go
@@ -30,6 +30,7 @@ import (
 
 	vmbuilder "github.com/deckhouse/virtualization-controller/pkg/builder/vm"
 	"github.com/deckhouse/virtualization-controller/pkg/common/testutil"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/kvbuilder"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/reconciler"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vm/internal/state"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
@@ -78,6 +79,48 @@ var _ = Describe("TestStatisticHandler", func() {
 			ActivePods: map[types.UID]string{podUID: podName},
 			NodeName:   nodeName,
 			Phase:      virtv1.Running,
+		}
+		return kvvmi
+	}
+
+	// Generate KVVMI with "dynamic cores" specifics: cores and sockets are intentionally
+	// swapped to bypass kvvm validations.
+	newKVVMIHotplug := func(cores, sockets, maxCores int, cpuFraction, memory, maxMemory string) *virtv1.VirtualMachineInstance {
+		kvvmi := newEmptyKVVMI(vmName, vmNamespace)
+		memoryGuest := resource.MustParse(memory)
+		memoryMaxGuest := resource.MustParse(maxMemory)
+
+		kvvmi.SetAnnotations(map[string]string{
+			kvbuilder.CPUResourcesRequestsFractionAnnotation: cpuFraction,
+			kvbuilder.VCPUTopologyDynamicCoresAnnotation:     "",
+		})
+		kvvmi.Spec = virtv1.VirtualMachineInstanceSpec{
+			Domain: virtv1.DomainSpec{
+				CPU: &virtv1.CPU{
+					Cores:      uint32(sockets),
+					Sockets:    uint32(cores),
+					MaxSockets: uint32(maxCores),
+					Threads:    1,
+				},
+				Memory: &virtv1.Memory{
+					Guest:    &memoryGuest,
+					MaxGuest: &memoryMaxGuest,
+				},
+				Resources: virtv1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: memoryGuest,
+					},
+				},
+			},
+		}
+		kvvmi.Status = virtv1.VirtualMachineInstanceStatus{
+			ActivePods: map[types.UID]string{podUID: podName},
+			NodeName:   nodeName,
+			Phase:      virtv1.Running,
+			CurrentCPUTopology: &virtv1.CPUTopology{
+				Cores:   uint32(sockets),
+				Sockets: uint32(cores),
+			},
 		}
 		return kvvmi
 	}
@@ -207,6 +250,57 @@ var _ = Describe("TestStatisticHandler", func() {
 				CPURuntimeOverhead: 0,
 
 				TopologyCoresPerSocket: 2,
+				TopologySockets:        1,
+
+				MemorySize:            2147483648,
+				MemoryRuntimeOverhead: 0,
+			},
+		),
+		Entry("Hotplug enabled: 8 cores, 100% fraction, 2 Gi",
+			newVM(8, ptr.To("100%"), "2Gi"),
+			newKVVMIHotplug(8, 1, 16, "100", "2Gi", "256Gi"),
+			newPod("8", "8", "2Gi", "2Gi"),
+			expectedValues{
+				CPUCores:           8,
+				CPUCoreFraction:    "100%",
+				CPURequestedCores:  8000,
+				CPURuntimeOverhead: 0,
+
+				TopologyCoresPerSocket: 8,
+				TopologySockets:        1,
+
+				MemorySize:            2147483648,
+				MemoryRuntimeOverhead: 0,
+			},
+		),
+		Entry("Hotplug enabled: 8 cores, 25% fraction, 2 Gi",
+			newVM(8, ptr.To("25%"), "2Gi"),
+			newKVVMIHotplug(8, 1, 16, "25", "2Gi", "256Gi"),
+			newPod("2", "8", "2Gi", "2Gi"),
+			expectedValues{
+				CPUCores:           8,
+				CPUCoreFraction:    "25%",
+				CPURequestedCores:  2000,
+				CPURuntimeOverhead: 0,
+
+				TopologyCoresPerSocket: 8,
+				TopologySockets:        1,
+
+				MemorySize:            2147483648,
+				MemoryRuntimeOverhead: 0,
+			},
+		),
+		Entry("Hotplug enabled: 1 core, 25% fraction, 2 Gi",
+			newVM(1, ptr.To("25%"), "2Gi"),
+			newKVVMIHotplug(1, 1, 16, "25", "2Gi", "256Gi"),
+			newPod("250m", "1", "2Gi", "2Gi"),
+			expectedValues{
+				CPUCores:           1,
+				CPUCoreFraction:    "25%",
+				CPURequestedCores:  250,
+				CPURuntimeOverhead: 0,
+
+				TopologyCoresPerSocket: 1,
 				TopologySockets:        1,
 
 				MemorySize:            2147483648,

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
@@ -383,10 +383,7 @@ func (h *SyncKvvmHandler) updateKVVM(ctx context.Context, s state.VirtualMachine
 	}
 
 	// Check for changes to skip unneeded updated.
-	isChanged, err := IsKVVMChanged(currentKVVM, newKVVM)
-	if err != nil {
-		return fmt.Errorf("update internal virtual machine: detect changes: %w", err)
-	}
+	isChanged := IsKVVMChanged(currentKVVM, newKVVM)
 
 	if isChanged {
 		// Update can't handle proper reset of memory fields, so patch-after-update:
@@ -511,17 +508,16 @@ func MakeKVVMFromVMSpec(ctx context.Context, s state.VirtualMachineState) (*virt
 }
 
 // IsKVVMChanged returns whether kvvm spec or special annotations are changed.
-func IsKVVMChanged(prevKVVM *virtv1.VirtualMachine, newKVVM *virtv1.VirtualMachine) (bool, error) {
-	isChanged := prevKVVM.Annotations[annotations.AnnVMLastAppliedSpec] != newKVVM.Annotations[annotations.AnnVMLastAppliedSpec]
-
-	if !isChanged {
-		isChanged = prevKVVM.Annotations[annotations.AnnVMClassLastAppliedSpec] != newKVVM.Annotations[annotations.AnnVMClassLastAppliedSpec]
+func IsKVVMChanged(prevKVVM, newKVVM *virtv1.VirtualMachine) bool {
+	if prevKVVM.Annotations[annotations.AnnVMLastAppliedSpec] != newKVVM.Annotations[annotations.AnnVMLastAppliedSpec] {
+		return true
 	}
 
-	if !isChanged {
-		isChanged = !reflect.DeepEqual(prevKVVM.Spec, newKVVM.Spec)
+	if prevKVVM.Annotations[annotations.AnnVMClassLastAppliedSpec] != newKVVM.Annotations[annotations.AnnVMClassLastAppliedSpec] {
+		return true
 	}
-	return isChanged, nil
+
+	return !reflect.DeepEqual(prevKVVM.Spec, newKVVM.Spec)
 }
 
 func (h *SyncKvvmHandler) loadLastAppliedSpec(vm *v1alpha2.VirtualMachine, kvvm *virtv1.VirtualMachine) *v1alpha2.VirtualMachineSpec {

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
@@ -384,24 +384,42 @@ func (h *SyncKvvmHandler) updateKVVM(ctx context.Context, s state.VirtualMachine
 	}
 
 	if isChanged {
-		memory := newKVVM.Spec.Template.Spec.Domain.Memory
-		if memory != nil && memory.MaxGuest != nil && memory.MaxGuest.IsZero() {
-			// Zero maxGuest is a special value to patch KVVM to unset maxGuest.
-			// Set it to nil for next update call.
-			memory.MaxGuest = nil
+		// Update can't handle removing of some fields, so patch them before update.
+		{
+			jsonPatch := patch.JSONPatch{}
+			memory := newKVVM.Spec.Template.Spec.Domain.Memory
+			if memory != nil && memory.MaxGuest != nil && memory.MaxGuest.IsZero() {
+				// maxGuest=0 is an invalid value for vm-validator webhook, we use it as
+				// a special value to patch KVVM to unset maxGuest.
+				// Set it to nil for the update call.
+				memory.MaxGuest = nil
 
-			// 2 operations: remove memory.maxGuest; set memory.guest.
-			// Remove is not enough, remove and set are needed both to pass the kubevirt vm-validator webhook.
-			patchBytes, err := patch.NewJSONPatch(
-				patch.WithRemove("/spec/template/spec/domain/memory/maxGuest"),
-				patch.WithReplace("/spec/template/spec/domain/memory/guest", memory.Guest.String()),
-			).Bytes()
-			if err != nil {
-				return fmt.Errorf("prepare json patch to unset memory.maxGuest: %w", err)
+				// 2 operations: remove memory.maxGuest; set memory.guest.
+				// Remove is not enough, remove and set are needed both to pass the kubevirt vm-validator webhook.
+				jsonPatch.Append(
+					patch.WithRemove("/spec/template/spec/domain/memory/maxGuest"),
+					patch.WithReplace("/spec/template/spec/domain/memory/guest", memory.Guest.String()),
+				)
 			}
+			//if len(newKVVM.Spec.Template.Spec.Domain.Resources.Requests) == 0 {
+			//	jsonPatch.Append(
+			//		patch.WithRemove("/spec/template/spec/domain/resources/requests"),
+			//	)
+			//}
+			//if len(newKVVM.Spec.Template.Spec.Domain.Resources.Limits) == 0 {
+			//	jsonPatch.Append(
+			//		patch.WithRemove("/spec/template/spec/domain/resources/limits"),
+			//	)
+			//}
 
-			if err = h.client.Patch(ctx, newKVVM, client.RawPatch(types.JSONPatchType, patchBytes)); err != nil {
-				return fmt.Errorf("patch internal virtual machine to unset memory.maxGuest: %w", err)
+			if jsonPatch.Len() > 0 {
+				patchBytes, err := jsonPatch.Bytes()
+				if err != nil {
+					return fmt.Errorf("prepare json patch for internal virtual machine: %w", err)
+				}
+				if err = h.client.Patch(ctx, newKVVM, client.RawPatch(types.JSONPatchType, patchBytes)); err != nil {
+					return fmt.Errorf("patch internal virtual machine before update: %w", err)
+				}
 			}
 		}
 

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
@@ -389,28 +389,17 @@ func (h *SyncKvvmHandler) updateKVVM(ctx context.Context, s state.VirtualMachine
 			jsonPatch := patch.JSONPatch{}
 			memory := newKVVM.Spec.Template.Spec.Domain.Memory
 			if memory != nil && memory.MaxGuest != nil && memory.MaxGuest.IsZero() {
-				// maxGuest=0 is an invalid value for vm-validator webhook, we use it as
-				// a special value to patch KVVM to unset maxGuest.
-				// Set it to nil for the update call.
+				// maxGuest=0 is an invalid value for the vm-validator webhook, we use 0 as
+				// an internal special value to patch KVVM before update.
+				// Set it to nil in the spec, so Update call will not fail.
 				memory.MaxGuest = nil
 
-				// 2 operations: remove memory.maxGuest; set memory.guest.
-				// Remove is not enough, remove and set are needed both to pass the kubevirt vm-validator webhook.
+				// Removing memory.maxGuest is not enough, replace memory.guest is needed to pass the vm-validator webhook.
 				jsonPatch.Append(
 					patch.WithRemove("/spec/template/spec/domain/memory/maxGuest"),
 					patch.WithReplace("/spec/template/spec/domain/memory/guest", memory.Guest.String()),
 				)
 			}
-			//if len(newKVVM.Spec.Template.Spec.Domain.Resources.Requests) == 0 {
-			//	jsonPatch.Append(
-			//		patch.WithRemove("/spec/template/spec/domain/resources/requests"),
-			//	)
-			//}
-			//if len(newKVVM.Spec.Template.Spec.Domain.Resources.Limits) == 0 {
-			//	jsonPatch.Append(
-			//		patch.WithRemove("/spec/template/spec/domain/resources/limits"),
-			//	)
-			//}
 
 			if jsonPatch.Len() > 0 {
 				patchBytes, err := jsonPatch.Bytes()

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
@@ -431,11 +431,11 @@ func (h *SyncKvvmHandler) updateKVVM(ctx context.Context, s state.VirtualMachine
 // kvbuilder sets maxGuest to 0 to indicate that KVVM needs to be patched
 // to clear maxGuest value: it is not possible to clear the value with the Update
 // once it was set previously.
-func saveKVVMDomainMemoryForPatching(prevKVVM *virtv1.VirtualMachine, newKVVM *virtv1.VirtualMachine) *virtv1.Memory {
+func saveKVVMDomainMemoryForPatching(prevKVVM, newKVVM *virtv1.VirtualMachine) *virtv1.Memory {
 	prevMemory := prevKVVM.Spec.Template.Spec.Domain.Memory
 	newMemory := newKVVM.Spec.Template.Spec.Domain.Memory
-	if newMemory != nil && newMemory.MaxGuest.IsZero() &&
-		prevMemory != nil && !prevMemory.MaxGuest.IsZero() {
+	if newMemory != nil && newMemory.MaxGuest != nil && newMemory.MaxGuest.IsZero() &&
+		prevMemory != nil && prevMemory.MaxGuest != nil && !prevMemory.MaxGuest.IsZero() {
 		return newMemory.DeepCopy()
 	}
 	return nil

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
@@ -377,39 +377,23 @@ func (h *SyncKvvmHandler) updateKVVM(ctx context.Context, s state.VirtualMachine
 		return fmt.Errorf("update internal virtual machine: make kvvm from the virtual machine spec: %w", err)
 	}
 
+	currentKVVM, err := s.KVVM(ctx)
+	if err != nil {
+		return fmt.Errorf("get current kvvm: %w", err)
+	}
+
 	// Check for changes to skip unneeded updated.
-	isChanged, err := IsKVVMChanged(ctx, s, newKVVM)
+	isChanged, err := IsKVVMChanged(currentKVVM, newKVVM)
 	if err != nil {
 		return fmt.Errorf("update internal virtual machine: detect changes: %w", err)
 	}
 
 	if isChanged {
-		// Update can't handle removing of some fields, so patch them before update.
-		{
-			jsonPatch := patch.JSONPatch{}
-			memory := newKVVM.Spec.Template.Spec.Domain.Memory
-			if memory != nil && memory.MaxGuest != nil && memory.MaxGuest.IsZero() {
-				// maxGuest=0 is an invalid value for the vm-validator webhook, we use 0 as
-				// an internal special value to patch KVVM before update.
-				// Set it to nil in the spec, so Update call will not fail.
-				memory.MaxGuest = nil
-
-				// Removing memory.maxGuest is not enough, replace memory.guest is needed to pass the vm-validator webhook.
-				jsonPatch.Append(
-					patch.WithRemove("/spec/template/spec/domain/memory/maxGuest"),
-					patch.WithReplace("/spec/template/spec/domain/memory/guest", memory.Guest.String()),
-				)
-			}
-
-			if jsonPatch.Len() > 0 {
-				patchBytes, err := jsonPatch.Bytes()
-				if err != nil {
-					return fmt.Errorf("prepare json patch for internal virtual machine: %w", err)
-				}
-				if err = h.client.Patch(ctx, newKVVM, client.RawPatch(types.JSONPatchType, patchBytes)); err != nil {
-					return fmt.Errorf("patch internal virtual machine before update: %w", err)
-				}
-			}
+		// Update can't handle proper reset of memory fields, so patch-after-update:
+		// (1) make memory copy, (2) reset memory in newKVVM and (3) patch memory field after update.
+		domainMemory := saveKVVMDomainMemoryForPatching(currentKVVM, newKVVM)
+		if domainMemory != nil {
+			newKVVM.Spec.Template.Spec.Domain.Memory = currentKVVM.Spec.Template.Spec.Domain.Memory
 		}
 
 		if err = h.client.Update(ctx, newKVVM); err != nil {
@@ -418,10 +402,42 @@ func (h *SyncKvvmHandler) updateKVVM(ctx context.Context, s state.VirtualMachine
 
 		log.Info("Update internal virtual machine done", "name", newKVVM.Name)
 		log.Debug("Update internal virtual machine done", "name", newKVVM.Name, "kvvm", newKVVM)
+
+		if domainMemory != nil {
+			jsonPatch := patch.JSONPatch{}
+			// Removing memory.maxGuest is not enough, replace memory.guest is needed to pass the vm-validator webhook.
+			jsonPatch.Append(
+				patch.WithRemove("/spec/template/spec/domain/memory/maxGuest"),
+				patch.WithReplace("/spec/template/spec/domain/memory/guest", domainMemory.Guest.String()),
+			)
+			patchBytes, err := jsonPatch.Bytes()
+			if err != nil {
+				return fmt.Errorf("prepare json patch for internal virtual machine: %w", err)
+			}
+			if err = h.client.Patch(ctx, newKVVM, client.RawPatch(types.JSONPatchType, patchBytes)); err != nil {
+				return fmt.Errorf("patch internal virtual machine before update: %w", err)
+			}
+		}
 	} else {
 		log.Debug("Update internal virtual machine is not needed", "name", newKVVM.Name, "kvvm", newKVVM)
 	}
 
+	return nil
+}
+
+// saveKVVMDomainMemoryForPatching returns copy of domain memory if maxGuest becomes 0.
+//
+// Note: maxGuest=0 is an invalid value for the vm-validator webhook,
+// kvbuilder sets maxGuest to 0 to indicate that KVVM needs to be patched
+// to clear maxGuest value: it is not possible to clear the value with the Update
+// once it was set previously.
+func saveKVVMDomainMemoryForPatching(prevKVVM *virtv1.VirtualMachine, newKVVM *virtv1.VirtualMachine) *virtv1.Memory {
+	prevMemory := prevKVVM.Spec.Template.Spec.Domain.Memory
+	newMemory := newKVVM.Spec.Template.Spec.Domain.Memory
+	if newMemory != nil && newMemory.MaxGuest.IsZero() &&
+		prevMemory != nil && !prevMemory.MaxGuest.IsZero() {
+		return newMemory.DeepCopy()
+	}
 	return nil
 }
 
@@ -495,20 +511,15 @@ func MakeKVVMFromVMSpec(ctx context.Context, s state.VirtualMachineState) (*virt
 }
 
 // IsKVVMChanged returns whether kvvm spec or special annotations are changed.
-func IsKVVMChanged(ctx context.Context, s state.VirtualMachineState, kvvm *virtv1.VirtualMachine) (bool, error) {
-	currentKVVM, err := s.KVVM(ctx)
-	if err != nil {
-		return false, fmt.Errorf("get current kvvm: %w", err)
-	}
-
-	isChanged := currentKVVM.Annotations[annotations.AnnVMLastAppliedSpec] != kvvm.Annotations[annotations.AnnVMLastAppliedSpec]
+func IsKVVMChanged(prevKVVM *virtv1.VirtualMachine, newKVVM *virtv1.VirtualMachine) (bool, error) {
+	isChanged := prevKVVM.Annotations[annotations.AnnVMLastAppliedSpec] != newKVVM.Annotations[annotations.AnnVMLastAppliedSpec]
 
 	if !isChanged {
-		isChanged = currentKVVM.Annotations[annotations.AnnVMClassLastAppliedSpec] != kvvm.Annotations[annotations.AnnVMClassLastAppliedSpec]
+		isChanged = prevKVVM.Annotations[annotations.AnnVMClassLastAppliedSpec] != newKVVM.Annotations[annotations.AnnVMClassLastAppliedSpec]
 	}
 
 	if !isChanged {
-		isChanged = !reflect.DeepEqual(kvvm.Spec, currentKVVM.Spec)
+		isChanged = !reflect.DeepEqual(prevKVVM.Spec, newKVVM.Spec)
 	}
 	return isChanged, nil
 }

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
@@ -264,7 +264,7 @@ func (h *SyncKvvmHandler) Name() string {
 }
 
 func (h *SyncKvvmHandler) isWaiting(vm *v1alpha2.VirtualMachine) bool {
-	return !checkVirtualMachineConfiguration(vm)
+	return !virtualMachineDependenciesAreReady(vm)
 }
 
 func (h *SyncKvvmHandler) syncKVVM(ctx context.Context, s state.VirtualMachineState, allChanges vmchange.SpecChanges) (bool, error) {

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_metadata.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_metadata.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"maps"
 
+	"github.com/deckhouse/virtualization-controller/pkg/controller/kvbuilder"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -188,10 +189,20 @@ func (h *SyncMetadataHandler) patchLabelsAndAnnotations(ctx context.Context, obj
 	return h.client.Patch(ctx, obj, client.RawPatch(types.JSONPatchType, bytes))
 }
 
+var annotationsToKeep = []string{
+	annotations.AnnNetworksSpec,
+	virtv1.AllowPodBridgeNetworkLiveMigrationAnnotation,
+	netmanager.AnnoIPAddressCNIRequest,
+	virtv1.USBMigrationStrategyAnn,
+	kvbuilder.CPUResourcesRequestsFractionAnnotation,
+	kvbuilder.VCPUTopologyDynamicCoresAnnotation,
+}
+
 // updateKVVMSpecTemplateMetadataAnnotations ensures that the special network annotation is present if it exists.
 // It also removes well-known annotations that are dangerous to propagate.
 func (h *SyncMetadataHandler) updateKVVMSpecTemplateMetadataAnnotations(currAnno, newAnno map[string]string) map[string]string {
 	res := make(map[string]string, len(newAnno))
+
 	for k, v := range newAnno {
 		if k == annotations.AnnVMLastAppliedSpec || k == annotations.AnnVMClassLastAppliedSpec {
 			continue
@@ -200,20 +211,11 @@ func (h *SyncMetadataHandler) updateKVVMSpecTemplateMetadataAnnotations(currAnno
 		res[k] = v
 	}
 
-	if v, ok := currAnno[annotations.AnnNetworksSpec]; ok {
-		res[annotations.AnnNetworksSpec] = v
-	}
-
-	if v, ok := currAnno[virtv1.AllowPodBridgeNetworkLiveMigrationAnnotation]; ok {
-		res[virtv1.AllowPodBridgeNetworkLiveMigrationAnnotation] = v
-	}
-
-	if v, ok := currAnno[netmanager.AnnoIPAddressCNIRequest]; ok {
-		res[netmanager.AnnoIPAddressCNIRequest] = v
-	}
-
-	if v, ok := currAnno[virtv1.USBMigrationStrategyAnn]; ok {
-		res[virtv1.USBMigrationStrategyAnn] = v
+	// Restore annotations set by kvbuilder.
+	for _, keepAnno := range annotationsToKeep {
+		if v, ok := currAnno[keepAnno]; ok {
+			res[keepAnno] = v
+		}
 	}
 
 	return commonvm.RemoveNonPropagatableAnnotations(res)

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_metadata.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_metadata.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"maps"
 
-	"github.com/deckhouse/virtualization-controller/pkg/controller/kvbuilder"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,6 +34,7 @@ import (
 	"github.com/deckhouse/virtualization-controller/pkg/common/merger"
 	"github.com/deckhouse/virtualization-controller/pkg/common/patch"
 	commonvm "github.com/deckhouse/virtualization-controller/pkg/common/vm"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/kvbuilder"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/netmanager"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vm/internal/state"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_power_state.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_power_state.go
@@ -127,7 +127,7 @@ func (h *SyncPowerStateHandler) syncPowerState(
 	})
 
 	changed := s.VirtualMachine().Changed()
-	isConfigurationApplied := checkVirtualMachineConfiguration(changed)
+	isConfigurationApplied := virtualMachineDependenciesAreReady(changed)
 	maintenance, _ := conditions.GetCondition(vmcondition.TypeMaintenance, changed.Status.Conditions)
 
 	var vmAction VMAction

--- a/images/virtualization-artifact/pkg/controller/vm/internal/util.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/util.go
@@ -95,14 +95,15 @@ type PhaseGetter func(vm *v1alpha2.VirtualMachine, kvvm *virtv1.VirtualMachine) 
 var mapPhases = map[virtv1.VirtualMachinePrintableStatus]PhaseGetter{
 	// VirtualMachineStatusStopped indicates that the virtual machine is currently stopped and isn't expected to start.
 	virtv1.VirtualMachineStatusStopped: func(vm *v1alpha2.VirtualMachine, kvvm *virtv1.VirtualMachine) v1alpha2.MachinePhase {
-		if vm != nil && kvvm != nil {
-			if !checkVirtualMachineConfiguration(vm) &&
-				kvvm != nil && kvvm.Annotations[annotations.AnnVMStartRequested] == "true" {
-				return v1alpha2.MachinePending
-			}
+		if vm == nil {
+			return v1alpha2.MachineStopped
 		}
 
-		if vm != nil && vm.Status.Phase == v1alpha2.MachinePending &&
+		if !virtualMachineDependenciesAreReady(vm) && kvvm.Annotations[annotations.AnnVMStartRequested] == "true" {
+			return v1alpha2.MachinePending
+		}
+
+		if vm.Status.Phase == v1alpha2.MachinePending &&
 			(vm.Spec.RunPolicy == v1alpha2.AlwaysOnPolicy || vm.Spec.RunPolicy == v1alpha2.AlwaysOnUnlessStoppedManually) {
 			return v1alpha2.MachinePending
 		}
@@ -184,6 +185,11 @@ var mapPhases = map[virtv1.VirtualMachinePrintableStatus]PhaseGetter{
 	virtv1.VirtualMachineStatusWaitingForVolumeBinding: func(_ *v1alpha2.VirtualMachine, _ *virtv1.VirtualMachine) v1alpha2.MachinePhase {
 		return v1alpha2.MachinePending
 	},
+	// VirtualMachineStatusWaitingForReceiver indicates that this virtual machine is a receiver VM and
+	// migration should start next.
+	virtv1.VirtualMachineStatusWaitingForReceiver: func(_ *v1alpha2.VirtualMachine, _ *virtv1.VirtualMachine) v1alpha2.MachinePhase {
+		return v1alpha2.MachineMigrating
+	},
 
 	kvvmEmptyPhase: func(_ *v1alpha2.VirtualMachine, _ *virtv1.VirtualMachine) v1alpha2.MachinePhase {
 		return v1alpha2.MachinePending
@@ -251,7 +257,8 @@ func podFinal(pod corev1.Pod) bool {
 	return pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed
 }
 
-func checkVirtualMachineConfiguration(vm *v1alpha2.VirtualMachine) bool {
+// virtualMachineDependenciesAreReady returns whether VM
+func virtualMachineDependenciesAreReady(vm *v1alpha2.VirtualMachine) bool {
 	for _, c := range vm.Status.Conditions {
 		switch vmcondition.Type(c.Type) {
 		case vmcondition.TypeBlockDevicesReady:

--- a/images/virtualization-artifact/pkg/controller/vm/internal/validators/cpu_count_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/validators/cpu_count_validator.go
@@ -22,6 +22,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	commonvm "github.com/deckhouse/virtualization-controller/pkg/common/vm"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
@@ -42,16 +43,11 @@ func (v *CPUCountValidator) ValidateUpdate(_ context.Context, _, newVM *v1alpha2
 func (v *CPUCountValidator) Validate(vm *v1alpha2.VirtualMachine) (admission.Warnings, error) {
 	cores := vm.Spec.CPU.Cores
 
-	switch {
-	case cores <= 16:
+	sockets, coresPerSocket := commonvm.CalculateCoresAndSockets(cores)
+
+	if cores == sockets*coresPerSocket {
 		return nil, nil
-	case cores > 16 && cores <= 32 && cores%2 != 0:
-		return nil, fmt.Errorf("the requested number of cores must be a multiple of 2")
-	case cores > 32 && cores <= 64 && cores%4 != 0:
-		return nil, fmt.Errorf("the requested number of cores must be a multiple of 4")
-	case cores > 64 && cores%8 != 0:
-		return nil, fmt.Errorf("the requested number of cores must be a multiple of 8")
 	}
 
-	return nil, nil
+	return nil, fmt.Errorf("the requested number of cores must be a multiple of %d", sockets)
 }

--- a/images/virtualization-artifact/pkg/controller/vmchange/comparator_cpu.go
+++ b/images/virtualization-artifact/pkg/controller/vmchange/comparator_cpu.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vmchange
+
+import (
+	"k8s.io/component-base/featuregate"
+
+	"github.com/deckhouse/virtualization-controller/pkg/common/vm"
+	"github.com/deckhouse/virtualization-controller/pkg/featuregates"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+)
+
+type comparatorCPU struct {
+	featureGate featuregate.FeatureGate
+}
+
+func NewComparatorCPU(featureGate featuregate.FeatureGate) VMSpecFieldComparator {
+	return &comparatorCPU{
+		featureGate: featureGate,
+	}
+}
+
+// Compare returns changes in the cpu section.
+// // It supports CPU hotplug mechanism for cores changes.
+// // It requires reboot if cpu fraction is changed or if COU hotplug is disabled.
+func (c *comparatorCPU) Compare(current, desired *v1alpha2.VirtualMachineSpec) []FieldChange {
+	// Cores can be changed "on the fly" using CPU Hotplug ...
+	coresChangedAction := ActionApplyImmediate
+	// ... but sockets count change requires a reboot.
+	currentSockets, _ := vm.CalculateCoresAndSockets(current.CPU.Cores)
+	desiredSockets, _ := vm.CalculateCoresAndSockets(desired.CPU.Cores)
+	if currentSockets != desiredSockets {
+		coresChangedAction = ActionRestart
+	}
+
+	// Require reboot if CPU hotplug is not enabled.
+	if !c.featureGate.Enabled(featuregates.HotplugCPUWithLiveMigration) {
+		coresChangedAction = ActionRestart
+	}
+
+	coresChanges := compareInts("cpu.cores", current.CPU.Cores, desired.CPU.Cores, 0, coresChangedAction)
+	fractionChanges := compareStrings("cpu.coreFraction", current.CPU.CoreFraction, desired.CPU.CoreFraction, DefaultCPUCoreFraction, ActionRestart)
+
+	// Yield full replace if both fields changed.
+	if HasChanges(coresChanges) && HasChanges(fractionChanges) {
+		return []FieldChange{
+			{
+				Operation:      ChangeReplace,
+				Path:           "cpu",
+				CurrentValue:   current.CPU,
+				DesiredValue:   desired.CPU,
+				ActionRequired: ActionRestart,
+			},
+		}
+	}
+
+	if HasChanges(coresChanges) {
+		return coresChanges
+	}
+
+	if HasChanges(fractionChanges) {
+		return fractionChanges
+	}
+
+	return nil
+}

--- a/images/virtualization-artifact/pkg/controller/vmchange/comparator_memory.go
+++ b/images/virtualization-artifact/pkg/controller/vmchange/comparator_memory.go
@@ -43,8 +43,8 @@ func NewComparatorMemory(featureGate featuregate.FeatureGate) VMSpecFieldCompara
 // Note: memory hotplug is enabled if VM has more than 1Gi of RAM.
 func (c *comparatorMemory) Compare(current, desired *v1alpha2.VirtualMachineSpec) []FieldChange {
 	hotplugThreshold := resource.NewQuantity(kvbuilder.EnableMemoryHotplugThreshold, resource.BinarySI)
-	isHotpluggable := current.Memory.Size.Cmp(*hotplugThreshold) > 0
-	isHotpluggableDesired := desired.Memory.Size.Cmp(*hotplugThreshold) > 0
+	isHotpluggable := current.Memory.Size.Cmp(*hotplugThreshold) >= 0
+	isHotpluggableDesired := desired.Memory.Size.Cmp(*hotplugThreshold) >= 0
 
 	actionType := ActionRestart
 	if isHotpluggable && isHotpluggableDesired {

--- a/images/virtualization-artifact/pkg/controller/vmchange/comparators.go
+++ b/images/virtualization-artifact/pkg/controller/vmchange/comparators.go
@@ -17,8 +17,6 @@ limitations under the License.
 package vmchange
 
 import (
-	"github.com/deckhouse/virtualization-controller/pkg/common/vm"
-	"github.com/deckhouse/virtualization-controller/pkg/featuregates"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
@@ -122,51 +120,6 @@ func compareBootloader(current, desired *v1alpha2.VirtualMachineSpec) []FieldCha
 		string(DefaultBootloader),
 		ActionRestart,
 	)
-}
-
-// compareCPU returns changes in the cpu section.
-// It supports CPU hotplug mechanism for cores changes.
-// It requires reboot if cpu fraction is changed or if COU hotplug is disabled.
-func compareCPU(current, desired *v1alpha2.VirtualMachineSpec) []FieldChange {
-	// Cores can be changed "on the fly" using CPU Hotplug ...
-	coresChangedAction := ActionApplyImmediate
-	// ... but sockets count change requires a reboot.
-	currentSockets, _ := vm.CalculateCoresAndSockets(current.CPU.Cores)
-	desiredSockets, _ := vm.CalculateCoresAndSockets(desired.CPU.Cores)
-	if currentSockets != desiredSockets {
-		coresChangedAction = ActionRestart
-	}
-
-	// Require reboot if CPU hotplug is not enabled.
-	if !featuregates.Default().Enabled(featuregates.HotplugCPUWithLiveMigration) {
-		coresChangedAction = ActionRestart
-	}
-
-	coresChanges := compareInts("cpu.cores", current.CPU.Cores, desired.CPU.Cores, 0, coresChangedAction)
-	fractionChanges := compareStrings("cpu.coreFraction", current.CPU.CoreFraction, desired.CPU.CoreFraction, DefaultCPUCoreFraction, ActionRestart)
-
-	// Yield full replace if both fields changed.
-	if HasChanges(coresChanges) && HasChanges(fractionChanges) {
-		return []FieldChange{
-			{
-				Operation:      ChangeReplace,
-				Path:           "cpu",
-				CurrentValue:   current.CPU,
-				DesiredValue:   desired.CPU,
-				ActionRequired: ActionRestart,
-			},
-		}
-	}
-
-	if HasChanges(coresChanges) {
-		return coresChanges
-	}
-
-	if HasChanges(fractionChanges) {
-		return fractionChanges
-	}
-
-	return nil
 }
 
 func compareProvisioning(current, desired *v1alpha2.VirtualMachineSpec) []FieldChange {

--- a/images/virtualization-artifact/pkg/controller/vmchange/comparators.go
+++ b/images/virtualization-artifact/pkg/controller/vmchange/comparators.go
@@ -18,6 +18,7 @@ package vmchange
 
 import (
 	"github.com/deckhouse/virtualization-controller/pkg/common/vm"
+	"github.com/deckhouse/virtualization-controller/pkg/featuregates"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
@@ -124,6 +125,8 @@ func compareBootloader(current, desired *v1alpha2.VirtualMachineSpec) []FieldCha
 }
 
 // compareCPU returns changes in the cpu section.
+// It supports CPU hotplug mechanism for cores changes.
+// It requires reboot if cpu fraction is changed or if COU hotplug is disabled.
 func compareCPU(current, desired *v1alpha2.VirtualMachineSpec) []FieldChange {
 	// Cores can be changed "on the fly" using CPU Hotplug ...
 	coresChangedAction := ActionApplyImmediate
@@ -133,6 +136,12 @@ func compareCPU(current, desired *v1alpha2.VirtualMachineSpec) []FieldChange {
 	if currentSockets != desiredSockets {
 		coresChangedAction = ActionRestart
 	}
+
+	// Require reboot if CPU hotplug is not enabled.
+	if !featuregates.Default().Enabled(featuregates.HotplugCPUWithLiveMigration) {
+		coresChangedAction = ActionRestart
+	}
+
 	coresChanges := compareInts("cpu.cores", current.CPU.Cores, desired.CPU.Cores, 0, coresChangedAction)
 	fractionChanges := compareStrings("cpu.coreFraction", current.CPU.CoreFraction, desired.CPU.CoreFraction, DefaultCPUCoreFraction, ActionRestart)
 

--- a/images/virtualization-artifact/pkg/controller/vmchange/comparators.go
+++ b/images/virtualization-artifact/pkg/controller/vmchange/comparators.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vmchange
 
 import (
+	"github.com/deckhouse/virtualization-controller/pkg/common/vm"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
@@ -124,7 +125,15 @@ func compareBootloader(current, desired *v1alpha2.VirtualMachineSpec) []FieldCha
 
 // compareCPU returns changes in the cpu section.
 func compareCPU(current, desired *v1alpha2.VirtualMachineSpec) []FieldChange {
-	coresChanges := compareInts("cpu.cores", current.CPU.Cores, desired.CPU.Cores, 0, ActionApplyImmediate)
+	// Cores can be changed "on the fly" using CPU Hotplug ...
+	coresChangedAction := ActionApplyImmediate
+	// ... but sockets count change requires a reboot.
+	currentSockets, _ := vm.CalculateCoresAndSockets(current.CPU.Cores)
+	desiredSockets, _ := vm.CalculateCoresAndSockets(desired.CPU.Cores)
+	if currentSockets != desiredSockets {
+		coresChangedAction = ActionRestart
+	}
+	coresChanges := compareInts("cpu.cores", current.CPU.Cores, desired.CPU.Cores, 0, coresChangedAction)
 	fractionChanges := compareStrings("cpu.coreFraction", current.CPU.CoreFraction, desired.CPU.CoreFraction, DefaultCPUCoreFraction, ActionRestart)
 
 	// Yield full replace if both fields changed.

--- a/images/virtualization-artifact/pkg/controller/vmchange/comparators.go
+++ b/images/virtualization-artifact/pkg/controller/vmchange/comparators.go
@@ -124,7 +124,7 @@ func compareBootloader(current, desired *v1alpha2.VirtualMachineSpec) []FieldCha
 
 // compareCPU returns changes in the cpu section.
 func compareCPU(current, desired *v1alpha2.VirtualMachineSpec) []FieldChange {
-	coresChanges := compareInts("cpu.cores", current.CPU.Cores, desired.CPU.Cores, 0, ActionRestart)
+	coresChanges := compareInts("cpu.cores", current.CPU.Cores, desired.CPU.Cores, 0, ActionApplyImmediate)
 	fractionChanges := compareStrings("cpu.coreFraction", current.CPU.CoreFraction, desired.CPU.CoreFraction, DefaultCPUCoreFraction, ActionRestart)
 
 	// Yield full replace if both fields changed.

--- a/images/virtualization-artifact/pkg/controller/vmchange/compare.go
+++ b/images/virtualization-artifact/pkg/controller/vmchange/compare.go
@@ -75,7 +75,7 @@ func (v *VMSpecComparator) comparators() []VMSpecFieldComparator {
 		vmSpecFieldComparator(compareEnableParavirtualization),
 		vmSpecFieldComparator(compareOSType),
 		vmSpecFieldComparator(compareBootloader),
-		vmSpecFieldComparator(compareCPU),
+		NewComparatorCPU(v.featureGate),
 		NewComparatorMemory(v.featureGate),
 		vmSpecFieldComparator(compareBlockDevices),
 		vmSpecFieldComparator(compareProvisioning),

--- a/images/virtualization-artifact/pkg/controller/workload-updater/internal/handler/hotplug.go
+++ b/images/virtualization-artifact/pkg/controller/workload-updater/internal/handler/hotplug.go
@@ -18,6 +18,7 @@ package handler
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	virtv1 "kubevirt.io/api/core/v1"
@@ -81,5 +82,5 @@ func (h *HotplugHandler) Name() string {
 }
 
 func getHotplugResourcesSum(vm *v1alpha2.VirtualMachine) string {
-	return vm.Spec.Memory.Size.String()
+	return fmt.Sprintf("cpu.cores=%d,memory.size=%s", vm.Spec.CPU.Cores, vm.Spec.Memory.Size.String())
 }

--- a/images/virtualization-artifact/pkg/controller/workload-updater/internal/handler/hotplug.go
+++ b/images/virtualization-artifact/pkg/controller/workload-updater/internal/handler/hotplug.go
@@ -56,7 +56,12 @@ func (h *HotplugHandler) Handle(ctx context.Context, vm *v1alpha2.VirtualMachine
 	}
 
 	cond, _ := conditions.GetKVVMICondition(virtv1.VirtualMachineInstanceMemoryChange, kvvmi.Status.Conditions)
-	if cond.Status != corev1.ConditionTrue {
+	isMemoryHotplug := cond.Status == corev1.ConditionTrue
+
+	cond, _ = conditions.GetKVVMICondition(virtv1.VirtualMachineInstanceVCPUChange, kvvmi.Status.Conditions)
+	isCPUHotplug := cond.Status == corev1.ConditionTrue
+
+	if !isCPUHotplug && !isMemoryHotplug {
 		return reconcile.Result{}, nil
 	}
 

--- a/images/virtualization-artifact/pkg/controller/workload-updater/internal/watcher/kvvmi.go
+++ b/images/virtualization-artifact/pkg/controller/workload-updater/internal/watcher/kvvmi.go
@@ -63,10 +63,7 @@ func (w *KVVMIWatcher) Watch(mgr manager.Manager, ctr controller.Controller) err
 						return true
 					}
 					hotCPUChangeCondition, _ := conditions.GetKVVMICondition(virtv1.VirtualMachineInstanceVCPUChange, e.ObjectNew.Status.Conditions)
-					if hotCPUChangeCondition.Status == corev1.ConditionTrue {
-						return true
-					}
-					return false
+					return hotCPUChangeCondition.Status == corev1.ConditionTrue
 				},
 			},
 		),

--- a/images/virtualization-artifact/pkg/controller/workload-updater/internal/watcher/kvvmi.go
+++ b/images/virtualization-artifact/pkg/controller/workload-updater/internal/watcher/kvvmi.go
@@ -55,8 +55,18 @@ func (w *KVVMIWatcher) Watch(mgr manager.Manager, ctr controller.Controller) err
 				DeleteFunc: func(e event.TypedDeleteEvent[*virtv1.VirtualMachineInstance]) bool { return false },
 				UpdateFunc: func(e event.TypedUpdateEvent[*virtv1.VirtualMachineInstance]) bool {
 					nodePlacementCondition, _ := conditions.GetKVVMICondition(conditions.VirtualMachineInstanceNodePlacementNotMatched, e.ObjectNew.Status.Conditions)
+					if nodePlacementCondition.Status == corev1.ConditionTrue {
+						return true
+					}
 					hotMemoryChangeCondition, _ := conditions.GetKVVMICondition(virtv1.VirtualMachineInstanceMemoryChange, e.ObjectNew.Status.Conditions)
-					return nodePlacementCondition.Status == corev1.ConditionTrue || hotMemoryChangeCondition.Status == corev1.ConditionTrue
+					if hotMemoryChangeCondition.Status == corev1.ConditionTrue {
+						return true
+					}
+					hotCPUChangeCondition, _ := conditions.GetKVVMICondition(virtv1.VirtualMachineInstanceVCPUChange, e.ObjectNew.Status.Conditions)
+					if hotCPUChangeCondition.Status == corev1.ConditionTrue {
+						return true
+					}
+					return false
 				},
 			},
 		),

--- a/images/virtualization-artifact/pkg/controller/workload-updater/workload_updater_controller.go
+++ b/images/virtualization-artifact/pkg/controller/workload-updater/workload_updater_controller.go
@@ -49,7 +49,9 @@ func SetupController(
 		handler.NewFirmwareHandler(client, service.NewOneShotMigrationService(client, "firmware-update-"), firmwareImage, namespace, virtControllerName),
 		handler.NewNodePlacementHandler(client, service.NewOneShotMigrationService(client, "nodeplacement-update-")),
 	}
-	if featuregates.Default().Enabled(featuregates.HotplugMemoryWithLiveMigration) {
+	isMemoryHotplug := featuregates.Default().Enabled(featuregates.HotplugMemoryWithLiveMigration)
+	isCPUHotplug := featuregates.Default().Enabled(featuregates.HotplugCPUWithLiveMigration)
+	if isMemoryHotplug || isCPUHotplug {
 		hotplugHandler := handler.NewHotplugHandler(client, service.NewOneShotMigrationService(client, "hotplug-resources-"))
 		handlers = append(handlers, hotplugHandler)
 	}

--- a/images/virtualization-artifact/pkg/featuregates/featuregate.go
+++ b/images/virtualization-artifact/pkg/featuregates/featuregate.go
@@ -30,6 +30,7 @@ const (
 	VolumeMigration                     featuregate.Feature = "VolumeMigration"
 	TargetMigration                     featuregate.Feature = "TargetMigration"
 	USB                                 featuregate.Feature = "USB"
+	HotplugCPUWithLiveMigration         featuregate.Feature = "HotplugCPUWithLiveMigration"
 	HotplugMemoryWithLiveMigration      featuregate.Feature = "HotplugMemoryWithLiveMigration"
 )
 
@@ -56,6 +57,11 @@ var featureSpecs = map[featuregate.Feature]featuregate.FeatureSpec{
 	USB: {
 		Default:       version.GetEdition() == version.EditionEE && kubeapi.HasDRAFeatureGates() && kubeapi.ResourceV1Available(),
 		LockToDefault: true,
+		PreRelease:    featuregate.Alpha,
+	},
+	HotplugCPUWithLiveMigration: {
+		Default:       false,
+		LockToDefault: version.GetEdition() == version.EditionCE,
 		PreRelease:    featuregate.Alpha,
 	},
 	HotplugMemoryWithLiveMigration: {

--- a/tools/kubeconform/fixtures/module-values.yaml
+++ b/tools/kubeconform/fixtures/module-values.yaml
@@ -397,6 +397,7 @@ virtualization:
         - 10.0.10.0/24
         - 10.0.20.0/24
         - 10.0.30.0/24
+      featureGates: []
     moduleState: {}
     virtConfig:
       phase: Deployed


### PR DESCRIPTION

## Description

- Change cpu cores setting from domain.resources/limits to domain.cpu fields.
- Support old VMs to not require reboot on module update.

This PR is a support of new "dynamic cores strategy" implemented in PR https://github.com/deckhouse/3p-kubevirt/pull/82

## Why do we need it, and what problem does it solve?

It is a phase 1 of implementation of the CPU hotplug support.

Limitations:

- No additional VMClass settings, only spec.cpu.cores in the VM is supported for now.
- CPU hotplug is disabled by default, add a feature gate to ModuleConfig to enable: spec.settings.featureGates array should contain string HotplugCPUWithLiveMigration.

Main difference from original Kubevirt:

- Dynamic cores, static sockets count: 1-16 cores 1 socket, 18-32 cores 2 sockets, etc.
- CPU cores reducing is allowed.
- Main Pod and target Pod always have resources.limits for CPU.


<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: vm
type: feature
summary: "Added the ability to change the number of CPUs in a virtual machine without manually stopping it. The new value is applied via live migration. To enable this functionality, add `HotplugCPUWithLiveMigration` to `.spec.settings.featureGates` in the `ModuleConfig` of the `virtualization` module."
```
