### PR TITLE
fix(vm): sync unschedulable KVVM on vmclass placement change

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
@@ -717,7 +717,7 @@ func (h *SyncKvvmHandler) isVMUnschedulable(
 func (h *SyncKvvmHandler) isPlacementPolicyChanged(allChanges vmchange.SpecChanges) bool {
 	for _, c := range allChanges.GetAll() {
 		switch c.Path {
-		case "affinity", "nodeSelector", "tolerations":
+		case "affinity", "nodeSelector", "tolerations", "virtualMachineClassName", "VirtualMachineClass:spec.nodeSelector", "VirtualMachineClass:spec.tolerations":
 			if !equality.Semantic.DeepEqual(c.CurrentValue, c.DesiredValue) {
 				return true
 			}

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/deckhouse/virtualization-controller/pkg/controller/reconciler"
 	vmservice "github.com/deckhouse/virtualization-controller/pkg/controller/vm/internal/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vm/internal/state"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/vmchange"
 	"github.com/deckhouse/virtualization-controller/pkg/eventrecord"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmcondition"
@@ -318,5 +319,20 @@ var _ = Describe("SyncKvvmHandler", func() {
 
 		Entry("Pending phase with changes applied, condition should not exist", v1alpha2.MachinePending, false, metav1.ConditionUnknown, false),
 		Entry("Pending phase with changes not applied, condition should not exist", v1alpha2.MachinePending, true, metav1.ConditionUnknown, false),
+	)
+
+	DescribeTable("isPlacementPolicyChanged",
+		func(path string, expected bool) {
+			h := &SyncKvvmHandler{}
+			changes := vmchange.SpecChanges{}
+			changes.Add(vmchange.FieldChange{Path: path, CurrentValue: "old", DesiredValue: "new"})
+
+			Expect(h.isPlacementPolicyChanged(changes)).To(Equal(expected))
+		},
+		Entry("vm tolerations change", "tolerations", true),
+		Entry("vmclass tolerations change", "VirtualMachineClass:spec.tolerations", true),
+		Entry("vmclass nodeSelector change", "VirtualMachineClass:spec.nodeSelector", true),
+		Entry("vmclass name change", "virtualMachineClassName", true),
+		Entry("cpu change is not a placement policy", "cpu.cores", false),
 	)
 })


### PR DESCRIPTION
## Description
Fix synchronization of internal KubeVirt VM when the VM is in `Unschedulable` state and placement-related settings are changed via VMClass.

The workaround path in `SyncKvvmHandler` now treats these change paths as placement policy updates:
- `virtualMachineClassName`
- `VirtualMachineClass:spec.nodeSelector`
- `VirtualMachineClass:spec.tolerations`

This allows controller to apply KVVM update and recycle launcher pod for unschedulable cases.

Also added unit tests for placement-path detection in `isPlacementPolicyChanged`.

## Why do we need it, and what problem does it solve?
When VM pod creation fails and KVVM stays `Unschedulable`, changing VMClass (for example, `discovery` -> `generic`) did not trigger full KVVM resync for placement-dependent fields.
As a result, `domain.cpu` / `tolerations` could stay stale and VM remained stuck.

This change makes unschedulable recovery react to VMClass-driven placement changes.

## What is the expected result?
1. Put VM into `Unschedulable` state.
2. Change VMClass name or update VMClass `spec.nodeSelector` / `spec.tolerations`.
3. Verify KVVM is synchronized and VM can leave `Unschedulable` when constraints become schedulable.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
