### PR TITLE
feat(nodeusbdevice): mirror usb attached condition

### DIFF
--- a/api/core/v1alpha2/node_device_usb.go
+++ b/api/core/v1alpha2/node_device_usb.go
@@ -36,6 +36,7 @@ const (
 // +kubebuilder:printcolumn:name="Node",type=string,JSONPath=`.status.nodeName`
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="Assigned",type=string,JSONPath=`.status.conditions[?(@.type=="Assigned")].status`
+// +kubebuilder:printcolumn:name="Attached",type=string,JSONPath=`.status.conditions[?(@.type=="Attached")].status`
 // +kubebuilder:printcolumn:name="Namespace",type=string,JSONPath=`.spec.assignedNamespace`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/api/core/v1alpha2/nodeusbdevicecondition/condition.go
+++ b/api/core/v1alpha2/nodeusbdevicecondition/condition.go
@@ -24,6 +24,8 @@ const (
 	AssignedType Type = "Assigned"
 	// ReadyType indicates whether the device is ready to use.
 	ReadyType Type = "Ready"
+	// AttachedType indicates whether the device is attached to a virtual machine.
+	AttachedType Type = "Attached"
 )
 
 func (t Type) String() string {
@@ -35,6 +37,8 @@ type (
 	AssignedReason string
 	// ReadyReason represents the various reasons for the `Ready` condition type.
 	ReadyReason string
+	// AttachedReason represents the various reasons for the `Attached` condition type.
+	AttachedReason string
 )
 
 const (
@@ -51,6 +55,15 @@ const (
 	NotReady ReadyReason = "NotReady"
 	// NotFound signifies that device is absent on the host.
 	NotFound ReadyReason = "NotFound"
+
+	// AttachedToVirtualMachine signifies that device is attached to a virtual machine.
+	AttachedToVirtualMachine AttachedReason = "AttachedToVirtualMachine"
+	// AttachedAvailable signifies that device is available for attachment to a virtual machine.
+	AttachedAvailable AttachedReason = "Available"
+	// DetachedForMigration signifies that device was detached for migration (e.g. live migration).
+	DetachedForMigration AttachedReason = "DetachedForMigration"
+	// NoFreeUSBIPPort signifies that device cannot be attached because there are no free USBIP ports on the target node.
+	NoFreeUSBIPPort AttachedReason = "NoFreeUSBIPPort"
 )
 
 func (r AssignedReason) String() string {
@@ -58,5 +71,9 @@ func (r AssignedReason) String() string {
 }
 
 func (r ReadyReason) String() string {
+	return string(r)
+}
+
+func (r AttachedReason) String() string {
 	return string(r)
 }

--- a/crds/doc-ru-nodeusbdevices.yaml
+++ b/crds/doc-ru-nodeusbdevices.yaml
@@ -126,6 +126,12 @@ spec:
                           * `Assigned` — неймспейс назначен для устройства и создан соответствующий ресурс USBDevice в этом неймспейсе;
                           * `Available` — для устройства не назначен неймспейс;
                           * `InProgress` — подключение устройства к неймспейсу выполняется (создание ресурса USBDevice).
+
+                          Для типа условия Attached возможные значения:
+                          * `AttachedToVirtualMachine` — устройство подключено к виртуальной машине;
+                          * `Available` — устройство не подключено к виртуальной машине;
+                          * `DetachedForMigration` — устройство было отключено для миграции;
+                          * `NoFreeUSBIPPort` — устройство не может быть подключено, так как на целевом узле нет свободных USBIP-портов.
                         maxLength: 1024
                         minLength: 1
                         pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
@@ -147,6 +153,8 @@ spec:
                           может быть реализован Garbage Collector для автоматической очистки.
                           * `Assigned` — указывает, назначен ли неймспейс для устройства. Когда reason — "Assigned",
                           status — "True". Когда reason — "Available" или "InProgress", status — "False".
+                          * `Attached` — указывает, подключено ли устройство к виртуальной машине. Когда reason — "AttachedToVirtualMachine",
+                          status — "True". Когда reason — "Available", "DetachedForMigration" или "NoFreeUSBIPPort", status — "False".
                         maxLength: 316
                         pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string

--- a/crds/nodeusbdevices.yaml
+++ b/crds/nodeusbdevices.yaml
@@ -31,6 +31,9 @@ spec:
         - jsonPath: .status.conditions[?(@.type=="Assigned")].status
           name: Assigned
           type: string
+        - jsonPath: .status.conditions[?(@.type=="Attached")].status
+          name: Attached
+          type: string
         - jsonPath: .spec.assignedNamespace
           name: Namespace
           type: string

--- a/images/virtualization-artifact/pkg/controller/nodeusbdevice/internal/handler/attached.go
+++ b/images/virtualization-artifact/pkg/controller/nodeusbdevice/internal/handler/attached.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/deckhouse/virtualization-controller/pkg/controller/nodeusbdevice/internal/state"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/nodeusbdevicecondition"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/usbdevicecondition"
+)
+
+const nameAttachedHandler = "AttachedHandler"
+
+func NewAttachedHandler(client client.Client) *AttachedHandler {
+	return &AttachedHandler{client: client}
+}
+
+type AttachedHandler struct {
+	client client.Client
+}
+
+func (h *AttachedHandler) Name() string {
+	return nameAttachedHandler
+}
+
+func (h *AttachedHandler) Handle(ctx context.Context, s state.NodeUSBDeviceState) (reconcile.Result, error) {
+	nodeUSBDevice := s.NodeUSBDevice()
+	if nodeUSBDevice.IsEmpty() {
+		return reconcile.Result{}, nil
+	}
+
+	current := nodeUSBDevice.Current()
+	changed := nodeUSBDevice.Changed()
+
+	if !current.GetDeletionTimestamp().IsZero() {
+		return reconcile.Result{}, nil
+	}
+
+	assignedNamespace := current.Spec.AssignedNamespace
+	if assignedNamespace == "" {
+		setAttachedCondition(current, &changed.Status.Conditions, metav1.ConditionFalse, nodeusbdevicecondition.AttachedAvailable, "Device is not assigned to any namespace and is not attached to a virtual machine.")
+		return reconcile.Result{}, nil
+	}
+
+	usbDevice := &v1alpha2.USBDevice{}
+	err := h.client.Get(ctx, types.NamespacedName{Namespace: assignedNamespace, Name: current.Name}, usbDevice)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			setAttachedCondition(current, &changed.Status.Conditions, metav1.ConditionFalse, nodeusbdevicecondition.AttachedAvailable, fmt.Sprintf("Corresponding USBDevice %s/%s not found.", assignedNamespace, current.Name))
+			return reconcile.Result{}, nil
+		}
+
+		return reconcile.Result{}, fmt.Errorf("failed to get USBDevice %s/%s: %w", assignedNamespace, current.Name, err)
+	}
+
+	attachedCondition := meta.FindStatusCondition(usbDevice.Status.Conditions, string(usbdevicecondition.AttachedType))
+	if attachedCondition == nil {
+		setAttachedCondition(current, &changed.Status.Conditions, metav1.ConditionFalse, nodeusbdevicecondition.AttachedAvailable, fmt.Sprintf("Attached condition not found in USBDevice %s/%s.", usbDevice.Namespace, usbDevice.Name))
+		return reconcile.Result{}, nil
+	}
+
+	setAttachedCondition(
+		current,
+		&changed.Status.Conditions,
+		attachedCondition.Status,
+		mapAttachedReason(attachedCondition.Reason),
+		attachedCondition.Message,
+	)
+
+	return reconcile.Result{}, nil
+}
+
+func mapAttachedReason(reason string) nodeusbdevicecondition.AttachedReason {
+	switch reason {
+	case string(usbdevicecondition.AttachedToVirtualMachine):
+		return nodeusbdevicecondition.AttachedToVirtualMachine
+	case string(usbdevicecondition.DetachedForMigration):
+		return nodeusbdevicecondition.DetachedForMigration
+	case string(usbdevicecondition.NoFreeUSBIPPort):
+		return nodeusbdevicecondition.NoFreeUSBIPPort
+	default:
+		return nodeusbdevicecondition.AttachedAvailable
+	}
+}

--- a/images/virtualization-artifact/pkg/controller/nodeusbdevice/internal/handler/attached_test.go
+++ b/images/virtualization-artifact/pkg/controller/nodeusbdevice/internal/handler/attached_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/deckhouse/virtualization-controller/pkg/controller/nodeusbdevice/internal/state"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/reconciler"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/nodeusbdevicecondition"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/usbdevicecondition"
+)
+
+var _ = Describe("AttachedHandler", func() {
+	DescribeTable("Handle",
+		func(assignedNamespace string, usbDevice *v1alpha2.USBDevice, expectedStatus metav1.ConditionStatus, expectedReason, expectedMessage string) {
+			scheme := apiruntime.NewScheme()
+			Expect(v1alpha2.AddToScheme(scheme)).To(Succeed())
+
+			node := &v1alpha2.NodeUSBDevice{
+				ObjectMeta: metav1.ObjectMeta{Name: "usb-device-1", Generation: 1},
+				Spec:       v1alpha2.NodeUSBDeviceSpec{AssignedNamespace: assignedNamespace},
+			}
+
+			objects := []client.Object{node}
+			if usbDevice != nil {
+				objects = append(objects, usbDevice)
+			}
+
+			cl := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objects...).
+				Build()
+
+			res := reconciler.NewResource(
+				types.NamespacedName{Name: node.Name},
+				cl,
+				func() *v1alpha2.NodeUSBDevice { return &v1alpha2.NodeUSBDevice{} },
+				func(obj *v1alpha2.NodeUSBDevice) v1alpha2.NodeUSBDeviceStatus { return obj.Status },
+			)
+			Expect(res.Fetch(context.Background())).To(Succeed())
+
+			h := NewAttachedHandler(cl)
+			st := state.New(cl, res)
+			_, err := h.Handle(context.Background(), st)
+			Expect(err).NotTo(HaveOccurred())
+
+			attached := meta.FindStatusCondition(res.Changed().Status.Conditions, string(nodeusbdevicecondition.AttachedType))
+			Expect(attached).NotTo(BeNil())
+			Expect(attached.Status).To(Equal(expectedStatus))
+			Expect(attached.Reason).To(Equal(expectedReason))
+			Expect(attached.Message).To(Equal(expectedMessage))
+		},
+		Entry("unassigned device is not attached", "", nil, metav1.ConditionFalse, string(nodeusbdevicecondition.AttachedAvailable), "Device is not assigned to any namespace and is not attached to a virtual machine."),
+		Entry("missing USBDevice returns available", "test-ns", nil, metav1.ConditionFalse, string(nodeusbdevicecondition.AttachedAvailable), "Corresponding USBDevice test-ns/usb-device-1 not found."),
+		Entry("mirrors attached USBDevice condition", "test-ns", &v1alpha2.USBDevice{
+			ObjectMeta: metav1.ObjectMeta{Name: "usb-device-1", Namespace: "test-ns"},
+			Status: v1alpha2.USBDeviceStatus{Conditions: []metav1.Condition{{
+				Type:    string(usbdevicecondition.AttachedType),
+				Status:  metav1.ConditionTrue,
+				Reason:  string(usbdevicecondition.AttachedToVirtualMachine),
+				Message: "Device is attached to VirtualMachine test-ns/vm-1.",
+			}}},
+		}, metav1.ConditionTrue, string(nodeusbdevicecondition.AttachedToVirtualMachine), "Device is attached to VirtualMachine test-ns/vm-1."),
+		Entry("mirrors detached for migration", "test-ns", &v1alpha2.USBDevice{
+			ObjectMeta: metav1.ObjectMeta{Name: "usb-device-1", Namespace: "test-ns"},
+			Status: v1alpha2.USBDeviceStatus{Conditions: []metav1.Condition{{
+				Type:    string(usbdevicecondition.AttachedType),
+				Status:  metav1.ConditionFalse,
+				Reason:  string(usbdevicecondition.DetachedForMigration),
+				Message: "Device was detached for migration.",
+			}}},
+		}, metav1.ConditionFalse, string(nodeusbdevicecondition.DetachedForMigration), "Device was detached for migration."),
+		Entry("mirrors no free port condition", "test-ns", &v1alpha2.USBDevice{
+			ObjectMeta: metav1.ObjectMeta{Name: "usb-device-1", Namespace: "test-ns"},
+			Status: v1alpha2.USBDeviceStatus{Conditions: []metav1.Condition{{
+				Type:    string(usbdevicecondition.AttachedType),
+				Status:  metav1.ConditionFalse,
+				Reason:  string(usbdevicecondition.NoFreeUSBIPPort),
+				Message: "No free USBIP ports are available.",
+			}}},
+		}, metav1.ConditionFalse, string(nodeusbdevicecondition.NoFreeUSBIPPort), "No free USBIP ports are available."),
+		Entry("missing attached condition falls back to available", "test-ns", &v1alpha2.USBDevice{
+			ObjectMeta: metav1.ObjectMeta{Name: "usb-device-1", Namespace: "test-ns"},
+		}, metav1.ConditionFalse, string(nodeusbdevicecondition.AttachedAvailable), "Attached condition not found in USBDevice test-ns/usb-device-1."),
+	)
+})

