### PR TITLE
test(e2e): improve additional network interfaces e2e test reliability

### DIFF
--- a/test/e2e/internal/framework/dump.go
+++ b/test/e2e/internal/framework/dump.go
@@ -65,6 +65,7 @@ func (f *Framework) saveTestCaseDump() {
 	f.saveIntvirtvmiDescriptions(ft, tmpDir)
 	f.saveNodeAdditionalInfo(ft, tmpDir)
 	f.saveEvents(ft, tmpDir)
+	f.saveClusterNetworkInfo(ft, tmpDir)
 }
 
 // GetFormattedTestCaseFullText returns CurrentSpecReport().FullText(), formatted with the following rules:
@@ -300,6 +301,43 @@ func (f *Framework) saveEvents(testCaseFullText, dumpPath string) {
 		err = os.WriteFile(fileName, data, 0o644)
 		if err != nil {
 			GinkgoWriter.Printf("Failed to write events dump:\nFile: %s\nError: %v\n", fileName, err)
+		}
+	}
+}
+
+func (f *Framework) saveClusterNetworkInfo(testCaseFullText, dumpPath string) {
+	GinkgoHelper()
+
+	// Only for tests that use additional networks
+	if !strings.Contains(testCaseFullText, "virtualmachineadditionalnetworkinterfaces") {
+		return
+	}
+
+	// Get all ClusterNetwork resources
+	cmd := f.Clients.Kubectl().RawCommand("get clusternetwork -o yaml", ShortTimeout)
+	if cmd.Error() != nil {
+		GinkgoWriter.Printf("Failed to get clusternetwork:\nCmdError: %v\nStderr: %s\n", cmd.Error(), cmd.StdErr())
+	}
+
+	fileName := fmt.Sprintf("%s/e2e_failed__%s__clusternetwork.yaml", dumpPath, testCaseFullText)
+	if len(cmd.StdOutBytes()) > 0 {
+		err := os.WriteFile(fileName, cmd.StdOutBytes(), 0o644)
+		if err != nil {
+			GinkgoWriter.Printf("Failed to write clusternetwork dump:\nFile: %s\nError: %v\n", fileName, err)
+		}
+	}
+
+	// Also get CEP (Cilium Endpoints) for the namespace
+	cepCmd := f.Clients.Kubectl().RawCommand(fmt.Sprintf("get cep -n %s -o yaml", f.Namespace().Name), ShortTimeout)
+	if cepCmd.Error() != nil {
+		GinkgoWriter.Printf("Failed to get cep:\nCmdError: %v\nStderr: %s\n", cepCmd.Error(), cepCmd.StdErr())
+	}
+
+	cepFileName := fmt.Sprintf("%s/e2e_failed__%s__cep.yaml", dumpPath, testCaseFullText)
+	if len(cepCmd.StdOutBytes()) > 0 {
+		err := os.WriteFile(cepFileName, cepCmd.StdOutBytes(), 0o644)
+		if err != nil {
+			GinkgoWriter.Printf("Failed to write cep dump:\nFile: %s\nError: %v\n", cepFileName, err)
 		}
 	}
 }

