### PR TITLE
test: fix e2e VirtualMachineMigration

### DIFF
--- a/test/e2e/vm/migration.go
+++ b/test/e2e/vm/migration.go
@@ -264,8 +264,8 @@ var _ = Describe("VirtualMachineMigration", func() {
 				g.Expect(vmopMigrateUEFI.Status.Phase).To(Equal(v1alpha2.VMOPPhaseCompleted))
 			}).WithPolling(time.Second).WithTimeout(framework.LongTimeout).To(Succeed())
 
-			checkMigratedVM(f, vmBIOS, biosDiskCountOriginal)
-			checkMigratedVM(f, vmUEFI, uefiDiskCountOriginal)
+			verifyDisksPreservedAfterMigration(f, vmBIOS, biosDiskCountOriginal)
+			verifyDisksPreservedAfterMigration(f, vmUEFI, uefiDiskCountOriginal)
 
 			cancelVMBDA()
 			Expect(<-vmbdaWatchErrCh).NotTo(HaveOccurred(), "VMBDAs should stay in Attached phase during migration")
@@ -329,7 +329,7 @@ func ensureVMBDAsStayAttached(ctx context.Context, w util.Watcher, names []strin
 	}
 }
 
-func checkMigratedVM(f *framework.Framework, vm *v1alpha2.VirtualMachine, originalDiskCount string) {
+func verifyDisksPreservedAfterMigration(f *framework.Framework, vm *v1alpha2.VirtualMachine, originalDiskCount string) {
 	GinkgoHelper()
 
 	By(fmt.Sprintf("Check access via ssh for vm %s", vm.Name), func() {

--- a/test/e2e/vm/migration.go
+++ b/test/e2e/vm/migration.go
@@ -260,16 +260,27 @@ var _ = Describe("VirtualMachineMigration", func() {
 				err = f.GenericClient().Get(context.Background(), crclient.ObjectKeyFromObject(vmopMigrateUEFI), vmopMigrateUEFI)
 				Expect(err).NotTo(HaveOccurred()) // Intentionally fail the test on a single error, so g.Expect is not needed
 
-				biosDiskCount, err := f.SSHCommand(vmBIOS.Name, f.Namespace().Name, lsblkCommand)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(biosDiskCount).To(Equal(biosDiskCountOriginal))
-				uefiDiskCount, err := f.SSHCommand(vmUEFI.Name, f.Namespace().Name, lsblkCommand)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(uefiDiskCount).To(Equal(uefiDiskCountOriginal))
+				// biosDiskCount, err := f.SSHCommand(vmBIOS.Name, f.Namespace().Name, lsblkCommand)
+				// Expect(err).NotTo(HaveOccurred())
+				// Expect(biosDiskCount).To(Equal(biosDiskCountOriginal))
+				// uefiDiskCount, err := f.SSHCommand(vmUEFI.Name, f.Namespace().Name, lsblkCommand)
+				// Expect(err).NotTo(HaveOccurred())
+				// Expect(uefiDiskCount).To(Equal(uefiDiskCountOriginal))
 
 				g.Expect(vmopMigrateBIOS.Status.Phase).To(Equal(v1alpha2.VMOPPhaseCompleted))
 				g.Expect(vmopMigrateUEFI.Status.Phase).To(Equal(v1alpha2.VMOPPhaseCompleted))
 			}).WithPolling(time.Second).WithTimeout(framework.LongTimeout).To(Succeed())
+
+			util.UntilSSHReady(f, vmBIOS, framework.MiddleTimeout)
+			util.UntilSSHReady(f, vmUEFI, framework.MiddleTimeout)
+
+			biosDiskCount, err := f.SSHCommand(vmBIOS.Name, f.Namespace().Name, lsblkCommand)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(biosDiskCount).To(Equal(biosDiskCountOriginal))
+
+			uefiDiskCount, err := f.SSHCommand(vmUEFI.Name, f.Namespace().Name, lsblkCommand)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(uefiDiskCount).To(Equal(uefiDiskCountOriginal))
 
 			cancelVMBDA()
 			Expect(<-vmbdaWatchErrCh).NotTo(HaveOccurred(), "VMBDAs should stay in Attached phase during migration")

--- a/test/e2e/vm/migration.go
+++ b/test/e2e/vm/migration.go
@@ -264,8 +264,20 @@ var _ = Describe("VirtualMachineMigration", func() {
 				g.Expect(vmopMigrateUEFI.Status.Phase).To(Equal(v1alpha2.VMOPPhaseCompleted))
 			}).WithPolling(time.Second).WithTimeout(framework.LongTimeout).To(Succeed())
 
-			verifyDisksPreservedAfterMigration(f, vmBIOS, biosDiskCountOriginal)
-			verifyDisksPreservedAfterMigration(f, vmUEFI, uefiDiskCountOriginal)
+			By("Check access via ssh for vms", func() {
+				util.UntilSSHReady(f, vmBIOS, framework.MiddleTimeout)
+				util.UntilSSHReady(f, vmUEFI, framework.MiddleTimeout)
+			})
+
+			By("Check disks are still attached after migration for vms", func() {
+				diskCount, err := f.SSHCommand(vmBIOS.Name, f.Namespace().Name, lsblkCommand)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(diskCount).To(Equal(biosDiskCountOriginal))
+
+				diskCount, err = f.SSHCommand(vmUEFI.Name, f.Namespace().Name, lsblkCommand)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(diskCount).To(Equal(uefiDiskCountOriginal))
+			})
 
 			cancelVMBDA()
 			Expect(<-vmbdaWatchErrCh).NotTo(HaveOccurred(), "VMBDAs should stay in Attached phase during migration")
@@ -327,20 +339,6 @@ func ensureVMBDAsStayAttached(ctx context.Context, w util.Watcher, names []strin
 			}
 		}
 	}
-}
-
-func verifyDisksPreservedAfterMigration(f *framework.Framework, vm *v1alpha2.VirtualMachine, originalDiskCount string) {
-	GinkgoHelper()
-
-	By(fmt.Sprintf("Check access via ssh for vm %s", vm.Name), func() {
-		util.UntilSSHReady(f, vm, framework.MiddleTimeout)
-	})
-
-	By(fmt.Sprintf("Check disks are still attached after migration for vm %s", vm.Name), func() {
-		diskCount, err := f.SSHCommand(vm.Name, f.Namespace().Name, lsblkCommand)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(diskCount).To(Equal(originalDiskCount))
-	})
 }
 
 func toObjects[T crclient.Object](objs []T) []crclient.Object {

--- a/test/e2e/vm/migration.go
+++ b/test/e2e/vm/migration.go
@@ -271,20 +271,20 @@ var _ = Describe("VirtualMachineMigration", func() {
 				g.Expect(vmopMigrateUEFI.Status.Phase).To(Equal(v1alpha2.VMOPPhaseCompleted))
 			}).WithPolling(time.Second).WithTimeout(framework.LongTimeout).To(Succeed())
 
-			util.UntilSSHReady(f, vmBIOS, framework.MiddleTimeout)
-			util.UntilSSHReady(f, vmUEFI, framework.MiddleTimeout)
+			for _, vm := range []*v1alpha2.VirtualMachine{vmBIOS, vmUEFI} {
+				By(fmt.Sprintf("Check access via ssh for vm %s", vm.Name), func() {
+					util.UntilSSHReady(f, vm, framework.MiddleTimeout)
+				})
+			}
 
-			By(fmt.Sprintf("Check disks are still attached after migration for vm %s", vmBIOS.Name), func() {
-				biosDiskCount, err := f.SSHCommand(vmBIOS.Name, f.Namespace().Name, lsblkCommand)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(biosDiskCount).To(Equal(biosDiskCountOriginal))
-			})
-
-			By(fmt.Sprintf("Check disks are still attached after migration for vm %s", vmUEFI.Name), func() {
-				uefiDiskCount, err := f.SSHCommand(vmUEFI.Name, f.Namespace().Name, lsblkCommand)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(uefiDiskCount).To(Equal(uefiDiskCountOriginal))
-			})
+			for i, vm := range []*v1alpha2.VirtualMachine{vmBIOS, vmUEFI} {
+				original := []string{biosDiskCountOriginal, uefiDiskCountOriginal}[i]
+				By(fmt.Sprintf("Check disks are still attached after migration for vm %s", vm.Name), func() {
+					diskCount, err := f.SSHCommand(vm.Name, f.Namespace().Name, lsblkCommand)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(diskCount).To(Equal(original))
+				})
+			}
 
 			cancelVMBDA()
 			Expect(<-vmbdaWatchErrCh).NotTo(HaveOccurred(), "VMBDAs should stay in Attached phase during migration")

--- a/test/e2e/vm/migration.go
+++ b/test/e2e/vm/migration.go
@@ -264,20 +264,8 @@ var _ = Describe("VirtualMachineMigration", func() {
 				g.Expect(vmopMigrateUEFI.Status.Phase).To(Equal(v1alpha2.VMOPPhaseCompleted))
 			}).WithPolling(time.Second).WithTimeout(framework.LongTimeout).To(Succeed())
 
-			for _, vm := range []*v1alpha2.VirtualMachine{vmBIOS, vmUEFI} {
-				By(fmt.Sprintf("Check access via ssh for vm %s", vm.Name), func() {
-					util.UntilSSHReady(f, vm, framework.MiddleTimeout)
-				})
-			}
-
-			for i, vm := range []*v1alpha2.VirtualMachine{vmBIOS, vmUEFI} {
-				original := []string{biosDiskCountOriginal, uefiDiskCountOriginal}[i]
-				By(fmt.Sprintf("Check disks are still attached after migration for vm %s", vm.Name), func() {
-					diskCount, err := f.SSHCommand(vm.Name, f.Namespace().Name, lsblkCommand)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(diskCount).To(Equal(original))
-				})
-			}
+			checkMigratedVM(f, vmBIOS, biosDiskCountOriginal)
+			checkMigratedVM(f, vmUEFI, uefiDiskCountOriginal)
 
 			cancelVMBDA()
 			Expect(<-vmbdaWatchErrCh).NotTo(HaveOccurred(), "VMBDAs should stay in Attached phase during migration")
@@ -339,6 +327,20 @@ func ensureVMBDAsStayAttached(ctx context.Context, w util.Watcher, names []strin
 			}
 		}
 	}
