### PR TITLE
chore(vm): add system migration policy

### DIFF
--- a/images/virtualization-artifact/cmd/virtualization-controller/main.go
+++ b/images/virtualization-artifact/cmd/virtualization-controller/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -28,6 +29,7 @@ import (
 	"github.com/spf13/pflag"
 	resourcev1 "k8s.io/api/resource/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	virtv1 "kubevirt.io/api/core/v1"
@@ -311,6 +313,18 @@ func main() {
 		log.Error(err.Error())
 		os.Exit(1)
 	}
+
+	systemMigrationPolicy := getSystemMigrationPolicyAnnotation(ctx, preManagerClient)
+	switch {
+	case systemMigrationPolicy == "":
+		appconfig.ResetSystemMigrationPolicyOverride()
+	case appconfig.SetSystemMigrationPolicyOverride(systemMigrationPolicy):
+		log.Info("System migration policy override is set", "value", systemMigrationPolicy)
+	default:
+		appconfig.ResetSystemMigrationPolicyOverride()
+		log.Warn("System migration policy override has invalid value, override disabled", "value", systemMigrationPolicy)
+	}
+
 	mCtrl, err := migration.NewController(preManagerClient, log)
 	if err != nil {
 		log.Error(err.Error())
@@ -507,4 +521,20 @@ func getEnv(env, defaultEnv string) string {
 		return e
 	}
 	return defaultEnv
+}
+
+func getSystemMigrationPolicyAnnotation(ctx context.Context, cli client.Client) string {
+	moduleConfigName := "virtualization"
+	systemMigrationPolicyAnnotation := "virtualization.deckhouse.io/system-migration-policy"
+
+	moduleConfig := &mcapi.ModuleConfig{}
+	err := cli.Get(ctx, client.ObjectKey{Name: moduleConfigName}, moduleConfig)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			slog.Default().Error("failed to get ModuleConfig virtualization", logger.SlogErr(err))
+		}
+		return ""
+	}
+
+	return moduleConfig.GetAnnotations()[systemMigrationPolicyAnnotation]
 }

--- a/images/virtualization-artifact/cmd/virtualization-controller/main.go
+++ b/images/virtualization-artifact/cmd/virtualization-controller/main.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -29,7 +28,6 @@ import (
 	"github.com/spf13/pflag"
 	resourcev1 "k8s.io/api/resource/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	virtv1 "kubevirt.io/api/core/v1"
@@ -71,6 +69,7 @@ import (
 	workloadupdater "github.com/deckhouse/virtualization-controller/pkg/controller/workload-updater"
 	"github.com/deckhouse/virtualization-controller/pkg/crd"
 	"github.com/deckhouse/virtualization-controller/pkg/featuregates"
+	livemigrationcfg "github.com/deckhouse/virtualization-controller/pkg/livemigration"
 	"github.com/deckhouse/virtualization-controller/pkg/logger"
 	"github.com/deckhouse/virtualization-controller/pkg/migration"
 	"github.com/deckhouse/virtualization-controller/pkg/version"
@@ -314,7 +313,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	systemMigrationPolicy := getSystemMigrationPolicyAnnotation(ctx, preManagerClient)
+	systemMigrationPolicy := livemigrationcfg.GetSystemMigrationPolicyAnnotation(ctx, preManagerClient)
 	switch {
 	case systemMigrationPolicy == "":
 		appconfig.ResetSystemMigrationPolicyOverride()
@@ -521,20 +520,4 @@ func getEnv(env, defaultEnv string) string {
 		return e
 	}
 	return defaultEnv
-}
-
-func getSystemMigrationPolicyAnnotation(ctx context.Context, cli client.Client) string {
-	moduleConfigName := "virtualization"
-	systemMigrationPolicyAnnotation := "virtualization.deckhouse.io/system-migration-policy"
-
-	moduleConfig := &mcapi.ModuleConfig{}
-	err := cli.Get(ctx, client.ObjectKey{Name: moduleConfigName}, moduleConfig)
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			slog.Default().Error("failed to get ModuleConfig virtualization", logger.SlogErr(err))
-		}
-		return ""
-	}
-
-	return moduleConfig.GetAnnotations()[systemMigrationPolicyAnnotation]
 }