--- a/images/virtualization-artifact/pkg/controller/nodeusbdevice/internal/handler/conditions.go
+++ b/images/virtualization-artifact/pkg/controller/nodeusbdevice/internal/handler/conditions.go
@@ -56,6 +56,22 @@ func setAssignedCondition(
 	conditions.SetCondition(cb, target)
 }
 
+func setAttachedCondition(
+	nodeUSBDevice *v1alpha2.NodeUSBDevice,
+	target *[]metav1.Condition,
+	status metav1.ConditionStatus,
+	reason nodeusbdevicecondition.AttachedReason,
+	message string,
+) {
+	cb := conditions.NewConditionBuilder(nodeusbdevicecondition.AttachedType).
+		Generation(nodeUSBDevice.GetGeneration()).
+		Status(status).
+		Reason(reason).
+		Message(message)
+
+	conditions.SetCondition(cb, target)
+}
+
 func isDeviceAbsentOnHost(conditions []metav1.Condition) bool {
 	readyCondition := meta.FindStatusCondition(conditions, string(nodeusbdevicecondition.ReadyType))
 	if readyCondition == nil {

--- a/images/virtualization-artifact/pkg/controller/nodeusbdevice/internal/watcher/resourceslice_watcher_test.go
+++ b/images/virtualization-artifact/pkg/controller/nodeusbdevice/internal/watcher/resourceslice_watcher_test.go
@@ -17,11 +17,10 @@ limitations under the License.
 package watcher
 
 import (
-	resourcev1 "k8s.io/api/resource/v1"
-	"k8s.io/utils/ptr"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	resourcev1 "k8s.io/api/resource/v1"
+	"k8s.io/utils/ptr"
 )
 
 var _ = Describe("ResourceSliceWatcher", func() {

--- a/images/virtualization-artifact/pkg/controller/nodeusbdevice/internal/watcher/resourceslice_watcher_test.go
+++ b/images/virtualization-artifact/pkg/controller/nodeusbdevice/internal/watcher/resourceslice_watcher_test.go
@@ -17,56 +17,56 @@ limitations under the License.
 package watcher
 
 import (
-	"testing"
-
 	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/utils/ptr"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestNodeUSBDeviceNamesFromSlice(t *testing.T) {
-	resourceSlice := &resourcev1.ResourceSlice{
-		Spec: resourcev1.ResourceSliceSpec{
-			Devices: []resourcev1.Device{
-				{Name: "gpu-1"},
-				{Name: "usb-1"},
-				{
-					Name: "usb-2",
-					Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
-						"name": {StringValue: ptr.To("USB.Device.2")},
+var _ = Describe("ResourceSliceWatcher", func() {
+	Describe("nodeUSBDeviceNamesFromSlice", func() {
+		It("returns normalized unique USB device names", func() {
+			resourceSlice := &resourcev1.ResourceSlice{
+				Spec: resourcev1.ResourceSliceSpec{
+					Devices: []resourcev1.Device{
+						{Name: "gpu-1"},
+						{Name: "usb-1"},
+						{
+							Name: "usb-2",
+							Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
+								"name": {StringValue: ptr.To("USB.Device.2")},
+							},
+						},
+						{
+							Name: "usb-duplicate",
+							Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
+								"name": {StringValue: ptr.To("USB.Device.2")},
+							},
+						},
 					},
 				},
-				{
-					Name: "usb-duplicate",
-					Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
-						"name": {StringValue: ptr.To("USB.Device.2")},
-					},
-				},
-			},
-		},
-	}
+			}
 
-	actual := nodeUSBDeviceNamesFromSlice(resourceSlice)
-	if len(actual) != 2 {
-		t.Fatalf("expected 2 device names, got %d", len(actual))
-	}
+			actual := nodeUSBDeviceNamesFromSlice(resourceSlice)
 
-	if actual[0] != "usb-1" {
-		t.Fatalf("unexpected first name %q", actual[0])
-	}
+			Expect(actual).To(Equal([]string{"usb-1", "usb-device-2"}))
+		})
+	})
 
-	if actual[1] != "usb-device-2" {
-		t.Fatalf("unexpected second name %q", actual[1])
-	}
-}
+	Describe("nodeUSBDeviceName", func() {
+		It("skips non-usb devices", func() {
+			name, ok := nodeUSBDeviceName(resourcev1.Device{Name: "gpu-1"})
 
-func TestNodeUSBDeviceName(t *testing.T) {
-	name, ok := nodeUSBDeviceName(resourcev1.Device{Name: "gpu-1"})
-	if ok {
-		t.Fatalf("expected non-usb device to be skipped, got %q", name)
-	}
+			Expect(ok).To(BeFalse())
+			Expect(name).To(BeEmpty())
+		})
 
-	name, ok = nodeUSBDeviceName(resourcev1.Device{Name: "usb-raw"})
-	if !ok || name != "usb-raw" {
-		t.Fatalf("expected usb raw name, got %q (%v)", name, ok)
-	}
-}
+		It("returns the raw usb name", func() {
+			name, ok := nodeUSBDeviceName(resourcev1.Device{Name: "usb-raw"})
+
+			Expect(ok).To(BeTrue())
+			Expect(name).To(Equal("usb-raw"))
+		})
+	})
+})

--- a/images/virtualization-artifact/pkg/controller/nodeusbdevice/internal/watcher/suite_test.go
+++ b/images/virtualization-artifact/pkg/controller/nodeusbdevice/internal/watcher/suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watcher
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestWatcher(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "NodeUSBDevice Watchers Suite")
+}

--- a/images/virtualization-artifact/pkg/controller/nodeusbdevice/internal/watcher/usbdevice_watcher.go
+++ b/images/virtualization-artifact/pkg/controller/nodeusbdevice/internal/watcher/usbdevice_watcher.go
@@ -46,12 +46,6 @@ func (w *USBDeviceWatcher) Watch(mgr manager.Manager, ctr controller.Controller)
 				return requestsByUSBDevice(usbDevice)
 			}),
 			predicate.TypedFuncs[*v1alpha2.USBDevice]{
-				CreateFunc: func(e event.TypedCreateEvent[*v1alpha2.USBDevice]) bool {
-					return e.Object != nil
-				},
-				DeleteFunc: func(e event.TypedDeleteEvent[*v1alpha2.USBDevice]) bool {
-					return e.Object != nil
-				},
 				UpdateFunc: func(e event.TypedUpdateEvent[*v1alpha2.USBDevice]) bool {
 					return shouldProcessUSBDeviceUpdate(e.ObjectOld, e.ObjectNew)
 				},

--- a/images/virtualization-artifact/pkg/controller/nodeusbdevice/internal/watcher/usbdevice_watcher.go
+++ b/images/virtualization-artifact/pkg/controller/nodeusbdevice/internal/watcher/usbdevice_watcher.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watcher
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+)
+
+func NewUSBDeviceWatcher() *USBDeviceWatcher {
+	return &USBDeviceWatcher{}
+}
+
+type USBDeviceWatcher struct{}
+
+func (w *USBDeviceWatcher) Watch(mgr manager.Manager, ctr controller.Controller) error {
+	return ctr.Watch(
+		source.Kind(mgr.GetCache(),
+			&v1alpha2.USBDevice{},
+			handler.TypedEnqueueRequestsFromMapFunc(func(_ context.Context, usbDevice *v1alpha2.USBDevice) []reconcile.Request {
+				return requestsByUSBDevice(usbDevice)
+			}),
+			predicate.TypedFuncs[*v1alpha2.USBDevice]{
+				CreateFunc: func(e event.TypedCreateEvent[*v1alpha2.USBDevice]) bool {
+					return e.Object != nil
+				},
+				DeleteFunc: func(e event.TypedDeleteEvent[*v1alpha2.USBDevice]) bool {
+					return e.Object != nil
+				},
+				UpdateFunc: func(e event.TypedUpdateEvent[*v1alpha2.USBDevice]) bool {
+					return shouldProcessUSBDeviceUpdate(e.ObjectOld, e.ObjectNew)
+				},
+			},
+		),
+	)
+}
+
+func requestsByUSBDevice(usbDevice *v1alpha2.USBDevice) []reconcile.Request {
+	if usbDevice == nil {
+		return nil
+	}
+
+	for _, ownerRef := range usbDevice.OwnerReferences {
+		if ownerRef.APIVersion != v1alpha2.SchemeGroupVersion.String() || ownerRef.Kind != v1alpha2.NodeUSBDeviceKind || ownerRef.Name == "" {
+			continue
+		}
+
+		return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: ownerRef.Name}}}
+	}
+
+	if usbDevice.Name == "" {
+		return nil
+	}
+
+	return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: usbDevice.Name}}}
+}
+
+func shouldProcessUSBDeviceUpdate(oldObj, newObj *v1alpha2.USBDevice) bool {
+	if oldObj == nil || newObj == nil {
+		return false
+	}
+
+	return !equality.Semantic.DeepEqual(oldObj.Status.Conditions, newObj.Status.Conditions) ||
+		!equality.Semantic.DeepEqual(oldObj.OwnerReferences, newObj.OwnerReferences) ||
+		!equality.Semantic.DeepEqual(oldObj.GetDeletionTimestamp(), newObj.GetDeletionTimestamp())
+}