+}
+
+func checkMigratedVM(f *framework.Framework, vm *v1alpha2.VirtualMachine, originalDiskCount string) {
+	GinkgoHelper()
+
+	By(fmt.Sprintf("Check access via ssh for vm %s", vm.Name), func() {
+		util.UntilSSHReady(f, vm, framework.MiddleTimeout)
+	})
+
+	By(fmt.Sprintf("Check disks are still attached after migration for vm %s", vm.Name), func() {
+		diskCount, err := f.SSHCommand(vm.Name, f.Namespace().Name, lsblkCommand)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(diskCount).To(Equal(originalDiskCount))
+	})
 }
 
 func toObjects[T crclient.Object](objs []T) []crclient.Object {

--- a/test/e2e/vm/migration.go
+++ b/test/e2e/vm/migration.go
@@ -76,7 +76,7 @@ var _ = Describe("VirtualMachineMigration", func() {
 
 	It("verifies that migrations are successful", func() {
 		By("Environment preparation", func() {
-			vdRootBIOS = object.NewVDFromCVI("vd-root-bios", f.Namespace().Name, object.PrecreatedCVIUbuntu,
+			vdRootBIOS = object.NewVDFromCVI("vd-root-bios", f.Namespace().Name, object.PrecreatedCVIAlpineBIOS,
 				vd.WithSize(ptr.To(resource.MustParse("10Gi"))),
 			)
 			vdBlankBIOS = vd.New(
@@ -105,7 +105,7 @@ var _ = Describe("VirtualMachineMigration", func() {
 					},
 				),
 				vm.WithBootloader(v1alpha2.BIOS),
-				vm.WithProvisioningUserData(object.UbuntuCloudInit),
+				vm.WithProvisioningUserData(object.AlpineCloudInit),
 				vm.WithLiveMigrationPolicy(v1alpha2.PreferSafeMigrationPolicy),
 				vm.WithName("vm-bios"),
 			)
@@ -264,27 +264,24 @@ var _ = Describe("VirtualMachineMigration", func() {
 				g.Expect(vmopMigrateUEFI.Status.Phase).To(Equal(v1alpha2.VMOPPhaseCompleted))
 			}).WithPolling(time.Second).WithTimeout(framework.LongTimeout).To(Succeed())
 
-			vmsToCheck := []struct {
-				vm                *v1alpha2.VirtualMachine
-				originalDiskCount string
-			}{
-				{vm: vmBIOS, originalDiskCount: biosDiskCountOriginal},
-				{vm: vmUEFI, originalDiskCount: uefiDiskCountOriginal},
+			vmOriginalDiskCount := map[*v1alpha2.VirtualMachine]string{
+				vmBIOS: biosDiskCountOriginal,
+				vmUEFI: uefiDiskCountOriginal,
 			}
 
-			By("Check access via ssh for vms")
-			for _, v := range vmsToCheck {
-				util.UntilSSHReady(f, v.vm, framework.MiddleTimeout)
+			By("Wait until the virtual machine is accessible via SSH after migration.")
+			for vm := range vmOriginalDiskCount {
+				util.UntilSSHReady(f, vm, framework.MiddleTimeout)
 			}
 
-			By("Check disks are still attached after migration for vms")
-			for _, v := range vmsToCheck {
-				diskCount, err := f.SSHCommand(v.vm.Name, f.Namespace().Name, lsblkCommand)
-				Expect(err).NotTo(HaveOccurred(),
-					"failed to run lsblk on VM %s", v.vm.Name)
-				Expect(diskCount).To(Equal(v.originalDiskCount),
+			By("Check that the disk count of the virtual machine is equal to the disk count before migration.")
+			for vm, originalDiskCount := range vmOriginalDiskCount {
+				diskCount, err := f.SSHCommand(vm.Name, f.Namespace().Name, lsblkCommand)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(diskCount).To(Equal(originalDiskCount),
 					"disk count mismatch on VM %s after migration: got %s, expected %s",
-					v.vm.Name, diskCount, v.originalDiskCount)
+					vm.Name, diskCount, originalDiskCount,
+				)
 			}
 
 			cancelVMBDA()

--- a/test/e2e/vm/migration.go
+++ b/test/e2e/vm/migration.go
@@ -264,20 +264,28 @@ var _ = Describe("VirtualMachineMigration", func() {
 				g.Expect(vmopMigrateUEFI.Status.Phase).To(Equal(v1alpha2.VMOPPhaseCompleted))
 			}).WithPolling(time.Second).WithTimeout(framework.LongTimeout).To(Succeed())
 
-			By("Check access via ssh for vms", func() {
-				util.UntilSSHReady(f, vmBIOS, framework.MiddleTimeout)
-				util.UntilSSHReady(f, vmUEFI, framework.MiddleTimeout)
-			})
+			vmsToCheck := []struct {
+				vm                *v1alpha2.VirtualMachine
+				originalDiskCount string
+			}{
+				{vm: vmBIOS, originalDiskCount: biosDiskCountOriginal},
+				{vm: vmUEFI, originalDiskCount: uefiDiskCountOriginal},
+			}
 
-			By("Check disks are still attached after migration for vms", func() {
-				diskCount, err := f.SSHCommand(vmBIOS.Name, f.Namespace().Name, lsblkCommand)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(diskCount).To(Equal(biosDiskCountOriginal))
+			By("Check access via ssh for vms")
+			for _, v := range vmsToCheck {
+				util.UntilSSHReady(f, v.vm, framework.MiddleTimeout)
+			}
 
-				diskCount, err = f.SSHCommand(vmUEFI.Name, f.Namespace().Name, lsblkCommand)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(diskCount).To(Equal(uefiDiskCountOriginal))
-			})
+			By("Check disks are still attached after migration for vms")
+			for _, v := range vmsToCheck {
+				diskCount, err := f.SSHCommand(v.vm.Name, f.Namespace().Name, lsblkCommand)
+				Expect(err).NotTo(HaveOccurred(),
+					"failed to run lsblk on VM %s", v.vm.Name)
+				Expect(diskCount).To(Equal(v.originalDiskCount),
+					"disk count mismatch on VM %s after migration: got %s, expected %s",
+					v.vm.Name, diskCount, v.originalDiskCount)
+			}
 
 			cancelVMBDA()
 			Expect(<-vmbdaWatchErrCh).NotTo(HaveOccurred(), "VMBDAs should stay in Attached phase during migration")

--- a/test/e2e/vm/migration.go
+++ b/test/e2e/vm/migration.go
@@ -274,13 +274,17 @@ var _ = Describe("VirtualMachineMigration", func() {
 			util.UntilSSHReady(f, vmBIOS, framework.MiddleTimeout)
 			util.UntilSSHReady(f, vmUEFI, framework.MiddleTimeout)
 
-			biosDiskCount, err := f.SSHCommand(vmBIOS.Name, f.Namespace().Name, lsblkCommand)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(biosDiskCount).To(Equal(biosDiskCountOriginal))
+			By(fmt.Sprintf("Check disks are still attached after migration for vm %s", vmBIOS.Name), func() {
+				biosDiskCount, err := f.SSHCommand(vmBIOS.Name, f.Namespace().Name, lsblkCommand)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(biosDiskCount).To(Equal(biosDiskCountOriginal))
+			})
 
-			uefiDiskCount, err := f.SSHCommand(vmUEFI.Name, f.Namespace().Name, lsblkCommand)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(uefiDiskCount).To(Equal(uefiDiskCountOriginal))
+			By(fmt.Sprintf("Check disks are still attached after migration for vm %s", vmUEFI.Name), func() {
+				uefiDiskCount, err := f.SSHCommand(vmUEFI.Name, f.Namespace().Name, lsblkCommand)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(uefiDiskCount).To(Equal(uefiDiskCountOriginal))
+			})
 
 			cancelVMBDA()
 			Expect(<-vmbdaWatchErrCh).NotTo(HaveOccurred(), "VMBDAs should stay in Attached phase during migration")

--- a/test/e2e/vm/migration.go
+++ b/test/e2e/vm/migration.go
@@ -260,13 +260,6 @@ var _ = Describe("VirtualMachineMigration", func() {
 				err = f.GenericClient().Get(context.Background(), crclient.ObjectKeyFromObject(vmopMigrateUEFI), vmopMigrateUEFI)
 				Expect(err).NotTo(HaveOccurred()) // Intentionally fail the test on a single error, so g.Expect is not needed
 
-				// biosDiskCount, err := f.SSHCommand(vmBIOS.Name, f.Namespace().Name, lsblkCommand)
-				// Expect(err).NotTo(HaveOccurred())
-				// Expect(biosDiskCount).To(Equal(biosDiskCountOriginal))
-				// uefiDiskCount, err := f.SSHCommand(vmUEFI.Name, f.Namespace().Name, lsblkCommand)
-				// Expect(err).NotTo(HaveOccurred())
-				// Expect(uefiDiskCount).To(Equal(uefiDiskCountOriginal))
-
 				g.Expect(vmopMigrateBIOS.Status.Phase).To(Equal(v1alpha2.VMOPPhaseCompleted))
 				g.Expect(vmopMigrateUEFI.Status.Phase).To(Equal(v1alpha2.VMOPPhaseCompleted))
 			}).WithPolling(time.Second).WithTimeout(framework.LongTimeout).To(Succeed())


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Fixes and improvements to VirtualMachineMigration e2e tests.                                                                                                                                                     
                                                                                                                                                                                                                  
 Changes:                                                                                                                                                                                                         
 - Removed commented-out disk verification code                                                                                                                                                                   
 - Refactored By blocks for better readability                                                                                                                                                                    
 - Added informative checks with VM name display                                                                                                                                                                  
 - Moved disk verification after migration into a separate loop with SSH accessibility check 
 - Fix vm CVI for vmBIOS to alpine

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
Migration tests contained commented-out code and lacked clear verification structure. After migration completes, VMs must remain accessible via SSH and retain their original disk count. 

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
After VirtualMachine migration:                                                                                                                                                                                  
 1. VM is accessible via SSH                                                                                                                                                                                      
 2. Disk count matches the original value 

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

