### PR TITLE
chore(e2e): prevent 'unable to use a TTY' message

### DIFF
--- a/test/e2e/internal/framework/dump.go
+++ b/test/e2e/internal/framework/dump.go
@@ -206,7 +206,7 @@ func (f *Framework) writePodDescription(name, namespace, filePath, testCaseFullT
 func (f *Framework) writeVirtualMachineGuestInfo(pod corev1.Pod, filePath, testCaseFullText string) {
 	if pod.Labels != nil && pod.Status.Phase == corev1.PodRunning {
 		if value, ok := pod.Labels["kubevirt.internal.virtualization.deckhouse.io"]; ok && value == "virt-launcher" {
-			vlctlGuestInfoCmd := f.Clients.Kubectl().RawCommand(fmt.Sprintf("exec --stdin=true --tty=true %s --namespace %s -- vlctl guest info", pod.Name, pod.Namespace), ShortTimeout)
+			vlctlGuestInfoCmd := f.Clients.Kubectl().RawCommand(fmt.Sprintf("exec %s --namespace %s -- vlctl guest info", pod.Name, pod.Namespace), ShortTimeout)
 			if vlctlGuestInfoCmd.Error() != nil {
 				GinkgoWriter.Printf("Failed to get pod guest info:\nPodName: %s\nError: %s\n", pod.Name, vlctlGuestInfoCmd.StdErr())
 			}


### PR DESCRIPTION
## Description

No need to enable tty and input when executing vlctl.

See also #1967


## Why do we need it, and what problem does it solve?

Error message is confusing while dumping Pod info on test fail:

```
STEP: Checking initial CPU configuration @ 04/24/26 10:45:39.046
  STEP: Applying CPU core changes @ 04/24/26 10:45:41.704
  [FAILED] in [It] - /home/runner/work/virtualization/virtualization/test/e2e/vm/hotplug_cpu.go:87 @ 04/24/26 10:45:42.312
  STEP: Failed: save resource dump @ 04/24/26 10:45:42.312
  Failed to get pod guest info:
  PodName: d8v-vm-vm-1-3-w24z6
  Error: Unable to use a TTY - input is not a terminal or the right kind of file
  ^^^^^^^^^^^^^^^^^^^^^^^^^^
  Error: failed to create client: context deadline exceeded
  command terminated with exit code 1
  STEP: Cleanup: process deferred deletions @ 04/24/26 10:46:10.139
  STEP: Cleanup: delete namespace @ 04/24/26 10:46:24.818
• [FAILED] [142.693 seconds]
```


"Unable to use a TTY" is not a relevant error: `vlctl guest info` not requires tty and input:

```
[virtlab] root@virtlab-mi-0 ~/vm-alpine # echo "QWE" | k -n vm exec -ti d8v-vm-vm-alpine-uefi-gh4ld -- vlctl guest info
Unable to use a TTY - input is not a terminal or the right kind of file
^^^^^^^^^^^^^^^^^^^
<VirtualMachineInstanceGuestAgentInfo>
  <Kind></Kind>
  <APIVersion></APIVersion>
  <GAVersion>9.1.2</GAVersion>
  <SupportedCommands>
    <Name>guest-network-get-route</Name>
    <Enabled>true</Enabled>
...

[virtlab] root@virtlab-mi-0 ~/vm-alpine # k -n vm exec d8v-vm-vm-alpine-uefi-gh4ld -- vlctl guest info
<VirtualMachineInstanceGuestAgentInfo>
  <Kind></Kind>
  <APIVersion></APIVersion>
  <GAVersion>9.1.2</GAVersion>
  <SupportedCommands>
...
```


## What is the expected result?

No errors when dumping Pod info.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->
