### PR TITLE
feat(images): fetch TLS certificate from secret for upload endpoints

### DIFF
--- a/images/virtualization-artifact/pkg/controller/cvi/cvi_controller.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/cvi_controller.go
@@ -77,7 +77,7 @@ func NewController(
 	sources.Set(v1alpha2.DataSourceTypeHTTP, source.NewHTTPDataSource(recorder, stat, importer, dvcrSettings, ns))
 	sources.Set(v1alpha2.DataSourceTypeContainerImage, source.NewRegistryDataSource(recorder, stat, importer, dvcrSettings, mgr.GetClient(), ns))
 	sources.Set(v1alpha2.DataSourceTypeObjectRef, source.NewObjectRefDataSource(recorder, stat, importer, disk, dvcrSettings, mgr.GetClient(), ns))
-	sources.Set(v1alpha2.DataSourceTypeUpload, source.NewUploadDataSource(recorder, stat, uploader, dvcrSettings, ns))
+	sources.Set(v1alpha2.DataSourceTypeUpload, source.NewUploadDataSource(recorder, stat, uploader, dvcrSettings, ns, mgr.GetClient()))
 
 	reconciler := NewReconciler(
 		mgr.GetClient(),

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/interfaces.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/interfaces.go
@@ -66,7 +66,7 @@ type Stat interface {
 	GetDVCRImageName(pod *corev1.Pod) string
 	GetDownloadSpeed(ownerUID types.UID, pod *corev1.Pod) *v1alpha2.StatusSpeed
 	GetProgress(ownerUID types.UID, pod *corev1.Pod, prevProgress string, opts ...service.GetProgressOption) string
-	IsUploaderReady(pod *corev1.Pod, svc *corev1.Service, ing *netv1.Ingress) (bool, error)
+	IsUploaderReady(pod *corev1.Pod, svc *corev1.Service, ing *netv1.Ingress, tlsSecret *corev1.Secret) (bool, error)
 	IsUploadStarted(ownerUID types.UID, pod *corev1.Pod) bool
 	CheckPod(pod *corev1.Pod) error
 }

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/mock.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/mock.go
@@ -1141,7 +1141,7 @@ var _ Stat = &StatMock{}
 //			IsUploadStartedFunc: func(ownerUID types.UID, pod *corev1.Pod) bool {
 //				panic("mock out the IsUploadStarted method")
 //			},
-//			IsUploaderReadyFunc: func(pod *corev1.Pod, svc *corev1.Service, ing *netv1.Ingress) (bool, error) {
+//			IsUploaderReadyFunc: func(pod *corev1.Pod, svc *corev1.Service, ing *netv1.Ingress, tlsSecret *corev1.Secret) (bool, error) {
 //				panic("mock out the IsUploaderReady method")
 //			},
 //		}
@@ -1176,7 +1176,7 @@ type StatMock struct {
 	IsUploadStartedFunc func(ownerUID types.UID, pod *corev1.Pod) bool
 
 	// IsUploaderReadyFunc mocks the IsUploaderReady method.
-	IsUploaderReadyFunc func(pod *corev1.Pod, svc *corev1.Service, ing *netv1.Ingress) (bool, error)
+	IsUploaderReadyFunc func(pod *corev1.Pod, svc *corev1.Service, ing *netv1.Ingress, tlsSecret *corev1.Secret) (bool, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -1238,6 +1238,8 @@ type StatMock struct {
 			Svc *corev1.Service
 			// Ing is the ing argument value.
 			Ing *netv1.Ingress
+			// TlsSecret is the tlsSecret argument value.
+			TlsSecret *corev1.Secret
 		}
 	}
 	lockCheckPod         sync.RWMutex
@@ -1528,23 +1530,25 @@ func (mock *StatMock) IsUploadStartedCalls() []struct {
 }
 
 // IsUploaderReady calls IsUploaderReadyFunc.
-func (mock *StatMock) IsUploaderReady(pod *corev1.Pod, svc *corev1.Service, ing *netv1.Ingress) (bool, error) {
+func (mock *StatMock) IsUploaderReady(pod *corev1.Pod, svc *corev1.Service, ing *netv1.Ingress, tlsSecret *corev1.Secret) (bool, error) {
 	if mock.IsUploaderReadyFunc == nil {
 		panic("StatMock.IsUploaderReadyFunc: method is nil but Stat.IsUploaderReady was just called")
 	}
 	callInfo := struct {
-		Pod *corev1.Pod
-		Svc *corev1.Service
-		Ing *netv1.Ingress
+		Pod       *corev1.Pod
+		Svc       *corev1.Service
+		Ing       *netv1.Ingress
+		TlsSecret *corev1.Secret
 	}{
-		Pod: pod,
-		Svc: svc,
-		Ing: ing,
+		Pod:       pod,
+		Svc:       svc,
+		Ing:       ing,
+		TlsSecret: tlsSecret,
 	}
 	mock.lockIsUploaderReady.Lock()
 	mock.calls.IsUploaderReady = append(mock.calls.IsUploaderReady, callInfo)
 	mock.lockIsUploaderReady.Unlock()
-	return mock.IsUploaderReadyFunc(pod, svc, ing)
+	return mock.IsUploaderReadyFunc(pod, svc, ing, tlsSecret)
 }
 
 // IsUploaderReadyCalls gets all the calls that were made to IsUploaderReady.
@@ -1552,14 +1556,16 @@ func (mock *StatMock) IsUploaderReady(pod *corev1.Pod, svc *corev1.Service, ing 
 //
 //	len(mockedStat.IsUploaderReadyCalls())
 func (mock *StatMock) IsUploaderReadyCalls() []struct {
-	Pod *corev1.Pod
-	Svc *corev1.Service
-	Ing *netv1.Ingress
+	Pod       *corev1.Pod
+	Svc       *corev1.Service
+	Ing       *netv1.Ingress
+	TlsSecret *corev1.Secret
 } {
 	var calls []struct {
-		Pod *corev1.Pod
-		Svc *corev1.Service
-		Ing *netv1.Ingress
+		Pod       *corev1.Pod
+		Svc       *corev1.Service
+		Ing       *netv1.Ingress
+		TlsSecret *corev1.Secret
 	}
 	mock.lockIsUploaderReady.RLock()
 	calls = mock.calls.IsUploaderReady

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/upload.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/upload.go
@@ -24,6 +24,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/deckhouse/virtualization-controller/pkg/common"
@@ -48,6 +49,7 @@ type UploadDataSource struct {
 	dvcrSettings        *dvcr.Settings
 	controllerNamespace string
 	recorder            eventrecord.EventRecorderLogger
+	client              client.Client
 }
 
 func NewUploadDataSource(
@@ -56,6 +58,7 @@ func NewUploadDataSource(
 	uploaderService Uploader,
 	dvcrSettings *dvcr.Settings,
 	controllerNamespace string,
+	client client.Client,
 ) *UploadDataSource {
 	return &UploadDataSource{
 		statService:         statService,
@@ -63,6 +66,7 @@ func NewUploadDataSource(
 		dvcrSettings:        dvcrSettings,
 		controllerNamespace: controllerNamespace,
 		recorder:            recorder,
+		client:              client,
 	}
 }
 
@@ -92,7 +96,12 @@ func (ds UploadDataSource) Sync(ctx context.Context, cvi *v1alpha2.ClusterVirtua
 		return reconcile.Result{}, err
 	}
 
-	isUploaderReady, err := ds.statService.IsUploaderReady(pod, svc, ing)
+	tlsSecret, err := supplements.GetTLSSecret(ctx, ds.client, supgen)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	isUploaderReady, err := ds.statService.IsUploaderReady(pod, svc, ing, tlsSecret)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/images/virtualization-artifact/pkg/controller/service/stat_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/stat_service.go
@@ -17,6 +17,8 @@ limitations under the License.
 package service
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"net/http"
@@ -272,7 +274,7 @@ func (s StatService) IsImportStarted(ownerUID types.UID, pod *corev1.Pod) bool {
 	return progress.ProgressRaw() > 0
 }
 
-func (s StatService) IsUploaderReady(pod *corev1.Pod, svc *corev1.Service, ing *netv1.Ingress) (bool, error) {
+func (s StatService) IsUploaderReady(pod *corev1.Pod, svc *corev1.Service, ing *netv1.Ingress, tlsSecret *corev1.Secret) (bool, error) {
 	if pod == nil || svc == nil || ing == nil {
 		return false, nil
 	}
@@ -283,7 +285,22 @@ func (s StatService) IsUploaderReady(pod *corev1.Pod, svc *corev1.Service, ing *
 
 	uploadURL, ok := ing.Annotations[annotations.AnnUploadURL]
 	if ok && uploadURL != "" {
-		client := &http.Client{Timeout: 5 * time.Second}
+		certPool, err := x509.SystemCertPool()
+		if err != nil {
+			certPool = x509.NewCertPool()
+		}
+
+		if tlsSecret != nil {
+			if certData, ok := tlsSecret.Data["tls.crt"]; ok && len(certData) > 0 {
+				certPool.AppendCertsFromPEM(certData)
+			}
+		}
+
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: certPool},
+		}
+		client := &http.Client{Transport: tr, Timeout: 5 * time.Second}
+
 		response, err := client.Get(uploadURL)
 		if err != nil {
 			return false, fmt.Errorf("failed to get upload server status: %w", err)

--- a/images/virtualization-artifact/pkg/controller/supplements/fetch.go
+++ b/images/virtualization-artifact/pkg/controller/supplements/fetch.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -171,5 +172,18 @@ func FetchSupplement[T client.Object](
 		return empty, err
 	}
 
+	return obj, nil
+}
+
+// GetTLSSecret fetches the TLS secret for the uploader ingress with fallback to legacy naming.
+func GetTLSSecret(ctx context.Context, c client.Client, gen Generator) (*corev1.Secret, error) {
+	var secret corev1.Secret
+	obj, err := FetchSupplement(ctx, c, gen, SupplementUploaderTLSSecret, &secret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get TLS secret: %w", err)
+	}
+	if obj == nil {
+		return nil, nil
+	}
 	return obj, nil
 }

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/upload.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/upload.go
@@ -122,7 +122,12 @@ func (ds UploadDataSource) Sync(ctx context.Context, vd *v1alpha2.VirtualDisk) (
 		vdsupplements.SetPVCName(vd, dv.Status.ClaimName)
 	}
 
-	isUploaderReady, err := ds.statService.IsUploaderReady(pod, svc, ing)
+	tlsSecret, err := supplements.GetTLSSecret(ctx, ds.client, supgen.Generator)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	isUploaderReady, err := ds.statService.IsUploaderReady(pod, svc, ing, tlsSecret)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/interfaces.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/interfaces.go
@@ -64,7 +64,7 @@ type Stat interface {
 	step.WaitForPodStepStat
 	step.ReadyContainerRegistryStepStat
 	IsUploadStarted(ownerUID types.UID, pod *corev1.Pod) bool
-	IsUploaderReady(pod *corev1.Pod, svc *corev1.Service, ing *netv1.Ingress) (bool, error)
+	IsUploaderReady(pod *corev1.Pod, svc *corev1.Service, ing *netv1.Ingress, tlsSecret *corev1.Secret) (bool, error)
 	GetDownloadSpeed(ownerUID types.UID, pod *corev1.Pod) *v1alpha2.StatusSpeed
 }
 

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/mock.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/mock.go
@@ -1130,7 +1130,7 @@ var _ Stat = &StatMock{}
 //			IsUploadStartedFunc: func(ownerUID types.UID, pod *corev1.Pod) bool {
 //				panic("mock out the IsUploadStarted method")
 //			},
-//			IsUploaderReadyFunc: func(pod *corev1.Pod, svc *corev1.Service, ing *netv1.Ingress) (bool, error) {
+//			IsUploaderReadyFunc: func(pod *corev1.Pod, svc *corev1.Service, ing *netv1.Ingress, tlsSecret *corev1.Secret) (bool, error) {
 //				panic("mock out the IsUploaderReady method")
 //			},
 //		}
@@ -1165,7 +1165,7 @@ type StatMock struct {
 	IsUploadStartedFunc func(ownerUID types.UID, pod *corev1.Pod) bool
 
 	// IsUploaderReadyFunc mocks the IsUploaderReady method.
-	IsUploaderReadyFunc func(pod *corev1.Pod, svc *corev1.Service, ing *netv1.Ingress) (bool, error)
+	IsUploaderReadyFunc func(pod *corev1.Pod, svc *corev1.Service, ing *netv1.Ingress, tlsSecret *corev1.Secret) (bool, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -1227,6 +1227,8 @@ type StatMock struct {
 			Svc *corev1.Service
 			// Ing is the ing argument value.
 			Ing *netv1.Ingress
+			// TlsSecret is the tlsSecret argument value.
+			TlsSecret *corev1.Secret
 		}
 	}
 	lockCheckPod         sync.RWMutex
@@ -1517,23 +1519,25 @@ func (mock *StatMock) IsUploadStartedCalls() []struct {
 }
 
 // IsUploaderReady calls IsUploaderReadyFunc.
-func (mock *StatMock) IsUploaderReady(pod *corev1.Pod, svc *corev1.Service, ing *netv1.Ingress) (bool, error) {
+func (mock *StatMock) IsUploaderReady(pod *corev1.Pod, svc *corev1.Service, ing *netv1.Ingress, tlsSecret *corev1.Secret) (bool, error) {
 	if mock.IsUploaderReadyFunc == nil {
 		panic("StatMock.IsUploaderReadyFunc: method is nil but Stat.IsUploaderReady was just called")
 	}
 	callInfo := struct {
-		Pod *corev1.Pod
-		Svc *corev1.Service
-		Ing *netv1.Ingress
+		Pod       *corev1.Pod
+		Svc       *corev1.Service
+		Ing       *netv1.Ingress
+		TlsSecret *corev1.Secret
 	}{
-		Pod: pod,
-		Svc: svc,
-		Ing: ing,
+		Pod:       pod,
+		Svc:       svc,
+		Ing:       ing,
+		TlsSecret: tlsSecret,
 	}
 	mock.lockIsUploaderReady.Lock()
 	mock.calls.IsUploaderReady = append(mock.calls.IsUploaderReady, callInfo)
 	mock.lockIsUploaderReady.Unlock()
-	return mock.IsUploaderReadyFunc(pod, svc, ing)
+	return mock.IsUploaderReadyFunc(pod, svc, ing, tlsSecret)
 }
 
 // IsUploaderReadyCalls gets all the calls that were made to IsUploaderReady.
@@ -1541,14 +1545,16 @@ func (mock *StatMock) IsUploaderReady(pod *corev1.Pod, svc *corev1.Service, ing 
 //
 //	len(mockedStat.IsUploaderReadyCalls())
 func (mock *StatMock) IsUploaderReadyCalls() []struct {
-	Pod *corev1.Pod
-	Svc *corev1.Service
-	Ing *netv1.Ingress
+	Pod       *corev1.Pod
+	Svc       *corev1.Service
+	Ing       *netv1.Ingress
+	TlsSecret *corev1.Secret
 } {
 	var calls []struct {
-		Pod *corev1.Pod
-		Svc *corev1.Service
-		Ing *netv1.Ingress
+		Pod       *corev1.Pod
+		Svc       *corev1.Service
+		Ing       *netv1.Ingress
+		TlsSecret *corev1.Secret
 	}
 	mock.lockIsUploaderReady.RLock()
 	calls = mock.calls.IsUploaderReady

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/upload.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/upload.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/deckhouse/virtualization-controller/pkg/common"
@@ -53,6 +54,7 @@ type UploadDataSource struct {
 	dvcrSettings    *dvcr.Settings
 	diskService     *service.DiskService
 	recorder        eventrecord.EventRecorderLogger
+	client          client.Client
 }
 
 func NewUploadDataSource(
@@ -61,6 +63,7 @@ func NewUploadDataSource(
 	uploaderService Uploader,
 	dvcrSettings *dvcr.Settings,
 	diskService *service.DiskService,
+	client client.Client,
 ) *UploadDataSource {
 	return &UploadDataSource{
 		recorder:        recorder,
@@ -68,6 +71,7 @@ func NewUploadDataSource(
 		uploaderService: uploaderService,
 		dvcrSettings:    dvcrSettings,
 		diskService:     diskService,
+		client:          client,
 	}
 }
 
@@ -100,7 +104,12 @@ func (ds UploadDataSource) StoreToPVC(ctx context.Context, vi *v1alpha2.VirtualI
 		return reconcile.Result{}, err
 	}
 
-	isUploaderReady, err := ds.statService.IsUploaderReady(pod, svc, ing)
+	tlsSecret, err := supplements.GetTLSSecret(ctx, ds.client, supgen)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	isUploaderReady, err := ds.statService.IsUploaderReady(pod, svc, ing, tlsSecret)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -362,7 +371,12 @@ func (ds UploadDataSource) StoreToDVCR(ctx context.Context, vi *v1alpha2.Virtual
 		return reconcile.Result{}, err
 	}
 
-	isUploaderReady, err := ds.statService.IsUploaderReady(pod, svc, ing)
+	tlsSecret, err := supplements.GetTLSSecret(ctx, ds.client, supgen)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	isUploaderReady, err := ds.statService.IsUploaderReady(pod, svc, ing, tlsSecret)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/images/virtualization-artifact/pkg/controller/vi/vi_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vi/vi_controller.go
@@ -82,7 +82,7 @@ func NewController(
 	sources.Set(v1alpha2.DataSourceTypeHTTP, source.NewHTTPDataSource(recorder, stat, importer, dvcr, disk))
 	sources.Set(v1alpha2.DataSourceTypeContainerImage, source.NewRegistryDataSource(recorder, stat, importer, dvcr, mgr.GetClient(), disk))
 	sources.Set(v1alpha2.DataSourceTypeObjectRef, source.NewObjectRefDataSource(recorder, stat, importer, bounder, dvcr, mgr.GetClient(), disk))
-	sources.Set(v1alpha2.DataSourceTypeUpload, source.NewUploadDataSource(recorder, stat, uploader, dvcr, disk))
+	sources.Set(v1alpha2.DataSourceTypeUpload, source.NewUploadDataSource(recorder, stat, uploader, dvcr, disk, mgr.GetClient()))
 
 	reconciler := NewReconciler(
 		mgr.GetClient(),


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Added TLS certificate retrieval from secrets for upload endpoints to fix TLS verification errors when using self-signed certificates.
 
## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
When the cluster uses a self-signed certificate for the ingress controller, the IsUploaderReady function fails with TLS verification error because it doesn't have access to the TLS secret containing the CA certificate. This prevents users from uploading images  through the upload endpoint.                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                       
The fix retrieves the TLS secret from the cluster and passes it to the IsUploaderReady function, enabling proper TLS verification.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
Upload endpoints work correctly with TLS verification, even when the ingress controller uses self-signed certificates. The implementation also supports legacy naming of TLS secrets for backward compatibility.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

