### PR TITLE
refactor(vm): set non migratable usb if firmware out of date and usb devices exists for 1.7

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm/internal/migrating.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/migrating.go
@@ -278,6 +278,9 @@ func (h *MigratingHandler) getVMOPCandidate(ctx context.Context, s state.Virtual
 }
 
 func (h *MigratingHandler) syncMigratable(ctx context.Context, s state.VirtualMachineState, vm *v1alpha2.VirtualMachine, kvvm *virtv1.VirtualMachine) error {
+	if h.setUSBNonMigratable(vm) {
+		return nil
+	}
 	cb := conditions.NewConditionBuilder(vmcondition.TypeMigratable).Generation(vm.GetGeneration())
 
 	if kvvm != nil {
@@ -344,4 +347,25 @@ func (h *MigratingHandler) syncMigratable(ctx context.Context, s state.VirtualMa
 
 func liveMigrationInProgress(migrationState *v1alpha2.VirtualMachineMigrationState) bool {
 	return migrationState != nil && migrationState.StartTimestamp != nil && migrationState.EndTimestamp == nil
+}
+
+// TODO: Delete me after 1.7 version
+func (h *MigratingHandler) setUSBNonMigratable(vm *v1alpha2.VirtualMachine) bool {
+	cond, _ := conditions.GetCondition(vmcondition.TypeFirmwareUpToDate, vm.Status.Conditions)
+	if cond.Status == metav1.ConditionTrue || cond.Reason != vmcondition.ReasonFirmwareOutOfDate.String() {
+		return false
+	}
+
+	usbExists := len(vm.Spec.USBDevices) > 0
+	if !usbExists {
+		return false
+	}
+
+	cb := conditions.NewConditionBuilder(vmcondition.TypeMigratable).
+		Generation(vm.GetGeneration()).
+		Status(metav1.ConditionFalse).
+		Reason(vmcondition.ReasonNonMigratable).
+		Message("USB devices cannot be migratable on this virtualization version, firmware should be updated first. Please restart virtual machine or unplug usb devices and migrate.")
+	conditions.SetCondition(cb, &vm.Status.Conditions)
+	return true
 }

--- a/images/virtualization-artifact/pkg/controller/vm/vm_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vm/vm_controller.go
@@ -80,8 +80,8 @@ func SetupController(
 		internal.NewSyncPowerStateHandler(client, recorder),
 		internal.NewSyncMetadataHandler(client),
 		internal.NewLifeCycleHandler(client, recorder),
-		internal.NewMigratingHandler(migrateVolumesService),
 		internal.NewFirmwareHandler(firmwareImage),
+		internal.NewMigratingHandler(migrateVolumesService),
 		internal.NewEvictHandler(),
 		internal.NewStatisticHandler(client),
 	}


### PR DESCRIPTION
## Description
set non migratable usb if firmware out of date and usb devices exists

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries

```changes
section: vm
type: fix
summary: "Action is required to update the firmware on virtual machines with a connected USB device."
impact_level: high
impact: |
  Action is required to update the firmware on virtual machines with a connected USB device (a corresponding migration prompt will appear in the VM status):
  - either disconnect the USB device and migrate the virtual machine;
  - or restart the virtual machine.

  Until the action is taken, the virtual machine will continue running, but it cannot be migrated.
  After completing the action, the virtual machine will be updated to the current firmware version and will be ready for migration again.
```



<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->
