### PR TITLE
fix(vmop): propagate target pod creation reasons to conditions

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle.go
@@ -731,17 +731,15 @@ func getPodPendingUnschedulableMessage(pod *corev1.Pod) (string, bool) {
 	}
 
 	for _, condition := range pod.Status.Conditions {
-		if condition.Type != corev1.PodScheduled ||
-			condition.Status != corev1.ConditionFalse ||
-			condition.Reason != corev1.PodReasonUnschedulable {
-			continue
+		if condition.Type == corev1.PodScheduled &&
+			condition.Status == corev1.ConditionFalse &&
+			condition.Reason == corev1.PodReasonUnschedulable {
+			message := fmt.Sprintf("Target pod %q is unschedulable", pod.Namespace+"/"+pod.Name)
+			if condition.Message != "" {
+				message = fmt.Sprintf("%s: %s", message, condition.Message)
+			}
+			return message, true
 		}
-
-		message := fmt.Sprintf("Target pod %q is unschedulable", pod.Namespace+"/"+pod.Name)
-		if condition.Message != "" {
-			message = fmt.Sprintf("%s: %s", message, condition.Message)
-		}
-		return message, true
 	}
 	return "", false
 }

--- a/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle.go
@@ -588,8 +588,8 @@ func (h LifecycleHandler) getInProgressReasonAndMessage(
 	if err != nil {
 		return "", "", err
 	}
-	if isPodPendingUnschedulable(pod) {
-		return vmopcondition.ReasonTargetUnschedulable, fmt.Sprintf("Target pod %q is unschedulable", pod.Namespace+"/"+pod.Name), nil
+	if unschedulableMsg, isUnschedulable := getPodPendingUnschedulableMessage(pod); isUnschedulable {
+		return vmopcondition.ReasonTargetUnschedulable, unschedulableMsg, nil
 	}
 	if diskErrMsg, hasDiskErr := h.getTargetPodDiskError(ctx, pod); hasDiskErr {
 		return vmopcondition.ReasonTargetDiskError, fmt.Sprintf("Target pod has disk attach error: %s", diskErrMsg), nil
@@ -722,20 +722,26 @@ func isContainerCreating(pod *corev1.Pod) bool {
 	return false
 }
 
-func isPodPendingUnschedulable(pod *corev1.Pod) bool {
+func getPodPendingUnschedulableMessage(pod *corev1.Pod) (string, bool) {
 	if pod == nil {
-		return false
+		return "", false
 	}
 	if pod.Status.Phase != corev1.PodPending || pod.DeletionTimestamp != nil {
-		return false
+		return "", false
 	}
 
 	for _, condition := range pod.Status.Conditions {
-		if condition.Type == corev1.PodScheduled &&
-			condition.Status == corev1.ConditionFalse &&
-			condition.Reason == corev1.PodReasonUnschedulable {
-			return true
+		if condition.Type != corev1.PodScheduled ||
+			condition.Status != corev1.ConditionFalse ||
+			condition.Reason != corev1.PodReasonUnschedulable {
+			continue
 		}
+
+		message := fmt.Sprintf("Target pod %q is unschedulable", pod.Namespace+"/"+pod.Name)
+		if condition.Message != "" {
+			message = fmt.Sprintf("%s: %s", message, condition.Message)
+		}
+		return message, true
 	}
-	return false
+	return "", false
 }

--- a/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle.go
@@ -731,14 +731,8 @@ func getPodPendingUnschedulableMessage(pod *corev1.Pod) (string, bool) {
 	}
 
 	for _, condition := range pod.Status.Conditions {
-		if condition.Type == corev1.PodScheduled &&
-			condition.Status == corev1.ConditionFalse &&
-			condition.Reason == corev1.PodReasonUnschedulable {
-			message := fmt.Sprintf("Target pod %q is unschedulable", pod.Namespace+"/"+pod.Name)
-			if condition.Message != "" {
-				message = fmt.Sprintf("%s: %s", message, condition.Message)
-			}
-			return message, true
+		if condition.Type == corev1.PodScheduled && condition.Status == corev1.ConditionFalse && condition.Reason == corev1.PodReasonUnschedulable {
+			return fmt.Sprintf("Target pod %q is unschedulable", pod.Namespace+"/"+pod.Name), true
 		}
 	}
 	return "", false

--- a/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle_test.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle_test.go
@@ -820,6 +820,41 @@ var _ = Describe("LifecycleHandler", func() {
 			Expect(completed.Reason).To(Equal(vmopcondition.ReasonAborted.String()))
 		})
 
+		It("should return unschedulable message from target pod condition", func() {
+			mig := newSimpleMigration("vmop-test", name)
+			mig.UID = "migration-uid"
+			mig.Status.Phase = virtv1.MigrationScheduling
+
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      "target-pod",
+					Labels: map[string]string{
+						virtv1.AppLabel:          "virt-launcher",
+						virtv1.MigrationJobLabel: "migration-uid",
+					},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					Conditions: []corev1.PodCondition{{
+						Type:    corev1.PodScheduled,
+						Status:  corev1.ConditionFalse,
+						Reason:  corev1.PodReasonUnschedulable,
+						Message: "0/3 nodes are available: 3 Insufficient memory.",
+					}},
+				},
+			}
+
+			fakeClient, err := testutil.NewFakeClientWithObjects(mig, pod)
+			Expect(err).NotTo(HaveOccurred())
+
+			h := LifecycleHandler{client: fakeClient}
+			reason, msg, err := h.getInProgressReasonAndMessage(ctx, mig)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(reason).To(Equal(vmopcondition.ReasonTargetUnschedulable))
+			Expect(msg).To(Equal("Target pod \"default/target-pod\" is unschedulable: 0/3 nodes are available: 3 Insufficient memory."))
+		})
+
 		It("should return TargetDiskError when target pod has disk attach error", func() {
 			mig := newSimpleMigration("vmop-test", name)
 			mig.UID = "migration-uid"

--- a/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle_test.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle_test.go
@@ -820,7 +820,7 @@ var _ = Describe("LifecycleHandler", func() {
 			Expect(completed.Reason).To(Equal(vmopcondition.ReasonAborted.String()))
 		})
 
-		It("should return unschedulable message from target pod condition", func() {
+		It("should return generic unschedulable message for target pod condition", func() {
 			mig := newSimpleMigration("vmop-test", name)
 			mig.UID = "migration-uid"
 			mig.Status.Phase = virtv1.MigrationScheduling
@@ -852,7 +852,7 @@ var _ = Describe("LifecycleHandler", func() {
 			reason, msg, err := h.getInProgressReasonAndMessage(ctx, mig)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(reason).To(Equal(vmopcondition.ReasonTargetUnschedulable))
-			Expect(msg).To(Equal("Target pod \"default/target-pod\" is unschedulable: 0/3 nodes are available: 3 Insufficient memory."))
+			Expect(msg).To(Equal("Target pod \"default/target-pod\" is unschedulable"))
 		})
 
 		It("should return TargetDiskError when target pod has disk attach error", func() {


### PR DESCRIPTION
## Description
Propagate the unschedulable message from the target migration pod into the VMOP in-progress condition.

## Why do we need it, and what problem does it solve?
When a migration target pod stays Pending because the scheduler cannot place it, the VMOP condition only reports a generic `TargetUnschedulable` message. This hides the actual scheduling failure reason, for example insufficient memory on cluster nodes, and makes debugging harder for users and operators.

This change preserves the scheduler message from the `PodScheduled=False, Reason=Unschedulable` condition and exposes it through the VMOP condition message.

## What is the expected result?
1. Start a migration that creates a target pod.
2. Make the target pod unschedulable, for example by exhausting cluster resources.
3. Check the VMOP in-progress condition.
4. Verify that the condition reason is `TargetUnschedulable` and the message contains the original scheduler details from the target pod condition.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: core
type: fix
summary: "Propagate target migration pod unschedulable details to VMOP conditions."
impact_level: low
```