### PR TITLE
chore(ci): disable schedule  for PR summary workflow

### DIFF
--- a/.github/workflows/dev_prs-summary.yml
+++ b/.github/workflows/dev_prs-summary.yml
@@ -15,8 +15,6 @@
 name: PR Summary
 
 on:
-  schedule:
-    - cron: "23 7 * * 1-5" # Runs on every day-of-week from Monday through Friday at 7:23 AM UTC (10:23 AM MSK)
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Disable schedule for PR summary workflow, since we are running this workflow via webhook.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->
