### PR TITLE
fix(cli): force handling for VM lifecycle operations initiated via CLI/VMOP

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vmop/powerstate/internal/service/restart.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/powerstate/internal/service/restart.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kvvmutil "github.com/deckhouse/virtualization-controller/pkg/common/kvvm"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/powerstate"
 	genericservice "github.com/deckhouse/virtualization-controller/pkg/controller/vmop/service"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmopcondition"
@@ -41,11 +42,23 @@ type RestartOperation struct {
 }
 
 func (o RestartOperation) Execute(ctx context.Context) error {
+	key := virtualMachineKeyByVmop(o.vmop)
+
 	kvvm := &virtv1.VirtualMachine{}
-	err := o.client.Get(ctx, virtualMachineKeyByVmop(o.vmop), kvvm)
+	err := o.client.Get(ctx, key, kvvm)
 	if err != nil {
 		return err
 	}
+
+	if o.vmop.Spec.Force != nil && *o.vmop.Spec.Force {
+		kvvmi := &virtv1.VirtualMachineInstance{}
+		err = o.client.Get(ctx, key, kvvmi)
+		if err != nil {
+			return err
+		}
+		return powerstate.RestartVM(ctx, o.client, kvvm, kvvmi, true)
+	}
+
 	return kvvmutil.AddRestartAnnotation(ctx, o.client, kvvm)
 }
 

--- a/src/cli/internal/cmd/lifecycle/vmop/vmop.go
+++ b/src/cli/internal/cmd/lifecycle/vmop/vmop.go
@@ -75,7 +75,7 @@ func WithCreateOnly(createOnly bool) func(*VirtualMachineOperation) {
 }
 
 func (v VirtualMachineOperation) Stop(ctx context.Context, vmName, vmNamespace string) (msg string, err error) {
-	vmop := v.newVMOP(vmName, vmNamespace, v1alpha2.VMOPTypeStop, false)
+	vmop := v.newVMOP(vmName, vmNamespace, v1alpha2.VMOPTypeStop, v.options.force)
 	return v.do(ctx, vmop, v.options.createOnly, v.options.waitComplete)
 }
 


### PR DESCRIPTION
## Description
Fix force handling for VM lifecycle operations initiated via CLI/VMOP:

1. CLI `stop` now correctly propagates `--force` to `VirtualMachineOperation.spec.force`.
2. VMOP `restart` now honors `spec.force` in the powerstate controller and performs force restart path when requested.

Previously:
- `d8 v stop --force` had no effect because CLI hardcoded `force=false` for Stop VMOP.
- `VirtualMachineOperation` with `type=Restart` and `spec.force=true` was processed via graceful restart annotation path, effectively ignoring force behavior.

## Why do we need it, and what problem does it solve?
Users expect force lifecycle actions to be applied consistently:
- `stop --force` should trigger force stop semantics.
- `restart --force` should trigger immediate restart semantics (force path), not graceful shutdown waiting behavior.

These fixes align implementation with API contract and documented `spec.force` semantics.

## What is the expected result?
1. Run `d8 v stop <vm> --force`.
2. Created `VirtualMachineOperation` has `spec.force=true` and force-stop behavior is applied.
3. Create `VirtualMachineOperation` with `type=Restart` and `spec.force=true`.
4. Controller uses force restart path (`powerstate.RestartVM(..., true)`) instead of annotation-only graceful path.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

