### PR TITLE
fix(ci): render nfs cluster

### DIFF
--- a/test/dvp-static-cluster/charts/infra/templates/_helpers.tpl
+++ b/test/dvp-static-cluster/charts/infra/templates/_helpers.tpl
@@ -36,6 +36,7 @@ spec:
   - kind: VirtualDisk
     name: {{ printf "%s-%d" $name $i }}
 {{- end }}
+{{- end }}
   networks:
     - type: Main
 {{- if $clusterNetworkName }}
@@ -129,6 +130,5 @@ spec:
     storageClassName: {{ $ctx.Values.storageClass }}
     {{- end }}
   {{- end }}
-{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description

Fix the `infra` Helm template for the static DVP cluster setup so that NFS deployments render complete `VirtualMachine` specs.

## Why do we need it, and what problem does it solve?

The current template places the `if ne .Values.storageType "nfs"` condition too broadly.  
As a result, when `storageType` is set to `nfs`, the rendered master/worker `VirtualMachine` resources lose required fields such as CPU, memory, run policy, and VM class reference.

This breaks bootstrap for the NFS e2e pipeline and leads to admission webhook errors during VM creation, including validation failures like:

`the specified ".spec.cpu.cores 0" value is not among the sizing policies allowed for the virtual machine`

## What is the expected result?

For `storageType: nfs`, the template should skip only NFS-incompatible parts such as additional disks, while still rendering a valid full `VirtualMachine` spec.

Steps to verify:
1. Render `test/dvp-static-cluster/charts/infra` with `storageType: nfs`.
2. Check the generated `VirtualMachine` manifests for master/worker nodes.
3. Confirm they still contain required fields such as `spec.cpu`, `spec.memory`, `spec.runPolicy`, and `spec.virtualMachineClassName`.
4. Apply the rendered manifests and verify that VM creation is no longer rejected by the admission webhook because of missing CPU configuration.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ci
type: fix
summary: "fix NFS infra Helm template rendering for e2e nested cluster bootstrap"