### PR TITLE
fix(ci): step configure virtualization

### DIFF
--- a/.github/workflows/e2e-reusable-pipeline.yml
+++ b/.github/workflows/e2e-reusable-pipeline.yml
@@ -1009,7 +1009,7 @@ jobs:
             name: virtualization
           spec:
             imageTag: ${{ env.VIRTUALIZATION_TAG }}
-            scanInterval: 10h
+            scanInterval: 120h
           EOF
 
           echo "[INFO] Show ModuleSource"

--- a/.github/workflows/e2e-reusable-pipeline.yml
+++ b/.github/workflows/e2e-reusable-pipeline.yml
@@ -967,7 +967,7 @@ jobs:
         run: |
           REGISTRY=$(base64 -d <<< "${{secrets.DEV_REGISTRY_DOCKER_CFG}}" | jq '.auths | to_entries | .[] | .key' -r)
 
-          echo "[INFO] Apply ModuleSource prod config"
+          echo "[INFO] Apply ModuleSource dev config"
           kubectl apply -f -<<EOF
           apiVersion: deckhouse.io/v1alpha1
           kind: ModuleSource
@@ -981,7 +981,7 @@ jobs:
               scheme: HTTPS
           EOF
 
-          kubectl wait --for=jsonpath='{.status.phase}'=Active ms deckhouse-dev --timeout=30s
+          kubectl wait --for=jsonpath='{.status.phase}'=Active ms deckhouse-dev --timeout=300s
 
           echo "[INFO] Apply Virtualization module config"
           kubectl apply -f -<<EOF


### PR DESCRIPTION
## Description
Fix CI configuration for the e2e reusable pipeline:

1. Fixed incorrect log message: changed `[INFO] Apply ModuleSource prod config` to `[INFO] Apply ModuleSource dev config`. The message was misleading during CI debugging.

2. Increased `kubectl wait` timeout from 30s to 300s for ModuleSource activation. The previous 30-second timeout was too short, causing intermittent CI failures when the ModuleSource took longer than expected to reach the `Active` phase.

3. Updated Virtualization module `scanInterval` from 10h to 120h. This is necessary to record the module's state at the time of the module bootstrap.

## Why do we need it, and what problem does it solve?
- The incorrect log message made CI debugging confusing.
- The insufficient timeout caused flaky CI pipeline failures, wasting CI resources and delaying development.
- Frequent image scanning with 10h interval creates unnecessary load during e2e tests.

## What is the expected result?
1. CI pipeline logs show correct "dev config" message
2. ModuleSource activation has sufficient time to complete reliably

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: fix
summary: fix CI configuration for e2e pipeline configure virtualization step.
impact_level: low
```
