### PR TITLE
fix(virtualization-dra): skip usb gateway detach for untracked devices

### DIFF
--- a/images/virtualization-dra/internal/usb/store.go
+++ b/images/virtualization-dra/internal/usb/store.go
@@ -447,9 +447,11 @@ func (s *AllocationStore) Unprepare(_ context.Context, claimUID types.UID) error
 		for _, device := range allocatedDevices {
 			if usbGatewayEnabled {
 				count, hasCount := s.usbipAllocatedDevicesCount[device]
-				s.log.Info("Device attached by USBGateway", slog.String("device", device), slog.Int("count", count))
+				s.log.Info("Device attached by USBGateway", slog.String("device", device), slog.Int("count", count), slog.Bool("tracked", hasCount))
 				switch {
-				case !hasCount || count <= 1:
+				case !hasCount:
+					s.log.Info("Device is not tracked by USBGateway, skipping detach", slog.String("device", device))
+				case count <= 1:
 					s.log.Info("Device has no tracked consumers, attempting detach cleanup", slog.String("device", device), slog.Int("count", count))
 					if err := s.usbGateway.Detach(device); err != nil {
 						return fmt.Errorf("failed to detach device %s: %w", device, err)

--- a/images/virtualization-dra/internal/usb/store.go
+++ b/images/virtualization-dra/internal/usb/store.go
@@ -451,15 +451,17 @@ func (s *AllocationStore) Unprepare(_ context.Context, claimUID types.UID) error
 				switch {
 				case !hasCount:
 					s.log.Info("Device is not tracked by USBGateway, skipping detach", slog.String("device", device))
-				case count <= 1:
+				case count == 1:
 					s.log.Info("Device has no tracked consumers, attempting detach cleanup", slog.String("device", device), slog.Int("count", count))
 					if err := s.usbGateway.Detach(device); err != nil {
 						return fmt.Errorf("failed to detach device %s: %w", device, err)
 					}
 					delete(s.usbipAllocatedDevicesCount, device)
-				default:
+				case count > 1:
 					s.log.Info("Decrementing device consumer count", slog.String("device", device), slog.Int("newCount", count-1))
 					s.usbipAllocatedDevicesCount[device]--
+				default:
+					s.log.Warn("Device has invalid USBGateway consumer count, skipping detach", slog.String("device", device), slog.Int("count", count))
 				}
 			}
 


### PR DESCRIPTION
## Description
Fix USB device cleanup in `virtualization-dra` during `Unprepare`.

The allocation store now checks whether a device is tracked in `usbipAllocatedDevicesCount` before calling USBGateway detach cleanup. Devices that are not tracked by USBGateway are skipped. For tracked devices, USBGateway detach is executed only when the current device has exactly one active tracked consumer. Devices with multiple consumers only have their consumer count decremented, and invalid zero-count tracked state is skipped with a warning.

## Why do we need it, and what problem does it solve?
When USBGateway is enabled, `Unprepare` iterates over all allocated devices for a claim. Local USB devices are not present in `usbipAllocatedDevicesCount`, but reading a missing map key returns `0`, so the previous `count <= 1` condition attempted to detach them through USBGateway.

Also, `count == 0` should not be treated as "last consumer". A valid last USBGateway consumer is represented by `count == 1`. Zero means either the device is not tracked by USBGateway or the allocation state is inconsistent, so detach must be skipped to avoid detaching/unexporting a device incorrectly.

## What is the expected result?
1. Prepare a claim with a local USB device while USBGateway is enabled.
2. Unprepare the claim.
3. Verify that USBGateway `Detach` is not called for the local untracked device.
4. Prepare several consumers for the same USBGateway device.
5. Unprepare one consumer and verify that USBGateway `Detach` is not called while `count > 1`.
6. Unprepare the last tracked consumer and verify that USBGateway `Detach` is called only when `count == 1`.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: module
type: fix
summary: Skip USBGateway detach cleanup for untracked USB devices and detach tracked devices only on the last active consumer.
impact_level: low
```