--- a/images/virtualization-artifact/pkg/controller/nodeusbdevice/internal/watcher/usbdevice_watcher_test.go
+++ b/images/virtualization-artifact/pkg/controller/nodeusbdevice/internal/watcher/usbdevice_watcher_test.go
@@ -17,81 +17,83 @@ limitations under the License.
 package watcher
 
 import (
-	"testing"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
-func TestRequestsByUSBDevice(t *testing.T) {
-	usbDevice := &v1alpha2.USBDevice{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "usb-device-1",
-			Namespace: "test-ns",
-			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: v1alpha2.SchemeGroupVersion.String(),
-				Kind:       v1alpha2.NodeUSBDeviceKind,
-				Name:       "node-usb-device-1",
-			}},
-		},
-	}
+var _ = Describe("USBDeviceWatcher", func() {
+	Describe("requestsByUSBDevice", func() {
+		It("returns a request for the owner NodeUSBDevice", func() {
+			usbDevice := &v1alpha2.USBDevice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "usb-device-1",
+					Namespace: "test-ns",
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion: v1alpha2.SchemeGroupVersion.String(),
+						Kind:       v1alpha2.NodeUSBDeviceKind,
+						Name:       "node-usb-device-1",
+					}},
+				},
+			}
 
-	requests := requestsByUSBDevice(usbDevice)
-	if len(requests) != 1 {
-		t.Fatalf("expected 1 request, got %d", len(requests))
-	}
-	if requests[0].Name != "node-usb-device-1" {
-		t.Fatalf("unexpected request name %q", requests[0].Name)
-	}
-	if requests[0].Namespace != "" {
-		t.Fatalf("expected cluster-scoped request, got namespace %q", requests[0].Namespace)
-	}
-}
+			requests := requestsByUSBDevice(usbDevice)
 
-func TestRequestsByUSBDeviceFallsBackToName(t *testing.T) {
-	usbDevice := &v1alpha2.USBDevice{ObjectMeta: metav1.ObjectMeta{Name: "usb-device-1", Namespace: "test-ns"}}
+			Expect(requests).To(HaveLen(1))
+			Expect(requests[0].Name).To(Equal("node-usb-device-1"))
+			Expect(requests[0].Namespace).To(BeEmpty())
+		})
 
