### PR TITLE
chore(ci): add automatic github release

### DIFF
--- a/.github/workflows/release_module_release-channels.yml
+++ b/.github/workflows/release_module_release-channels.yml
@@ -501,7 +501,7 @@ jobs:
       - job-SE-Plus
       - job-FE
       - check-version-on-release-channel
-    if: ${{ always() && inputs.release_to_github && !contains(needs.*.result, 'failure') && needs.check-version-on-release-channel.result == 'success' && (inputs.check_only || inputs.ce || inputs.ee) }}
+    if: ${{ !inputs.check_only && inputs.release_to_github && needs.check-version-on-release-channel.result == 'success' && (inputs.ce || inputs.ee) }}
     permissions:
       contents: write
       pull-requests: read
@@ -563,17 +563,18 @@ jobs:
           notes_file=$(mktemp)
           printf '%s\n' "$pr_body" > "$notes_file"
 
-          echo "DRY RUN: gh release create \"$TAG\" --repo \"$REPOSITORY\" --title \"$TAG\" --notes-file \"$notes_file\""
-          echo "DRY RUN: release notes source PR #${pr_number}: ${pr_url}"
-          echo "DRY RUN: release notes content start"
-          cat "$notes_file"
-          echo "DRY RUN: release notes content end"
+          gh release create "$TAG" \
+            --repo "$REPOSITORY" \
+            --title "$TAG" \
+            --notes-file "$notes_file"
 
-          echo "release_status=dry-run" >> "$GITHUB_OUTPUT"
-          echo "release_url=" >> "$GITHUB_OUTPUT"
+          release_url=$(gh release view "$TAG" --repo "$REPOSITORY" --json url --jq '.url')
+
+          echo "release_status=created" >> "$GITHUB_OUTPUT"
+          echo "release_url=${release_url}" >> "$GITHUB_OUTPUT"
           echo "release_pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
           echo "release_pr_url=${pr_url}" >> "$GITHUB_OUTPUT"
-          echo "release_reason=Dry run: GitHub release would be created from changelog PR #${pr_number}" >> "$GITHUB_OUTPUT"
+          echo "release_reason=GitHub release created from changelog PR #${pr_number}" >> "$GITHUB_OUTPUT"
 
   send-release-results-to-loop:
     name: Send release results to Loop
@@ -589,7 +590,7 @@ jobs:
     steps:
       - name: Send results to Loop
         env:
-          LOOP_WEBHOOK_URL: ${{ secrets.LOOP_TEST_CHANNEL }}
+          LOOP_WEBHOOK_URL: ${{ secrets.LOOP_WEBHOOK_URL }}
           TAG: ${{ github.event.inputs.tag }}
           CHANNEL: ${{ github.event.inputs.channel }}
           RELEASE_TO_GITHUB: ${{ inputs.release_to_github }}

--- a/.github/workflows/release_module_release-channels.yml
+++ b/.github/workflows/release_module_release-channels.yml
@@ -635,6 +635,21 @@ jobs:
           HEADER_ROW+=" Check |"
           STATUS_ROW+=" $(get_status_emoji $CHECK_RESULT) |"
 
+          if [[ "$RELEASE_TO_GITHUB" == "true" && "$CHECK_ONLY" != "true" ]]; then
+            HEADER_ROW+=" GitHub Release |"
+            if [[ "$GH_RELEASE_RESULT" == "failure" ]]; then
+              STATUS_ROW+=" :x: |"
+            elif [[ "$GH_RELEASE_STATUS" == "created" ]]; then
+              STATUS_ROW+=" :white_check_mark: |"
+            elif [[ "$GH_RELEASE_STATUS" == "dry-run" ]]; then
+              STATUS_ROW+=" :memo: |"
+            elif [[ "$GH_RELEASE_STATUS" == "skipped" ]]; then
+              STATUS_ROW+=" :fast_forward: |"
+            else
+              STATUS_ROW+=" :grey_question: |"
+            fi
+          fi
+
           COL_COUNT=$(echo "$HEADER_ROW" | tr -cd '|' | wc -c)
           COL_COUNT=$((COL_COUNT - 1))
           SEPARATOR_ROW="|"
