### PR TITLE
chore(ci): increase timeout for nfs

### DIFF
--- a/test/e2e/vmop/restore.go
+++ b/test/e2e/vmop/restore.go
@@ -115,7 +115,7 @@ var _ = Describe("VirtualMachineOperationRestore", label.Slow(), func() {
 
 			err = f.CreateWithDeferredDeletion(context.Background(), t.VMSnapshot)
 			Expect(err).NotTo(HaveOccurred())
-			util.UntilObjectPhase(string(v1alpha2.VirtualMachineSnapshotPhaseReady), framework.ShortTimeout, t.VMSnapshot)
+			util.UntilObjectPhase(string(v1alpha2.VirtualMachineSnapshotPhaseReady), framework.MiddleTimeout, t.VMSnapshot)
 		})
 		By("Changing VM", func() {
 			util.WriteFile(f, t.VM, fileDataPath, changedValueOnDisk)


### PR DESCRIPTION
## Description
Increase `VirtualMachineSnapshot` readiness wait timeout from `ShortTimeout` (30s) to `MiddleTimeout` (60s) in the `VirtualMachineOperationRestore` e2e test.

## Why do we need it, and what problem does it solve?
The `VirtualMachineOperationRestore` e2e tests on NFS storage were consistently failing during "Environment preparation" with:

```
Timed out after 30.001s.
object <ns>/vmsnapshot status.phase is InProgress, expected Ready
```

Root cause: the test uses an Ubuntu-based `VirtualDisk` (`PrecreatedCVIUbuntu`), which results in a ~1.5 GiB PVC (sparse raw image). NFS CSI snapshots work by running `tar czf` — mounting the PVC directory over NFS, reading the full sparse file (~1.5 GiB), and writing the `.tar.gz` back to NFS. With NFS cold-read throughput of ~77 MB/s on this cluster, snapshotting 1.5 GiB takes **25–40 seconds**, which exceeds the 30s `ShortTimeout`.

This was confirmed by inspecting CSI controller logs, where `CreateSnapshot` gRPC calls for `vd-root` consistently took 25–42 seconds:

```
03:51:16 - tar .../pvc-563fef21.../pvc-563fef21 -> .../pvc-563fef21.tar.gz
03:51:42 - tar complete  (26s)
```

## What is the expected result?
`VirtualMachineOperationRestore` tests pass on NFS storage — the snapshot completes within the 60s `MiddleTimeout`.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: test
type: fix
summary: Increase VirtualMachineSnapshot readiness timeout in VirtualMachineOperationRestore e2e test to fix flakiness on NFS storage.
impact_level: low
```
