### PR TITLE
test(usb): fix broken NodeUSBDevices e2e test

### DIFF
--- a/test/e2e/internal/util/vm.go
+++ b/test/e2e/internal/util/vm.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -182,6 +183,32 @@ func UntilSSHReady(f *framework.Framework, vm *v1alpha2.VirtualMachine, timeout 
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(result).To(ContainSubstring("test"))
 	}).WithTimeout(timeout).WithPolling(time.Second).Should(Succeed())
+}
+
+func UntilGuestCommandsReady(f *framework.Framework, vm *v1alpha2.VirtualMachine, commands []string, timeout time.Duration) {
+	GinkgoHelper()
+
+	cmd := fmt.Sprintf(`
+		missing=""
+		for command in %s; do
+			command -v "$command" >/dev/null 2>&1 || missing="$missing $command"
+		done
+		[ -z "$missing" ] || { echo "missing commands:$missing"; exit 1; }
+	`, shellArgs(commands))
+
+	Eventually(func() error {
+		_, err := f.SSHCommand(vm.Name, vm.Namespace, cmd, framework.WithSSHTimeout(5*time.Second))
+		return err
+	}).WithTimeout(timeout).WithPolling(time.Second).Should(Succeed())
+}
+
+func shellArgs(args []string) string {
+	quoted := make([]string, 0, len(args))
+	for _, arg := range args {
+		quoted = append(quoted, fmt.Sprintf("%q", arg))
+	}
+
+	return strings.Join(quoted, " ")
 }
 
 func UntilVMMigrationSucceeded(key client.ObjectKey, timeout time.Duration) {

--- a/test/e2e/vm/usb.go
+++ b/test/e2e/vm/usb.go
@@ -77,8 +77,8 @@ var _ = Describe("VirtualMachineUSB", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			util.UntilObjectPhase(string(v1alpha2.MachineRunning), framework.LongTimeout, t.VM)
-			util.UntilVMAgentReady(crclient.ObjectKeyFromObject(t.VM), framework.LongTimeout)
 			util.UntilSSHReady(f, t.VM, framework.MiddleTimeout)
+			util.UntilGuestCommandsReady(f, t.VM, []string{"sudo", "tee", "udevadm"}, framework.LongTimeout)
 		})
 
 		By("Waiting for USB device to be attached and ready", func() {

--- a/test/e2e/vm/usb.go
+++ b/test/e2e/vm/usb.go
@@ -265,36 +265,31 @@ func (t *VMUSBTest) assignNodeUSB() {
 
 func (t *VMUSBTest) mountUSB() {
 	mountCmd := fmt.Sprintf(`
-		set -e
-		last_error=/tmp/usb-mount.err
+		sudo mkdir -p /mnt/usb && \
+		(sudo mountpoint -q /mnt/usb || sudo mount %s /mnt/usb 2>/tmp/usb-mount.err || sudo mount -o rw %s /mnt/usb 2>>/tmp/usb-mount.err) && \
+		ls -la /mnt/usb
+	`, t.DevicePath, t.DevicePath)
 
-		for i in $(seq 1 300); do
-			sudo mkdir -p /mnt/usb
+	Eventually(func() error {
+		_, err := t.Framework.SSHCommand(t.VM.Name, t.VM.Namespace, mountCmd)
+		return err
+	}).WithTimeout(framework.MaxTimeout).WithPolling(time.Second).Should(Succeed(), t.usbDiagnostics())
+}
 
-			if sudo mountpoint -q /mnt/usb; then
-				ls -la /mnt/usb
-				exit 0
-			fi
+func (t *VMUSBTest) usbDiagnostics() string {
+	diagnosticsCmd := `
+		echo "mount error:" && cat /tmp/usb-mount.err 2>/dev/null || true
+		echo "mount:" && mount || true
+		echo "lsusb:" && lsusb || true
+		echo "dmesg:" && sudo dmesg | tail -n 100 || true
+	`
 
-			: > "$last_error"
-			if sudo mount %s /mnt/usb 2>"$last_error" || sudo mount -o rw %s /mnt/usb 2>>"$last_error"; then
-				ls -la /mnt/usb
-				exit 0
-			fi
+	result, err := t.Framework.SSHCommand(t.VM.Name, t.VM.Namespace, diagnosticsCmd, framework.WithSSHTimeout(framework.MiddleTimeout))
+	if err != nil {
+		return fmt.Sprintf("failed to collect USB diagnostics: %v", err)
+	}
 
-			sleep 1
-		done
-
-		echo "Failed to mount USB device %s" >&2
-		cat "$last_error" >&2 || true
-		mount >&2 || true
-		lsusb >&2 || true
-		sudo dmesg | tail -n 100 >&2 || true
-		exit 1
-	`, t.DevicePath, t.DevicePath, t.DevicePath)
-
-	_, err := t.Framework.SSHCommand(t.VM.Name, t.VM.Namespace, mountCmd, framework.WithSSHTimeout(framework.MaxTimeout))
-	Expect(err).NotTo(HaveOccurred())
+	return result
 }
 
 func nodeUSBAttachedCondition(nodeUSBDevice *v1alpha2.NodeUSBDevice) *metav1.Condition {

--- a/test/e2e/vm/usb.go
+++ b/test/e2e/vm/usb.go
@@ -263,47 +263,34 @@ func (t *VMUSBTest) assignNodeUSB() {
 }
 
 func (t *VMUSBTest) mountUSB() {
-	serial := t.NodeUSBDevice.Status.Attributes.Serial
-	Expect(serial).NotTo(BeEmpty(), "USB device serial must be set")
-
 	mountCmd := fmt.Sprintf(`
 		set -e
-		usb_serial=%q
-		sudo modprobe usb-storage 2>/dev/null || true
+		last_error=/tmp/usb-mount.err
 
 		for i in $(seq 1 300); do
-			for host in /sys/class/scsi_host/host*; do
-				if [ -w "$host/scan" ]; then
-					echo "- - -" | sudo tee "$host/scan" >/dev/null || true
-				fi
-			done
+			sudo mkdir -p /mnt/usb
 
-			usb_link=$(find /dev/disk/by-id -maxdepth 1 -name "usb-*${usb_serial}*" ! -name "*-part*" 2>/dev/null | head -n 1)
-			if [ -n "$usb_link" ]; then
-				break
+			if sudo mountpoint -q /mnt/usb; then
+				ls -la /mnt/usb
+				exit 0
 			fi
+
+			: > "$last_error"
+			if sudo mount %s /mnt/usb 2>"$last_error" || sudo mount -o rw %s /mnt/usb 2>>"$last_error"; then
+				ls -la /mnt/usb
+				exit 0
+			fi
+
 			sleep 1
 		done
 
-		if [ -z "$usb_link" ]; then
-			echo "USB block device by serial ${usb_serial} not found" >&2
-			lsusb >&2 || true
-			find /dev/disk -maxdepth 2 -type l -print >&2 || true
-			lsblk -a -o PATH,TRAN,TYPE,RM,MODEL,SERIAL >&2 || true
-			sudo dmesg | tail -n 100 >&2 || true
-			exit 1
-		fi
-
-		mount_device=$(readlink -f "$usb_link")
-		sudo mkdir -p /mnt/usb
-
-		if sudo mountpoint -q /mnt/usb; then
-			sudo umount /mnt/usb
-		fi
-
-		sudo mount -o rw "$mount_device" /mnt/usb
-		ls -la /mnt/usb
-	`, serial)
+		echo "Failed to mount USB device %s" >&2
+		cat "$last_error" >&2 || true
+		mount >&2 || true
+		lsusb >&2 || true
+		sudo dmesg | tail -n 100 >&2 || true
+		exit 1
+	`, t.DevicePath, t.DevicePath, t.DevicePath)
 
 	_, err := t.Framework.SSHCommand(t.VM.Name, t.VM.Namespace, mountCmd, framework.WithSSHTimeout(framework.MaxTimeout))
 	Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/vm/usb.go
+++ b/test/e2e/vm/usb.go
@@ -269,6 +269,10 @@ func (t *VMUSBTest) mountUSB() {
 		done
 		[ -n "$usb_present" ] || { echo "USB device with serial $usb_serial not found" >/tmp/usb-mount.err; exit 1; }
 
+		for host in /sys/class/scsi_host/host*; do
+			echo "- - -" | sudo tee "$host/scan" >/dev/null || true
+		done
+
 		for dev in /dev/sd*; do
 			[ -b "$dev" ] || continue
 			if lsblk -dno TRAN,RM "$dev" 2>/dev/null | grep -Eq '^usb[[:space:]]+1$'; then

--- a/test/e2e/vm/usb.go
+++ b/test/e2e/vm/usb.go
@@ -265,7 +265,14 @@ func (t *VMUSBTest) assignNodeUSB() {
 func (t *VMUSBTest) mountUSB() {
 	mountCmd := `
 		set -e
+		sudo modprobe usb-storage 2>/dev/null || true
 		for i in $(seq 1 120); do
+			for host in /sys/class/scsi_host/host*; do
+				if [ -w "$host/scan" ]; then
+					echo "- - -" | sudo tee "$host/scan" >/dev/null || true
+				fi
+			done
+
 			usb_device=""
 			for block in /sys/block/*; do
 				if [ ! -e "$block" ]; then
@@ -292,7 +299,9 @@ func (t *VMUSBTest) mountUSB() {
 		done
 		if [ -z "$usb_device" ]; then
 			echo "USB block device not found" >&2
+			lsusb >&2 || true
 			lsblk -a -o PATH,TRAN,TYPE,RM,MODEL >&2 || true
+			sudo dmesg | tail -n 100 >&2 || true
 			exit 1
 		fi
 

--- a/test/e2e/vm/usb.go
+++ b/test/e2e/vm/usb.go
@@ -137,6 +137,7 @@ var _ = Describe("VirtualMachineUSB", func() {
 
 				for _, dev := range vm.Status.USBDevices {
 					if dev.Name == t.NodeUSBDevice.Name && dev.Attached && dev.Ready {
+						t.DevicePath = fmt.Sprintf("/dev/bus/usb/%d/%d", dev.Address.Bus, dev.Address.Port)
 						return nil
 					}
 				}

--- a/test/e2e/vm/usb.go
+++ b/test/e2e/vm/usb.go
@@ -269,39 +269,24 @@ func (t *VMUSBTest) mountUSB() {
 		: > /tmp/usb-mount.err
 		for serial_file in /sys/bus/usb/devices/*/serial; do
 			if [ -f "$serial_file" ] && [ "$(cat "$serial_file")" = "$usb_serial" ]; then
-				usb_sys_device="$(dirname "$serial_file")"
+				usb_present=1
 				break
 			fi
 		done
-		[ -n "$usb_sys_device" ] || { echo "USB device with serial $usb_serial not found" >/tmp/usb-mount.err; exit 1; }
+		[ -n "$usb_present" ] || { echo "USB device with serial $usb_serial not found" >/tmp/usb-mount.err; exit 1; }
 
-		for block_path in /sys/block/*; do
-			[ -e "$block_path" ] || continue
-			block_name="$(basename "$block_path")"
-			if [ -b "/dev/$block_name" ] && lsblk -dno TRAN,RM "/dev/$block_name" 2>/dev/null | grep -Eq '^usb[[:space:]]+1$'; then
-				mount_device="/dev/$block_name"
+		for dev in /dev/sd*; do
+			[ -b "$dev" ] || continue
+			if lsblk -dno TRAN,RM "$dev" 2>/dev/null | grep -Eq '^usb[[:space:]]+1$'; then
+				mount_device="$dev"
 				break
 			fi
-			done
+		done
 		[ -n "$mount_device" ] || {
-			echo "USB block device for serial $usb_serial not found" >>/tmp/usb-mount.err
-			echo "usb_sys_device=$usb_sys_device" >>/tmp/usb-mount.err
-			find "$usb_sys_device" -maxdepth 8 -print >>/tmp/usb-mount.err 2>&1 || true
-			for block_path in /sys/block/*; do
-				[ -e "$block_path" ] || continue
-				block_name="$(basename "$block_path")"
-				echo "$(basename "$block_path") -> $(readlink -f "$block_path/device" 2>/dev/null || true)" >>/tmp/usb-mount.err
-				lsblk -dno NAME,PATH,TRAN,RM,SERIAL,MODEL "/dev/$block_name" >>/tmp/usb-mount.err 2>&1 || true
-			done
+			echo "USB block device not found for serial $usb_serial" >>/tmp/usb-mount.err
+			lsblk -a -o NAME,PATH,TYPE,TRAN,RM,SERIAL,MODEL >>/tmp/usb-mount.err 2>&1 || true
 			exit 1
 		}
-
-		for partition in /sys/block/$block_name/${block_name}[0-9]* /sys/block/$block_name/${block_name}p[0-9]*; do
-			if [ -e "$partition" ] && [ -b "/dev/$(basename "$partition")" ]; then
-				mount_device="/dev/$(basename "$partition")"
-				break
-			fi
-		done
 
 		sudo mkdir -p /mnt/usb && \
 		(sudo mountpoint -q /mnt/usb || sudo mount "$mount_device" /mnt/usb 2>>/tmp/usb-mount.err || sudo mount -o rw "$mount_device" /mnt/usb 2>>/tmp/usb-mount.err) && \

--- a/test/e2e/vm/usb.go
+++ b/test/e2e/vm/usb.go
@@ -257,11 +257,35 @@ func (t *VMUSBTest) assignNodeUSB() {
 }
 
 func (t *VMUSBTest) mountUSB() {
-	mountCmd := fmt.Sprintf(`
-		sudo mkdir -p /mnt/usb || true && \
-		sudo mount %s /mnt/usb 2>/dev/null || sudo mount -o rw %s /mnt/usb || true && \
-		ls -la /mnt/usb || true
-	`, t.DevicePath, t.DevicePath)
+	mountCmd := `
+		set -e
+		for i in $(seq 1 60); do
+			usb_device=$(lsblk -dpno PATH,TRAN,TYPE 2>/dev/null | awk "\$2 == \"usb\" && \$3 == \"disk\" { print \$1; exit }")
+			if [ -n "$usb_device" ]; then
+				break
+			fi
+			sleep 1
+		done
+		if [ -z "$usb_device" ]; then
+			echo "USB block device not found" >&2
+			exit 1
+		fi
+
+		mount_device="$usb_device"
+		for partition in "${usb_device}"[0-9]* "${usb_device}"p[0-9]*; do
+			if [ -b "$partition" ]; then
+				mount_device="$partition"
+				break
+			fi
+		done
+
+		sudo mkdir -p /mnt/usb
+		if sudo mountpoint -q /mnt/usb; then
+			sudo umount /mnt/usb
+		fi
+		sudo mount -o rw "$mount_device" /mnt/usb
+		ls -la /mnt/usb
+	`
 
 	_, err := t.Framework.SSHCommand(t.VM.Name, t.VM.Namespace, mountCmd)
 	Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/vm/usb.go
+++ b/test/e2e/vm/usb.go
@@ -292,7 +292,9 @@ func (t *VMUSBTest) mountUSB() {
 		if sudo mountpoint -q /mnt/usb; then
 			sudo umount /mnt/usb || true
 		fi
-		sudo mount "$mount_device" /mnt/usb 2>>/tmp/usb-mount.err || sudo mount -o rw "$mount_device" /mnt/usb 2>>/tmp/usb-mount.err
+		sudo mount -t auto "$mount_device" /mnt/usb 2>>/tmp/usb-mount.err || \
+			sudo mount -t vfat -o rw "$mount_device" /mnt/usb 2>>/tmp/usb-mount.err || \
+			sudo mount -o rw "$mount_device" /mnt/usb 2>>/tmp/usb-mount.err
 		ls -la /mnt/usb
 	`, serial)
 
@@ -311,6 +313,7 @@ func (t *VMUSBTest) usbDiagnostics() string {
 		echo "lsblk:" && lsblk -a -o NAME,PATH,TYPE,TRAN,RM,SERIAL,MODEL || true
 		echo "disks:" && for dev in /dev/sd*; do [ -b "$dev" ] && echo "== $dev ==" && lsblk -dno NAME,PATH,TRAN,RM,SERIAL,MODEL "$dev"; done || true
 		echo "lsusb:" && lsusb || true
+		echo "fstype:" && blkid /dev/sd* || true
 		echo "dmesg:" && sudo dmesg | tail -n 100 || true
 	`
 

--- a/test/e2e/vm/usb.go
+++ b/test/e2e/vm/usb.go
@@ -82,6 +82,7 @@ var _ = Describe("VirtualMachineUSB", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			util.UntilObjectPhase(string(v1alpha2.MachineRunning), framework.LongTimeout, t.VM)
+			util.UntilVMAgentReady(crclient.ObjectKeyFromObject(t.VM), framework.LongTimeout)
 			util.UntilSSHReady(f, t.VM, framework.MiddleTimeout)
 		})
 
@@ -264,8 +265,26 @@ func (t *VMUSBTest) assignNodeUSB() {
 func (t *VMUSBTest) mountUSB() {
 	mountCmd := `
 		set -e
-		for i in $(seq 1 60); do
-			usb_device=$(lsblk -dpno PATH,TRAN,TYPE 2>/dev/null | awk "\$2 == \"usb\" && \$3 == \"disk\" { print \$1; exit }")
+		for i in $(seq 1 120); do
+			usb_device=""
+			for block in /sys/block/*; do
+				if [ ! -e "$block" ]; then
+					continue
+				fi
+				device_path=$(readlink -f "$block/device" 2>/dev/null || true)
+				case "$device_path" in
+					*usb*)
+						usb_device="/dev/$(basename "$block")"
+						break
+						;;
+				esac
+			done
+			if [ -z "$usb_device" ]; then
+				usb_device=$(lsblk -dpno PATH,TRAN,TYPE 2>/dev/null | awk "\$2 == \"usb\" && \$3 == \"disk\" { print \$1; exit }")
+			fi
+			if [ -z "$usb_device" ]; then
+				usb_device=$(lsblk -dpno PATH,TYPE,RM 2>/dev/null | awk "\$2 == \"disk\" && \$3 == \"1\" { print \$1; exit }")
+			fi
 			if [ -n "$usb_device" ]; then
 				break
 			fi
@@ -273,6 +292,7 @@ func (t *VMUSBTest) mountUSB() {
 		done
 		if [ -z "$usb_device" ]; then
 			echo "USB block device not found" >&2
+			lsblk -a -o PATH,TRAN,TYPE,RM,MODEL >&2 || true
 			exit 1
 		fi
 
@@ -292,7 +312,7 @@ func (t *VMUSBTest) mountUSB() {
 		ls -la /mnt/usb
 	`
 
-	_, err := t.Framework.SSHCommand(t.VM.Name, t.VM.Namespace, mountCmd)
+	_, err := t.Framework.SSHCommand(t.VM.Name, t.VM.Namespace, mountCmd, framework.WithSSHTimeout(framework.LongTimeout))
 	Expect(err).NotTo(HaveOccurred())
 }
 

--- a/test/e2e/vm/usb.go
+++ b/test/e2e/vm/usb.go
@@ -62,13 +62,10 @@ var _ = Describe("VirtualMachineUSB", func() {
 			}
 
 			t.GenerateEnvironmentResources()
-			err := f.CreateWithDeferredDeletion(context.Background(), t.VD, t.VM)
+			err := f.CreateWithDeferredDeletion(context.Background(), t.VD)
 			Expect(err).NotTo(HaveOccurred())
 
 			t.assignNodeUSB()
-
-			util.UntilObjectPhase(string(v1alpha2.MachineRunning), framework.LongTimeout, t.VM)
-			util.UntilSSHReady(f, t.VM, framework.MiddleTimeout)
 		})
 
 		By("Verifying NodeUSBDevice is not attached before VM attachment", func() {
@@ -78,6 +75,14 @@ var _ = Describe("VirtualMachineUSB", func() {
 				g.Expect(nodeUSBAttachedCondition(nodeUSBDevice)).NotTo(BeNil())
 				g.Expect(nodeUSBAttachedCondition(nodeUSBDevice).Status).To(Equal(metav1.ConditionFalse))
 			}).WithTimeout(framework.MaxTimeout).WithPolling(time.Second).Should(Succeed())
+		})
+
+		By("Creating VM with USB device", func() {
+			err := f.CreateWithDeferredDeletion(context.Background(), t.VM)
+			Expect(err).NotTo(HaveOccurred())
+
+			util.UntilObjectPhase(string(v1alpha2.MachineRunning), framework.LongTimeout, t.VM)
+			util.UntilSSHReady(f, t.VM, framework.MiddleTimeout)
 		})
 
 		By("Waiting for USB device to be attached and ready", func() {

--- a/test/e2e/vm/usb.go
+++ b/test/e2e/vm/usb.go
@@ -269,9 +269,15 @@ func (t *VMUSBTest) mountUSB() {
 		done
 		[ -n "$usb_present" ] || { echo "USB device with serial $usb_serial not found" >/tmp/usb-mount.err; exit 1; }
 
+		sudo modprobe usb-storage
+		sudo modprobe uas || true
+
 		for host in /sys/class/scsi_host/host*; do
 			echo "- - -" | sudo tee "$host/scan" >/dev/null || true
 		done
+
+		sudo udevadm trigger
+		sudo udevadm settle
 
 		for dev in /dev/sd*; do
 			[ -b "$dev" ] || continue

--- a/test/e2e/vm/usb.go
+++ b/test/e2e/vm/usb.go
@@ -277,24 +277,21 @@ func (t *VMUSBTest) mountUSB() {
 
 		for block_path in /sys/block/*; do
 			[ -e "$block_path" ] || continue
-			device_realpath="$(readlink -f "$block_path/device" 2>/dev/null || true)"
-			case "$device_realpath" in
-				"$usb_sys_device"/*)
-					block_name="$(basename "$block_path")"
-					if [ -b "/dev/$block_name" ]; then
-						mount_device="/dev/$block_name"
-						break
-					fi
-					;;
-			esac
-			done
+			block_name="$(basename "$block_path")"
+			if [ -b "/dev/$block_name" ] && udevadm info --query=property --name "/dev/$block_name" 2>/dev/null | grep -q "ID_SERIAL_SHORT=$usb_serial"; then
+				mount_device="/dev/$block_name"
+				break
+			fi
+		done
 		[ -n "$mount_device" ] || {
 			echo "USB block device for serial $usb_serial not found" >>/tmp/usb-mount.err
 			echo "usb_sys_device=$usb_sys_device" >>/tmp/usb-mount.err
 			find "$usb_sys_device" -maxdepth 8 -print >>/tmp/usb-mount.err 2>&1 || true
 			for block_path in /sys/block/*; do
 				[ -e "$block_path" ] || continue
+				block_name="$(basename "$block_path")"
 				echo "$(basename "$block_path") -> $(readlink -f "$block_path/device" 2>/dev/null || true)" >>/tmp/usb-mount.err
+				udevadm info --query=property --name "/dev/$block_name" >>/tmp/usb-mount.err 2>&1 || true
 			done
 			exit 1
 		}
@@ -324,6 +321,7 @@ func (t *VMUSBTest) usbDiagnostics() string {
 		echo "usb serials:" && for serial_file in /sys/bus/usb/devices/*/serial; do [ -f "$serial_file" ] && echo "$serial_file=$(cat "$serial_file")"; done || true
 		echo "usb sysfs:" && find /sys/bus/usb/devices -maxdepth 3 -print || true
 		echo "lsblk:" && lsblk -a -o NAME,PATH,TYPE,TRAN,RM,SERIAL,MODEL || true
+		echo "udevadm:" && for dev in /dev/sd*; do [ -b "$dev" ] && echo "== $dev ==" && udevadm info --query=property --name "$dev"; done || true
 		echo "lsusb:" && lsusb || true
 		echo "dmesg:" && sudo dmesg | tail -n 100 || true
 	`

--- a/test/e2e/vm/usb.go
+++ b/test/e2e/vm/usb.go
@@ -93,7 +93,6 @@ var _ = Describe("VirtualMachineUSB", func() {
 
 				for _, dev := range vm.Status.USBDevices {
 					if dev.Name == t.NodeUSBDevice.Name && dev.Attached && dev.Ready {
-						t.DevicePath = fmt.Sprintf("/dev/bus/usb/%d/%d", dev.Address.Bus, dev.Address.Port)
 						return nil
 					}
 				}
@@ -137,7 +136,6 @@ var _ = Describe("VirtualMachineUSB", func() {
 
 				for _, dev := range vm.Status.USBDevices {
 					if dev.Name == t.NodeUSBDevice.Name && dev.Attached && dev.Ready {
-						t.DevicePath = fmt.Sprintf("/dev/bus/usb/%d/%d", dev.Address.Bus, dev.Address.Port)
 						return nil
 					}
 				}
@@ -174,7 +172,6 @@ type VMUSBTest struct {
 	VM            *v1alpha2.VirtualMachine
 	VD            *v1alpha2.VirtualDisk
 	NodeUSBDevice *v1alpha2.NodeUSBDevice
-	DevicePath    string
 
 	testFile    string
 	testContent string

--- a/test/e2e/vm/usb.go
+++ b/test/e2e/vm/usb.go
@@ -266,7 +266,7 @@ func (t *VMUSBTest) mountUSB() {
 	mountCmd := `
 		set -e
 		sudo modprobe usb-storage 2>/dev/null || true
-		for i in $(seq 1 120); do
+		for i in $(seq 1 300); do
 			for host in /sys/class/scsi_host/host*; do
 				if [ -w "$host/scan" ]; then
 					echo "- - -" | sudo tee "$host/scan" >/dev/null || true
@@ -321,7 +321,7 @@ func (t *VMUSBTest) mountUSB() {
 		ls -la /mnt/usb
 	`
 
-	_, err := t.Framework.SSHCommand(t.VM.Name, t.VM.Namespace, mountCmd, framework.WithSSHTimeout(framework.LongTimeout))
+	_, err := t.Framework.SSHCommand(t.VM.Name, t.VM.Namespace, mountCmd, framework.WithSSHTimeout(framework.MaxTimeout))
 	Expect(err).NotTo(HaveOccurred())
 }
 

--- a/test/e2e/vm/usb.go
+++ b/test/e2e/vm/usb.go
@@ -265,12 +265,6 @@ func (t *VMUSBTest) assignNodeUSB() {
 func (t *VMUSBTest) mountUSB() {
 	mountCmd := `
 		set -e
-		root_source=$(findmnt -n -o SOURCE /)
-		root_disk="$(lsblk -no PKNAME "$root_source" 2>/dev/null || true)"
-		if [ -z "$root_disk" ]; then
-			root_disk="$(basename "$root_source")"
-		fi
-
 		for i in $(seq 1 120); do
 			usb_device=""
 			for block in /sys/block/*; do
@@ -290,14 +284,6 @@ func (t *VMUSBTest) mountUSB() {
 			fi
 			if [ -z "$usb_device" ]; then
 				usb_device=$(lsblk -dpno PATH,TYPE,RM 2>/dev/null | awk "\$2 == \"disk\" && \$3 == \"1\" { print \$1; exit }")
-			fi
-			if [ -z "$usb_device" ]; then
-				for disk in $(lsblk -dpno PATH,TYPE 2>/dev/null | awk "\$2 == \"disk\" { print \$1 }"); do
-					if [ "$(basename "$disk")" != "$root_disk" ]; then
-						usb_device="$disk"
-						break
-					fi
-				done
 			fi
 			if [ -n "$usb_device" ]; then
 				break

--- a/test/e2e/vm/usb.go
+++ b/test/e2e/vm/usb.go
@@ -278,11 +278,11 @@ func (t *VMUSBTest) mountUSB() {
 		for block_path in /sys/block/*; do
 			[ -e "$block_path" ] || continue
 			block_name="$(basename "$block_path")"
-			if [ -b "/dev/$block_name" ] && udevadm info --query=property --name "/dev/$block_name" 2>/dev/null | grep -q "ID_SERIAL_SHORT=$usb_serial"; then
+			if [ -b "/dev/$block_name" ] && lsblk -dno TRAN,RM "/dev/$block_name" 2>/dev/null | grep -Eq '^usb[[:space:]]+1$'; then
 				mount_device="/dev/$block_name"
 				break
 			fi
-		done
+			done
 		[ -n "$mount_device" ] || {
 			echo "USB block device for serial $usb_serial not found" >>/tmp/usb-mount.err
 			echo "usb_sys_device=$usb_sys_device" >>/tmp/usb-mount.err
@@ -291,7 +291,7 @@ func (t *VMUSBTest) mountUSB() {
 				[ -e "$block_path" ] || continue
 				block_name="$(basename "$block_path")"
 				echo "$(basename "$block_path") -> $(readlink -f "$block_path/device" 2>/dev/null || true)" >>/tmp/usb-mount.err
-				udevadm info --query=property --name "/dev/$block_name" >>/tmp/usb-mount.err 2>&1 || true
+				lsblk -dno NAME,PATH,TRAN,RM,SERIAL,MODEL "/dev/$block_name" >>/tmp/usb-mount.err 2>&1 || true
 			done
 			exit 1
 		}
@@ -321,7 +321,7 @@ func (t *VMUSBTest) usbDiagnostics() string {
 		echo "usb serials:" && for serial_file in /sys/bus/usb/devices/*/serial; do [ -f "$serial_file" ] && echo "$serial_file=$(cat "$serial_file")"; done || true
 		echo "usb sysfs:" && find /sys/bus/usb/devices -maxdepth 3 -print || true
 		echo "lsblk:" && lsblk -a -o NAME,PATH,TYPE,TRAN,RM,SERIAL,MODEL || true
-		echo "udevadm:" && for dev in /dev/sd*; do [ -b "$dev" ] && echo "== $dev ==" && udevadm info --query=property --name "$dev"; done || true
+		echo "disks:" && for dev in /dev/sd*; do [ -b "$dev" ] && echo "== $dev ==" && lsblk -dno NAME,PATH,TRAN,RM,SERIAL,MODEL "$dev"; done || true
 		echo "lsusb:" && lsusb || true
 		echo "dmesg:" && sudo dmesg | tail -n 100 || true
 	`

--- a/test/e2e/vm/usb.go
+++ b/test/e2e/vm/usb.go
@@ -265,6 +265,12 @@ func (t *VMUSBTest) assignNodeUSB() {
 func (t *VMUSBTest) mountUSB() {
 	mountCmd := `
 		set -e
+		root_source=$(findmnt -n -o SOURCE /)
+		root_disk="$(lsblk -no PKNAME "$root_source" 2>/dev/null || true)"
+		if [ -z "$root_disk" ]; then
+			root_disk="$(basename "$root_source")"
+		fi
+
 		for i in $(seq 1 120); do
 			usb_device=""
 			for block in /sys/block/*; do
@@ -284,6 +290,14 @@ func (t *VMUSBTest) mountUSB() {
 			fi
 			if [ -z "$usb_device" ]; then
 				usb_device=$(lsblk -dpno PATH,TYPE,RM 2>/dev/null | awk "\$2 == \"disk\" && \$3 == \"1\" { print \$1; exit }")
+			fi
+			if [ -z "$usb_device" ]; then
+				for disk in $(lsblk -dpno PATH,TYPE 2>/dev/null | awk "\$2 == \"disk\" { print \$1 }"); do
+					if [ "$(basename "$disk")" != "$root_disk" ]; then
+						usb_device="$disk"
+						break
+					fi
+				done
 			fi
 			if [ -n "$usb_device" ]; then
 				break

--- a/test/e2e/vm/usb.go
+++ b/test/e2e/vm/usb.go
@@ -264,11 +264,57 @@ func (t *VMUSBTest) assignNodeUSB() {
 }
 
 func (t *VMUSBTest) mountUSB() {
+	serial := t.NodeUSBDevice.Status.Attributes.Serial
+	Expect(serial).NotTo(BeEmpty(), "USB device serial must be set")
+
 	mountCmd := fmt.Sprintf(`
+		set -e
+		usb_serial=%q
+		sudo modprobe usb-storage 2>/dev/null || true
+
+		for host in /sys/class/scsi_host/host*; do
+			if [ -w "$host/scan" ]; then
+				echo "- - -" | sudo tee "$host/scan" >/dev/null || true
+			fi
+		done
+
+		usb_sys_device=""
+		for serial_file in /sys/bus/usb/devices/*/serial; do
+			if [ -f "$serial_file" ] && [ "$(cat "$serial_file")" = "$usb_serial" ]; then
+				usb_sys_device="$(dirname "$serial_file")"
+				break
+			fi
+		done
+		if [ -z "$usb_sys_device" ]; then
+			echo "USB device with serial $usb_serial not found" >/tmp/usb-mount.err
+			exit 1
+		fi
+
+		block_name=""
+		for block_path in $(find "$usb_sys_device" -path "*/block/*" -type d 2>/dev/null); do
+			name="$(basename "$block_path")"
+			if [ -b "/dev/$name" ]; then
+				block_name="$name"
+				break
+			fi
+		done
+		if [ -z "$block_name" ]; then
+			echo "USB block device for serial $usb_serial not found" >/tmp/usb-mount.err
+			exit 1
+		fi
+
+		mount_device="/dev/$block_name"
+		for partition in /sys/block/$block_name/${block_name}[0-9]* /sys/block/$block_name/${block_name}p[0-9]*; do
+			if [ -e "$partition" ] && [ -b "/dev/$(basename "$partition")" ]; then
+				mount_device="/dev/$(basename "$partition")"
+				break
+			fi
+		done
+
 		sudo mkdir -p /mnt/usb && \
-		(sudo mountpoint -q /mnt/usb || sudo mount %s /mnt/usb 2>/tmp/usb-mount.err || sudo mount -o rw %s /mnt/usb 2>>/tmp/usb-mount.err) && \
+		(sudo mountpoint -q /mnt/usb || sudo mount "$mount_device" /mnt/usb 2>/tmp/usb-mount.err || sudo mount -o rw "$mount_device" /mnt/usb 2>>/tmp/usb-mount.err) && \
 		ls -la /mnt/usb
-	`, t.DevicePath, t.DevicePath)
+	`, serial)
 
 	Eventually(func() error {
 		_, err := t.Framework.SSHCommand(t.VM.Name, t.VM.Namespace, mountCmd)
@@ -280,6 +326,7 @@ func (t *VMUSBTest) usbDiagnostics() string {
 	diagnosticsCmd := `
 		echo "mount error:" && cat /tmp/usb-mount.err 2>/dev/null || true
 		echo "mount:" && mount || true
+		echo "usb serials:" && for serial_file in /sys/bus/usb/devices/*/serial; do [ -f "$serial_file" ] && echo "$serial_file=$(cat "$serial_file")"; done || true
 		echo "lsusb:" && lsusb || true
 		echo "dmesg:" && sudo dmesg | tail -n 100 || true
 	`

--- a/test/e2e/vm/usb.go
+++ b/test/e2e/vm/usb.go
@@ -116,7 +116,7 @@ var _ = Describe("VirtualMachineUSB", func() {
 		})
 
 		By("Writing data to USB device", func() {
-			result, err := t.Framework.SSHCommand(t.VM.Name, t.VM.Namespace, fmt.Sprintf("echo \"%s\" | sudo tee %s", t.testContent, t.testFile))
+			result, err := t.Framework.SSHCommand(t.VM.Name, t.VM.Namespace, fmt.Sprintf("echo \"%s\" | sudo tee %s && sudo sync && sudo umount /mnt/usb", t.testContent, t.testFile))
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(ContainSubstring(t.testContent))

--- a/test/e2e/vm/usb.go
+++ b/test/e2e/vm/usb.go
@@ -69,12 +69,7 @@ var _ = Describe("VirtualMachineUSB", func() {
 		})
 
 		By("Verifying NodeUSBDevice is not attached before VM attachment", func() {
-			Eventually(func(g Gomega) {
-				nodeUSBDevice, err := t.Framework.VirtClient().NodeUSBDevices().Get(t.ctx, t.NodeUSBDevice.Name, metav1.GetOptions{})
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(nodeUSBAttachedCondition(nodeUSBDevice)).NotTo(BeNil())
-				g.Expect(nodeUSBAttachedCondition(nodeUSBDevice).Status).To(Equal(metav1.ConditionFalse))
-			}).WithTimeout(framework.MaxTimeout).WithPolling(time.Second).Should(Succeed())
+			t.waitForNodeUSBAttached(metav1.ConditionFalse)
 		})
 
 		By("Creating VM with USB device", func() {
@@ -87,27 +82,11 @@ var _ = Describe("VirtualMachineUSB", func() {
 		})
 
 		By("Waiting for USB device to be attached and ready", func() {
-			Eventually(func() error {
-				vm, err := t.Framework.VirtClient().VirtualMachines(t.VM.Namespace).Get(t.ctx, t.VM.Name, metav1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-
-				for _, dev := range vm.Status.USBDevices {
-					if dev.Name == t.NodeUSBDevice.Name && dev.Attached && dev.Ready {
-						return nil
-					}
-				}
-
-				return fmt.Errorf("USB device %s not attached or not ready", t.NodeUSBDevice.Name)
-			}).WithTimeout(framework.MaxTimeout).WithPolling(time.Second).Should(Succeed())
+			t.waitForVMUSBReady("USB device %s not attached or not ready")
 		})
 
 		By("Verifying NodeUSBDevice is attached", func() {
-			Eventually(func(g Gomega) {
-				nodeUSBDevice, err := t.Framework.VirtClient().NodeUSBDevices().Get(t.ctx, t.NodeUSBDevice.Name, metav1.GetOptions{})
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(nodeUSBAttachedCondition(nodeUSBDevice)).NotTo(BeNil())
-				g.Expect(nodeUSBAttachedCondition(nodeUSBDevice).Status).To(Equal(metav1.ConditionTrue))
-			}).WithTimeout(framework.MaxTimeout).WithPolling(time.Second).Should(Succeed())
+			t.waitForNodeUSBAttached(metav1.ConditionTrue)
 		})
 
 		By("Mounting USB device", func() {
@@ -115,10 +94,7 @@ var _ = Describe("VirtualMachineUSB", func() {
 		})
 
 		By("Writing data to USB device", func() {
-			result, err := t.Framework.SSHCommand(t.VM.Name, t.VM.Namespace, fmt.Sprintf("echo \"%s\" | sudo tee %s && sudo sync && sudo umount /mnt/usb", t.testContent, t.testFile))
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(ContainSubstring(t.testContent))
+			t.writeUSBTestData()
 		})
 
 		By("Migrating VM", func() {
@@ -130,27 +106,11 @@ var _ = Describe("VirtualMachineUSB", func() {
 		})
 
 		By("Waiting for USB device to be ready after migration", func() {
-			Eventually(func() error {
-				vm, err := t.Framework.VirtClient().VirtualMachines(t.VM.Namespace).Get(t.ctx, t.VM.Name, metav1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-
-				for _, dev := range vm.Status.USBDevices {
-					if dev.Name == t.NodeUSBDevice.Name && dev.Attached && dev.Ready {
-						return nil
-					}
-				}
-
-				return fmt.Errorf("USB device %s not ready after migration", t.NodeUSBDevice.Name)
-			}).WithTimeout(framework.MaxTimeout).WithPolling(time.Second).Should(Succeed())
+			t.waitForVMUSBReady("USB device %s not ready after migration")
 		})
 
 		By("Verifying NodeUSBDevice is attached after migration", func() {
-			Eventually(func(g Gomega) {
-				nodeUSBDevice, err := t.Framework.VirtClient().NodeUSBDevices().Get(t.ctx, t.NodeUSBDevice.Name, metav1.GetOptions{})
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(nodeUSBAttachedCondition(nodeUSBDevice)).NotTo(BeNil())
-				g.Expect(nodeUSBAttachedCondition(nodeUSBDevice).Status).To(Equal(metav1.ConditionTrue))
-			}).WithTimeout(framework.MaxTimeout).WithPolling(time.Second).Should(Succeed())
+			t.waitForNodeUSBAttached(metav1.ConditionTrue)
 		})
 
 		By("Remounting USB device after migration", func() {
@@ -158,9 +118,7 @@ var _ = Describe("VirtualMachineUSB", func() {
 		})
 
 		By("Verifying data persists after migration", func() {
-			result, err := t.Framework.SSHCommand(t.VM.Name, t.VM.Namespace, fmt.Sprintf("cat %s", t.testFile))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(ContainSubstring(t.testContent))
+			t.verifyUSBTestData()
 		})
 	})
 })
@@ -258,6 +216,42 @@ func (t *VMUSBTest) assignNodeUSB() {
 
 		return nil
 	}).WithTimeout(framework.MaxTimeout).WithPolling(time.Second).Should(Succeed())
+}
+
+func (t *VMUSBTest) waitForNodeUSBAttached(status metav1.ConditionStatus) {
+	Eventually(func(g Gomega) {
+		nodeUSBDevice, err := t.Framework.VirtClient().NodeUSBDevices().Get(t.ctx, t.NodeUSBDevice.Name, metav1.GetOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(nodeUSBAttachedCondition(nodeUSBDevice)).NotTo(BeNil())
+		g.Expect(nodeUSBAttachedCondition(nodeUSBDevice).Status).To(Equal(status))
+	}).WithTimeout(framework.MaxTimeout).WithPolling(time.Second).Should(Succeed())
+}
+
+func (t *VMUSBTest) waitForVMUSBReady(message string) {
+	Eventually(func() error {
+		vm, err := t.Framework.VirtClient().VirtualMachines(t.VM.Namespace).Get(t.ctx, t.VM.Name, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		for _, dev := range vm.Status.USBDevices {
+			if dev.Name == t.NodeUSBDevice.Name && dev.Attached && dev.Ready {
+				return nil
+			}
+		}
+
+		return fmt.Errorf(message, t.NodeUSBDevice.Name)
+	}).WithTimeout(framework.MaxTimeout).WithPolling(time.Second).Should(Succeed())
+}
+
+func (t *VMUSBTest) writeUSBTestData() {
+	result, err := t.Framework.SSHCommand(t.VM.Name, t.VM.Namespace, fmt.Sprintf("echo \"%s\" | sudo tee %s && sudo sync && sudo umount /mnt/usb", t.testContent, t.testFile))
+	Expect(err).NotTo(HaveOccurred())
+	Expect(result).To(ContainSubstring(t.testContent))
+}
+
+func (t *VMUSBTest) verifyUSBTestData() {
+	result, err := t.Framework.SSHCommand(t.VM.Name, t.VM.Namespace, fmt.Sprintf("cat %s", t.testFile))
+	Expect(err).NotTo(HaveOccurred())
+	Expect(result).To(ContainSubstring(t.testContent))
 }
 
 func (t *VMUSBTest) mountUSB() {

--- a/test/e2e/vm/usb.go
+++ b/test/e2e/vm/usb.go
@@ -303,7 +303,7 @@ func (t *VMUSBTest) mountUSB() {
 	Eventually(func() error {
 		_, err := t.Framework.SSHCommand(t.VM.Name, t.VM.Namespace, mountCmd, framework.WithSSHTimeout(framework.MiddleTimeout))
 		return err
-	}).WithTimeout(framework.MaxTimeout).WithPolling(time.Second).Should(Succeed(), t.usbDiagnostics())
+	}).WithTimeout(framework.MiddleTimeout).WithPolling(time.Second).Should(Succeed(), t.usbDiagnostics())
 }
 
 func (t *VMUSBTest) usbDiagnostics() string {

--- a/test/e2e/vm/usb.go
+++ b/test/e2e/vm/usb.go
@@ -275,16 +275,27 @@ func (t *VMUSBTest) mountUSB() {
 		done
 		[ -n "$usb_sys_device" ] || { echo "USB device with serial $usb_serial not found" >/tmp/usb-mount.err; exit 1; }
 
-		for block_path in $(find "$usb_sys_device" -path "*/block/*" -type d 2>/dev/null); do
-			block_name="$(basename "$block_path")"
-			if [ -b "/dev/$block_name" ]; then
-				mount_device="/dev/$block_name"
-				break
-			fi
-		done
+		for block_path in /sys/block/*; do
+			[ -e "$block_path" ] || continue
+			device_realpath="$(readlink -f "$block_path/device" 2>/dev/null || true)"
+			case "$device_realpath" in
+				"$usb_sys_device"/*)
+					block_name="$(basename "$block_path")"
+					if [ -b "/dev/$block_name" ]; then
+						mount_device="/dev/$block_name"
+						break
+					fi
+					;;
+			esac
+			done
 		[ -n "$mount_device" ] || {
 			echo "USB block device for serial $usb_serial not found" >>/tmp/usb-mount.err
-			find "$usb_sys_device" -maxdepth 6 -print >>/tmp/usb-mount.err 2>&1 || true
+			echo "usb_sys_device=$usb_sys_device" >>/tmp/usb-mount.err
+			find "$usb_sys_device" -maxdepth 8 -print >>/tmp/usb-mount.err 2>&1 || true
+			for block_path in /sys/block/*; do
+				[ -e "$block_path" ] || continue
+				echo "$(basename "$block_path") -> $(readlink -f "$block_path/device" 2>/dev/null || true)" >>/tmp/usb-mount.err
+			done
 			exit 1
 		}
 

--- a/test/e2e/vm/usb.go
+++ b/test/e2e/vm/usb.go
@@ -263,9 +263,14 @@ func (t *VMUSBTest) assignNodeUSB() {
 }
 
 func (t *VMUSBTest) mountUSB() {
-	mountCmd := `
+	serial := t.NodeUSBDevice.Status.Attributes.Serial
+	Expect(serial).NotTo(BeEmpty(), "USB device serial must be set")
+
+	mountCmd := fmt.Sprintf(`
 		set -e
+		usb_serial=%q
 		sudo modprobe usb-storage 2>/dev/null || true
+
 		for i in $(seq 1 300); do
 			for host in /sys/class/scsi_host/host*; do
 				if [ -w "$host/scan" ]; then
@@ -273,53 +278,32 @@ func (t *VMUSBTest) mountUSB() {
 				fi
 			done
 
-			usb_device=""
-			for block in /sys/block/*; do
-				if [ ! -e "$block" ]; then
-					continue
-				fi
-				device_path=$(readlink -f "$block/device" 2>/dev/null || true)
-				case "$device_path" in
-					*usb*)
-						usb_device="/dev/$(basename "$block")"
-						break
-						;;
-				esac
-			done
-			if [ -z "$usb_device" ]; then
-				usb_device=$(lsblk -dpno PATH,TRAN,TYPE 2>/dev/null | awk "\$2 == \"usb\" && \$3 == \"disk\" { print \$1; exit }")
-			fi
-			if [ -z "$usb_device" ]; then
-				usb_device=$(lsblk -dpno PATH,TYPE,RM 2>/dev/null | awk "\$2 == \"disk\" && \$3 == \"1\" { print \$1; exit }")
-			fi
-			if [ -n "$usb_device" ]; then
+			usb_link=$(find /dev/disk/by-id -maxdepth 1 -name "usb-*${usb_serial}*" ! -name "*-part*" 2>/dev/null | head -n 1)
+			if [ -n "$usb_link" ]; then
 				break
 			fi
 			sleep 1
 		done
-		if [ -z "$usb_device" ]; then
-			echo "USB block device not found" >&2
+
+		if [ -z "$usb_link" ]; then
+			echo "USB block device by serial ${usb_serial} not found" >&2
 			lsusb >&2 || true
-			lsblk -a -o PATH,TRAN,TYPE,RM,MODEL >&2 || true
+			find /dev/disk -maxdepth 2 -type l -print >&2 || true
+			lsblk -a -o PATH,TRAN,TYPE,RM,MODEL,SERIAL >&2 || true
 			sudo dmesg | tail -n 100 >&2 || true
 			exit 1
 		fi
 
-		mount_device="$usb_device"
-		for partition in "${usb_device}"[0-9]* "${usb_device}"p[0-9]*; do
-			if [ -b "$partition" ]; then
-				mount_device="$partition"
-				break
-			fi
-		done
-
+		mount_device=$(readlink -f "$usb_link")
 		sudo mkdir -p /mnt/usb
+
 		if sudo mountpoint -q /mnt/usb; then
 			sudo umount /mnt/usb
 		fi
+
 		sudo mount -o rw "$mount_device" /mnt/usb
 		ls -la /mnt/usb
-	`
+	`, serial)
 
 	_, err := t.Framework.SSHCommand(t.VM.Name, t.VM.Namespace, mountCmd, framework.WithSSHTimeout(framework.MaxTimeout))
 	Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/vm/usb.go
+++ b/test/e2e/vm/usb.go
@@ -288,8 +288,11 @@ func (t *VMUSBTest) mountUSB() {
 			exit 1
 		}
 
-		sudo mkdir -p /mnt/usb && \
-		(sudo mountpoint -q /mnt/usb || sudo mount "$mount_device" /mnt/usb 2>>/tmp/usb-mount.err || sudo mount -o rw "$mount_device" /mnt/usb 2>>/tmp/usb-mount.err) && \
+		sudo mkdir -p /mnt/usb
+		if sudo mountpoint -q /mnt/usb; then
+			sudo umount /mnt/usb || true
+		fi
+		sudo mount "$mount_device" /mnt/usb 2>>/tmp/usb-mount.err || sudo mount -o rw "$mount_device" /mnt/usb 2>>/tmp/usb-mount.err
 		ls -la /mnt/usb
 	`, serial)
 

--- a/test/e2e/vm/usb.go
+++ b/test/e2e/vm/usb.go
@@ -265,42 +265,24 @@ func (t *VMUSBTest) mountUSB() {
 	Expect(serial).NotTo(BeEmpty(), "USB device serial must be set")
 
 	mountCmd := fmt.Sprintf(`
-		set -e
 		usb_serial=%q
-		sudo modprobe usb-storage 2>/dev/null || true
-
-		for host in /sys/class/scsi_host/host*; do
-			if [ -w "$host/scan" ]; then
-				echo "- - -" | sudo tee "$host/scan" >/dev/null || true
-			fi
-		done
-
-		usb_sys_device=""
 		for serial_file in /sys/bus/usb/devices/*/serial; do
 			if [ -f "$serial_file" ] && [ "$(cat "$serial_file")" = "$usb_serial" ]; then
 				usb_sys_device="$(dirname "$serial_file")"
 				break
 			fi
 		done
-		if [ -z "$usb_sys_device" ]; then
-			echo "USB device with serial $usb_serial not found" >/tmp/usb-mount.err
-			exit 1
-		fi
+		[ -n "$usb_sys_device" ] || { echo "USB device with serial $usb_serial not found" >/tmp/usb-mount.err; exit 1; }
 
-		block_name=""
 		for block_path in $(find "$usb_sys_device" -path "*/block/*" -type d 2>/dev/null); do
-			name="$(basename "$block_path")"
-			if [ -b "/dev/$name" ]; then
-				block_name="$name"
+			block_name="$(basename "$block_path")"
+			if [ -b "/dev/$block_name" ]; then
+				mount_device="/dev/$block_name"
 				break
 			fi
 		done
-		if [ -z "$block_name" ]; then
-			echo "USB block device for serial $usb_serial not found" >/tmp/usb-mount.err
-			exit 1
-		fi
+		[ -n "$mount_device" ] || { echo "USB block device for serial $usb_serial not found" >/tmp/usb-mount.err; exit 1; }
 
-		mount_device="/dev/$block_name"
 		for partition in /sys/block/$block_name/${block_name}[0-9]* /sys/block/$block_name/${block_name}p[0-9]*; do
 			if [ -e "$partition" ] && [ -b "/dev/$(basename "$partition")" ]; then
 				mount_device="/dev/$(basename "$partition")"
@@ -314,7 +296,7 @@ func (t *VMUSBTest) mountUSB() {
 	`, serial)
 
 	Eventually(func() error {
-		_, err := t.Framework.SSHCommand(t.VM.Name, t.VM.Namespace, mountCmd)
+		_, err := t.Framework.SSHCommand(t.VM.Name, t.VM.Namespace, mountCmd, framework.WithSSHTimeout(framework.MiddleTimeout))
 		return err
 	}).WithTimeout(framework.MaxTimeout).WithPolling(time.Second).Should(Succeed(), t.usbDiagnostics())
 }

--- a/test/e2e/vm/usb.go
+++ b/test/e2e/vm/usb.go
@@ -266,6 +266,7 @@ func (t *VMUSBTest) mountUSB() {
 
 	mountCmd := fmt.Sprintf(`
 		usb_serial=%q
+		: > /tmp/usb-mount.err
 		for serial_file in /sys/bus/usb/devices/*/serial; do
 			if [ -f "$serial_file" ] && [ "$(cat "$serial_file")" = "$usb_serial" ]; then
 				usb_sys_device="$(dirname "$serial_file")"
@@ -281,7 +282,11 @@ func (t *VMUSBTest) mountUSB() {
 				break
 			fi
 		done
-		[ -n "$mount_device" ] || { echo "USB block device for serial $usb_serial not found" >/tmp/usb-mount.err; exit 1; }
+		[ -n "$mount_device" ] || {
+			echo "USB block device for serial $usb_serial not found" >>/tmp/usb-mount.err
+			find "$usb_sys_device" -maxdepth 6 -print >>/tmp/usb-mount.err 2>&1 || true
+			exit 1
+		}
 
 		for partition in /sys/block/$block_name/${block_name}[0-9]* /sys/block/$block_name/${block_name}p[0-9]*; do
 			if [ -e "$partition" ] && [ -b "/dev/$(basename "$partition")" ]; then
@@ -291,7 +296,7 @@ func (t *VMUSBTest) mountUSB() {
 		done
 
 		sudo mkdir -p /mnt/usb && \
-		(sudo mountpoint -q /mnt/usb || sudo mount "$mount_device" /mnt/usb 2>/tmp/usb-mount.err || sudo mount -o rw "$mount_device" /mnt/usb 2>>/tmp/usb-mount.err) && \
+		(sudo mountpoint -q /mnt/usb || sudo mount "$mount_device" /mnt/usb 2>>/tmp/usb-mount.err || sudo mount -o rw "$mount_device" /mnt/usb 2>>/tmp/usb-mount.err) && \
 		ls -la /mnt/usb
 	`, serial)
 
@@ -306,6 +311,8 @@ func (t *VMUSBTest) usbDiagnostics() string {
 		echo "mount error:" && cat /tmp/usb-mount.err 2>/dev/null || true
 		echo "mount:" && mount || true
 		echo "usb serials:" && for serial_file in /sys/bus/usb/devices/*/serial; do [ -f "$serial_file" ] && echo "$serial_file=$(cat "$serial_file")"; done || true
+		echo "usb sysfs:" && find /sys/bus/usb/devices -maxdepth 3 -print || true
+		echo "lsblk:" && lsblk -a -o NAME,PATH,TYPE,TRAN,RM,SERIAL,MODEL || true
 		echo "lsusb:" && lsusb || true
 		echo "dmesg:" && sudo dmesg | tail -n 100 || true
 	`


### PR DESCRIPTION
## Description
Stabilize the `VirtualMachineUSB` e2e scenario and simplify the USB handling flow in the guest.

Changes include:
- check `NodeUSBDevice` detached state before creating the VM;
- wait for the VM guest agent and USB readiness explicitly;
- extract repeated USB test actions into helper methods;
- rescan SCSI hosts before mount attempts in the guest;
- detect the guest USB disk through `lsblk` while validating that the expected USB serial is present;
- remount the USB filesystem after migration before reading the test data;
- flush data with `sync` and unmount the filesystem before migration;
- increase retries/timeouts around guest-side USB disk discovery after reconnect.

## Why do we need it, and what problem does it solve?
The USB e2e scenario was flaky in several places:
- the detached check ran after VM creation and raced with attachment;
- the guest could see the USB device in `lsusb` before the block disk was ready;
- after migration the USB disk could reconnect later and require additional wait time before remounting;
- data could remain in cache if the filesystem was not flushed before migration.

These changes make the test validate the expected sequence more accurately and reduce random failures caused by delayed guest-side USB storage discovery.

## What is the expected result?
Run the USB e2e scenario:

```bash
FOCUS="VirtualMachineUSB" task e2e:run
```

Expected behavior:
1. `NodeUSBDevice` is detached before VM creation.
2. VM starts and reports the USB device as attached and ready.
3. The guest finds and mounts the USB mass-storage disk.
4. Test data is written, flushed, and unmounted.
5. VM is migrated.
6. The guest waits for the USB disk to reappear and remounts it after reconnect.
7. The previously written data is still present.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: test
type: fix
summary: Stabilized the VirtualMachineUSB e2e test by improving guest USB disk detection, remount flow, and timeouts around migration.
impact_level: low
```
