### PR TITLE
feat(module): add non-linux stubs for linux-specific modules

### DIFF
--- a/images/cdi-cloner/cloner-startup/internal/helpers/size.go
+++ b/images/cdi-cloner/cloner-startup/internal/helpers/size.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 /*
 Copyright 2025 Flant JSC
 

--- a/images/cdi-cloner/cloner-startup/internal/helpers/size_unsupported.go
+++ b/images/cdi-cloner/cloner-startup/internal/helpers/size_unsupported.go
@@ -1,0 +1,50 @@
+//go:build !linux
+
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import "fmt"
+
+func GetBlockDeviceSize(device string) (uint64, error) {
+	_ = device
+	return 0, fmt.Errorf("block device size detection is supported only on linux")
+}
+
+func GetDirectorySize(path string) (uint64, uint64, error) {
+	_ = path
+	return 0, 0, fmt.Errorf("directory size calculation is supported only on linux in this helper")
+}
+
+func FormatBytes(s float64) string {
+	base := 1024.0
+	sizes := []string{"B", "kB", "MB", "GB", "TB", "PB", "EB"}
+
+	unitsLimit := len(sizes)
+	i := 0
+	for s >= base && i < unitsLimit {
+		s /= base
+		i++
+	}
+
+	f := "%.0f %s"
+	if i > 1 {
+		f = "%.2f %s"
+	}
+
+	return fmt.Sprintf(f, s, sizes[i])
+}

--- a/images/virt-launcher/node-labeller/cmd/node-labeller/run.go
+++ b/images/virt-launcher/node-labeller/cmd/node-labeller/run.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 /*
 Copyright 2025 Flant JSC
 

--- a/images/virt-launcher/node-labeller/cmd/node-labeller/run_unsupported.go
+++ b/images/virt-launcher/node-labeller/cmd/node-labeller/run_unsupported.go
@@ -1,5 +1,7 @@
+//go:build !linux
+
 /*
-Copyright 2024 Flant JSC
+Copyright 2025 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,4 +16,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package route
+package main
+
+import (
+	"fmt"
+	"log/slog"
+)
+
+func run(logger *slog.Logger) error {
+	_ = logger
+	return fmt.Errorf("node-labeller is supported only on linux")
+}

--- a/images/virt-launcher/node-labeller/pkg/helpers/helpers.go
+++ b/images/virt-launcher/node-labeller/pkg/helpers/helpers.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 /*
 Copyright 2025 Flant JSC
 

--- a/images/virt-launcher/node-labeller/pkg/helpers/helpers_unsupported.go
+++ b/images/virt-launcher/node-labeller/pkg/helpers/helpers_unsupported.go
@@ -1,0 +1,93 @@
+//go:build !linux
+
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"fmt"
+	"log/slog"
+	"runtime"
+)
+
+func GetArch() string {
+	switch runtime.GOARCH {
+	case "arm64":
+		return "aarch64"
+	case "amd64":
+		return "x86_64"
+	case "s390x":
+		return "s390x"
+	default:
+		return ""
+	}
+}
+
+func GetMachineType(arch string) string {
+	switch arch {
+	case "aarch64":
+		return "virt"
+	case "s390x":
+		return "s390-ccw-virtio"
+	case "x86_64":
+		return "q35"
+	default:
+		return ""
+	}
+}
+
+func GetKVMMinor() string {
+	return ""
+}
+
+func CreateCharDevice(path string, major, minor int) error {
+	_ = path
+	_ = major
+	_ = minor
+	return fmt.Errorf("character device management is supported only on linux")
+}
+
+func CreateKVMDevice(minor string) error {
+	_ = minor
+	return fmt.Errorf("kvm device management is supported only on linux")
+}
+
+func SetPermissionsRW(path string) error {
+	_ = path
+	return fmt.Errorf("device permission management is supported only on linux")
+}
+
+func StartVirtqemud() error {
+	return fmt.Errorf("virtqemud startup is supported only on linux")
+}
+
+func RunCommand(cmd string, args []string) (string, error) {
+	_ = cmd
+	_ = args
+	return "", fmt.Errorf("command execution is supported only on linux in this helper")
+}
+
+func RunCommandWithError(cmd string, args []string) error {
+	_, err := RunCommand(cmd, args)
+	return err
+}
+
+func GetCPUFeatureDomCaps(domCapsXML string, logger *slog.Logger) ([]string, error) {
+	_ = domCapsXML
+	_ = logger
+	return nil, fmt.Errorf("libvirt capability parsing is supported only on linux in this helper")
+}

--- a/images/virtualization-dra/pkg/modprobe/modprobe.go
+++ b/images/virtualization-dra/pkg/modprobe/modprobe.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 /*
 Copyright 2025 Flant JSC
 

--- a/images/virtualization-dra/pkg/modprobe/modprobe_unsupported.go
+++ b/images/virtualization-dra/pkg/modprobe/modprobe_unsupported.go
@@ -1,5 +1,7 @@
+//go:build !linux
+
 /*
-Copyright 2024 Flant JSC
+Copyright 2025 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,4 +16,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package route
+package modprobe
+
+import "fmt"
+
+func LoadModules(modules ...string) error {
+	if len(modules) == 0 {
+		return nil
+	}
+	return fmt.Errorf("kernel module loading is supported only on linux")
+}
+
+func KernelRelease() (string, error) {
+	return "", fmt.Errorf("kernel module operations are supported only on linux")
+}

--- a/images/virtualization-dra/pkg/udev/conn.go
+++ b/images/virtualization-dra/pkg/udev/conn.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 /*
 Copyright 2025 Flant JSC
 

--- a/images/virtualization-dra/pkg/udev/conn_unsupported.go
+++ b/images/virtualization-dra/pkg/udev/conn_unsupported.go
@@ -1,0 +1,84 @@
+//go:build !linux
+
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package udev
+
+import "fmt"
+
+// Mode determines the event source.
+type Mode int
+
+const (
+	// KernelEvent - raw kernel events (faster, less info)
+	KernelEvent Mode = 1
+	// UdevEvent - events processed by udevd (richer, with more attributes like vendor info, serial numbers)
+	UdevEvent Mode = 2
+)
+
+// HostNetNS is a path to the host network namespace.
+const HostNetNS = "/proc/1/ns/net"
+
+// Conn represents a netlink connection for uevents.
+type Conn struct {
+	fd    int
+	netNS string
+}
+
+// ConnOption is a functional option for Conn.
+type ConnOption func(*Conn)
+
+// WithNetNS sets the network namespace path for the connection.
+func WithNetNS(path string) ConnOption {
+	return func(c *Conn) {
+		c.netNS = path
+	}
+}
+
+// NewConn creates a new udev connection.
+func NewConn(opts ...ConnOption) *Conn {
+	c := &Conn{}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// Connect is unsupported on non-Linux platforms.
+func (c *Conn) Connect(_ Mode) error {
+	return fmt.Errorf("udev netlink is supported only on linux")
+}
+
+// Close closes the connection.
+func (c *Conn) Close() error {
+	return nil
+}
+
+// ReadMsg is unsupported on non-Linux platforms.
+func (c *Conn) ReadMsg() ([]byte, error) {
+	return nil, fmt.Errorf("udev netlink is supported only on linux")
+}
+
+// ReadUEvent is unsupported on non-Linux platforms.
+func (c *Conn) ReadUEvent() (*UEvent, error) {
+	return nil, fmt.Errorf("udev netlink is supported only on linux")
+}
+
+// Fd returns the file descriptor of the connection.
+func (c *Conn) Fd() int {
+	return c.fd
+}

--- a/images/vm-route-forge/cmd/vm-route-forge/app/root.go
+++ b/images/vm-route-forge/cmd/vm-route-forge/app/root.go
@@ -76,10 +76,7 @@ func NewVmRouteForgeCommand() *cobra.Command {
 }
 
 func setupLogger(verbosity int) {
-	debug := false
-	if verbosity > 1 {
-		debug = true
-	}
+	debug := verbosity > 1
 
 	// The logger instantiated here can be changed to any logger
 	// implementing the logr.Logger interface. This logger will

--- a/images/vm-route-forge/internal/controller/route/ebpf.go
+++ b/images/vm-route-forge/internal/controller/route/ebpf.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 /*
 Copyright 2024 Flant JSC
 

--- a/images/vm-route-forge/internal/controller/route/netlink_ticker.go
+++ b/images/vm-route-forge/internal/controller/route/netlink_ticker.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 /*
 Copyright 2024 Flant JSC
 

--- a/images/vm-route-forge/internal/controller/route/route_controller.go
+++ b/images/vm-route-forge/internal/controller/route/route_controller.go
@@ -57,7 +57,7 @@ func NewController(
 	logger logr.Logger,
 ) (*Controller, error) {
 
-	queue := workqueue.NewRateLimitingQueueWithConfig(workqueue.DefaultControllerRateLimiter(), workqueue.RateLimitingQueueConfig{Name: controllerName})
+	queue := workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.DefaultTypedControllerRateLimiter[string](), workqueue.TypedRateLimitingQueueConfig[string]{Name: controllerName})
 	log := logger.WithValues("controller", controllerName)
 	routeController := &Controller{
 		queue:        queue,
@@ -98,7 +98,7 @@ type Controller struct {
 	vmLister     virtlisters.VirtualMachineLister
 	routeWatcher Watcher
 	hasSynced    cache.InformerSynced
-	queue        workqueue.RateLimitingInterface
+	queue        workqueue.TypedRateLimitingInterface[string]
 	netlinkMgr   *netlinkmanager.Manager
 	log          logr.Logger
 }
@@ -257,7 +257,7 @@ func (c *Controller) worker(ctx context.Context) {
 		}
 		defer c.queue.Done(key)
 
-		if err := c.sync(key.(string)); err != nil {
+		if err := c.sync(key); err != nil {
 			c.log.Error(err, fmt.Sprintf("re-enqueuing VirtualMachine %v", key))
 			c.queue.AddRateLimited(key)
 		} else {

--- a/images/vm-route-forge/internal/controller/route/watch_unsupported.go
+++ b/images/vm-route-forge/internal/controller/route/watch_unsupported.go
@@ -1,3 +1,5 @@
+//go:build !linux
+
 /*
 Copyright 2024 Flant JSC
 
@@ -25,35 +27,49 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	vmipcache "vm-route-forge/internal/cache"
-	netlinkwrap "vm-route-forge/internal/netlinkwrap"
+	"vm-route-forge/internal/netlinkwrap"
 )
 
-type Watcher interface {
-	ResultChannel() <-chan types.NamespacedName
-	Stop()
+type unsupportedWatcher struct{}
+
+func (w *unsupportedWatcher) ResultChannel() <-chan types.NamespacedName {
+	ch := make(chan types.NamespacedName)
+	close(ch)
+	return ch
 }
 
-type KindRouteWatcher string
+func (w *unsupportedWatcher) Stop() {}
 
-const (
-	NetlinkTickerKind KindRouteWatcher = "netlinkTicker"
-	EbpfKind          KindRouteWatcher = "ebpf"
-)
+func NewEbpfWatcher(
+	ctx context.Context,
+	cidrs []*net.IPNet,
+	routeTableID int,
+	cache vmipcache.Cache,
+	nlWrapper *netlinkwrap.Funcs,
+	log logr.Logger,
+) (*unsupportedWatcher, error) {
+	_ = ctx
+	_ = cidrs
+	_ = routeTableID
+	_ = cache
+	_ = nlWrapper
+	_ = log
+	return nil, fmt.Errorf("ebpf watcher is supported only on linux")
+}
 
-func WatchFactory(ctx context.Context,
-	kind KindRouteWatcher,
+func NewNetlinkTickerWatcher(
+	ctx context.Context,
 	cidrs []*net.IPNet,
 	cache vmipcache.Cache,
 	routeTableID int,
 	nlWrapper *netlinkwrap.Funcs,
 	log logr.Logger,
-) (Watcher, error) {
-	switch kind {
-	case NetlinkTickerKind:
-		return NewNetlinkTickerWatcher(ctx, cidrs, cache, routeTableID, nlWrapper, log), nil
-	case EbpfKind:
-		return NewEbpfWatcher(ctx, cidrs, routeTableID, cache, nlWrapper, log)
-	default:
-		return nil, fmt.Errorf("unknown kind %s", kind)
-	}
+) *unsupportedWatcher {
+	_ = ctx
+	_ = cidrs
+	_ = cache
+	_ = routeTableID
+	_ = nlWrapper
+	_ = log
+	return &unsupportedWatcher{}
 }

--- a/images/vm-route-forge/internal/netlinkmanager/manager.go
+++ b/images/vm-route-forge/internal/netlinkmanager/manager.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 /*
 Copyright 2024 Flant JSC
 

--- a/images/vm-route-forge/internal/netlinkmanager/manager_unsupported.go
+++ b/images/vm-route-forge/internal/netlinkmanager/manager_unsupported.go
@@ -1,0 +1,68 @@
+//go:build !linux
+
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package netlinkmanager
+
+import (
+	"fmt"
+	"net"
+
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/types"
+
+	vmipcache "vm-route-forge/internal/cache"
+	"vm-route-forge/internal/netlinkwrap"
+
+	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+)
+
+const DefaultCiliumRouteTable = 1490
+
+type Manager struct{}
+
+func New(
+	cache vmipcache.Cache,
+	log logr.Logger,
+	routeTableID int,
+	cidrs []*net.IPNet,
+	nlWrapper *netlinkwrap.Funcs,
+) *Manager {
+	_ = cache
+	_ = log
+	_ = routeTableID
+	_ = cidrs
+	_ = nlWrapper
+	return &Manager{}
+}
+
+func (m *Manager) AddSubnetsRoutesToBlackHole() error {
+	return fmt.Errorf("netlink route management is supported only on linux")
+}
+
+func (m *Manager) SyncRules() error {
+	return fmt.Errorf("netlink rule management is supported only on linux")
+}
+
+func (m *Manager) UpdateRoute(_ *v1alpha2.VirtualMachine, _ *ciliumv2.CiliumNode) error {
+	return fmt.Errorf("netlink route management is supported only on linux")
+}
+
+func (m *Manager) DeleteRoute(_ types.NamespacedName, _ string) error {
+	return fmt.Errorf("netlink route management is supported only on linux")
+}

--- a/images/vm-route-forge/internal/server/healthz.go
+++ b/images/vm-route-forge/internal/server/healthz.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package server
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/go-logr/logr"
+)
 
 func (s *Server) getHealthzHandler() http.Handler {
 	if s.healthzHandler != nil {
@@ -24,6 +28,8 @@ func (s *Server) getHealthzHandler() http.Handler {
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("ok"))
+		if _, err := w.Write([]byte("ok")); err != nil {
+			logr.FromContextOrDiscard(r.Context()).Error(err, "failed to write healthz response")
+		}
 	})
 }

--- a/images/vm-route-forge/internal/server/readyz.go
+++ b/images/vm-route-forge/internal/server/readyz.go
@@ -21,17 +21,21 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/go-logr/logr"
 )
 
 func (s *Server) getReadyzHandler() http.Handler {
 	if s.readyzHandler != nil {
 		return s.readyzHandler
 	}
-	unhealthy := func(err error, w http.ResponseWriter) {
+	unhealthy := func(err error, w http.ResponseWriter, r *http.Request) {
 		res := map[string]interface{}{"connectivity": "failed", "error": fmt.Sprintf("%v", err)}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(res)
+		if encodeErr := json.NewEncoder(w).Encode(res); encodeErr != nil {
+			logr.FromContextOrDiscard(r.Context()).Error(encodeErr, "failed to write readyz error response")
+		}
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := s.client.
@@ -42,19 +46,20 @@ func (s *Server) getReadyzHandler() http.Handler {
 			Do(context.Background()).
 			Raw()
 		if err != nil {
-			unhealthy(err, w)
+			unhealthy(err, w, r)
 			return
 		}
 		var version interface{}
 		err = json.Unmarshal(body, &version)
 		if err != nil {
-			unhealthy(err, w)
+			unhealthy(err, w, r)
 			return
 		}
 		res := map[string]interface{}{"connectivity": "ok", "version": version}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(res)
-
+		if err := json.NewEncoder(w).Encode(res); err != nil {
+			logr.FromContextOrDiscard(r.Context()).Error(err, "failed to write readyz response")
+		}
 	})
 }


### PR DESCRIPTION
## Description
Add non-Linux stubs and build constraints for Linux-specific packages so the repository can be type-checked on macOS and other non-Linux environments.

Updated modules:
- `images/virtualization-dra`
- `images/vm-route-forge`
- `images/cdi-cloner/cloner-startup`
- `images/virt-launcher/node-labeller`

The changes add `//go:build linux` guards to Linux-only implementations and provide non-Linux fallback files for packages that use Linux-only APIs such as netlink, `setns`, `finit_module`, block-device ioctls, eBPF, and libvirt-dependent entrypoints.

## Why do we need it, and what problem does it solve?
When running typecheck and lint on macOS, several modules failed because Linux-only code was compiled in non-Linux environments. This made local validation noisy and blocked developer workflows even though the affected code is intentionally Linux-specific.

This change makes the platform split explicit and keeps non-Linux checks green without changing Linux runtime behavior.

## What is the expected result?
1. Run typecheck/lint on macOS or another non-Linux environment.
2. Verify Linux-only packages are excluded from non-Linux builds via build tags.
3. Verify non-Linux stubs satisfy package APIs needed for typecheck.
4. Confirm the previously failing modules no longer report Linux-specific typecheck errors.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: chore
summary: "Add non-Linux stubs for Linux-specific Go packages so non-Linux typecheck passes."
impact_level: low
```