-	requests := requestsByUSBDevice(usbDevice)
-	if len(requests) != 1 {
-		t.Fatalf("expected 1 request, got %d", len(requests))
-	}
-	if requests[0].Name != "usb-device-1" {
-		t.Fatalf("unexpected fallback request name %q", requests[0].Name)
-	}
-}
+		It("falls back to the USBDevice name", func() {
+			usbDevice := &v1alpha2.USBDevice{ObjectMeta: metav1.ObjectMeta{Name: "usb-device-1", Namespace: "test-ns"}}
 
-func TestShouldProcessUSBDeviceUpdate(t *testing.T) {
-	oldObj := &v1alpha2.USBDevice{
-		ObjectMeta: metav1.ObjectMeta{Name: "usb-device-1"},
-		Status: v1alpha2.USBDeviceStatus{Conditions: []metav1.Condition{{
-			Type:   "Attached",
-			Status: metav1.ConditionFalse,
-			Reason: "Available",
-		}}},
-	}
+			requests := requestsByUSBDevice(usbDevice)
 
-	sameObj := oldObj.DeepCopy()
-	if shouldProcessUSBDeviceUpdate(oldObj, sameObj) {
-		t.Fatal("expected unchanged object update to be ignored")
-	}
+			Expect(requests).To(HaveLen(1))
+			Expect(requests[0].Name).To(Equal("usb-device-1"))
+		})
+	})
 
