### PR TITLE
chore(ci): gather logs when bootstrap success or failed

### DIFF
--- a/.github/workflows/e2e-reusable-pipeline.yml
+++ b/.github/workflows/e2e-reusable-pipeline.yml
@@ -1270,6 +1270,7 @@ jobs:
           DATE=$(date +"%Y-%m-%d")
           START_TIME=$(date +"%H:%M:%S")
           summary_file_name_junit="e2e_summary_${CSI}_${DATE}.xml"
+          ginkgo_json_report="e2e_summary_${CSI}_${DATE}-ginkgo-report".json"
           summary_file_name_json="e2e_summary_${CSI}_${DATE}.json"
 
           cp -a legacy/testdata /tmp/testdata
@@ -1280,10 +1281,12 @@ jobs:
             go tool ginkgo \
               --focus="$FOCUS" \
               -v --race --timeout=$TIMEOUT \
+              --json-report=$ginkgo_json_report \
               --junit-report=$summary_file_name_junit | tee $GINKGO_RESULT
           else
             go tool ginkgo \
               -v --race --timeout=$TIMEOUT \
+              --json-report=$ginkgo_json_report \
               --junit-report=$summary_file_name_junit | tee $GINKGO_RESULT
           fi
           GINKGO_EXIT_CODE=$?

--- a/.github/workflows/e2e-reusable-pipeline.yml
+++ b/.github/workflows/e2e-reusable-pipeline.yml
@@ -421,18 +421,18 @@ jobs:
           d8vscp "${DEFAULT_USER}@${nested_master}.$NAMESPACE:/var/log/cloud-init*.log" "./${{ env.SETUP_CLUSTER_TYPE_PATH }}/tmp/"
 
       - name: Prepare artifact
-        if: always() && steps.dhctl-bootstrap.outcome == 'success'
+        if: success() || failure()
         run: |
-          sudo chown -fR 1001:1001 ${{ env.SETUP_CLUSTER_TYPE_PATH }}
-          yq e '.deckhouse.registryDockerCfg = "None"' -i ./${{ env.SETUP_CLUSTER_TYPE_PATH }}/values.yaml
+          sudo chown -fR 1001:1001 ${{ env.SETUP_CLUSTER_TYPE_PATH }} || true
+          yq e '.deckhouse.registryDockerCfg = "None"' -i ./${{ env.SETUP_CLUSTER_TYPE_PATH }}/values.yaml || true
           yq e 'select(.kind == "InitConfiguration").deckhouse.registryDockerCfg = "None"' -i ./${{ env.SETUP_CLUSTER_TYPE_PATH }}/tmp/config.yaml || echo "The config.yaml file is not generated, skipping"
           yq e '.discovered.registry_url = "None"' -i ./${{ env.SETUP_CLUSTER_TYPE_PATH }}/tmp/discovered-values.yaml || echo "The discovered-values.yaml file is not generated, skipping editing registry_url"
           yq e '.discovered.registry_auth = "None"' -i ./${{ env.SETUP_CLUSTER_TYPE_PATH }}/tmp/discovered-values.yaml || echo "The discovered-values.yaml file is not generated, skipping editing registry_auth"
-          echo "${{ steps.generate-kubeconfig.outputs.kubeconfig }}" | base64 -d | base64 -d > ./${{ env.SETUP_CLUSTER_TYPE_PATH }}/kube-config
+          echo "${{ steps.generate-kubeconfig.outputs.kubeconfig }}" | base64 -d | base64 -d > ./${{ env.SETUP_CLUSTER_TYPE_PATH }}/kube-config || echo "kubeconfig not available, skipping"
 
       - name: Upload generated files
         uses: actions/upload-artifact@v4
-        if: always() && steps.dhctl-bootstrap.outcome == 'success'
+        if: success() || failure()
         with:
           name: ${{ inputs.storage_type }}-generated-files-${{ inputs.date_start }}
           path: |

--- a/.github/workflows/e2e-reusable-pipeline.yml
+++ b/.github/workflows/e2e-reusable-pipeline.yml
@@ -1270,7 +1270,7 @@ jobs:
           DATE=$(date +"%Y-%m-%d")
           START_TIME=$(date +"%H:%M:%S")
           summary_file_name_junit="e2e_summary_${CSI}_${DATE}.xml"
-          ginkgo_json_report="e2e_summary_${CSI}_${DATE}-ginkgo-report".json"
+          ginkgo_json_report="e2e_summary_${CSI}_${DATE}-ginkgo-report.json"
           summary_file_name_json="e2e_summary_${CSI}_${DATE}.json"
 
           cp -a legacy/testdata /tmp/testdata


### PR DESCRIPTION
## Description
Ensure the reusable E2E pipeline always prepares and uploads bootstrap artifacts, even when `dhctl-bootstrap` fails before generating the full set of files.

## Why do we need it, and what problem does it solve?
When nested cluster bootstrap fails, the workflow used to skip the artifact preparation and upload steps because they only ran after a successful bootstrap. That made postmortem debugging harder: generated files, partial configuration, and related bootstrap outputs were not preserved in failed runs.

This change makes artifact preparation and upload run on both success and failure, and tolerates missing files that are not produced in failed bootstrap scenarios. As a result, failed runs still publish the available bootstrap data needed for investigation.

## What is the expected result?
1. Run the reusable E2E pipeline.
2. If bootstrap succeeds, generated files are prepared and uploaded as before.
3. If bootstrap fails, the workflow still sanitizes and uploads whatever bootstrap files were produced.
4. Missing optional files do not break artifact preparation.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: chore
summary: Preserve generated bootstrap artifacts for reusable E2E pipeline runs even when bootstrap fails.
impact_level: low
```
