### PR TITLE
fix(vm): prevent negative cpu and memory overheads in vm statistics

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm/internal/statistic.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/statistic.go
@@ -150,6 +150,9 @@ func (h *StatisticHandler) syncResources(changed *v1alpha2.VirtualMachine,
 
 		cpuOverhead := cpuPODRequest.DeepCopy()
 		cpuOverhead.Sub(*cpuFractionRequests)
+		if cpuOverhead.Value() < 0 {
+			cpuOverhead.Set(0)
+		}
 
 		memoryKVVMIRequest := kvvmi.Spec.Domain.Resources.Requests[corev1.ResourceMemory]
 		memoryPodRequest := ctr.Resources.Requests[corev1.ResourceMemory]
@@ -158,6 +161,9 @@ func (h *StatisticHandler) syncResources(changed *v1alpha2.VirtualMachine,
 		memoryOverhead.Sub(memoryKVVMIRequest)
 		mi := int64(1024 * 1024)
 		memoryOverhead = *resource.NewQuantity(int64(math.Ceil(float64(memoryOverhead.Value())/float64(mi)))*mi, resource.BinarySI)
+		if memoryOverhead.Value() < 0 {
+			memoryOverhead.Set(0)
+		}
 
 		resources = v1alpha2.ResourcesStatus{
 			CPU: v1alpha2.CPUStatus{


### PR DESCRIPTION
## Description
prevent negative cpu and memory overheads in vm statistics


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
