### PR TITLE
chore(core): prevent vm restarts on update

### DIFF
--- a/templates/kubevirt/kubevirt.yaml
+++ b/templates/kubevirt/kubevirt.yaml
@@ -363,17 +363,6 @@ volumes:
 - name: node-labeller
   hostPath:
     path: /var/run/d8-virtualization/node-labeller
-# Other directories to communicate with virt-launcher.
-# Also rewrite to prevent errors.
-- name: libvirt-runtimes
-  hostPath:
-    path: /var/run/d8-virtualization/libvirt-runtimes
-- name: virt-share-dir
-  hostPath:
-    path: /var/run/d8-virtualization/kubevirt
-- name: virt-private-dir
-  hostPath:
-    path: /var/run/d8-virtualization/kubevirt-private
 {{- end }}
     - resourceName: virt-handler
       resourceType: DaemonSet


### PR DESCRIPTION

## Description
<!---
  Describe your changes with technical details.
-->

- Revert patching hostPath for volumes in virt-handler.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->

Changing directories required for compatibility with original Kubevirt, but it is not safe when VMs are already running.

## What is the expected result?

Updating from v1.7 to main should not lead to VM restarts.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->
