### PR TITLE
chore(e2e): fix long filenames

### DIFF
--- a/test/e2e/internal/framework/dump.go
+++ b/test/e2e/internal/framework/dump.go
@@ -37,16 +37,18 @@ const (
 	// Linux filesystems (ext4/xfs) limit filenames to 255 bytes. We reserve ~70 bytes
 	// for the "e2e_failed__" prefix, "__<namespace>__events.yaml" suffix, and directory path.
 	maxTestNameLen = 180
+	ellipsis       = "..."
 )
 
 // truncateTestName shortens s to at most maxLen bytes while keeping the text
-// human-readable: it preserves a prefix and a suffix separated by "...".
+// human-readable: it preserves a prefix and a suffix separated by ellipsis.
 func truncateTestName(s string, maxLen int) string {
 	if len(s) <= maxLen {
 		return s
 	}
-	half := (maxLen - 3) / 2
-	return s[:half] + "..." + s[len(s)-(maxLen-3-half):]
+	available := maxLen - len(ellipsis)
+	half := available / 2
+	return s[:half] + ellipsis + s[len(s)-(available-half):]
 }
 
 // SaveTestCaseDump dump some resources, logs and descriptions that may help in further diagnostic.

--- a/test/e2e/internal/framework/dump.go
+++ b/test/e2e/internal/framework/dump.go
@@ -31,7 +31,23 @@ import (
 	"github.com/deckhouse/virtualization/test/e2e/internal/kubectl"
 )
 
-const d8vContainerPrefix = "d8v"
+const (
+	d8vContainerPrefix = "d8v"
+	// maxTestNameLen is the maximum length of the test name portion in a dump filename.
+	// Linux filesystems (ext4/xfs) limit filenames to 255 bytes. We reserve ~70 bytes
+	// for the "e2e_failed__" prefix, "__<namespace>__events.yaml" suffix, and directory path.
+	maxTestNameLen = 180
+)
+
+// truncateTestName shortens s to at most maxLen bytes while keeping the text
+// human-readable: it preserves a prefix and a suffix separated by "...".
+func truncateTestName(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	half := (maxLen - 3) / 2
+	return s[:half] + "..." + s[len(s)-(maxLen-3-half):]
+}
 
 // SaveTestCaseDump dump some resources, logs and descriptions that may help in further diagnostic.
 //
@@ -72,7 +88,8 @@ func GetFormattedTestCaseFullText() string {
 		"`", "",
 		"'", "",
 	)
-	return replacer.Replace(strings.ToLower(CurrentSpecReport().FullText()))
+	result := replacer.Replace(strings.ToLower(CurrentSpecReport().FullText()))
+	return truncateTestName(result, maxTestNameLen)
 }
 
 // GetTMPDir returns the temporary directory used for the test case resource dump.

--- a/test/e2e/internal/framework/dump.go
+++ b/test/e2e/internal/framework/dump.go
@@ -37,7 +37,7 @@ const (
 	// Linux filesystems (ext4/xfs) limit filenames to 255 bytes. We reserve ~70 bytes
 	// for the "e2e_failed__" prefix, "__<namespace>__events.yaml" suffix, and directory path.
 	maxTestNameLen = 180
-	ellipsis       = "..."
+	delimiter       = "..."
 )
 
 // truncateTestName shortens s to at most maxLen bytes while keeping the text
@@ -46,9 +46,9 @@ func truncateTestName(s string, maxLen int) string {
 	if len(s) <= maxLen {
 		return s
 	}
-	available := maxLen - len(ellipsis)
-	half := available / 2
-	return s[:half] + ellipsis + s[len(s)-(available-half):]
+	availableLen := maxLen - len(delimiter)
+	halfAvailableLen := availableLen / 2
+	return s[:halfAvailableLen] + delimiter + s[len(s)-(availableLen-halfAvailableLen):]
 }
 
 // SaveTestCaseDump dump some resources, logs and descriptions that may help in further diagnostic.

--- a/test/e2e/internal/framework/dump.go
+++ b/test/e2e/internal/framework/dump.go
@@ -37,7 +37,7 @@ const (
 	// Linux filesystems (ext4/xfs) limit filenames to 255 bytes. We reserve ~70 bytes
 	// for the "e2e_failed__" prefix, "__<namespace>__events.yaml" suffix, and directory path.
 	maxTestNameLen = 180
-	delimiter       = "..."
+	delimiter      = "..."
 )
 
 // truncateTestName shortens s to at most maxLen bytes while keeping the text


### PR DESCRIPTION
## Description
Fix "file name too long" error in e2e test dump functions by truncating long test names in generated filenames.

## Why do we need it, and what problem does it solve?
E2e tests with deeply nested `Describe`/`It` blocks produce very long spec names. When these names are used verbatim in dump filenames (e.g. `e2e_failed__<testname>__<namespace>__events.yaml`), the resulting path exceeds the 255-byte filename limit on Linux filesystems (ext4/xfs), causing the dump to fail with `file name too long`.

Example failing filename:
```
e2e_failed__virtualmachineadditionalnetworkinterfaces_verifies_interface_name_persistence_after_removing_middle_clusternetwork_should_preserve_interface_name_after_removing_middle_clusternetwork_and_rebooting__v12n-e2e-vm-additional-network-2wqtt__events.yaml
```

## What is the expected result?
1. Run an e2e test with a long nested spec name that previously failed to write dump files.
2. Verify dump files are written successfully with a truncated name containing `...` in the middle.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
