### PR TITLE
fix(vd): fix data volume watcher

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vd/internal/watcher/datavolume_watcher.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/watcher/datavolume_watcher.go
@@ -53,8 +53,11 @@ func (w *DataVolumeWatcher) Watch(mgr manager.Manager, ctr controller.Controller
 						return true
 					}
 
-					if e.ObjectOld.Status.Phase != e.ObjectNew.Status.Phase && e.ObjectNew.Status.Phase == cdiv1.Succeeded {
-						return true
+					if e.ObjectOld.Status.Phase != e.ObjectNew.Status.Phase {
+						switch e.ObjectNew.Status.Phase {
+						case cdiv1.Succeeded, cdiv1.WaitForFirstConsumer, cdiv1.PendingPopulation:
+							return true
+						}
 					}
 
 					if e.ObjectOld.Status.ClaimName != e.ObjectNew.Status.ClaimName {

--- a/images/virtualization-artifact/pkg/controller/vi/internal/watcher/datavolume_watcher.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/watcher/datavolume_watcher.go
@@ -49,14 +49,16 @@ func (w *DataVolumeWatcher) Watch(mgr manager.Manager, ctr controller.Controller
 			),
 			predicate.TypedFuncs[*cdiv1.DataVolume]{
 				CreateFunc: func(e event.TypedCreateEvent[*cdiv1.DataVolume]) bool { return false },
-				DeleteFunc: func(e event.TypedDeleteEvent[*cdiv1.DataVolume]) bool { return false },
 				UpdateFunc: func(e event.TypedUpdateEvent[*cdiv1.DataVolume]) bool {
 					if e.ObjectOld.Status.Progress != e.ObjectNew.Status.Progress {
 						return true
 					}
 
-					if e.ObjectOld.Status.Phase != e.ObjectNew.Status.Phase && e.ObjectNew.Status.Phase == cdiv1.Succeeded {
-						return true
+					if e.ObjectOld.Status.Phase != e.ObjectNew.Status.Phase {
+						switch e.ObjectNew.Status.Phase {
+						case cdiv1.Succeeded, cdiv1.WaitForFirstConsumer, cdiv1.PendingPopulation:
+							return true
+						}
 					}
 
 					if e.ObjectOld.Status.ClaimName != e.ObjectNew.Status.ClaimName {
@@ -77,6 +79,7 @@ func (w *DataVolumeWatcher) Watch(mgr manager.Manager, ctr controller.Controller
 					dvRunning := service.GetDataVolumeCondition(cdiv1.DataVolumeRunning, e.ObjectNew.Status.Conditions)
 					return dvRunning != nil && dvRunning.Reason == "Error"
 				},
+				DeleteFunc: func(e event.TypedDeleteEvent[*cdiv1.DataVolume]) bool { return false },
 			},
 		),
 	); err != nil {


### PR DESCRIPTION
## Description

Fix data volume watcher.

The data volume entered the WFFC phase, but there was no watcher this event. As a result, the controller didn’t know that the data volume was ready and didn’t transition the disk into the WFFC phase.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries

```changes
section: vd
type: fix
summary: Fixed a potential issue where a virtual disk could get stuck in the Provisioning state when using a storage class with the WaitForFirstConsumer mode.
```
