### PR TITLE
chore(ci): fix NNI labeling in nested e2e tests

### DIFF
--- a/.github/workflows/e2e-reusable-pipeline.yml
+++ b/.github/workflows/e2e-reusable-pipeline.yml
@@ -538,7 +538,7 @@ jobs:
 
           for i in $(seq 1 $count); do
             nodes=$(kubectl get nodes -o name | wc -l)
-            actual=$(kubectl get nodenetworkinterfaces -o json | jq -r '.items[] | select(.status.operationalState == "Up") | .metadata.name' | wc -l) || true)
+            actual=$(kubectl get nodenetworkinterfaces -o json | jq -r '.items[] | select(.status.operationalState == "Up") | .metadata.name' | wc -l) || true
             expected=$((nodes * 2))
 
             echo "[INFO] Attempt $i/$count: expected=$expected, actual=$actual"

--- a/.github/workflows/e2e-reusable-pipeline.yml
+++ b/.github/workflows/e2e-reusable-pipeline.yml
@@ -538,7 +538,7 @@ jobs:
 
           for i in $(seq 1 $count); do
             nodes=$(kubectl get nodes -o name | wc -l)
-            actual=$(kubectl get nodenetworkinterfaces -o name 2>/dev/null | wc -l) || true
+            actual=$(kubectl get nodenetworkinterfaces -o json | jq -r '.items[] | select(.status.operationalState == "Up") | .metadata.name' | wc -l) || true)
             expected=$((nodes * 2))
 
             echo "[INFO] Attempt $i/$count: expected=$expected, actual=$actual"
@@ -554,11 +554,11 @@ jobs:
               echo ::group::📝 [DEBUG] show namespaces d8-sdn
               kubectl -n d8-sdn get pods || true
               echo ::endgroup::
-              
+
               echo ::group::📝 [DEBUG] show nodenetworkinterfaces d8-sdn
               kubectl get nodenetworkinterfaces || true
               echo ::endgroup::
-              
+
               echo "[INFO] Retrying in 10 seconds..."
               sleep $wait_time_seconds
             elif [ $i -lt $count ]; then


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
calculate only NNIs that thave state=up

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

