### PR TITLE
chore(ci): add apt mirror support for ubuntu in cloud-init

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -346,6 +346,7 @@ jobs:
       randuuid4c: ${{ needs.set-vars.outputs.randuuid4c }}
       cluster_config_workers_memory: "9Gi"
       cluster_config_k8s_version: "1.34"
+      apt_mirror_enabled: true
     secrets:
       DEV_REGISTRY_DOCKER_CFG: ${{ secrets.DEV_REGISTRY_DOCKER_CFG }}
       VIRT_E2E_NIGHTLY_SA_TOKEN: ${{ secrets.VIRT_E2E_NIGHTLY_SA_TOKEN }}
@@ -371,6 +372,7 @@ jobs:
       randuuid4c: ${{ needs.set-vars.outputs.randuuid4c }}
       cluster_config_workers_memory: "9Gi"
       cluster_config_k8s_version: "Automatic"
+      apt_mirror_enabled: true
     secrets:
       DEV_REGISTRY_DOCKER_CFG: ${{ secrets.DEV_REGISTRY_DOCKER_CFG }}
       VIRT_E2E_NIGHTLY_SA_TOKEN: ${{ secrets.VIRT_E2E_NIGHTLY_SA_TOKEN }}

--- a/.github/workflows/e2e-reusable-pipeline.yml
+++ b/.github/workflows/e2e-reusable-pipeline.yml
@@ -98,6 +98,21 @@ on:
         type: string
         default: "cn-4006-for-e2e-test"
         description: "ClusterNetwork name for nested VM additional network interface"
+      apt_mirror_enabled:
+        required: false
+        type: boolean
+        default: true
+        description: "Use custom APT mirror inside VMs cloud-init (Ubuntu). When false, VMs use stock Ubuntu repositories."
+      apt_mirror_name:
+        required: false
+        type: string
+        default: "hetzner"
+        description: "APT mirror short name (used as /etc/apt/sources.list.d/<name>.list file name)"
+      apt_mirror_url:
+        required: false
+        type: string
+        default: "https://mirror.hetzner.com/ubuntu/packages"
+        description: "APT mirror base URL (without trailing slash)"
     secrets:
       DEV_REGISTRY_DOCKER_CFG:
         required: true
@@ -220,6 +235,10 @@ jobs:
             - console
             - virtualization
           instances:
+            aptMirror:
+              enabled: ${{ inputs.apt_mirror_enabled }}
+              name: ${{ inputs.apt_mirror_name }}
+              url: ${{ inputs.apt_mirror_url }}
             masterNodes:
               count: 1
               cfg:

