### PR TITLE
fix(cdi): add metricRelabelings for kubevirt_cdi_* metrics

### DIFF
--- a/templates/cdi/service-monitor.yaml
+++ b/templates/cdi/service-monitor.yaml
@@ -13,22 +13,17 @@ spec:
       name: prometheus-token
     path: /metrics
     port: metrics
-    # relabelings:
-    # - action: labeldrop
-    #   regex: endpoint|namespace|pod|container
-    # - action: replace
-    #   replacement: linstor-controller
-    #   targetLabel: job
-    # - action: replace
-    #   replacement: cluster
-    #   targetLabel: tier
-    # - action: keep
-    #   regex: "true"
-    #   sourceLabels:
-    #   - __meta_kubernetes_endpoint_ready
     scheme: https
     tlsConfig:
       insecureSkipVerify: true
+    metricRelabelings:
+      # rename kubevirt_cdi_* -> d8_internal_virtualization_kubevirt_cdi_*
+      - action: replace
+        regex: kubevirt_cdi_(.*)
+        replacement: d8_internal_virtualization_kubevirt_cdi_$1
+        sourceLabels:
+          - __name__
+        targetLabel: __name__
   namespaceSelector:
     matchNames:
     - d8-{{ .Chart.Name }}


### PR DESCRIPTION
## Description
Add metricRelabelings to CDI ServiceMonitor to rename kubevirt_cdi_* metrics to d8_internal_virtualization_kubevirt_cdi_* for consistency with other virtualization  metrics.


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: cdi                                                                       
type: fix                                                                          
summary: "Rename kubevirt_cdi_* metrics to d8_internal_virtualization_kubevirt_cdi_* via metricRelabelings" 
impact_level: low
```