@@ -648,27 +663,6 @@ jobs:
           RELEASE_SUMMARY+="${HEADER_ROW}\n"
           RELEASE_SUMMARY+="${SEPARATOR_ROW}\n"
           RELEASE_SUMMARY+="${STATUS_ROW}\n"
-
-          if [[ "$RELEASE_TO_GITHUB" != "true" ]]; then
-            RELEASE_SUMMARY+="\n### GitHub release\n- Status: skipped\n- Reason: disabled by workflow input\n"
-          elif [[ "$CHECK_ONLY" == "true" ]]; then
-            RELEASE_SUMMARY+="\n### GitHub release\n- Status: skipped\n- Reason: check_only mode\n"
-          elif [[ "$GH_RELEASE_RESULT" == "failure" ]]; then
-            RELEASE_SUMMARY+="\n### GitHub release\n- Status: failed\n- Reason: workflow step failed\n"
-          elif [[ -n "$GH_RELEASE_STATUS" ]]; then
-            RELEASE_SUMMARY+="\n### GitHub release\n- Status: ${GH_RELEASE_STATUS}\n"
-            if [[ -n "$GH_RELEASE_REASON" ]]; then
-              RELEASE_SUMMARY+="- Reason: ${GH_RELEASE_REASON}\n"
-            fi
-            if [[ -n "$GH_RELEASE_URL" ]]; then
-              RELEASE_SUMMARY+="- URL: ${GH_RELEASE_URL}\n"
-            fi
-            if [[ -n "$GH_RELEASE_PR_NUMBER" && -n "$GH_RELEASE_PR_URL" ]]; then
-              RELEASE_SUMMARY+="- Source PR: [#${GH_RELEASE_PR_NUMBER}](${GH_RELEASE_PR_URL})\n"
-            fi
-          else
-            RELEASE_SUMMARY+="\n### GitHub release\n- Status: skipped\n- Reason: job was not started\n"
-          fi
 
           echo -e "$RELEASE_SUMMARY"
           curl --request POST \

--- a/.github/workflows/release_module_release-channels.yml
+++ b/.github/workflows/release_module_release-channels.yml
@@ -501,7 +501,7 @@ jobs:
       - job-SE-Plus
       - job-FE
       - check-version-on-release-channel
-    if: ${{ inputs.release_to_github && needs.check-version-on-release-channel.result == 'success' && (inputs.check_only || inputs.ce || inputs.ee) }}
+    if: ${{ always() && inputs.release_to_github && !contains(needs.*.result, 'failure') && needs.check-version-on-release-channel.result == 'success' && (inputs.check_only || inputs.ce || inputs.ee) }}
     permissions:
       contents: write
       pull-requests: read

--- a/.github/workflows/release_module_release-channels.yml
+++ b/.github/workflows/release_module_release-channels.yml
@@ -501,7 +501,7 @@ jobs:
       - job-SE-Plus
       - job-FE
       - check-version-on-release-channel
-    if: ${{ !inputs.check_only && inputs.release_to_github && needs.check-version-on-release-channel.result == 'success' && (inputs.ce || inputs.ee) }}
+    if: ${{ inputs.release_to_github && needs.check-version-on-release-channel.result == 'success' && (inputs.check_only || inputs.ce || inputs.ee) }}
     permissions:
       contents: write
       pull-requests: read

--- a/.github/workflows/release_module_release-channels.yml
+++ b/.github/workflows/release_module_release-channels.yml
@@ -57,6 +57,11 @@ on:
         default: true
         description: "Set to true if build is required"
 
+      release_to_github:
+        type: boolean
+        default: true
+        description: "Create GitHub release from changelog PR"
+
       check_only:
         type: boolean
         description: "Run only check version on release channel"
@@ -487,6 +492,81 @@ jobs:
           COUNT=5 \
           task -d tools/moduleversions check:docs
 