--- a/test/dvp-static-cluster/charts/infra/templates/_cloudinit.tpl
+++ b/test/dvp-static-cluster/charts/infra/templates/_cloudinit.tpl
@@ -1,0 +1,116 @@
+{{- define "cloudinit.ubuntu" -}}
+{{- $codename := .Values.image.ubuntuCodename | default "noble" -}}
+#cloud-config
+ssh_pwauth: true
+package_update: true
+bootcmd:
+  - mv -f /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources.bak
+write_files:
+  - path: /etc/apt/sources.list.d/hetzner.list
+    owner: root:root
+    permissions: '0644'
+    content: |
+      # Packages and Updates from the Hetzner Ubuntu Mirror
+      deb https://mirror.hetzner.com/ubuntu/packages {{ $codename }}           main restricted universe multiverse
+      deb https://mirror.hetzner.com/ubuntu/packages {{ $codename }}-updates   main restricted universe multiverse
+      deb https://mirror.hetzner.com/ubuntu/packages {{ $codename }}-backports main restricted universe multiverse
+      deb https://mirror.hetzner.com/ubuntu/packages {{ $codename }}-security  main restricted universe multiverse
+  - path: /etc/netplan/99-eno2.yaml
+    content: |
+      network:
+        version: 2
+        ethernets:
+          eno2:
+            dhcp4: false
+            dhcp6: false
+            addresses: []
+            link-local: []
+            optional: true
+apt:
+  preserve_sources_list: true
+  primary:
+    - arches: [default]
+      uri: https://mirror.hetzner.com/ubuntu/packages
+  security:
+    - arches: [default]
+      uri: https://mirror.hetzner.com/ubuntu/packages
+packages:
+  - qemu-guest-agent
+  - jq
+  - rsync
+  - bind9-dnsutils
+users:
+  - default
+  - name: cloud
+    passwd: {{ .Values.discovered.userPasswd }}
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    chpasswd: {expire: False}
+    lock_passwd: false
+    ssh_authorized_keys:
+      - {{ .Values.discovered.publicSSHKey }}
+runcmd:
+  - netplan apply
+  - ip link set eno2 up
+  - systemctl enable --now qemu-guest-agent.service
+
+final_message: "\U0001F525\U0001F525\U0001F525 The system is finally up, after $UPTIME seconds \U0001F525\U0001F525\U0001F525"
+{{- end }}
+
+{{- define "cloudinit.alpine" -}}
+#cloud-config
+package_update: true
+packages:
+  - tmux
+  - htop
+  - qemu-guest-agent
+  - nfs-utils
+  - e2fsprogs
+users:
+  - name: cloud
+    passwd: $6$rounds=4096$vln/.aPHBOI7BMYR$bBMkqQvuGs5Gyd/1H5DP4m9HjQSy.kgrxpaGEHwkX7KEFV8BS.HZWPitAtZ2Vd8ZqIZRqmlykRCagTgPejt1i.
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    chpasswd: {expire: False}
+    lock_passwd: false
+    ssh_authorized_keys:
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFzMcx+aKT7jfkaeQrDdsKfeuSqX/4bqR4Z6IaDsiAFI user@default
+disk_setup:
+  /dev/sdc:
+    table_type: mbr
+    layout:
+      - 100%: ext4
+    overwrite: true
+fs_setup:
+  - label: nfs_shared
+    filesystem: ext4
+    device: /dev/sdc
+    replace_fs: true
+mounts:
+  - [LABEL=nfs_shared, /srv/nfs/shared, ext4, "defaults,nofail", "0", "0"]
+runcmd:
+  - mkdir -p /srv/nfs/shared
+  - |
+    for i in $(seq 1 60); do
+      mountpoint -q /srv/nfs/shared && break || sleep 1
+    done
+    if [ $? -ne 0 ]; then
+      echo "Disk not mounted after 60 seconds" >&2
+      exit 1
+    fi
+  - mkdir -p /var/lib/nfs/statd
+  - chmod 755 /var/lib/nfs/statd
+  - echo "/srv/nfs/shared *(rw,fsid=0,async,no_subtree_check,no_auth_nlm,insecure,no_root_squash)" > /etc/exports
+  - rc-service rpcbind restart
+  - rc-service rpc.statd restart || echo "Failed to start rpc.statd" >&2
+  - rc-service nfs restart
+  - rc-update add rpcbind
+  - rc-update add rpc.statd
+  - rc-update add nfs
+  - rc-update add qemu-guest-agent
+  - rc-service qemu-guest-agent start
+  - exportfs -arv
+  - rc-status
+  - exportfs -v
+final_message: "\U0001F525\U0001F525\U0001F525 The system is finally up, after $UPTIME seconds \U0001F525\U0001F525\U0001F525"
+{{- end }}

--- a/test/dvp-static-cluster/charts/infra/templates/_cloudinit.tpl
+++ b/test/dvp-static-cluster/charts/infra/templates/_cloudinit.tpl
@@ -1,20 +1,28 @@
 {{- define "cloudinit.ubuntu" -}}
-{{- $codename := .Values.image.ubuntuCodename | default "noble" -}}
+{{- $codename      := .Values.image.ubuntuCodename | default "noble" -}}
+{{- $mirror        := .Values.instances.aptMirror | default dict -}}
+{{- $mirrorEnabled := $mirror.enabled | default false -}}
+{{- $mirrorUrl     := $mirror.url     | default "" -}}
+{{- $mirrorName    := $mirror.name    | default "custom" -}}
 #cloud-config
 ssh_pwauth: true
 package_update: true
