### PR TITLE
test(vm): enable "should be reverted first and completed second" migration case

### DIFF
--- a/test/e2e/Taskfile.yaml
+++ b/test/e2e/Taskfile.yaml
@@ -75,7 +75,10 @@ tasks:
           --timeout=3h \
           {{end -}}
           {{if .FOCUS -}}
-          --focus "{{ .FOCUS }}"
+          --focus "{{ .FOCUS }}" \
+          {{end -}}
+          {{if .REPEAT -}}
+          --repeat "{{ .REPEAT }}"
           {{end -}}
 
   runp:

--- a/test/e2e/vm/volume_migration_local_disks.go
+++ b/test/e2e/vm/volume_migration_local_disks.go
@@ -247,10 +247,7 @@ var _ = Describe("RWOVirtualDiskMigration", decoratorsForVolumeMigrations(), Lab
 		}
 	})
 
-	// TODO: need v1.6.2 kubevirt to fix this test
 	It("should be reverted first and completed second", func() {
-		Skip("TODO: need v1.6.2 kubevirt to fix this test")
-
 		ns := f.Namespace().Name
 
 		vm, vds := localMigrationRootAndAdditionalBuild()


### PR DESCRIPTION
## Description
Enables the migration test:

`should be reverted first and completed second`

## Why do we need it, and what problem does it solve?
This test was flaky/failing because migration cancel could leave a `concluded` block job in QEMU.
When that happened, subsequent migration attempts could not start (stale block-migration job state after abort).

Now we enable this test to validate the fix path for cancel/retry behavior and protect against regressions.

## What is the expected result?
1. Run migration test suite including `should be reverted first and completed second`.
2. Test should pass consistently.
3. No intermittent failures caused by lingering `concluded` block jobs after migration cancel.

## Checklist
- [ ] The code is covered by unit tests.
- [X] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