+  create-github-release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    needs:
+      - job-CE
+      - job-EE
+      - job-SE-Plus
+      - job-FE
+      - check-version-on-release-channel
+    if: ${{ !inputs.check_only && inputs.release_to_github && needs.check-version-on-release-channel.result == 'success' && (inputs.ce || inputs.ee) }}
+    permissions:
+      contents: write
+      pull-requests: read
+    outputs:
+      release_status: ${{ steps.release.outputs.release_status }}
+      release_url: ${{ steps.release.outputs.release_url }}
+      release_pr_number: ${{ steps.release.outputs.release_pr_number }}
+      release_pr_url: ${{ steps.release.outputs.release_pr_url }}
+      release_reason: ${{ steps.release.outputs.release_reason }}
+    steps:
+      - name: Create GitHub release from changelog PR
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.inputs.tag }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          gh release view "$TAG" --repo "$REPOSITORY" >/tmp/release-view.txt 2>/dev/null && release_exists=true || release_exists=false
+          if [[ "$release_exists" == "true" ]]; then
+            release_url=$(gh release view "$TAG" --repo "$REPOSITORY" --json url --jq '.url')
+            echo "release_status=skipped" >> "$GITHUB_OUTPUT"
+            echo "release_url=${release_url}" >> "$GITHUB_OUTPUT"
+            echo "release_reason=GitHub release already exists for ${TAG}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changelog_prs=$(gh pr list \
+            --repo "$REPOSITORY" \
+            --state merged \
+            --search "label:changelog milestone:${TAG}" \
+            --json number,title,url,body,milestone)
+
+          changelog_pr_count=$(echo "$changelog_prs" | jq 'length')
+          if [[ "$changelog_pr_count" -ne 1 ]]; then
+            echo "Expected exactly one merged changelog PR for milestone ${TAG}, found ${changelog_pr_count}" >&2
+            exit 1
+          fi
+
+          pr_number=$(echo "$changelog_prs" | jq -r '.[0].number')
+          pr_url=$(echo "$changelog_prs" | jq -r '.[0].url')
+          pr_body=$(echo "$changelog_prs" | jq -r '.[0].body')
+
+          if [[ -z "${pr_body//[[:space:]]/}" ]]; then
+            echo "Changelog PR #${pr_number} body is empty" >&2
+            exit 1
+          fi
+
+          notes_file=$(mktemp)
+          printf '%s\n' "$pr_body" > "$notes_file"
+
+          gh release create "$TAG" \
+            --repo "$REPOSITORY" \
+            --title "$TAG" \
+            --notes-file "$notes_file"
+
+          release_url=$(gh release view "$TAG" --repo "$REPOSITORY" --json url --jq '.url')
+
+          echo "release_status=created" >> "$GITHUB_OUTPUT"
+          echo "release_url=${release_url}" >> "$GITHUB_OUTPUT"
+          echo "release_pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
+          echo "release_pr_url=${pr_url}" >> "$GITHUB_OUTPUT"
+          echo "release_reason=GitHub release created from changelog PR #${pr_number}" >> "$GITHUB_OUTPUT"
+
   send-release-results-to-loop:
     name: Send release results to Loop
     runs-on: ubuntu-latest
@@ -496,6 +576,7 @@ jobs:
       - job-SE-Plus
       - job-FE
       - check-version-on-release-channel
+      - create-github-release
     if: ${{ always() && inputs.send_results_to_loop }}
     steps:
       - name: Send results to Loop
@@ -503,14 +584,21 @@ jobs:
           LOOP_WEBHOOK_URL: ${{ secrets.LOOP_WEBHOOK_URL }}
           TAG: ${{ github.event.inputs.tag }}
           CHANNEL: ${{ github.event.inputs.channel }}
+          RELEASE_TO_GITHUB: ${{ inputs.release_to_github }}
+          CHECK_ONLY: ${{ inputs.check_only }}
           CE_ENABLED: ${{ inputs.ce }}
           EE_ENABLED: ${{ inputs.ee }}
           CE_RESULT: ${{ needs.job-CE.result }}
           EE_RESULT: ${{ needs.job-EE.result }}
           SE_PLUS_RESULT: ${{ needs.job-SE-Plus.result }}
           FE_RESULT: ${{ needs.job-FE.result }}
-          # will be `success` only if all jobs in the matrix have succeeded
           CHECK_RESULT: ${{ needs.check-version-on-release-channel.result }}