-	changedConditions := oldObj.DeepCopy()
-	changedConditions.Status.Conditions[0].Status = metav1.ConditionTrue
-	if !shouldProcessUSBDeviceUpdate(oldObj, changedConditions) {
-		t.Fatal("expected conditions update to be processed")
-	}
+	Describe("shouldProcessUSBDeviceUpdate", func() {
+		var oldObj *v1alpha2.USBDevice
 
-	changedOwners := oldObj.DeepCopy()
-	changedOwners.OwnerReferences = []metav1.OwnerReference{{Name: "node-usb-device-1"}}
-	if !shouldProcessUSBDeviceUpdate(oldObj, changedOwners) {
-		t.Fatal("expected owner references update to be processed")
-	}
+		BeforeEach(func() {
+			oldObj = &v1alpha2.USBDevice{
+				ObjectMeta: metav1.ObjectMeta{Name: "usb-device-1"},
+				Status: v1alpha2.USBDeviceStatus{Conditions: []metav1.Condition{{
+					Type:   "Attached",
+					Status: metav1.ConditionFalse,
+					Reason: "Available",
+				}}},
+			}
+		})
 
-	if shouldProcessUSBDeviceUpdate(nil, changedConditions) {
-		t.Fatal("expected nil old object to be ignored")
-	}
-	if shouldProcessUSBDeviceUpdate(oldObj, nil) {
-		t.Fatal("expected nil new object to be ignored")
-	}
-}
+		It("ignores unchanged objects", func() {
+			sameObj := oldObj.DeepCopy()
+
+			Expect(shouldProcessUSBDeviceUpdate(oldObj, sameObj)).To(BeFalse())
+		})
+
+		It("processes condition changes", func() {
+			changedConditions := oldObj.DeepCopy()
+			changedConditions.Status.Conditions[0].Status = metav1.ConditionTrue
+
+			Expect(shouldProcessUSBDeviceUpdate(oldObj, changedConditions)).To(BeTrue())
+		})
+
+		It("processes owner reference changes", func() {
+			changedOwners := oldObj.DeepCopy()
+			changedOwners.OwnerReferences = []metav1.OwnerReference{{Name: "node-usb-device-1"}}
+
+			Expect(shouldProcessUSBDeviceUpdate(oldObj, changedOwners)).To(BeTrue())
+		})
+
+		It("ignores nil objects", func() {
+			Expect(shouldProcessUSBDeviceUpdate(nil, oldObj)).To(BeFalse())
+			Expect(shouldProcessUSBDeviceUpdate(oldObj, nil)).To(BeFalse())
+		})
+	})
+})