+{{- if $mirrorEnabled }}
 bootcmd:
   - mv -f /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources.bak
+{{- end }}
 write_files:
-  - path: /etc/apt/sources.list.d/hetzner.list
+{{- if $mirrorEnabled }}
+  - path: /etc/apt/sources.list.d/{{ $mirrorName }}.list
     owner: root:root
     permissions: '0644'
     content: |
-      # Packages and Updates from the Hetzner Ubuntu Mirror
-      deb https://mirror.hetzner.com/ubuntu/packages {{ $codename }}           main restricted universe multiverse
-      deb https://mirror.hetzner.com/ubuntu/packages {{ $codename }}-updates   main restricted universe multiverse
-      deb https://mirror.hetzner.com/ubuntu/packages {{ $codename }}-backports main restricted universe multiverse
-      deb https://mirror.hetzner.com/ubuntu/packages {{ $codename }}-security  main restricted universe multiverse
+      # Packages and Updates from the {{ $mirrorName | title }} Ubuntu Mirror
+      deb {{ $mirrorUrl }} {{ $codename }}           main restricted universe multiverse
+      deb {{ $mirrorUrl }} {{ $codename }}-updates   main restricted universe multiverse
+      deb {{ $mirrorUrl }} {{ $codename }}-backports main restricted universe multiverse
+      deb {{ $mirrorUrl }} {{ $codename }}-security  main restricted universe multiverse
+{{- end }}
   - path: /etc/netplan/99-eno2.yaml
     content: |
       network:
@@ -26,14 +34,10 @@ write_files:
             addresses: []
             link-local: []
             optional: true
+{{- if $mirrorEnabled }}
 apt:
   preserve_sources_list: true
-  primary:
-    - arches: [default]
-      uri: https://mirror.hetzner.com/ubuntu/packages
-  security:
-    - arches: [default]
-      uri: https://mirror.hetzner.com/ubuntu/packages
+{{- end }}
 packages:
   - qemu-guest-agent
   - jq

--- a/test/dvp-static-cluster/charts/infra/templates/_helpers.tpl
+++ b/test/dvp-static-cluster/charts/infra/templates/_helpers.tpl
@@ -57,42 +57,7 @@ spec:
   provisioning:
     type: UserData
     userData: |
-      #cloud-config
-      ssh_pwauth: true
-      package_update: true
-      write_files:
-        - path: /etc/netplan/99-eno2.yaml
-          content: |
-            network:
-              version: 2
-              ethernets:
-                eno2:
-                  dhcp4: false
-                  dhcp6: false
-                  addresses: []
-                  link-local: []
-                  optional: true
-      packages:
-        - qemu-guest-agent
-        - jq
-        - rsync
-        - bind9-dnsutils
-      users:
-        - default
-        - name: cloud
-          passwd: {{ $ctx.Values.discovered.userPasswd }}
-          shell: /bin/bash
-          sudo: ALL=(ALL) NOPASSWD:ALL
-          chpasswd: {expire: False}
-          lock_passwd: false
-          ssh_authorized_keys:
-            - {{ $ctx.Values.discovered.publicSSHKey }}
-
-      runcmd:
-        - netplan apply
-        - ip link set eno2 up
-        - systemctl enable --now qemu-guest-agent.service
-      final_message: "\U0001F525\U0001F525\U0001F525 The system is finally up, after $UPTIME seconds \U0001F525\U0001F525\U0001F525"
+{{ include "cloudinit.ubuntu" $ctx | indent 6 }}
   runPolicy: AlwaysOn
   virtualMachineClassName: {{ include "infra.vmclass-name" $ctx }}
 ---

--- a/test/dvp-static-cluster/charts/infra/templates/nfs/vm.yaml
+++ b/test/dvp-static-cluster/charts/infra/templates/nfs/vm.yaml
@@ -53,71 +53,7 @@ spec:
   provisioning:
     type: UserData
     userData: |