+          GH_RELEASE_RESULT: ${{ needs.create-github-release.result }}
+          GH_RELEASE_STATUS: ${{ needs.create-github-release.outputs.release_status }}
+          GH_RELEASE_URL: ${{ needs.create-github-release.outputs.release_url }}
+          GH_RELEASE_PR_NUMBER: ${{ needs.create-github-release.outputs.release_pr_number }}
+          GH_RELEASE_PR_URL: ${{ needs.create-github-release.outputs.release_pr_url }}
+          GH_RELEASE_REASON: ${{ needs.create-github-release.outputs.release_reason }}
         run: |
           export TZ=Europe/Moscow
           DATE=$(date +"%Y-%m-%d %H:%M:%S UTC+03:00")
@@ -526,7 +614,6 @@ jobs:
             esac
           }
 
-          # Build header row and status row dynamically
           HEADER_ROW="| Edition |"
           STATUS_ROW="| Status |"
 
@@ -549,7 +636,6 @@ jobs:
           HEADER_ROW+=" Check |"
           STATUS_ROW+=" $(get_status_emoji $CHECK_RESULT) |"
 
-          # Count columns for separator
           COL_COUNT=$(echo "$HEADER_ROW" | tr -cd '|' | wc -c)
           COL_COUNT=$((COL_COUNT - 1))
           SEPARATOR_ROW="|"
@@ -563,6 +649,27 @@ jobs:
           RELEASE_SUMMARY+="${HEADER_ROW}\n"
           RELEASE_SUMMARY+="${SEPARATOR_ROW}\n"
           RELEASE_SUMMARY+="${STATUS_ROW}\n"
+
+          if [[ "$RELEASE_TO_GITHUB" != "true" ]]; then
+            RELEASE_SUMMARY+="\n### GitHub release\n- Status: skipped\n- Reason: disabled by workflow input\n"
+          elif [[ "$CHECK_ONLY" == "true" ]]; then
+            RELEASE_SUMMARY+="\n### GitHub release\n- Status: skipped\n- Reason: check_only mode\n"
+          elif [[ "$GH_RELEASE_RESULT" == "failure" ]]; then
+            RELEASE_SUMMARY+="\n### GitHub release\n- Status: failed\n- Reason: workflow step failed\n"
+          elif [[ -n "$GH_RELEASE_STATUS" ]]; then
+            RELEASE_SUMMARY+="\n### GitHub release\n- Status: ${GH_RELEASE_STATUS}\n"
+            if [[ -n "$GH_RELEASE_REASON" ]]; then
+              RELEASE_SUMMARY+="- Reason: ${GH_RELEASE_REASON}\n"
+            fi
+            if [[ -n "$GH_RELEASE_URL" ]]; then
+              RELEASE_SUMMARY+="- URL: ${GH_RELEASE_URL}\n"
+            fi
+            if [[ -n "$GH_RELEASE_PR_NUMBER" && -n "$GH_RELEASE_PR_URL" ]]; then
+              RELEASE_SUMMARY+="- Source PR: [#${GH_RELEASE_PR_NUMBER}](${GH_RELEASE_PR_URL})\n"
+            fi
+          else
+            RELEASE_SUMMARY+="\n### GitHub release\n- Status: skipped\n- Reason: job was not started\n"
+          fi
 
           echo -e "$RELEASE_SUMMARY"
           curl --request POST \

--- a/.github/workflows/release_module_release-channels.yml
+++ b/.github/workflows/release_module_release-channels.yml
@@ -554,18 +554,17 @@ jobs:
           notes_file=$(mktemp)
           printf '%s\n' "$pr_body" > "$notes_file"
 
-          gh release create "$TAG" \
-            --repo "$REPOSITORY" \
-            --title "$TAG" \
-            --notes-file "$notes_file"
+          echo "DRY RUN: gh release create \"$TAG\" --repo \"$REPOSITORY\" --title \"$TAG\" --notes-file \"$notes_file\""
+          echo "DRY RUN: release notes source PR #${pr_number}: ${pr_url}"
+          echo "DRY RUN: release notes content start"
+          cat "$notes_file"
+          echo "DRY RUN: release notes content end"
 