--- a/images/virtualization-artifact/pkg/controller/nodeusbdevice/internal/watcher/usbdevice_watcher_test.go
+++ b/images/virtualization-artifact/pkg/controller/nodeusbdevice/internal/watcher/usbdevice_watcher_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watcher
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+)
+
+func TestRequestsByUSBDevice(t *testing.T) {
+	usbDevice := &v1alpha2.USBDevice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "usb-device-1",
+			Namespace: "test-ns",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: v1alpha2.SchemeGroupVersion.String(),
+				Kind:       v1alpha2.NodeUSBDeviceKind,
+				Name:       "node-usb-device-1",
+			}},
+		},
+	}
+
+	requests := requestsByUSBDevice(usbDevice)
+	if len(requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(requests))
+	}
+	if requests[0].Name != "node-usb-device-1" {
+		t.Fatalf("unexpected request name %q", requests[0].Name)
+	}
+	if requests[0].Namespace != "" {
+		t.Fatalf("expected cluster-scoped request, got namespace %q", requests[0].Namespace)
+	}
+}
+
+func TestRequestsByUSBDeviceFallsBackToName(t *testing.T) {
+	usbDevice := &v1alpha2.USBDevice{ObjectMeta: metav1.ObjectMeta{Name: "usb-device-1", Namespace: "test-ns"}}
+
+	requests := requestsByUSBDevice(usbDevice)
+	if len(requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(requests))
+	}
+	if requests[0].Name != "usb-device-1" {
+		t.Fatalf("unexpected fallback request name %q", requests[0].Name)
+	}
+}
+
+func TestShouldProcessUSBDeviceUpdate(t *testing.T) {
+	oldObj := &v1alpha2.USBDevice{
+		ObjectMeta: metav1.ObjectMeta{Name: "usb-device-1"},
+		Status: v1alpha2.USBDeviceStatus{Conditions: []metav1.Condition{{
+			Type:   "Attached",
+			Status: metav1.ConditionFalse,
+			Reason: "Available",
+		}}},
+	}
+
+	sameObj := oldObj.DeepCopy()
+	if shouldProcessUSBDeviceUpdate(oldObj, sameObj) {
+		t.Fatal("expected unchanged object update to be ignored")
+	}
+
+	changedConditions := oldObj.DeepCopy()
+	changedConditions.Status.Conditions[0].Status = metav1.ConditionTrue
+	if !shouldProcessUSBDeviceUpdate(oldObj, changedConditions) {
+		t.Fatal("expected conditions update to be processed")
+	}
+
+	changedOwners := oldObj.DeepCopy()
+	changedOwners.OwnerReferences = []metav1.OwnerReference{{Name: "node-usb-device-1"}}
+	if !shouldProcessUSBDeviceUpdate(oldObj, changedOwners) {
+		t.Fatal("expected owner references update to be processed")
+	}
+
+	if shouldProcessUSBDeviceUpdate(nil, changedConditions) {
+		t.Fatal("expected nil old object to be ignored")
+	}
+	if shouldProcessUSBDeviceUpdate(oldObj, nil) {
+		t.Fatal("expected nil new object to be ignored")
+	}
+}

