### PR TITLE
fix(ci): render infra config

### DIFF
--- a/.github/workflows/e2e-reusable-pipeline.yml
+++ b/.github/workflows/e2e-reusable-pipeline.yml
@@ -240,8 +240,8 @@ jobs:
                   size: ${{ inputs.cluster_config_workers_memory }}
                 additionalDisks:
                 - size: 50Gi
-          networkConfig:
-            clusterNetworkName: ${{ inputs.nested_cluster_network_name }}
+            networkConfig:
+              clusterNetworkName: ${{ inputs.nested_cluster_network_name }}
           EOF
 
           mkdir -p tmp

--- a/test/dvp-static-cluster/charts/infra/templates/_helpers.tpl
+++ b/test/dvp-static-cluster/charts/infra/templates/_helpers.tpl
@@ -16,7 +16,9 @@ group: {{ $prefix }}
 {{- $ctx := index . 0 -}}
 {{- $name := index . 1 -}}
 {{- $cfg := index . 2 -}}
-{{- $clusterNetworkName := dig $ctx.Values "networkConfig" "clusterNetworkName" "" -}}
+{{- $networkConfig := get $ctx.Values.instances "networkConfig" | default dict -}}
+{{- $clusterNetworkName := get $networkConfig "clusterNetworkName" | default "" -}}
+
 ---
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualMachine


### PR DESCRIPTION
## Description
Fixes the infrastructure configuration rendering for nested e2e clusters by correcting the YAML structure and the Helm template lookup logic.

Changes:
- Fixed YAML indentation in `e2e-reusable-pipeline.yml` - moved `networkConfig` to the correct nesting level
- Fixed `_helpers.tpl` to properly extract `networkConfig` from the `instances` values using `get` function instead of incorrect `dig` call

## Why do we need it, and what problem does it solve?
The previous implementation (#2181) introduced SDN configuration for nested e2e clusters, but the YAML structure was incorrectly nested and the Helm template was unable to properly access the `networkConfig` values. This caused the `clusterNetworkName` to be empty, preventing VMs from connecting to the configured ClusterNetwork.

## What is the expected result?
1. The `networkConfig` block is correctly rendered in the infra values YAML
2. The Helm template properly retrieves `networkConfig.clusterNetworkName` from instances
3. VMs in nested e2e clusters can use the configured ClusterNetwork for additional network interfaces

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: fix
summary: Fix infrastructure config rendering for nested e2e clusters
impact_level: low
```