### PR TITLE
chore(observability): fix cpu core usage gauge

### DIFF
--- a/monitoring/grafana-dashboards/main/propagated-vm.json
+++ b/monitoring/grafana-dashboards/main/propagated-vm.json
@@ -360,7 +360,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum by (namespace,name) (rate(d8_virtualization_virtualmachine_hypervisor_cpu_usage_seconds_total{namespace=\"$namespace\", name=\"$name\"}[$__rate_interval])) \n/\n(\n  (avg by (namespace,name) ( sum by (namespace,name) (d8_virtualization_virtualmachine_cpu_cores{namespace=\"$namespace\", name=\"$name\"}) / 100))\n)",
+          "expr": "sum by (namespace,name) (rate(d8_virtualization_virtualmachine_hypervisor_cpu_usage_seconds_total{namespace=\"$namespace\", name=\"$name\"}[$__rate_interval])) \n/\n(\n  (avg by (namespace,name) ( sum by (namespace,name,pod) (d8_virtualization_virtualmachine_cpu_cores{namespace=\"$namespace\", name=\"$name\"}) / 100))\n)",
           "hide": false,
           "instant": true,
           "legendFormat": "OS Usage",

--- a/monitoring/grafana-dashboards/main/propagated-vm.json
+++ b/monitoring/grafana-dashboards/main/propagated-vm.json
@@ -360,7 +360,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum by (namespace,name) (rate(d8_virtualization_virtualmachine_hypervisor_cpu_usage_seconds_total{namespace=\"$namespace\", name=\"$name\"}[$__rate_interval])) \n/\n(\n    sum by (namespace,name) (d8_virtualization_virtualmachine_cpu_cores{namespace=\"$namespace\", name=\"$name\"}) / 100\n)",
+          "expr": "sum by (namespace,name) (rate(d8_virtualization_virtualmachine_hypervisor_cpu_usage_seconds_total{namespace=\"$namespace\", name=\"$name\"}[$__rate_interval])) \n/\n(\n  (avg by (namespace,name) ( sum by (namespace,name) (d8_virtualization_virtualmachine_cpu_cores{namespace=\"$namespace\", name=\"$name\"}) / 100))\n)",
           "hide": false,
           "instant": true,
           "legendFormat": "OS Usage",

--- a/monitoring/grafana-dashboards/main/propagated-vm.json
+++ b/monitoring/grafana-dashboards/main/propagated-vm.json
@@ -303,7 +303,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
-      "description": "Shows the current CPU core usage percentage of the virtual machine, including OS usage, hypervisor overhead, and CPU reservation levels.",
+      "description": "Shows the current CPU core usage percentage of the virtual machine, including OS usage and hypervisor overhead.",
       "fieldConfig": {
         "defaults": {
           "decimals": 1,
@@ -360,7 +360,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum by (namespace,name) (rate(d8_virtualization_virtualmachine_cpu_usage_seconds_total{namespace=\"$namespace\", name=\"$name\"}[$__rate_interval])) \n/\n(\n    sum by (namespace,name) (d8_virtualization_virtualmachine_cpu_cores{namespace=\"$namespace\", name=\"$name\"}) / 100\n)",
+          "expr": "sum by (namespace,name) (rate(d8_virtualization_virtualmachine_hypervisor_cpu_usage_seconds_total{namespace=\"$namespace\", name=\"$name\"}[$__rate_interval])) \n/\n(\n    sum by (namespace,name) (d8_virtualization_virtualmachine_cpu_cores{namespace=\"$namespace\", name=\"$name\"}) / 100\n)",
           "hide": false,
           "instant": true,
           "legendFormat": "OS Usage",

--- a/monitoring/grafana-dashboards/main/propagated-vm.json
+++ b/monitoring/grafana-dashboards/main/propagated-vm.json
@@ -303,7 +303,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
-      "description": "Shows the current CPU core usage percentage of the virtual machine, including OS usage and hypervisor overhead.",
+      "description": "Shows the current OS CPU core usage percentage of the virtual machine, excluding hypervisor overhead.",
       "fieldConfig": {
         "defaults": {
           "decimals": 1,
@@ -360,7 +360,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum by (namespace,name) (rate(d8_virtualization_virtualmachine_hypervisor_cpu_usage_seconds_total{namespace=\"$namespace\", name=\"$name\"}[$__rate_interval])) \n/\n(\n  (avg by (namespace,name) ( sum by (namespace,name,pod) (d8_virtualization_virtualmachine_cpu_cores{namespace=\"$namespace\", name=\"$name\"}) / 100))\n)",
+          "expr": "sum by (namespace,name) (rate(d8_virtualization_virtualmachine_cpu_usage_seconds_total{namespace=\"$namespace\", name=\"$name\"}[$__rate_interval])) \n/\n(\n  (avg by (namespace,name) ( sum by (namespace,name,pod) (d8_virtualization_virtualmachine_cpu_cores{namespace=\"$namespace\", name=\"$name\"}) / 100))\n)",
           "hide": false,
           "instant": true,
           "legendFormat": "OS Usage",


### PR DESCRIPTION
## Description
Adjust the VM CPU usage dashboard query to use the hypervisor CPU usage metric and deduplicate replicated `virtualmachine_cpu_cores` series exposed by multiple `virtualization-controller` pods in HA clusters. Also update the panel description to remove the CPU reservation mention.

## Why do we need it, and what problem does it solve?
In multi-master clusters, `d8_virtualization_virtualmachine_cpu_cores` is exposed by each `virtualization-controller` replica. Using the raw gauge in the dashboard query can multiply the denominator depending on the number of controller pods and show misleading CPU usage values. This change makes the panel resilient to duplicated HA scrape targets and aligns the calculation with the hypervisor CPU usage metric.

## What is the expected result?
1. Open the VM dashboard for a virtual machine in a multi-master cluster.
2. Check the CPU usage panel.
3. Verify that the percentage is no longer affected by the number of `virtualization-controller` replicas.
4. Verify that single-master clusters continue to show the expected value.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: observability
type: fix
summary: "Fix VM CPU usage dashboard calculation in HA clusters by deduplicating replicated controller metrics."
impact_level: low