### PR TITLE
fix(vmsnapshot): snapshotting vm without main network

### DIFF
--- a/images/virtualization-artifact/pkg/controller/service/restorer/secret_restorer.go
+++ b/images/virtualization-artifact/pkg/controller/service/restorer/secret_restorer.go
@@ -121,10 +121,12 @@ func (r SecretRestorer) RestoreMACAddressOrder(_ context.Context, secret *corev1
 
 	var macAddressOrder []string
 	for _, ns := range vm.Status.Networks {
-		if ns.Type == v1alpha2.NetworksTypeMain {
-			continue
+		switch ns.Type {
+		case v1alpha2.NetworksTypeMain:
+			macAddressOrder = append(macAddressOrder, "")
+		default:
+			macAddressOrder = append(macAddressOrder, ns.MAC)
 		}
-		macAddressOrder = append(macAddressOrder, ns.MAC)
 	}
 	return macAddressOrder, nil
 }

--- a/images/virtualization-artifact/pkg/controller/service/restorer/secret_restorer.go
+++ b/images/virtualization-artifact/pkg/controller/service/restorer/secret_restorer.go
@@ -180,6 +180,10 @@ func (r SecretRestorer) setVirtualMachineBlockDeviceAttachments(ctx context.Cont
 }
 
 func (r SecretRestorer) setVirtualMachineIPAddress(ctx context.Context, secret *corev1.Secret, vm *v1alpha2.VirtualMachine, keepIPAddress v1alpha2.KeepIPAddress) error {
+	if vm.Status.VirtualMachineIPAddress == "" {
+		return nil
+	}
+
 	vmip, err := object.FetchObject(ctx, types.NamespacedName{
 		Namespace: vm.Namespace,
 		Name:      vm.Status.VirtualMachineIPAddress,

--- a/images/virtualization-artifact/pkg/controller/service/restorer/secret_restorer_test.go
+++ b/images/virtualization-artifact/pkg/controller/service/restorer/secret_restorer_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package restorer
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+)
+
+func TestRestorer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Restorer Suite")
+}
+
+var _ = Describe("SecretRestorer", func() {
+	Describe("RestoreMACAddressOrder", func() {
+		It("keeps an empty slot for the main network", func() {
+			vm := &v1alpha2.VirtualMachine{
+				Status: v1alpha2.VirtualMachineStatus{
+					Networks: []v1alpha2.NetworksStatus{
+						{Type: v1alpha2.NetworksTypeMain},
+						{Type: v1alpha2.NetworksTypeNetwork, MAC: "02:00:00:00:00:11"},
+						{Type: v1alpha2.NetworksTypeNetwork, MAC: "02:00:00:00:00:22"},
+					},
+				},
+			}
+
+			vmJSON, err := json.Marshal(vm)
+			Expect(err).NotTo(HaveOccurred())
+
+			secret := &corev1.Secret{
+				Data: map[string][]byte{virtualMachineKey: vmJSON},
+			}
+
+			order, err := (SecretRestorer{}).RestoreMACAddressOrder(context.Background(), secret)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(order).To(Equal([]string{"", "02:00:00:00:00:11", "02:00:00:00:00:22"}))
+		})
+	})
+
+	Describe("setVirtualMachineIPAddress", func() {
+		It("returns nil and does not write to secret when VM has no IP address reference", func() {
+			secret := &corev1.Secret{Data: map[string][]byte{}}
+			vm := &v1alpha2.VirtualMachine{}
+
+			err := (SecretRestorer{}).setVirtualMachineIPAddress(
+				context.Background(), secret, vm, v1alpha2.KeepIPAddressAlways,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(secret.Data).NotTo(HaveKey(virtualMachineIPAddressKey))
+		})
+	})
+})

--- a/images/virtualization-artifact/pkg/controller/service/restorer/snapshot_resources.go
+++ b/images/virtualization-artifact/pkg/controller/service/restorer/snapshot_resources.go
@@ -129,19 +129,13 @@ func (r *SnapshotResources) Prepare(ctx context.Context) error {
 			macAddressNamesByAddress[vmmac.Status.Address] = vmmac.Name
 		}
 
-		hasMainNetwork := len(vm.Spec.Networks) > 0 && vm.Spec.Networks[0].Type == v1alpha2.NetworksTypeMain
-
 		for i := range vm.Spec.Networks {
 			ns := &vm.Spec.Networks[i]
 			if ns.Type == v1alpha2.NetworksTypeMain {
 				continue
 			}
 
-			delta := 0
-			if hasMainNetwork {
-				delta = 1
-			}
-			ns.VirtualMachineMACAddressName = macAddressNamesByAddress[macAddressOrder[i-delta]]
+			ns.VirtualMachineMACAddressName = macAddressNamesByAddress[macAddressOrder[i]]
 		}
 	} else {
 		for i := range vm.Spec.Networks {

--- a/images/virtualization-artifact/pkg/controller/service/restorer/snapshot_resources.go
+++ b/images/virtualization-artifact/pkg/controller/service/restorer/snapshot_resources.go
@@ -129,13 +129,19 @@ func (r *SnapshotResources) Prepare(ctx context.Context) error {
 			macAddressNamesByAddress[vmmac.Status.Address] = vmmac.Name
 		}
 
+		hasMainNetwork := len(vm.Spec.Networks) > 0 && vm.Spec.Networks[0].Type == v1alpha2.NetworksTypeMain
+
 		for i := range vm.Spec.Networks {
 			ns := &vm.Spec.Networks[i]
 			if ns.Type == v1alpha2.NetworksTypeMain {
 				continue
 			}
 
-			ns.VirtualMachineMACAddressName = macAddressNamesByAddress[macAddressOrder[i-1]]
+			delta := 0
+			if hasMainNetwork {
+				delta = 1
+			}
+			ns.VirtualMachineMACAddressName = macAddressNamesByAddress[macAddressOrder[i-delta]]
 		}
 	} else {
 		for i := range vm.Spec.Networks {

--- a/images/virtualization-artifact/pkg/controller/service/restorer/snapshot_resources_test.go
+++ b/images/virtualization-artifact/pkg/controller/service/restorer/snapshot_resources_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package restorer
+
+import (
+	"context"
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/deckhouse/virtualization-controller/pkg/common/testutil"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+)
+
+var _ = Describe("SnapshotResources.Prepare", func() {
+	It("maps VirtualMachineMACAddressName by original network index", func() {
+		vm := &v1alpha2.VirtualMachine{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       v1alpha2.VirtualMachineKind,
+				APIVersion: v1alpha2.SchemeGroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "vm",
+				Namespace: "default",
+			},
+			Spec: v1alpha2.VirtualMachineSpec{
+				Networks: []v1alpha2.NetworksSpec{
+					{Type: v1alpha2.NetworksTypeMain},
+					{Type: v1alpha2.NetworksTypeNetwork},
+				},
+			},
+			Status: v1alpha2.VirtualMachineStatus{
+				Networks: []v1alpha2.NetworksStatus{
+					{Type: v1alpha2.NetworksTypeMain},
+					{Type: v1alpha2.NetworksTypeNetwork, MAC: "02:00:00:00:00:11"},
+				},
+			},
+		}
+
+		vmmacs := []v1alpha2.VirtualMachineMACAddress{
+			{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       v1alpha2.VirtualMachineMACAddressKind,
+					APIVersion: v1alpha2.SchemeGroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{Name: "vm-mac-secondary", Namespace: "default"},
+				Status:     v1alpha2.VirtualMachineMACAddressStatus{Address: "02:00:00:00:00:11"},
+			},
+		}
+
+		vmJSON, err := json.Marshal(vm)
+		Expect(err).NotTo(HaveOccurred())
+
+		vmmacsJSON, err := json.Marshal(vmmacs)
+		Expect(err).NotTo(HaveOccurred())
+
+		restorerSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "restorer-secret", Namespace: "default"},
+			Data: map[string][]byte{
+				virtualMachineKey:             vmJSON,
+				virtualMachineMACAddressesKey: vmmacsJSON,
+			},
+		}
+
+		fakeClient, err := testutil.NewFakeClientWithObjects()
+		Expect(err).NotTo(HaveOccurred())
+
+		vmSnapshot := &v1alpha2.VirtualMachineSnapshot{
+			ObjectMeta: metav1.ObjectMeta{Name: "snapshot", Namespace: "default"},
+			Spec:       v1alpha2.VirtualMachineSnapshotSpec{VirtualMachineName: "vm"},
+		}
+
+		resources := NewSnapshotResources(
+			fakeClient, v1alpha2.VMOPTypeRestore, v1alpha2.SnapshotOperationModeStrict,
+			restorerSecret, vmSnapshot, "restore-uid",
+		)
+		Expect(resources.Prepare(context.Background())).To(Succeed())
+
+		var restoredVM *v1alpha2.VirtualMachine
+		for _, handler := range resources.GetObjectHandlers() {
+			if obj, ok := handler.Object().(*v1alpha2.VirtualMachine); ok {
+				restoredVM = obj
+				break
+			}
+		}
+
+		Expect(restoredVM).NotTo(BeNil())
+		Expect(restoredVM.Spec.Networks[0].VirtualMachineMACAddressName).To(BeEmpty())
+		Expect(restoredVM.Spec.Networks[1].VirtualMachineMACAddressName).To(Equal("vm-mac-secondary"))
+	})
+})

--- a/images/virtualization-artifact/pkg/controller/vmrestore/internal/handler_test.go
+++ b/images/virtualization-artifact/pkg/controller/vmrestore/internal/handler_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/deckhouse/virtualization-controller/pkg/logger"
+)
+
+func TestHandlers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "VMRestore Handlers")
+}
+
+func testContext() context.Context {
+	return logger.ToContext(context.Background(), slog.Default())
+}

