### PR TITLE
fix(vm): disconnecting Main network

### DIFF
--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
@@ -119,6 +119,17 @@ func (b *KVVM) SetKVVMIAnnotation(annoKey, annoValue string) {
 	b.Resource.Spec.Template.ObjectMeta.SetAnnotations(anno)
 }
 
+func (b *KVVM) RemoveKVVMIAnnotation(annoKey string) {
+	anno := b.Resource.Spec.Template.ObjectMeta.GetAnnotations()
+	if anno == nil {
+		return
+	}
+
+	delete(anno, annoKey)
+
+	b.Resource.Spec.Template.ObjectMeta.SetAnnotations(anno)
+}
+
 func (b *KVVM) SetCPUModel(class *v1alpha2.VirtualMachineClass) error {
 	if b.Resource.Spec.Template.Spec.Domain.CPU == nil {
 		b.Resource.Spec.Template.Spec.Domain.CPU = &virtv1.CPU{}

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
@@ -290,6 +290,8 @@ func ApplyVirtualMachineSpec(
 	if ipAddress != "" {
 		// Set ip address cni request annotation.
 		kvvm.SetKVVMIAnnotation(netmanager.AnnoIPAddressCNIRequest, ipAddress)
+	} else {
+		kvvm.RemoveKVVMIAnnotation(netmanager.AnnoIPAddressCNIRequest)
 	}
 
 	// Set live migration annotation.


### PR DESCRIPTION
## Description
Fix Main network disconnection handling by removing the cilium IP request annotation from KVVMI when the Main network is disabled.

## Why do we need it, and what problem does it solve?
When the Main network was disabled, the cilium-related annotation remained on the KVVMI object. This left stale networking metadata on the instance template and could lead to incorrect behavior after disconnecting the Main network.

## What is the expected result?
1. Create or update a VM so that the Main network is enabled and the cilium IP request annotation is present on KVVMI.
2. Disable the Main network.
3. Verify that the cilium annotation is removed from KVVMI.
4. Verify that the VM no longer keeps stale Main network cilium metadata.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: vm
type: fix
summary: "Fixed removal of the `Main` network from a virtual machine: the virtual machine no longer uses an IP address from the virtualization CIDR after the network is removed."
```
