### PR TITLE
test(ci): add pre-check system to CI workflow

### DIFF
--- a/.github/workflows/e2e-reusable-pipeline.yml
+++ b/.github/workflows/e2e-reusable-pipeline.yml
@@ -1281,7 +1281,7 @@ jobs:
 
           cp -a legacy/testdata /tmp/testdata
 
-          ./test/e2e/scripts/precheck-prepare_ci.sh
+          ./scripts/precheck-prepare_ci.sh
 
           set +e
           FOCUS="${{ inputs.e2e_focus_tests }}"

--- a/.github/workflows/e2e-reusable-pipeline.yml
+++ b/.github/workflows/e2e-reusable-pipeline.yml
@@ -1281,6 +1281,8 @@ jobs:
 
           cp -a legacy/testdata /tmp/testdata
 
+          ./test/e2e/scripts/precheck-prepare_ci.sh
+
           set +e
           FOCUS="${{ inputs.e2e_focus_tests }}"
           if [ -n "$FOCUS" ]; then

--- a/test/e2e/Taskfile.yaml
+++ b/test/e2e/Taskfile.yaml
@@ -34,10 +34,13 @@ tasks:
 
   run:ci:
     desc: "Separate task to run e2e tests in the CI environment"
+    env:
+      FOCUS: "VirtualMachineAdditionalNetworkInterfaces"
     deps:
       - copy
       - kubectl
       - d8
+      - precheck:prepare
     cmds:
       - ./scripts/task_run_ci.sh
 

--- a/test/e2e/scripts/precheck-prepare_ci.sh
+++ b/test/e2e/scripts/precheck-prepare_ci.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Generate JSON report via ginkgo dry-run for precheck preparation
+# This script suppresses output while preserving error reporting
+
+set -e
+
+# Build ginkgo command
+CMD="go tool ginkgo --json-report=/tmp/e2e-specs.json --dry-run --no-color"
+
+# Run with suppressed stdout, but show stderr
+$CMD 2>&1 > /dev/null
+
+echo "Precheck prepare completed"

--- a/test/e2e/scripts/task_run_ci.sh
+++ b/test/e2e/scripts/task_run_ci.sh
@@ -21,9 +21,10 @@ echo "DATE=$DATE" >> $GITHUB_ENV
 START_TIME=$(date +"%H:%M:%S")
 echo "START_TIME=$START_TIME" >> $GITHUB_ENV
 
-go tool ginkgo \
-    --focus="VirtualMachineAdditionalNetworkInterfaces" \
-    -v --race --timeout=$TIMEOUT | tee $GINKGO_RESULT
+go tool ginkgo -v \
+    --race \
+    --focus=$FOCUS \
+    --timeout=$TIMEOUT | tee $GINKGO_RESULT
 EXIT_CODE="${PIPESTATUS[0]}"
 RESULT=$(sed -e "s/\x1b\[[0-9;]*m//g" $GINKGO_RESULT | grep --color=never -E "FAIL!|SUCCESS!")
 if [[ $RESULT == FAIL!* || $EXIT_CODE -ne "0" ]]; then


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Added pre-check system to CI workflow:
- Created script `test/e2e/scripts/precheck-prepare_ci.sh` that generates JSON report via `ginkgo dry-run`
- Integrated script call into `.github/workflows/e2e-reusable-pipeline.yml`
- Updated `test/e2e/Taskfile.yaml` to use `FOCUS` environment variable instead of hardcoded value
- Updated `test/e2e/scripts/task_run_ci.sh` to use `$FOCUS` variable

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
Need the ability to prepare test information before running e2e tests in CI. The script performs ginkgo dry-run to generate a JSON report with test list that can be used for further analysis.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
When CI pipeline runs `precheck-prepare_ci.sh` is executed, generating `/tmp/e2e-specs.json`.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: ci
type: chore
summary: "Add pre-check system to CI workflow for ginkgo dry-run preparation."
```