--- a/images/virtualization-artifact/pkg/controller/nodeusbdevice/internal/watcher/usbdevice_watcher_test.go
+++ b/images/virtualization-artifact/pkg/controller/nodeusbdevice/internal/watcher/usbdevice_watcher_test.go
@@ -17,10 +17,9 @@ limitations under the License.
 package watcher
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
 )

--- a/images/virtualization-artifact/pkg/controller/nodeusbdevice/nodeusbdevice_controller.go
+++ b/images/virtualization-artifact/pkg/controller/nodeusbdevice/nodeusbdevice_controller.go
@@ -49,6 +49,7 @@ func NewController(
 		handler.NewDeletionHandler(client),
 		handler.NewReadyHandler(client),
 		handler.NewAssignedHandler(client),
+		handler.NewAttachedHandler(client),
 	}
 
 	r := NewReconciler(client, handlers...)

--- a/images/virtualization-artifact/pkg/controller/nodeusbdevice/nodeusbdevice_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/nodeusbdevice/nodeusbdevice_reconciler.go
@@ -69,6 +69,7 @@ func (r *Reconciler) SetupController(_ context.Context, mgr manager.Manager, ctr
 	for _, w := range []Watcher{
 		watcher.NewResourceSliceWatcher(),
 		watcher.NewNamespaceWatcher(),
+		watcher.NewUSBDeviceWatcher(),
 	} {
 		err := w.Watch(mgr, ctr)
 		if err != nil {

--- a/test/e2e/vm/usb.go
+++ b/test/e2e/vm/usb.go
@@ -23,6 +23,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -69,6 +70,15 @@ var _ = Describe("VirtualMachineUSB", func() {
 			util.UntilSSHReady(f, t.VM, framework.MiddleTimeout)
 		})
 
+		By("Verifying NodeUSBDevice is not attached before VM attachment", func() {
+			Eventually(func(g Gomega) {
+				nodeUSBDevice, err := t.Framework.VirtClient().NodeUSBDevices().Get(t.ctx, t.NodeUSBDevice.Name, metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(nodeUSBAttachedCondition(nodeUSBDevice)).NotTo(BeNil())
+				g.Expect(nodeUSBAttachedCondition(nodeUSBDevice).Status).To(Equal(metav1.ConditionFalse))
+			}).WithTimeout(framework.MaxTimeout).WithPolling(time.Second).Should(Succeed())
+		})
+
 		By("Waiting for USB device to be attached and ready", func() {
 			Eventually(func() error {
 				vm, err := t.Framework.VirtClient().VirtualMachines(t.VM.Namespace).Get(t.ctx, t.VM.Name, metav1.GetOptions{})
@@ -82,6 +92,15 @@ var _ = Describe("VirtualMachineUSB", func() {
 				}
 
 				return fmt.Errorf("USB device %s not attached or not ready", t.NodeUSBDevice.Name)
+			}).WithTimeout(framework.MaxTimeout).WithPolling(time.Second).Should(Succeed())
+		})
+
+		By("Verifying NodeUSBDevice is attached", func() {
+			Eventually(func(g Gomega) {
+				nodeUSBDevice, err := t.Framework.VirtClient().NodeUSBDevices().Get(t.ctx, t.NodeUSBDevice.Name, metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(nodeUSBAttachedCondition(nodeUSBDevice)).NotTo(BeNil())
+				g.Expect(nodeUSBAttachedCondition(nodeUSBDevice).Status).To(Equal(metav1.ConditionTrue))
 			}).WithTimeout(framework.MaxTimeout).WithPolling(time.Second).Should(Succeed())
 		})
 
@@ -116,6 +135,15 @@ var _ = Describe("VirtualMachineUSB", func() {
 				}
 
 				return fmt.Errorf("USB device %s not ready after migration", t.NodeUSBDevice.Name)
+			}).WithTimeout(framework.MaxTimeout).WithPolling(time.Second).Should(Succeed())
+		})
+
+		By("Verifying NodeUSBDevice is attached after migration", func() {
+			Eventually(func(g Gomega) {
+				nodeUSBDevice, err := t.Framework.VirtClient().NodeUSBDevices().Get(t.ctx, t.NodeUSBDevice.Name, metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(nodeUSBAttachedCondition(nodeUSBDevice)).NotTo(BeNil())
+				g.Expect(nodeUSBAttachedCondition(nodeUSBDevice).Status).To(Equal(metav1.ConditionTrue))
 			}).WithTimeout(framework.MaxTimeout).WithPolling(time.Second).Should(Succeed())
 		})
 
@@ -236,6 +264,14 @@ func (t *VMUSBTest) mountUSB() {
 
 	_, err := t.Framework.SSHCommand(t.VM.Name, t.VM.Namespace, mountCmd)
 	Expect(err).NotTo(HaveOccurred())
+}
+
+func nodeUSBAttachedCondition(nodeUSBDevice *v1alpha2.NodeUSBDevice) *metav1.Condition {
+	if nodeUSBDevice == nil {
+		return nil
+	}
+
+	return meta.FindStatusCondition(nodeUSBDevice.Status.Conditions, "Attached")
 }
 
 func (t *VMUSBTest) unassignNodeUSB() {

--- a/test/e2e/vm/usb.go
+++ b/test/e2e/vm/usb.go
@@ -31,6 +31,7 @@ import (
 
 	vmbuilder "github.com/deckhouse/virtualization-controller/pkg/builder/vm"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/nodeusbdevicecondition"
 	"github.com/deckhouse/virtualization/test/e2e/internal/framework"
 	"github.com/deckhouse/virtualization/test/e2e/internal/object"
 	"github.com/deckhouse/virtualization/test/e2e/internal/util"
@@ -271,7 +272,7 @@ func nodeUSBAttachedCondition(nodeUSBDevice *v1alpha2.NodeUSBDevice) *metav1.Con
 		return nil
 	}
 
-	return meta.FindStatusCondition(nodeUSBDevice.Status.Conditions, "Attached")
+	return meta.FindStatusCondition(nodeUSBDevice.Status.Conditions, string(nodeusbdevicecondition.AttachedType))
 }
 
 func (t *VMUSBTest) unassignNodeUSB() {


### PR DESCRIPTION
## Description
Add the `Attached` condition to `NodeUSBDevice` and mirror it from `USBDevice.status.conditions[type=Attached]`.

The change also adds an `Attached` printer column for `NodeUSBDevice`, updates the controller to reconcile this condition, and adds a watcher so `NodeUSBDevice` is refreshed when the corresponding `USBDevice` changes.

## Why do we need it, and what problem does it solve?
`NodeUSBDevice` currently exposes only `Ready` and `Assigned` conditions, so it is not possible to tell from this resource whether the device is currently attached to a virtual machine.

The actual attachment state already exists in `USBDevice`, but it is inconvenient for cluster-level device visibility because `NodeUSBDevice` is the cluster-scoped source operators look at first.

This change makes `NodeUSBDevice` reflect the existing attachment state without introducing a second source of truth. The controller simply mirrors `USBDevice.Attached` status, reason, and message into `NodeUSBDevice.Attached`.

## What is the expected result?
1. Assign a `NodeUSBDevice` to a namespace.
2. Before the device is attached to a VM, `kubectl get nodeusbdevices` shows `Attached=False`.
3. Attach the corresponding `USBDevice` to a `VirtualMachine`.
4. `NodeUSBDevice.status.conditions[type=Attached]` becomes `True` and the `Attached` printer column is updated.
5. When the device is detached or temporarily unavailable for migration, `NodeUSBDevice` mirrors the corresponding `USBDevice.Attached` state and reason.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