--- a/test/e2e/internal/framework/dump.go
+++ b/test/e2e/internal/framework/dump.go
@@ -308,8 +308,9 @@ func (f *Framework) saveEvents(testCaseFullText, dumpPath string) {
 func (f *Framework) saveClusterNetworkInfo(testCaseFullText, dumpPath string) {
 	GinkgoHelper()
 
-	// Only for tests that use additional networks
-	if !strings.Contains(testCaseFullText, "virtualmachineadditionalnetworkinterfaces") {
+	// Only for tests that use additional networks.
+	// We use the original full text for checking because testCaseFullText may be truncated.
+	if !strings.Contains(CurrentSpecReport().FullText(), "VirtualMachineAdditionalNetworkInterfaces") {
 		return
 	}
 

--- a/test/e2e/internal/framework/dump.go
+++ b/test/e2e/internal/framework/dump.go
@@ -327,7 +327,7 @@ func (f *Framework) saveClusterNetworkInfo(testCaseFullText, dumpPath string) {
 		}
 	}
 
-	// Also get CEP (Cilium Endpoints) for the namespace
+	// Get CEP (Cilium Endpoints) for the namespace
 	cepCmd := f.Clients.Kubectl().RawCommand(fmt.Sprintf("get cep -n %s -o yaml", f.Namespace().Name), ShortTimeout)
 	if cepCmd.Error() != nil {
 		GinkgoWriter.Printf("Failed to get cep:\nCmdError: %v\nStderr: %s\n", cepCmd.Error(), cepCmd.StdErr())

--- a/test/e2e/vm/additional_network_interfaces.go
+++ b/test/e2e/vm/additional_network_interfaces.go
@@ -183,12 +183,11 @@ var _ = Describe("VirtualMachineAdditionalNetworkInterfaces", Label(precheck.NoP
 		)
 
 		const (
-			getLastInterfaceNameCmd = "ip -o link show | tail -1 | cut -d: -f2 | awk \"{print \\$1}\""
+			getLastInterfaceNameCmd   = "ip -o link show | tail -1 | cut -d: -f2 | awk \"{print \\$1}\""
+			expectedLastInterfaceName = "eno3"
 		)
 
 		It("should preserve interface name after removing middle ClusterNetwork and rebooting", func() {
-			var lastInterfaceNameBeforeRemoval string
-
 			By("Create VM with Main network and two additional ClusterNetworks", func() {
 				ns := f.Namespace().Name
 
@@ -216,10 +215,7 @@ var _ = Describe("VirtualMachineAdditionalNetworkInterfaces", Label(precheck.NoP
 
 			By("Get last interface name via SSH", func() {
 				util.UntilSSHReady(f, vm, framework.LongTimeout)
-				output, err := f.SSHCommand(vm.Name, vm.Namespace, getLastInterfaceNameCmd)
-				Expect(err).NotTo(HaveOccurred())
-				lastInterfaceNameBeforeRemoval = strings.TrimSpace(output)
-				Expect(lastInterfaceNameBeforeRemoval).NotTo(BeEmpty(), "Failed to get last interface name")
+				checkResultSSHCommand(f, vm.Name, vm.Namespace, getLastInterfaceNameCmd, expectedLastInterfaceName)
 			})
 
 			By("Remove middle ClusterNetwork from VM spec", func() {
@@ -253,13 +249,7 @@ var _ = Describe("VirtualMachineAdditionalNetworkInterfaces", Label(precheck.NoP
 
 			By("Verify last interface name has not changed", func() {
 				util.UntilSSHReady(f, vm, framework.LongTimeout)
-				output, err := f.SSHCommand(vm.Name, vm.Namespace, getLastInterfaceNameCmd)
-				Expect(err).NotTo(HaveOccurred())
-				lastInterfaceNameAfterRemoval := strings.TrimSpace(output)
-				Expect(lastInterfaceNameAfterRemoval).NotTo(BeEmpty(), "Failed to get last interface name")
-
-				Expect(lastInterfaceNameAfterRemoval).To(Equal(lastInterfaceNameBeforeRemoval),
-					fmt.Sprintf("Interface name changed from %s to %s after removing middle ClusterNetwork", lastInterfaceNameBeforeRemoval, lastInterfaceNameAfterRemoval))
+				checkResultSSHCommand(f, vm.Name, vm.Namespace, getLastInterfaceNameCmd, expectedLastInterfaceName)
 			})
 		})
 	})

--- a/test/e2e/vm/additional_network_interfaces.go
+++ b/test/e2e/vm/additional_network_interfaces.go
@@ -18,6 +18,7 @@ package vm
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -183,7 +184,6 @@ var _ = Describe("VirtualMachineAdditionalNetworkInterfaces", Label(precheck.NoP
 		)
 
 		const (
-			getLastInterfaceNameCmd   = "ip -o link show | tail -1 | cut -d: -f2 | awk \"{print \\$1}\""
 			expectedLastInterfaceName = "eno3"
 		)
 
@@ -215,7 +215,7 @@ var _ = Describe("VirtualMachineAdditionalNetworkInterfaces", Label(precheck.NoP
 
 			By("Get last interface name via SSH", func() {
 				util.UntilSSHReady(f, vm, framework.LongTimeout)
-				checkResultSSHCommand(f, vm.Name, vm.Namespace, getLastInterfaceNameCmd, expectedLastInterfaceName)
+				checkLastInterfaceName(f, vm.Name, vm.Namespace, expectedLastInterfaceName)
 			})
 
 			By("Remove middle ClusterNetwork from VM spec", func() {
@@ -249,7 +249,7 @@ var _ = Describe("VirtualMachineAdditionalNetworkInterfaces", Label(precheck.NoP
 
 			By("Verify last interface name has not changed", func() {
 				util.UntilSSHReady(f, vm, framework.LongTimeout)
-				checkResultSSHCommand(f, vm.Name, vm.Namespace, getLastInterfaceNameCmd, expectedLastInterfaceName)
+				checkLastInterfaceName(f, vm.Name, vm.Namespace, expectedLastInterfaceName)
 			})
 		})
 	})
@@ -350,4 +350,34 @@ func checkResultSSHCommand(f *framework.Framework, vmName, vmNamespace, cmd, equ
 		}
 		return strings.TrimSpace(res), nil
 	}).WithTimeout(Timeout).WithPolling(Interval).Should(Equal(equal))
+}
+
+func checkLastInterfaceName(f *framework.Framework, vmName, vmNamespace, expected string) {
+	GinkgoHelper()
+	Eventually(func() (string, error) {
+		cmd := "ip -j link show"
+		result, err := f.SSHCommand(vmName, vmNamespace, cmd, framework.WithSSHTimeout(5*time.Second))
+		if err != nil {
+			return "", fmt.Errorf("failed to execute command: %w: %s", err, result)
+		}
+
+		var links IPLinks
+		err = json.Unmarshal([]byte(result), &links)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse ip JSON output: %w", err)
+		}
+		if len(links) == 0 {
+			return "", fmt.Errorf("no network interfaces found")
+		}
+
+		return links[len(links)-1].IFName, nil
+	}).WithTimeout(Timeout).WithPolling(Interval).Should(Equal(expected))
+}
+
+// IPLinks represents the JSON output of ip -j link show command.
+type IPLinks []IPLink
+
+// IPLink represents a single network interface in the ip JSON output.
+type IPLink struct {
+	IFName string `json:"ifname"`
 }


### PR DESCRIPTION
## Description
This PR improves the reliability and diagnostics of the `VirtualMachineAdditionalNetworkInterfaces` E2E test.

Key changes:
1. **Retry logic for SSH commands**: Replaced direct `SSHCommand` calls with `checkResultSSHCommand` which includes `Eventually` retry logic. This helps avoid test failures due to transient SSH connectivity issues during VM boot or configuration.
2. **Enhanced Diagnostics**: Added automatic dumping of `ClusterNetwork` and `CiliumEndpoint` (CEP) resources when tests in the `virtualmachineadditionalnetworkinterfaces` block fail.

## Why do we need it, and what problem does it solve?
- The E2E tests were occasionally failing due to SSH timeouts or transient errors before the VM was fully ready.
- Diagnosing network-related failures in E2E was difficult without seeing the state of the underlying network resources (`ClusterNetwork`, `CEP`).

## What is the expected result?
- `VirtualMachineAdditionalNetworkInterfaces` tests are more stable.
- If a failure occurs, the diagnostic dump contains `clusternetwork.yaml` and `cep.yaml`.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: test
type: fix
summary: Improve VirtualMachineAdditionalNetworkInterfaces e2e test reliability and diagnostics.
impact_level: low
```