-      #cloud-config
-      package_update: true
-      packages:
-        - tmux
-        - htop
-        - qemu-guest-agent
-        - nfs-utils
-        - e2fsprogs
-      users:
-        - name: cloud
-          # passwd: cloud
-          passwd: $6$rounds=4096$vln/.aPHBOI7BMYR$bBMkqQvuGs5Gyd/1H5DP4m9HjQSy.kgrxpaGEHwkX7KEFV8BS.HZWPitAtZ2Vd8ZqIZRqmlykRCagTgPejt1i.
-          shell: /bin/bash
-          sudo: ALL=(ALL) NOPASSWD:ALL
-          chpasswd: {expire: False}
-          lock_passwd: false
-          ssh_authorized_keys:
-            - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFzMcx+aKT7jfkaeQrDdsKfeuSqX/4bqR4Z6IaDsiAFI user@default
-      disk_setup:
-        /dev/sdc:
-          table_type: mbr
-          layout:
-            - 100%: ext4
-          overwrite: true
-      fs_setup:
-        - label: nfs_shared
-          filesystem: ext4
-          device: /dev/sdc
-          replace_fs: true
-      mounts:
-        - [LABEL=nfs_shared, /srv/nfs/shared, ext4, "defaults,nofail", "0", "0"]
-      runcmd:
-        # 1. Ensure the directory exists
-        - mkdir -p /srv/nfs/shared
-        # 2. Wait for the disk to be mounted (up to 60 seconds)
-        - |
-          for i in $(seq 1 60); do
-            mountpoint -q /srv/nfs/shared && break || sleep 1
-          done
-          if [ $? -ne 0 ]; then
-            echo "Disk not mounted after 60 seconds" >&2
-            exit 1
-          fi
-        # 3. Ensure rpc.statd can work by creating its required directory
-        - mkdir -p /var/lib/nfs/statd
-        - chmod 755 /var/lib/nfs/statd
-        # 4. Configure NFS exports
-        - echo "/srv/nfs/shared *(rw,fsid=0,async,no_subtree_check,no_auth_nlm,insecure,no_root_squash)" > /etc/exports
-        # 5. Forcefully restart rpcbind and related services
-        - rc-service rpcbind restart
-        - rc-service rpc.statd restart || echo "Failed to start rpc.statd" >&2
-        # 6. Start NFS service
-        - rc-service nfs restart
-        # 7. Add all services to autostart
-        - rc-update add rpcbind
-        - rc-update add rpc.statd
-        - rc-update add nfs
-        - rc-update add qemu-guest-agent
-        - rc-service qemu-guest-agent start
-        # 8. Apply exports forcefully
-        - exportfs -arv
-        # 9. Check service status
-        - rc-status
-        - exportfs -v
-      final_message: "\U0001F525\U0001F525\U0001F525 The system is finally up, after $UPTIME seconds \U0001F525\U0001F525\U0001F525"
+{{ include "cloudinit.alpine" . | indent 6 }}
   runPolicy: AlwaysOn
   virtualMachineClassName: {{ include "infra.vmclass-name" . }}
 {{ end }}


### PR DESCRIPTION
## Description

This PR adds APT mirror support for Ubuntu in e2e tests and cloud-init configurations.

### Changes

- **CI (e2e-reusable-pipeline.yml)**: Added apt_mirror_enabled, apt_mirror_name, and apt_mirror_url input parameters with Hetzner mirror as default
- **CI (e2e-matrix.yml)**: Enabled aptMirror in Deckhouse config for replicated and NFS e2e test jobs
- **Cloud-init (_cloudinit.tpl)**: New template for configuring APT repositories in VM cloud-init
- **NFS VM**: Updated to use the new cloud-init module with mirror support


## Why do we need it, and what problem does it solve?

E2e tests running on Hetzner infrastructure experience slow or failing package downloads from default Ubuntu repositories. Using a local Hetzner mirror (https://mirror.hetzner.com/ubuntu/packages) improves reliability and speed.


## What is the expected result?

VMs created during e2e tests use Hetzner mirror for apt package downloads, resulting in faster and more reliable test execution on Hetzner infrastructure.


## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries

```changes
section: ci
type: chore
summary: "Added APT mirror support for Ubuntu in e2e tests with Hetzner mirror as default."
```
