### PR TITLE
chore(vm): disable internal DHCP configurator

### DIFF
--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -3,7 +3,7 @@ firmware:
   libvirt: v10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: v1.6.2-v12n.26
+  3p-kubevirt: v1.6.2-v12n.27
   3p-containerized-data-importer: v1.60.3-v12n.18
   distribution: 2.8.3
 package:


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Disables the internal DHCP configurator ( https://github.com/deckhouse/3p-kubevirt/pull/105 )

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
The virtual machine receives an IP address from the Cilium DHCP server, and responses from the internal DHCP configurator are discarded. We are disabling the unused functionality.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->