--- a/images/virtualization-artifact/pkg/config/load_live_migration_settings.go
+++ b/images/virtualization-artifact/pkg/config/load_live_migration_settings.go
@@ -25,3 +25,40 @@ import (
 const (
 	DefaultLiveMigrationPolicy = v1alpha2.PreferSafeMigrationPolicy
 )
+
+var systemMigrationPolicyOverride v1alpha2.LiveMigrationPolicy
+
+func SetSystemMigrationPolicyOverride(rawPolicy string) bool {
+	policy := v1alpha2.LiveMigrationPolicy(rawPolicy)
+	if !isValidLiveMigrationPolicy(policy) {
+		systemMigrationPolicyOverride = ""
+		return false
+	}
+	systemMigrationPolicyOverride = policy
+	return true
+}
+
+func GetSystemMigrationPolicyOverride() (v1alpha2.LiveMigrationPolicy, bool) {
+	if systemMigrationPolicyOverride == "" {
+		return "", false
+	}
+	return systemMigrationPolicyOverride, true
+}
+
+func ResetSystemMigrationPolicyOverride() {
+	systemMigrationPolicyOverride = ""
+}
+
+func isValidLiveMigrationPolicy(policy v1alpha2.LiveMigrationPolicy) bool {
+	switch policy {
+	case v1alpha2.ManualMigrationPolicy,
+		v1alpha2.NeverMigrationPolicy,
+		v1alpha2.AlwaysSafeMigrationPolicy,
+		v1alpha2.PreferSafeMigrationPolicy,
+		v1alpha2.AlwaysForcedMigrationPolicy,
+		v1alpha2.PreferForcedMigrationPolicy:
+		return true
+	default:
+		return false
+	}
+}

--- a/images/virtualization-artifact/pkg/config/load_live_migration_settings_test.go
+++ b/images/virtualization-artifact/pkg/config/load_live_migration_settings_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+)
+
+var _ = Describe("SystemMigrationPolicyOverride", func() {
+	BeforeEach(func() {
+		ResetSystemMigrationPolicyOverride()
+	})
+
+	AfterEach(func() {
+		ResetSystemMigrationPolicyOverride()
+	})
+
+	DescribeTable("accepts valid values",
+		func(policy v1alpha2.LiveMigrationPolicy) {
+			ok := SetSystemMigrationPolicyOverride(string(policy))
+			Expect(ok).To(BeTrue())
+
+			actual, exists := GetSystemMigrationPolicyOverride()
+			Expect(exists).To(BeTrue())
+			Expect(actual).To(Equal(policy))
+		},
+		Entry("Manual", v1alpha2.ManualMigrationPolicy),
+		Entry("Never", v1alpha2.NeverMigrationPolicy),
+		Entry("AlwaysSafe", v1alpha2.AlwaysSafeMigrationPolicy),
+		Entry("PreferSafe", v1alpha2.PreferSafeMigrationPolicy),
+		Entry("AlwaysForced", v1alpha2.AlwaysForcedMigrationPolicy),
+		Entry("PreferForced", v1alpha2.PreferForcedMigrationPolicy),
+	)
+
+	It("rejects invalid value", func() {
+		ok := SetSystemMigrationPolicyOverride("invalid")
+		Expect(ok).To(BeFalse())
+
+		actual, exists := GetSystemMigrationPolicyOverride()
+		Expect(exists).To(BeFalse())
+		Expect(actual).To(Equal(v1alpha2.LiveMigrationPolicy("")))
+	})
+
+	It("reset clears override", func() {
+		ok := SetSystemMigrationPolicyOverride(string(v1alpha2.PreferSafeMigrationPolicy))
+		Expect(ok).To(BeTrue())
+
+		ResetSystemMigrationPolicyOverride()
+
+		actual, exists := GetSystemMigrationPolicyOverride()
+		Expect(exists).To(BeFalse())
+		Expect(actual).To(Equal(v1alpha2.LiveMigrationPolicy("")))
+	})
+})
+
+func TestSystemMigrationPolicyOverride(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "SystemMigrationPolicyOverride Suite")
+}

