### PR TITLE
fix(core): clarify migration timeout failure message

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle.go
@@ -508,7 +508,7 @@ func getMessageByMigrationFailedReason(mig *virtv1.VirtualMachineInstanceMigrati
 		case virtv1.VirtualMachineInstanceMigrationFailedReasonVMIDoesNotExist, virtv1.VirtualMachineInstanceMigrationFailedReasonVMIIsShutdown:
 			return "VirtualMachine is stopped"
 		default:
-			return cond.Message
+			return humanizeMigrationFailedMessage(cond.Message)
 		}
 	}
 
@@ -676,6 +676,14 @@ func (h LifecycleHandler) forgetProgress(vmop *v1alpha2.VirtualMachineOperation)
 		return
 	}
 	h.progressStrategy.Forget(vmop.UID)
+}
+
+func humanizeMigrationFailedMessage(message string) string {
+	if strings.Contains(message, "unschedulable target pod") && strings.Contains(message, "timeout period expiration") {
+		return "No available nodes were found to place the target VM within the timeout period"
+	}
+
+	return message
 }
 
 func (h LifecycleHandler) getTargetPod(ctx context.Context, mig *virtv1.VirtualMachineInstanceMigration) (*corev1.Pod, error) {

--- a/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle_test.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle_test.go
@@ -902,4 +902,31 @@ var _ = Describe("LifecycleHandler", func() {
 			Expect(reason).To(Equal(vmopcondition.ReasonTargetPreparing))
 		})
 	})
+
+	DescribeTable("humanizeMigrationFailedMessage", func(message, expected string) {
+		Expect(humanizeMigrationFailedMessage(message)).To(Equal(expected))
+	},
+		Entry(
+			"should humanize unschedulable target pod timeout message",
+			"unschedulable target pod \"virt-launcher-bastion-demo-z7hcs\" was deleted due to timeout period expiration",
+			"No available nodes were found to place the target VM within the timeout period",
+		),
+		Entry(
+			"should keep other messages as is",
+			"some other migration failure",
+			"some other migration failure",
+		),
+	)
+
+	It("should use humanized message for migration failed condition", func() {
+		mig := newSimpleMigration("test", name)
+		mig.Status.Conditions = []virtv1.VirtualMachineInstanceMigrationCondition{{
+			Type:    virtv1.VirtualMachineInstanceMigrationFailed,
+			Status:  corev1.ConditionTrue,
+			Reason:  "SomeOtherReason",
+			Message: "unschedulable target pod \"virt-launcher-bastion-demo-z7hcs\" was deleted due to timeout period expiration",
+		}}
+
+		Expect(getMessageByMigrationFailedReason(mig)).To(Equal("No available nodes were found to place the target VM within the timeout period"))
+	})
 })


### PR DESCRIPTION
## Description
Clarify the VM migration failure condition message when KubeVirt reports that the target pod was unschedulable and deleted after the scheduling timeout.

Instead of exposing the raw low-level message from KubeVirt, the controller now returns a user-friendly condition message that explains the actual reason: no suitable node was found for placing the target VM within the timeout period.

## Why do we need it, and what problem does it solve?
The previous condition message was too technical:

`unschedulable target pod "..." was deleted due to timeout period expiration`

It exposed KubeVirt internals and did not clearly explain the problem from the user point of view. This change makes the failure easier to understand by surfacing the real issue: there were no available nodes to schedule the target VM before the timeout expired.

## What is the expected result?
1. Start a VM migration in a situation where no node can host the target VM.
2. Wait until the scheduling timeout expires.
3. Check the migration-related VMOP condition message.
4. Verify the condition message says that no available nodes were found to place the target VM within the timeout period.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: core
type: fix
summary: "Clarify VM migration failure message when no node is available for the target VM."
impact_level: low
```