--- a/images/virtualization-artifact/pkg/controller/vmrestore/internal/life_cycle.go
+++ b/images/virtualization-artifact/pkg/controller/vmrestore/internal/life_cycle.go
@@ -180,13 +180,18 @@ func (h LifeCycleHandler) Handle(ctx context.Context, vmRestore *v1alpha2.Virtua
 			macAddressNamesByAddress[vmmac.Status.Address] = vmmac.Name
 		}
 
+		hasMainNetwork := len(vm.Spec.Networks) > 0 && vm.Spec.Networks[0].Type == v1alpha2.NetworksTypeMain
 		for i := range vm.Spec.Networks {
 			ns := &vm.Spec.Networks[i]
 			if ns.Type == v1alpha2.NetworksTypeMain {
 				continue
 			}
 
-			ns.VirtualMachineMACAddressName = macAddressNamesByAddress[macAddressOrder[i-1]]
+			delta := 0
+			if hasMainNetwork {
+				delta = 1
+			}
+			ns.VirtualMachineMACAddressName = macAddressNamesByAddress[macAddressOrder[i-delta]]
 		}
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vmrestore/internal/life_cycle.go
+++ b/images/virtualization-artifact/pkg/controller/vmrestore/internal/life_cycle.go
@@ -180,18 +180,13 @@ func (h LifeCycleHandler) Handle(ctx context.Context, vmRestore *v1alpha2.Virtua
 			macAddressNamesByAddress[vmmac.Status.Address] = vmmac.Name
 		}
 
