### PR TITLE
fix(ci): gate USB e2e by Kubernetes version and fallback to default NFS storage class

### DIFF
--- a/.github/workflows/e2e-reusable-pipeline.yml
+++ b/.github/workflows/e2e-reusable-pipeline.yml
@@ -1248,6 +1248,37 @@ jobs:
           echo "Download dependencies"
           go mod download
 
+      - name: Detect Kubernetes version for E2E
+        id: detect-k8s-version
+        run: |
+          set -euo pipefail
+
+          VERSION_JSON=$(kubectl version -o json)
+          SERVER_VERSION=$(echo "$VERSION_JSON" | jq -r '.serverVersion.gitVersion')
+          SERVER_MAJOR=$(echo "$VERSION_JSON" | jq -r '.serverVersion.major' | tr -cd '0-9')
+          SERVER_MINOR=$(echo "$VERSION_JSON" | jq -r '.serverVersion.minor' | tr -cd '0-9')
+
+          if [[ -z "$SERVER_MAJOR" || -z "$SERVER_MINOR" ]]; then
+            echo "[ERROR] Failed to parse Kubernetes server version: $SERVER_VERSION"
+            exit 1
+          fi
+
+          LABEL_FILTER=""
+          USB_SUPPORTED=false
+
+          if (( SERVER_MAJOR > 1 || (SERVER_MAJOR == 1 && SERVER_MINOR >= 34) )); then
+            USB_SUPPORTED=true
+            echo "[INFO] Kubernetes server version $SERVER_VERSION supports USB E2E tests"
+          else
+            LABEL_FILTER="!usb-precheck"
+            echo "[INFO] Kubernetes server version $SERVER_VERSION does not support USB E2E tests"
+            echo "[INFO] USB-labeled specs will be excluded with label filter: $LABEL_FILTER"
+          fi
+
+          echo "server-version=$SERVER_VERSION" >> "$GITHUB_OUTPUT"
+          echo "usb-supported=$USB_SUPPORTED" >> "$GITHUB_OUTPUT"
+          echo "label-filter=$LABEL_FILTER" >> "$GITHUB_OUTPUT"
+
       - name: Create vmclass for e2e tests
         run: |
           if ! (kubectl get vmclass generic-for-e2e 2>/dev/null); then
@@ -1270,6 +1301,9 @@ jobs:
           TIMEOUT: ${{ inputs.e2e_timeout }}
           CSI: ${{ inputs.storage_type }}
           STORAGE_CLASS_NAME: ${{ inputs.nested_storageclass_name }}
+          LABELS: ${{ steps.detect-k8s-version.outputs.label-filter }}
+          SERVER_K8S_VERSION: ${{ steps.detect-k8s-version.outputs.server-version }}
+          USB_SUPPORTED: ${{ steps.detect-k8s-version.outputs.usb-supported }}
         working-directory: ./test/e2e/
         run: |
           GINKGO_RESULT=$(mktemp -p $RUNNER_TEMP)
@@ -1278,25 +1312,36 @@ jobs:
           summary_file_name_junit="e2e_summary_${CSI}_${DATE}.xml"
           ginkgo_json_report="ginkgo_report_${CSI}_${DATE}.json"
           summary_file_name_json="e2e_summary_${CSI}_${DATE}.json"
+          FOCUS="${{ inputs.e2e_focus_tests }}"
 
           cp -a legacy/testdata /tmp/testdata
+
+          echo "[INFO] Kubernetes server version: ${SERVER_K8S_VERSION}"
+          echo "[INFO] USB E2E supported: ${USB_SUPPORTED}"
+          if [ -n "${LABELS:-}" ]; then
+            echo "[INFO] Applying Ginkgo label filter: ${LABELS}"
+          fi
 
           ./scripts/precheck-prepare_ci.sh
 
           set +e
-          FOCUS="${{ inputs.e2e_focus_tests }}"
-          if [ -n "$FOCUS" ]; then
-            go tool ginkgo \
-              --focus="$FOCUS" \
-              -v --race --timeout=$TIMEOUT \
-              --json-report=$ginkgo_json_report \
-              --junit-report=$summary_file_name_junit | tee $GINKGO_RESULT
-          else
-            go tool ginkgo \
-              -v --race --timeout=$TIMEOUT \
-              --json-report=$ginkgo_json_report \
-              --junit-report=$summary_file_name_junit | tee $GINKGO_RESULT
+          GINKGO_ARGS=(
+            -v
+            --race
+            --timeout="$TIMEOUT"
+            --json-report="$ginkgo_json_report"
+            --junit-report="$summary_file_name_junit"
+          )
+
+          if [ -n "${LABELS:-}" ]; then
+            GINKGO_ARGS+=(--label-filter="$LABELS")
           fi
+
+          if [ -n "$FOCUS" ]; then
+            GINKGO_ARGS+=(--focus="$FOCUS")
+          fi
+
+          go tool ginkgo "${GINKGO_ARGS[@]}" | tee $GINKGO_RESULT
           GINKGO_EXIT_CODE=$?
           set -e
 

--- a/test/dvp-static-cluster/charts/infra/templates/nfs/vm.yaml
+++ b/test/dvp-static-cluster/charts/infra/templates/nfs/vm.yaml
@@ -10,7 +10,9 @@ metadata:
 spec:
   persistentVolumeClaim:
     size: 150G
-    storageClassName: linstor-thin-r1
+    {{- if .Values.storageClass }}
+    storageClassName: {{ .Values.storageClass }}
+    {{- end }}
 ---
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualDisk
@@ -26,7 +28,9 @@ spec:
     type: ContainerImage
   persistentVolumeClaim:
     size: 1Gi
-    storageClassName: linstor-thin-r1
+    {{- if .Values.storageClass }}
+    storageClassName: {{ .Values.storageClass }}
+    {{- end }}
 ---
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualMachine
@@ -44,7 +48,7 @@ spec:
     name: nfs-vd-data
   bootloader: EFI
   cpu:
-    coreFraction: 20%
+    coreFraction: 50%
     cores: 1
   disruptions:
     restartApprovalMode: Automatic


### PR DESCRIPTION
## Description
Skip USB e2e specs on nested clusters that run Kubernetes versions below 1.34 by checking the actual API server version during the reusable CI pipeline. Also make NFS infra disks omit `storageClassName` when no storage class is explicitly set so the cluster default storage class can be used.

## Why do we need it, and what problem does it solve?
The nested NFS CI job can be created with an automatically selected Kubernetes version, and that version may be lower than 1.34. In that case the cluster does not provide the USB setup required by the `usb-precheck`, so the suite fails in `SynchronizedBeforeSuite` before any regular specs run.

This change makes the pipeline decide whether USB e2e should run from the actual nested cluster server version instead of relying on the requested cluster configuration. It also keeps the NFS infra templates aligned with the existing storage class behavior by falling back to the cluster default storage class when one is not passed explicitly.

## What is the expected result?
1. Run the nested e2e pipeline against a cluster with Kubernetes version lower than 1.34.
2. Verify that USB-labeled specs are excluded from the e2e run and the suite proceeds without failing in `usb-precheck`.
3. Run the same pipeline against a cluster with Kubernetes version 1.34 or higher.
4. Verify that USB e2e specs remain enabled.
5. Verify that NFS infra `VirtualDisk` resources can still be created when `storageClass` is omitted and the cluster default storage class is configured.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: fix
summary: Skip USB nested e2e on Kubernetes versions below 1.34 and fall back to the default NFS storage class.
impact_level: low
```