-          release_url=$(gh release view "$TAG" --repo "$REPOSITORY" --json url --jq '.url')
-
-          echo "release_status=created" >> "$GITHUB_OUTPUT"
-          echo "release_url=${release_url}" >> "$GITHUB_OUTPUT"
+          echo "release_status=dry-run" >> "$GITHUB_OUTPUT"
+          echo "release_url=" >> "$GITHUB_OUTPUT"
           echo "release_pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
           echo "release_pr_url=${pr_url}" >> "$GITHUB_OUTPUT"
-          echo "release_reason=GitHub release created from changelog PR #${pr_number}" >> "$GITHUB_OUTPUT"
+          echo "release_reason=Dry run: GitHub release would be created from changelog PR #${pr_number}" >> "$GITHUB_OUTPUT"
 
   send-release-results-to-loop:
     name: Send release results to Loop
@@ -581,7 +580,7 @@ jobs:
     steps:
       - name: Send results to Loop
         env:
-          LOOP_WEBHOOK_URL: ${{ secrets.LOOP_WEBHOOK_URL }}
+          LOOP_WEBHOOK_URL: ${{ secrets.LOOP_TEST_CHANNEL }}
           TAG: ${{ github.event.inputs.tag }}
           CHANNEL: ${{ github.event.inputs.channel }}
           RELEASE_TO_GITHUB: ${{ inputs.release_to_github }}

--- a/.github/workflows/release_module_release-channels.yml
+++ b/.github/workflows/release_module_release-channels.yml
@@ -521,22 +521,31 @@ jobs:
         run: |
           set -euo pipefail
 
+          echo "Checking GitHub release for tag: $TAG"
+          echo "Repository: $REPOSITORY"
+
           gh release view "$TAG" --repo "$REPOSITORY" >/tmp/release-view.txt 2>/dev/null && release_exists=true || release_exists=false
           if [[ "$release_exists" == "true" ]]; then
+            echo "GitHub release already exists for ${TAG}, skipping"
             release_url=$(gh release view "$TAG" --repo "$REPOSITORY" --json url --jq '.url')
+            echo "Existing release URL: ${release_url}"
             echo "release_status=skipped" >> "$GITHUB_OUTPUT"
             echo "release_url=${release_url}" >> "$GITHUB_OUTPUT"
             echo "release_reason=GitHub release already exists for ${TAG}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
+          echo "Searching merged changelog PRs for milestone ${TAG}"
           changelog_prs=$(gh pr list \
             --repo "$REPOSITORY" \
             --state merged \
             --search "label:changelog milestone:${TAG}" \
             --json number,title,url,body,milestone)
 
+          echo "$changelog_prs" | jq '.'
+
           changelog_pr_count=$(echo "$changelog_prs" | jq 'length')
+          echo "Found ${changelog_pr_count} merged changelog PR(s)"
           if [[ "$changelog_pr_count" -ne 1 ]]; then
             echo "Expected exactly one merged changelog PR for milestone ${TAG}, found ${changelog_pr_count}" >&2
             exit 1


### PR DESCRIPTION
## Description
Add automatic GitHub release handling to the `Deploy Prod` workflow and extend Loop notifications with GitHub release status.

## Why do we need it, and what problem does it solve?
`Deploy Prod` already publishes module versions to release channels, but GitHub releases are still created separately. This change lets the workflow automatically prepare a GitHub release from the generated changelog PR for the same version.

For testing, the release creation step is temporarily switched to dry-run mode and Loop notifications are sent to the test webhook channel. This makes it possible to validate PR lookup, release notes generation, and notification formatting without creating a real GitHub release or posting to the production Loop channel.

## What is the expected result?
1. Run `Deploy Prod` with `release_to_github=true` for a tag that has exactly one merged `changelog` PR with milestone equal to the tag.
2. Verify the workflow checks whether a GitHub release for the tag already exists.
3. If the release does not exist, verify the workflow finds the changelog PR and prints the exact `gh release create` command it would execute.
4. Verify the workflow logs the generated release notes content.
5. Verify the Loop notification is sent to `LOOP_TEST_CHANNEL` and includes a separate `GitHub release` section.
6. Verify `check_only=true` or `release_to_github=false` skips the GitHub release step.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: feature
summary: "Deploy Prod workflow can prepare GitHub releases from changelog PRs and report release status to Loop."
impact_level: low
```