--- a/images/virtualization-artifact/pkg/livemigration/policy.go
+++ b/images/virtualization-artifact/pkg/livemigration/policy.go
@@ -39,15 +39,18 @@ func AutoConvergeForPolicy(policy v1alpha2.LiveMigrationPolicy) (autoConverge *b
 // Also, autoConverge value may be overridden from VMOP.
 func CalculateEffectivePolicy(vm v1alpha2.VirtualMachine, vmop *v1alpha2.VirtualMachineOperation) (effectivePolicy v1alpha2.LiveMigrationPolicy, autoConverge bool, err error) {
 	effectivePolicy = config.DefaultLiveMigrationPolicy
+	overridePolicy, hasSystemOverride := config.GetSystemMigrationPolicyOverride()
 
-	if vm.Spec.LiveMigrationPolicy != "" {
+	if hasSystemOverride {
+		effectivePolicy = overridePolicy
+	} else if vm.Spec.LiveMigrationPolicy != "" {
 		effectivePolicy = vm.Spec.LiveMigrationPolicy
 	}
 
 	autoConvergePtr := AutoConvergeForPolicy(effectivePolicy)
 
-	// Override autoConverge value.
-	if vmop != nil {
+	// VMOP force may override autoConverge only when system override is not set.
+	if vmop != nil && !hasSystemOverride {
 		switch effectivePolicy {
 		case v1alpha2.PreferSafeMigrationPolicy, v1alpha2.PreferForcedMigrationPolicy:
 			if vmop.Spec.Force != nil {

--- a/images/virtualization-artifact/pkg/livemigration/policy_test.go
+++ b/images/virtualization-artifact/pkg/livemigration/policy_test.go
@@ -24,10 +24,19 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/utils/ptr"
 
+	"github.com/deckhouse/virtualization-controller/pkg/config"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
 var _ = Describe("CalculateEffectivePolicy", func() {
+	BeforeEach(func() {
+		config.ResetSystemMigrationPolicyOverride()
+	})
+
+	AfterEach(func() {
+		config.ResetSystemMigrationPolicyOverride()
+	})
+
 	DescribeTable("effective policy and autoConverge value",
 		func(
 			vmPolicy v1alpha2.LiveMigrationPolicy,
@@ -79,6 +88,53 @@ var _ = Describe("CalculateEffectivePolicy", func() {
 		Entry("AlwaysForced with force=false", v1alpha2.AlwaysForcedMigrationPolicy, ptr.To(false), v1alpha2.AlwaysForcedMigrationPolicy, true, true),
 
 		Entry("No VM policy with no vmop", v1alpha2.LiveMigrationPolicy(""), nil, v1alpha2.PreferSafeMigrationPolicy, false, false),
+	)
+
+	DescribeTable("system override takes precedence and ignores force",
+		func(
+			systemPolicy v1alpha2.LiveMigrationPolicy,
+			vmPolicy v1alpha2.LiveMigrationPolicy,
+			vmopForce *bool,
+			expectedPolicy v1alpha2.LiveMigrationPolicy,
+			expectedResult bool,
+			expectError bool,
+		) {
+			ok := config.SetSystemMigrationPolicyOverride(string(systemPolicy))
+			require.True(GinkgoT(), ok)
+
+			vm := v1alpha2.VirtualMachine{}
+			if vmPolicy != "" {
+				vm.Spec.LiveMigrationPolicy = vmPolicy
+			}
+
+			var vmop *v1alpha2.VirtualMachineOperation
+			if vmopForce != nil {
+				vmop = &v1alpha2.VirtualMachineOperation{
+					Spec: v1alpha2.VirtualMachineOperationSpec{
+						Force: vmopForce,
+					},
+				}
+			}
+
+			policy, result, err := CalculateEffectivePolicy(vm, vmop)
+
+			if expectError {
+				require.Error(GinkgoT(), err)
+			} else {
+				require.NoError(GinkgoT(), err)
+			}
+
+			require.Equal(GinkgoT(), expectedPolicy, policy)
+			require.Equal(GinkgoT(), expectedResult, result)
+		},
+
+		Entry("system override AlwaysForced overrides VM PreferSafe", v1alpha2.AlwaysForcedMigrationPolicy, v1alpha2.PreferSafeMigrationPolicy, nil, v1alpha2.AlwaysForcedMigrationPolicy, true, false),
+		Entry("system override AlwaysSafe overrides VM PreferForced", v1alpha2.AlwaysSafeMigrationPolicy, v1alpha2.PreferForcedMigrationPolicy, nil, v1alpha2.AlwaysSafeMigrationPolicy, false, false),
+		Entry("system override Never overrides default policy", v1alpha2.NeverMigrationPolicy, v1alpha2.LiveMigrationPolicy(""), nil, v1alpha2.NeverMigrationPolicy, false, false),
+		Entry("force=true is ignored when system override PreferSafe is set", v1alpha2.PreferSafeMigrationPolicy, v1alpha2.PreferSafeMigrationPolicy, ptr.To(true), v1alpha2.PreferSafeMigrationPolicy, false, false),
+		Entry("force=false is ignored when system override PreferForced is set", v1alpha2.PreferForcedMigrationPolicy, v1alpha2.PreferForcedMigrationPolicy, ptr.To(false), v1alpha2.PreferForcedMigrationPolicy, true, false),
+		Entry("AlwaysSafe with force=true does not error when system override is set", v1alpha2.AlwaysSafeMigrationPolicy, v1alpha2.PreferForcedMigrationPolicy, ptr.To(true), v1alpha2.AlwaysSafeMigrationPolicy, false, false),
+		Entry("AlwaysForced with force=false does not error when system override is set", v1alpha2.AlwaysForcedMigrationPolicy, v1alpha2.PreferSafeMigrationPolicy, ptr.To(false), v1alpha2.AlwaysForcedMigrationPolicy, true, false),
 	)
 })
 

--- a/images/virtualization-artifact/pkg/livemigration/system_migration_policy.go
+++ b/images/virtualization-artifact/pkg/livemigration/system_migration_policy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 Flant JSC
+Copyright 2026 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/images/virtualization-artifact/pkg/livemigration/system_migration_policy.go
+++ b/images/virtualization-artifact/pkg/livemigration/system_migration_policy.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package livemigration
+
+import (
+	"context"
+	"log/slog"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	mcapi "github.com/deckhouse/virtualization-controller/pkg/controller/moduleconfig/api"
+	"github.com/deckhouse/virtualization-controller/pkg/logger"
+)
+
+const (
+	moduleConfigName                = "virtualization"
+	systemMigrationPolicyAnnotation = "virtualization.deckhouse.io/system-migration-policy"
+)
+
+func GetSystemMigrationPolicyAnnotation(ctx context.Context, kubeClient client.Client) string {
+	moduleConfig := &mcapi.ModuleConfig{}
+	err := kubeClient.Get(ctx, client.ObjectKey{Name: moduleConfigName}, moduleConfig)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			slog.Default().Error("failed to get ModuleConfig virtualization", logger.SlogErr(err))
+		}
+		return ""
+	}
+
+	return moduleConfig.GetAnnotations()[systemMigrationPolicyAnnotation]
+}

--- a/templates/virtualization-controller/rbac-for-us.yaml
+++ b/templates/virtualization-controller/rbac-for-us.yaml
@@ -112,6 +112,12 @@ rules:
   - list
   - watch
 - apiGroups:
+  - deckhouse.io
+  resources:
+  - moduleconfigs
+  verbs:
+  - get
+- apiGroups:
   - cdi.internal.virtualization.deckhouse.io
   resources:
   - internalvirtualizationdatavolumes


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Add a system-level live migration policy override sourced from `ModuleConfig/virtualization` annotation `virtualization.deckhouse.io/system-migration-policy`.

The controller now reads this annotation at startup and, when valid, applies it globally in live migration policy calculation.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
1. Set annotation on `ModuleConfig/virtualization`:
   `virtualization.deckhouse.io/system-migration-policy: <valid policy>`.
2. Restart/rollout virtualization-controller.
3. Run VMOP migration/eviction.
4. Confirm effective migration configuration follows the system policy override (VM spec and VMOP force do not override it).
5. If annotation is missing or invalid, behavior remains unchanged.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: core
type: chore
summary: "Add a system live migration policy override via ModuleConfig annotation for VMOP/live migration policy calculation."
impact_level: low
```
