### PR TITLE
test: fix external connectivity

### DIFF
--- a/test/e2e/internal/network/external_connectivity.go
+++ b/test/e2e/internal/network/external_connectivity.go
@@ -19,6 +19,7 @@ package network
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -26,16 +27,30 @@ import (
 	"github.com/deckhouse/virtualization/test/e2e/internal/framework"
 )
 
-const (
-	HTTPStatusOk = "200"
-	ExternalHost = "https://flant.ru"
-)
+var ExternalConnectivityHosts = []string{
+	"https://flant.ru",
+	"https://google.com",
+	"https://ya.ru",
+}
 
-func CheckExternalConnectivity(f *framework.Framework, vmName, host, expectedHTTPCode string) {
+func CheckExternalConnectivity(f *framework.Framework, vmName string, hosts []string) {
 	GinkgoHelper()
 
-	cmd := fmt.Sprintf("curl -o /dev/null -k -s -w \"%%{http_code}\\n\" %s", host)
-	httpCode, err := f.SSHCommand(vmName, f.Namespace().Name, cmd)
-	Expect(err).NotTo(HaveOccurred(), "failed external connectivity check for VM %s", vmName)
-	Expect(strings.TrimSpace(httpCode)).To(Equal(expectedHTTPCode), "HTTP response code from %s should be %s, got %s", host, expectedHTTPCode, httpCode)
+	cmd := fmt.Sprintf(`set -e
+for host in %s; do
+	if curl --head -k -sS -o /dev/null --connect-timeout 5 --max-time 15 "$host"; then
+		echo "$host"
+		exit 0
+	fi
+done
+exit 1`, strings.Join(hosts, " "))
+
+	reachableHost, err := f.SSHCommand(
+		vmName,
+		f.Namespace().Name,
+		cmd,
+		framework.WithSSHTimeout(time.Minute),
+	)
+	Expect(err).NotTo(HaveOccurred(), "VM %s should have outbound connectivity via at least one host from %v", vmName, hosts)
+	Expect(strings.TrimSpace(reachableHost)).NotTo(BeEmpty(), "VM %s should report a reachable external host from %v", vmName, hosts)
 }

--- a/test/e2e/vm/additional_network_interfaces.go
+++ b/test/e2e/vm/additional_network_interfaces.go
@@ -149,10 +149,10 @@ var _ = Describe("VirtualMachineAdditionalNetworkInterfaces", Label(precheck.NoP
 			})
 
 			By("Check VM can reach external network after migration", func() {
-				network.CheckExternalConnectivity(f, vmFoo.Name, network.ExternalHost, network.HTTPStatusOk)
+				network.CheckExternalConnectivity(f, vmFoo.Name, network.ExternalConnectivityHosts)
 
 				if tc.vmBarHasMainNetwork {
-					network.CheckExternalConnectivity(f, vmBar.Name, network.ExternalHost, network.HTTPStatusOk)
+					network.CheckExternalConnectivity(f, vmBar.Name, network.ExternalConnectivityHosts)
 				}
 			})
 

--- a/test/e2e/vm/connectivity.go
+++ b/test/e2e/vm/connectivity.go
@@ -77,8 +77,8 @@ var _ = Describe("VirtualMachineConnectivity", Label(precheck.NoPrecheck), func(
 		})
 
 		By("Check VMs can reach external network", func() {
-			network.CheckExternalConnectivity(f, t.VMa.Name, network.ExternalHost, network.HTTPStatusOk)
-			network.CheckExternalConnectivity(f, t.VMb.Name, network.ExternalHost, network.HTTPStatusOk)
+			network.CheckExternalConnectivity(f, t.VMa.Name, network.ExternalConnectivityHosts)
+			network.CheckExternalConnectivity(f, t.VMb.Name, network.ExternalConnectivityHosts)
 		})
 
 		By("Check nginx status on VMs", func() {

--- a/test/e2e/vm/migration.go
+++ b/test/e2e/vm/migration.go
@@ -303,8 +303,8 @@ var _ = Describe("VirtualMachineMigration", Label(precheck.NoPrecheck), func() {
 		By("Check VM can reach external network", func() {
 			util.UntilSSHReady(f, vmBIOS, framework.MiddleTimeout)
 			util.UntilSSHReady(f, vmUEFI, framework.MiddleTimeout)
-			network.CheckExternalConnectivity(f, vmBIOS.Name, network.ExternalHost, network.HTTPStatusOk)
-			network.CheckExternalConnectivity(f, vmUEFI.Name, network.ExternalHost, network.HTTPStatusOk)
+			network.CheckExternalConnectivity(f, vmBIOS.Name, network.ExternalConnectivityHosts)
+			network.CheckExternalConnectivity(f, vmUEFI.Name, network.ExternalConnectivityHosts)
 		})
 	})
 })

--- a/test/e2e/vm/power_state.go
+++ b/test/e2e/vm/power_state.go
@@ -174,7 +174,7 @@ var _ = Describe("PowerState", Label(precheck.NoPrecheck), func() {
 		By("Check VM can reach external network", func() {
 			err := network.CheckCiliumAgents(context.Background(), f.Kubectl(), t.VM.Name, f.Namespace().Name)
 			Expect(err).NotTo(HaveOccurred(), "Cilium agents check should succeed for VM %s", t.VM.Name)
-			network.CheckExternalConnectivity(f, t.VM.Name, network.ExternalHost, network.HTTPStatusOk)
+			network.CheckExternalConnectivity(f, t.VM.Name, network.ExternalConnectivityHosts)
 		})
 	},
 		Entry(


### PR DESCRIPTION
## Description
Fix the e2e external connectivity check so it validates outbound connectivity instead of requiring a specific HTTP status from a single website.

## Why do we need it, and what problem does it solve?
The previous `CheckExternalConnectivity` implementation treated external connectivity as a successful `curl` response with HTTP 200 from one hardcoded host. This made the test flaky and semantically incorrect: the VM could still have outbound network connectivity while the selected website was unavailable, redirected, or returned a non-200 status.

This change makes the check align with the actual test intent. The VM is now considered externally connected if it can successfully reach at least one host from a fallback list within bounded timeouts.

## What is the expected result?
1. Run e2e tests that call `CheckExternalConnectivity`.
2. Ensure the check succeeds when the VM has outbound access and at least one fallback host is reachable.
3. Ensure the check no longer fails only because a single website returns a non-200 HTTP status.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: test
type: fix
summary: "Make the e2e external connectivity check rely on successful outbound access to fallback hosts instead of HTTP 200 from a single site."
impact_level: low
```
