### PR TITLE
fix(ci): e2e nested bootstrap cluster add d8 v ssh timeout

### DIFF
--- a/.github/workflows/e2e-reusable-pipeline.yml
+++ b/.github/workflows/e2e-reusable-pipeline.yml
@@ -316,6 +316,9 @@ jobs:
             --local-ssh=true \
             --local-ssh-opts="-o StrictHostKeyChecking=no" \
             --local-ssh-opts="-o UserKnownHostsFile=/dev/null" \
+            --local-ssh-opts="-o ServerAliveInterval=15" \
+            --local-ssh-opts="-o ServerAliveCountMax=8" \
+            --local-ssh-opts="-o ConnectTimeout=10" \
             ${DEFAULT_USER}@${host}.${NAMESPACE} \
             -c "$cmd"
           }
@@ -363,6 +366,9 @@ jobs:
             --local-ssh=true \
             --local-ssh-opts="-o StrictHostKeyChecking=no" \
             --local-ssh-opts="-o UserKnownHostsFile=/dev/null" \
+            --local-ssh-opts="-o ServerAliveInterval=15" \
+            --local-ssh-opts="-o ServerAliveCountMax=8" \
+            --local-ssh-opts="-o ConnectTimeout=10" \
             ${DEFAULT_USER}@${nested_master}.${NAMESPACE} \
             -c "$cmd"
           }

--- a/test/e2e/internal/d8/d8.go
+++ b/test/e2e/internal/d8/d8.go
@@ -101,7 +101,7 @@ func (v D8VirtualizationCMD) SSHCommand(vmName, command string, opts SSHOptions)
 	}
 
 	localSSHOpts := "--local-ssh-opts='-o StrictHostKeyChecking=no' --local-ssh-opts='-o UserKnownHostsFile=/dev/null' --local-ssh-opts='-o LogLevel=ERROR'"
-	localSSHOpts = fmt.Sprintf("%s --local-ssh-opts='-o ConnectTimeout=%s'", localSSHOpts, timeout.String())
+	localSSHOpts = fmt.Sprintf("%s --local-ssh-opts='-o ServerAliveInterval=15' --local-ssh-opts='-o ServerAliveCountMax=8' --local-ssh-opts='-o ConnectTimeout=10'", localSSHOpts)
 
 	cmd := fmt.Sprintf("%s ssh %s -c '%s' --local-ssh=true %s", v.cmd, vmName, command, localSSHOpts)
 	cmd = v.addNamespace(cmd, opts.Namespace)


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Add SSH keepalive options to `d8 v ssh` calls used in nested-cluster CI and the e2e `d8` helper.
This keeps long-lived SSH sessions more stable when the VM connection is proxied through `virtualization-api` port-forwarding.
The following SSH options were added:
- `ServerAliveInterval=15` to send periodic keepalive probes during long-running sessions.
- `ServerAliveCountMax=8` to tolerate short interruptions before the SSH client gives up.
- `ConnectTimeout=10` to fail stalled connection attempts quickly and avoid hanging retries.


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
Nested cluster bootstrap and kubeconfig generation use `d8 v ssh` over a websocket-backed port-forward path.
When that path is interrupted, CI may fail with errors like `websocket: close 1006`, `Broken pipe`, or `exit status 255`.
Adding `ServerAliveInterval`, `ServerAliveCountMax`, and a fixed `ConnectTimeout` makes these SSH sessions more resilient to transient transport issues and short interruptions.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
`d8 v ssh` sessions in CI and e2e helpers should better survive short-lived connection drops.
This should reduce flaky failures during long-running nested-cluster operations without changing the functional behavior of the tests.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: ci
type: fix
summary: add SSH keepalive options to d8-based nested cluster access in CI and e2e helpers
impact_level: low
```
