### PR TITLE
ci: bump d8-cli version to v0.29.24

### DIFF
--- a/.github/actions/install-d8/action.yml
+++ b/.github/actions/install-d8/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: version of deckhouse-cli (like v0.25.1)
     required: false
-    default: v0.25.1
+    default: v0.29.24
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
The DataExport test case requires a new version of d8-cli because it uses the --cleanup option, which is not present in the current v0.25.1 version.
```bash
failed to execute command `d8 data export download vd/vd-data -n v12n-e2e-data-exports-pv9l9 -o exported-disk.img --publish --cleanup 2>&1`: exit status 1:
      Error executing command: unknown flag: --cleanup
```

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
The DataExport test case should pass.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.