-		hasMainNetwork := len(vm.Spec.Networks) > 0 && vm.Spec.Networks[0].Type == v1alpha2.NetworksTypeMain
 		for i := range vm.Spec.Networks {
 			ns := &vm.Spec.Networks[i]
 			if ns.Type == v1alpha2.NetworksTypeMain {
 				continue
 			}
 
-			delta := 0
-			if hasMainNetwork {
-				delta = 1
-			}
-			ns.VirtualMachineMACAddressName = macAddressNamesByAddress[macAddressOrder[i-delta]]
+			ns.VirtualMachineMACAddressName = macAddressNamesByAddress[macAddressOrder[i]]
 		}
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vmrestore/internal/life_cycle_test.go
+++ b/images/virtualization-artifact/pkg/controller/vmrestore/internal/life_cycle_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/deckhouse/virtualization-controller/pkg/common/testutil"
+	"github.com/deckhouse/virtualization-controller/pkg/eventrecord"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+	vmrestorecondition "github.com/deckhouse/virtualization/api/core/v1alpha2/vm-restore-condition"
+)
+
+var _ = Describe("LifeCycleHandler", func() {
+	It("maps VirtualMachineMACAddressName by original network index", func() {
+		vm := &v1alpha2.VirtualMachine{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       v1alpha2.VirtualMachineKind,
+				APIVersion: v1alpha2.SchemeGroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "vm",
+				Namespace: "default",
+			},
+			Spec: v1alpha2.VirtualMachineSpec{
+				Networks: []v1alpha2.NetworksSpec{
+					{Type: v1alpha2.NetworksTypeMain},
+					{Type: v1alpha2.NetworksTypeNetwork},
+				},
+			},
+		}
+
+		vmmac := &v1alpha2.VirtualMachineMACAddress{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       v1alpha2.VirtualMachineMACAddressKind,
+				APIVersion: v1alpha2.SchemeGroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "vm-mac-secondary",
+				Namespace: "default",
+			},
+			Status: v1alpha2.VirtualMachineMACAddressStatus{
+				Address:        "02:00:00:00:00:11",
+				VirtualMachine: "vm",
+			},
+		}
+
+		vmSnapshot := &v1alpha2.VirtualMachineSnapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "snapshot",
+				Namespace: "default",
+			},
+			Spec: v1alpha2.VirtualMachineSnapshotSpec{
+				VirtualMachineName: "vm",
+			},
+			Status: v1alpha2.VirtualMachineSnapshotStatus{
+				VirtualMachineSnapshotSecretName: "restorer-secret",
+			},
+		}
+
+		vmRestore := &v1alpha2.VirtualMachineRestore{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "restore",
+				Namespace: "default",
+				UID:       types.UID("restore-uid"),
+			},
+			Spec: v1alpha2.VirtualMachineRestoreSpec{
+				VirtualMachineSnapshotName: "snapshot",
+				RestoreMode:                v1alpha2.RestoreModeSafe,
+			},
+			Status: v1alpha2.VirtualMachineRestoreStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   vmrestorecondition.VirtualMachineSnapshotReadyToUseType.String(),
+						Status: metav1.ConditionTrue,
+					},
+				},
+			},
+		}
+
+		restorerSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "restorer-secret",
+				Namespace: "default",
+			},
+		}
+
+		fakeClient, err := testutil.NewFakeClientWithObjects(vmSnapshot, vmRestore, restorerSecret)
+		Expect(err).NotTo(HaveOccurred())
+
+		restorerMock := &RestorerMock{
+			RestoreVirtualMachineFunc: func(context.Context, *corev1.Secret) (*v1alpha2.VirtualMachine, error) {
+				return vm.DeepCopy(), nil
+			},
+			RestoreProvisionerFunc: func(context.Context, *corev1.Secret) (*corev1.Secret, error) {
+				return nil, nil
+			},
+			RestoreVirtualMachineIPAddressFunc: func(context.Context, *corev1.Secret) (*v1alpha2.VirtualMachineIPAddress, error) {
+				return nil, nil
+			},
+			RestoreVirtualMachineBlockDeviceAttachmentsFunc: func(context.Context, *corev1.Secret) ([]*v1alpha2.VirtualMachineBlockDeviceAttachment, error) {
+				return nil, nil
+			},
+			RestoreVirtualMachineMACAddressesFunc: func(context.Context, *corev1.Secret) ([]*v1alpha2.VirtualMachineMACAddress, error) {
+				return []*v1alpha2.VirtualMachineMACAddress{vmmac.DeepCopy()}, nil
+			},
+			RestoreMACAddressOrderFunc: func(context.Context, *corev1.Secret) ([]string, error) {
+				return []string{"", "02:00:00:00:00:11"}, nil
+			},
+		}
+
+		recorder := &eventrecord.EventRecorderLoggerMock{}
+		recorder.EventFunc = func(client.Object, string, string, string) {}
+		recorder.EventfFunc = func(client.Object, string, string, string, ...interface{}) {}
+		recorder.AnnotatedEventfFunc = func(client.Object, map[string]string, string, string, string, ...interface{}) {}
+		recorder.WithLoggingFunc = func(eventrecord.InfoLogger) eventrecord.EventRecorderLogger {
+			return recorder
+		}
+
+		handler := NewLifeCycleHandler(fakeClient, restorerMock, recorder)
+		_, err = handler.Handle(testContext(), vmRestore)
+		Expect(err).NotTo(HaveOccurred())
+
+		restoredVM := &v1alpha2.VirtualMachine{}
+		err = fakeClient.Get(testContext(), types.NamespacedName{Name: "vm", Namespace: "default"}, restoredVM)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(restoredVM.Spec.Networks[0].VirtualMachineMACAddressName).To(BeEmpty())
+		Expect(restoredVM.Spec.Networks[1].VirtualMachineMACAddressName).To(Equal("vm-mac-secondary"))
+	})
+})

