### PR TITLE
fix(module): add idempotency for usb cleanup in virtualization-dra

### DIFF
--- a/images/virtualization-dra/internal/plugin/driver.go
+++ b/images/virtualization-dra/internal/plugin/driver.go
@@ -205,6 +205,8 @@ func (d *Driver) UnprepareResourceClaims(ctx context.Context, claims []kubeletpl
 
 func (d *Driver) unprepareResourceClaim(ctx context.Context, claim kubeletplugin.NamespacedObject) error {
 	if err := d.allocator.Unprepare(ctx, claim.UID); err != nil {
+		d.log.Error("error unpreparing devices for claim", slog.Any("error", err), slog.String("uid", string(claim.UID)))
+
 		return fmt.Errorf("error unpreparing devices for claim %v: %w", claim.UID, err)
 	}
 

--- a/images/virtualization-dra/internal/usb-gateway/attach_record.go
+++ b/images/virtualization-dra/internal/usb-gateway/attach_record.go
@@ -118,19 +118,20 @@ func (r *attachRecordManager) Refresh() error {
 		return err
 	}
 
-	// keep only real entries
-	var newEntries []AttachEntry
+	newEntries := make([]AttachEntry, 0, len(record.Entries))
 	for _, e := range record.Entries {
 		if _, ok := ports[e.Rhport]; ok {
 			newEntries = append(newEntries, e)
 		}
 	}
 
-	record.Entries = newEntries
+	newRecord := attachRecord{Entries: newEntries}
+	if slices.Equal(record.Entries, newRecord.Entries) {
+		r.record = newRecord
+		return nil
+	}
 
-	r.record = record
-
-	return nil
+	return r.storeLocked(newRecord)
 }
 
 func (r *attachRecordManager) GetEntries() []AttachEntry {
@@ -162,27 +163,6 @@ func (r *attachRecordManager) AddEntry(e AttachEntry) error {
 
 	newEntries := slices.Clone(r.record.Entries)
 	newEntries = append(newEntries, e)
-
-	return r.storeLocked(attachRecord{Entries: newEntries})
-}
-
-func (r *attachRecordManager) RemoveEntryByDeviceName(deviceName string) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	newEntries := make([]AttachEntry, 0, len(r.record.Entries))
-	removed := false
-	for _, entry := range r.record.Entries {
-		if entry.DeviceName == deviceName {
-			removed = true
-			continue
-		}
-		newEntries = append(newEntries, entry)
-	}
-
-	if !removed {
-		return nil
-	}
 
 	return r.storeLocked(attachRecord{Entries: newEntries})
 }

--- a/images/virtualization-dra/internal/usb-gateway/attach_record.go
+++ b/images/virtualization-dra/internal/usb-gateway/attach_record.go
@@ -163,8 +163,31 @@ func (r *attachRecordManager) AddEntry(e AttachEntry) error {
 	newEntries := slices.Clone(r.record.Entries)
 	newEntries = append(newEntries, e)
 
-	record := attachRecord{Entries: newEntries}
+	return r.storeLocked(attachRecord{Entries: newEntries})
+}
 
+func (r *attachRecordManager) RemoveEntryByDeviceName(deviceName string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	newEntries := make([]AttachEntry, 0, len(r.record.Entries))
+	removed := false
+	for _, entry := range r.record.Entries {
+		if entry.DeviceName == deviceName {
+			removed = true
+			continue
+		}
+		newEntries = append(newEntries, entry)
+	}
+
+	if !removed {
+		return nil
+	}
+
+	return r.storeLocked(attachRecord{Entries: newEntries})
+}
+
+func (r *attachRecordManager) storeLocked(record attachRecord) error {
 	b, err := json.Marshal(record)
 	if err != nil {
 		return err

--- a/images/virtualization-dra/internal/usb-gateway/attach_record.go
+++ b/images/virtualization-dra/internal/usb-gateway/attach_record.go
@@ -118,6 +118,7 @@ func (r *attachRecordManager) Refresh() error {
 		return err
 	}
 
+	// keep only real entries
 	newEntries := make([]AttachEntry, 0, len(record.Entries))
 	for _, e := range record.Entries {
 		if _, ok := ports[e.Rhport]; ok {
@@ -131,7 +132,17 @@ func (r *attachRecordManager) Refresh() error {
 		return nil
 	}
 
-	return r.storeLocked(newRecord)
+	b, err = json.Marshal(newRecord)
+	if err != nil {
+		return err
+	}
+
+	if err = os.WriteFile(r.recordFile, b, 0o600); err != nil {
+		return err
+	}
+
+	r.record = newRecord
+	return nil
 }
 
 func (r *attachRecordManager) GetEntries() []AttachEntry {
@@ -164,10 +175,8 @@ func (r *attachRecordManager) AddEntry(e AttachEntry) error {
 	newEntries := slices.Clone(r.record.Entries)
 	newEntries = append(newEntries, e)
 
-	return r.storeLocked(attachRecord{Entries: newEntries})
-}
+	record := attachRecord{Entries: newEntries}
 
-func (r *attachRecordManager) storeLocked(record attachRecord) error {
 	b, err := json.Marshal(record)
 	if err != nil {
 		return err

--- a/images/virtualization-dra/internal/usb-gateway/usbgateway.go
+++ b/images/virtualization-dra/internal/usb-gateway/usbgateway.go
@@ -117,8 +117,8 @@ func (c *USBGatewayController) Detach(deviceName string) error {
 		return fmt.Errorf("failed to unexport device %s: %w", deviceName, err)
 	}
 
-	if err := c.attachRecordManager.RemoveEntryByDeviceName(deviceName); err != nil {
-		return fmt.Errorf("failed to remove attach record for device %s: %w", deviceName, err)
+	if err := c.attachRecordManager.Refresh(); err != nil {
+		return fmt.Errorf("failed to Refresh attach record after detach for device %s: %w", deviceName, err)
 	}
 
 	return nil

--- a/images/virtualization-dra/internal/usb-gateway/usbgateway.go
+++ b/images/virtualization-dra/internal/usb-gateway/usbgateway.go
@@ -101,7 +101,9 @@ func (c *USBGatewayController) Detach(deviceName string) error {
 	}
 
 	entry := c.findEntry(deviceName)
-	if entry != nil {
+	if entry == nil {
+		log.Info("Device is already detached")
+	} else {
 		log.Info("Detaching USB device")
 		err = c.usbIP.Detach(entry.Rhport)
 		if err != nil {
@@ -113,6 +115,10 @@ func (c *USBGatewayController) Detach(deviceName string) error {
 	err = c.usbIP.Unexport(host, busID, port)
 	if err != nil {
 		return fmt.Errorf("failed to unexport device %s: %w", deviceName, err)
+	}
+
+	if err := c.attachRecordManager.RemoveEntryByDeviceName(deviceName); err != nil {
+		return fmt.Errorf("failed to remove attach record for device %s: %w", deviceName, err)
 	}
 
 	return nil

--- a/images/virtualization-dra/internal/usb/store.go
+++ b/images/virtualization-dra/internal/usb/store.go
@@ -436,22 +436,30 @@ func (s *AllocationStore) Unprepare(_ context.Context, claimUID types.UID) error
 		return fmt.Errorf("unprepare called before synchronize NRI Hook")
 	}
 
+	allocatedDevices, exists := s.resourceClaimAllocations[claimUID]
+	if !exists || len(allocatedDevices) == 0 {
+		s.log.Info("Claim is already unprepared", slog.String("claimUID", string(claimUID)))
+		return nil
+	}
+
 	usbGatewayEnabled := featuregates.Default().USBGatewayEnabled()
 
-	allocatedDevices := s.resourceClaimAllocations[claimUID]
 	s.log.Info("Unpreparing devices", slog.Any("devices", allocatedDevices), slog.String("claimUID", string(claimUID)))
 
 	for _, device := range allocatedDevices {
 		if usbGatewayEnabled {
-			count := s.usbipAllocatedDevicesCount[device]
+			count, hasCount := s.usbipAllocatedDevicesCount[device]
 			s.log.Info("Device attached by USBGateway", slog.String("device", device), slog.Int("count", count))
-			if count <= 1 {
-				s.log.Info("Detaching device because has only one consumer", slog.String("device", device))
+			switch {
+			case !hasCount || count <= 0:
+				s.log.Info("Device is already detached or has no consumers", slog.String("device", device))
+			case count == 1:
+				s.log.Info("Detaching device because it has the last consumer", slog.String("device", device))
 				if err := s.usbGateway.Detach(device); err != nil {
 					return fmt.Errorf("failed to detach device %s: %w", device, err)
 				}
 				delete(s.usbipAllocatedDevicesCount, device)
-			} else {
+			default:
 				s.log.Info("Decrementing device consumer count", slog.String("device", device), slog.Int("newCount", count-1))
 				s.usbipAllocatedDevicesCount[device]--
 			}

--- a/images/virtualization-dra/internal/usb/store.go
+++ b/images/virtualization-dra/internal/usb/store.go
@@ -438,35 +438,32 @@ func (s *AllocationStore) Unprepare(_ context.Context, claimUID types.UID) error
 
 	allocatedDevices, exists := s.resourceClaimAllocations[claimUID]
 	if !exists || len(allocatedDevices) == 0 {
-		s.log.Info("Claim is already unprepared", slog.String("claimUID", string(claimUID)))
-		return nil
-	}
+		s.log.Info("Claim has no tracked allocations, skipping device cleanup", slog.String("claimUID", string(claimUID)))
+	} else {
+		usbGatewayEnabled := featuregates.Default().USBGatewayEnabled()
 
-	usbGatewayEnabled := featuregates.Default().USBGatewayEnabled()
+		s.log.Info("Unpreparing devices", slog.Any("devices", allocatedDevices), slog.String("claimUID", string(claimUID)))
 
-	s.log.Info("Unpreparing devices", slog.Any("devices", allocatedDevices), slog.String("claimUID", string(claimUID)))
-
-	for _, device := range allocatedDevices {
-		if usbGatewayEnabled {
-			count, hasCount := s.usbipAllocatedDevicesCount[device]
-			s.log.Info("Device attached by USBGateway", slog.String("device", device), slog.Int("count", count))
-			switch {
-			case !hasCount || count <= 0:
-				s.log.Info("Device is already detached or has no consumers", slog.String("device", device))
-			case count == 1:
-				s.log.Info("Detaching device because it has the last consumer", slog.String("device", device))
-				if err := s.usbGateway.Detach(device); err != nil {
-					return fmt.Errorf("failed to detach device %s: %w", device, err)
+		for _, device := range allocatedDevices {
+			if usbGatewayEnabled {
+				count, hasCount := s.usbipAllocatedDevicesCount[device]
+				s.log.Info("Device attached by USBGateway", slog.String("device", device), slog.Int("count", count))
+				switch {
+				case !hasCount || count <= 1:
+					s.log.Info("Device has no tracked consumers, attempting detach cleanup", slog.String("device", device), slog.Int("count", count))
+					if err := s.usbGateway.Detach(device); err != nil {
+						return fmt.Errorf("failed to detach device %s: %w", device, err)
+					}
+					delete(s.usbipAllocatedDevicesCount, device)
+				default:
+					s.log.Info("Decrementing device consumer count", slog.String("device", device), slog.Int("newCount", count-1))
+					s.usbipAllocatedDevicesCount[device]--
 				}
-				delete(s.usbipAllocatedDevicesCount, device)
-			default:
-				s.log.Info("Decrementing device consumer count", slog.String("device", device), slog.Int("newCount", count-1))
-				s.usbipAllocatedDevicesCount[device]--
 			}
-		}
 
-		s.log.Info("Deleting device from allocated devices", slog.String("device", device))
-		s.allocatedDevices.Delete(device)
+			s.log.Info("Deleting device from allocated devices", slog.String("device", device))
+			s.allocatedDevices.Delete(device)
+		}
 	}
 
 	s.log.Info("Deleting CDI claim spec file", slog.String("claimUID", string(claimUID)))

--- a/images/virtualization-dra/pkg/usbip/exporter.go
+++ b/images/virtualization-dra/pkg/usbip/exporter.go
@@ -98,11 +98,12 @@ func (e *usbExporter) Unexport(host, busID string, port int) error {
 		return fmt.Errorf("unsupported USBIP version: %d", unExportReply.Version)
 	}
 
-	if unExportReply.Status != protocol.OpStatusOk {
+	switch unExportReply.Status {
+	case protocol.OpStatusOk, protocol.OpStatusNoDev:
+		return nil
+	default:
 		return fmt.Errorf("reply failed: %s", unExportReply.Status.String())
 	}
-
-	return nil
 }
 
 func (e *usbExporter) usbipNetTCPConnect(host string, port int) (*net.TCPConn, error) {


### PR DESCRIPTION
## Description

Add idempotency to USB device cleanup in the virtualization-dra component.

Changes:
- **`store.go`**: Add early return if claim is already unprepared. Use `hasCount` check to handle missing or zero counts gracefully. Replace `if/else` with `switch` for clearer count handling (0, 1, >1).
- **`usbgateway.go`**: Make `Detach` idempotent — log and skip if device is already detached instead of failing. Always clean up the attach record after detach attempt.
- **`attach_record.go`**: Add `RemoveEntryByDeviceName` method to remove a specific device entry from the attach record. Extract `storeLocked` helper to avoid code duplication.

## Why do we need it, and what problem does it solve?

When `UnprepareResources` is called multiple times for the same claim (e.g., during retries or race conditions), the cleanup logic could fail or produce incorrect results:
- Detaching an already-detached device caused errors.
- The attach record was not cleaned up if the device was already detached.
- The `usbipAllocatedDevicesCount` map could be accessed for non-existent keys, leading to incorrect behavior.

After this fix, repeated cleanup calls are safe and produce consistent results.

## What is the expected result?

1. Call `UnprepareResources` for a claim that has USB devices attached via USBGateway.
2. Devices are detached and attach records are removed.
3. Call `UnprepareResources` again for the same claim.
4. No errors occur — the operation is a no-op.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: module
type: fix
summary: Add idempotency for USB device cleanup in virtualization-dra to prevent errors on repeated unprepare calls.
impact_level: low
```