--- a/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/life_cycle.go
+++ b/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/life_cycle.go
@@ -804,7 +804,7 @@ func (h LifeCycleHandler) fillStatusResources(ctx context.Context, vmSnapshot *v
 		Name:       vm.Name,
 	})
 
-	if vmSnapshot.Spec.KeepIPAddress == v1alpha2.KeepIPAddressAlways {
+	if vmSnapshot.Spec.KeepIPAddress == v1alpha2.KeepIPAddressAlways && vm.Status.VirtualMachineIPAddress != "" {
 		vmip, err := object.FetchObject(ctx, types.NamespacedName{
 			Namespace: vm.Namespace,
 			Name:      vm.Status.VirtualMachineIPAddress,
@@ -824,7 +824,7 @@ func (h LifeCycleHandler) fillStatusResources(ctx context.Context, vmSnapshot *v
 		})
 	}
 
-	if len(vm.Spec.Networks) > 1 {
+	if len(vm.Spec.Networks) > 0 {
 		for _, ns := range vm.Status.Networks {
 			if ns.Type == v1alpha2.NetworksTypeMain {
 				continue

--- a/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/life_cycle_test.go
+++ b/images/virtualization-artifact/pkg/controller/vmsnapshot/internal/life_cycle_test.go
@@ -391,4 +391,69 @@ var _ = Describe("LifeCycle handler", func() {
 			Expect(vmSnapshot.Status.Consistent).To(BeNil())
 		})
 	})
+
+	Context("fill status resources", func() {
+		It("includes a mac address resource for a single non-main network", func() {
+			vmmac := &v1alpha2.VirtualMachineMACAddress{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       v1alpha2.VirtualMachineMACAddressKind,
+					APIVersion: v1alpha2.SchemeGroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vm-mac-secondary",
+					Namespace: vm.Namespace,
+				},
+			}
+
+			vm.Spec.Networks = []v1alpha2.NetworksSpec{
+				{
+					Type: v1alpha2.NetworksTypeNetwork,
+				},
+			}
+			vm.Status.Networks = []v1alpha2.NetworksStatus{
+				{
+					Type:                         v1alpha2.NetworksTypeNetwork,
+					VirtualMachineMACAddressName: vmmac.Name,
+				},
+			}
+
+			var err error
+			fakeClient, err = testutil.NewFakeClientWithObjects(vd, vm, vmSnapshot, vdSnapshot, vmmac)
+			Expect(err).NotTo(HaveOccurred())
+
+			h := NewLifeCycleHandler(recorder, snapshotter, storer, fakeClient)
+			err = h.fillStatusResources(testContext(), vmSnapshot, vm)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(vmSnapshot.Status.Resources).To(ContainElement(v1alpha2.ResourceRef{
+				Kind:       vmmac.Kind,
+				ApiVersion: vmmac.APIVersion,
+				Name:       vmmac.Name,
+			}))
+		})
+
+		It("skips virtual machine ip address lookup when the status reference is empty", func() {
+			vm.Spec.Networks = nil
+			vm.Status.Networks = nil
+			vm.Spec.BlockDeviceRefs = nil
+			vm.Status.BlockDeviceRefs = nil
+			vmSnapshot.Spec.KeepIPAddress = v1alpha2.KeepIPAddressAlways
+			vm.Status.VirtualMachineIPAddress = ""
+
+			var err error
+			fakeClient, err = testutil.NewFakeClientWithObjects(vm, vmSnapshot)
+			Expect(err).NotTo(HaveOccurred())
+
+			h := NewLifeCycleHandler(recorder, snapshotter, storer, fakeClient)
+			err = h.fillStatusResources(testContext(), vmSnapshot, vm)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(vmSnapshot.Status.Resources).To(Equal([]v1alpha2.ResourceRef{
+				{
+					Kind:       vm.Kind,
+					ApiVersion: vm.APIVersion,
+					Name:       vm.Name,
+				},
+			}))
+		})
+	})
 })


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Fix snapshotting VM without Main network.


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: vmsnapshot
type: fix
summary: "Fixed snapshot creation for a virtual machine without the `Main` network."
```
