### PR TITLE
fix(ci): bootstrap virtualization print nodes for debug

### DIFF
--- a/.github/workflows/e2e-reusable-pipeline.yml
+++ b/.github/workflows/e2e-reusable-pipeline.yml
@@ -836,18 +836,18 @@ jobs:
 
             echo "[ERROR] Blockdevices is not 3"
             echo "[DEBUG] Show cluster nodes"
-            kubectl get nodes
+            kubectl get nodes || echo "[WARNING] Failed to get cluster nodes"
             echo "[DEBUG] Show blockdevices"
-            kubectl get blockdevice
+            kubectl get blockdevice || echo "[WARNING] Failed to get blockdevices"
             echo "[DEBUG] Show sds namespaces"
-            kubectl get ns | grep sds || echo "ns sds is not found"
+            kubectl get ns | grep sds || echo "[WARNING] Namespace sds is not found"
             echo "[DEBUG] Show pods in sds-replicated-volume"
             echo "::group::📦 pods in sds-replicated-volume"
-            kubectl -n d8-sds-replicated-volume get pods || true
+            kubectl -n d8-sds-replicated-volume get pods || echo "[WARNING] Failed to get pods in sds-replicated-volume"
             echo "::endgroup::"
             echo "[DEBUG] Show deckhouse logs"
             echo "::group::📝 deckhouse logs"
-            d8 s logs | tail -n 100
+            d8 s logs | tail -n 100 || echo "[WARNING] Failed to get deckhouse logs"
             echo "::endgroup::"
             exit 1
           }
@@ -1070,7 +1070,7 @@ jobs:
             echo "[DEBUG] Show cluster StorageClasses"
             kubectl get storageclasses || true
             echo "[DEBUG] Show cluster nodes"
-            kubectl get node
+            kubectl get node || true
 
             echo "[DEBUG] Show cluster node yaml and describe"
             NODES=$(kubectl get no -o jsonpath='{range .items[?(@.metadata.name)]}{.metadata.name}{"\n"}{end}')
@@ -1158,27 +1158,33 @@ jobs:
             local workers
             local time_wait=10
 
-            workers=$(kubectl get nodes -o name | grep worker | wc -l || true)
-            workers=$((workers))
-
             for i in $(seq 1 $count); do
+              workers=$(kubectl get nodes -o name | grep worker | wc -l || true)
+              workers=$((workers))
+              if [[ $workers -eq 0 ]]; then
+                echo "[WARNING] No worker nodes found, keep waiting"
+                echo "[INFO] Wait ${time_wait}s virt-handler pods are ready (attempt $i/$count)"
+                sleep ${time_wait}
+                continue
+              fi
+
               virt_handler_ready=$(kubectl -n d8-virtualization get pods | grep "virt-handler.*Running" | wc -l || true)
 
               if [[ $virt_handler_ready -ge $workers ]]; then
-                echo "[SUCCESS] virt-handlers pods are ready"
+                echo "[SUCCESS] virt-handlers pods are ready $virt_handler_ready/$workers"
                 return 0
               fi
 
-              echo "[INFO] virt-handler pods $virt_handler_ready/$workers "
+              echo "[INFO] virt-handler pods $virt_handler_ready/$workers"
               echo "[INFO] Wait ${time_wait}s virt-handler pods are ready (attempt $i/$count)"
               if (( i % 5 == 0 )); then
                 echo "[DEBUG] Show pods in namespace d8-virtualization"
                 echo "::group::📦 virtualization pods"
-                kubectl -n d8-virtualization get pods || echo "No pods in virtualization namespace found"
+                kubectl -n d8-virtualization get pods || echo "[WARNING] No pods in virtualization namespace found"
                 echo "::endgroup::"
                 echo "[DEBUG] Show cluster nodes"
                 echo "::group::📦 cluster nodes"
-                kubectl get node
+                kubectl get node || echo "[WARNING] Failed to get cluster nodes"
                 echo "::endgroup::"
               fi
               sleep ${time_wait}


### PR DESCRIPTION
## Description
Make the nested E2E bootstrap diagnostics more tolerant to temporary Kubernetes API failures.

This change keeps debug output commands from failing the workflow when the nested cluster API temporarily returns errors, and updates the `virt-handler` readiness loop to recalculate worker nodes on every attempt. If worker nodes cannot be listed, the loop now keeps waiting instead of treating `0/0` as a successful `virt-handler` readiness state.

## Why do we need it, and what problem does it solve?
Nested E2E clusters can briefly lose API availability while the control plane is recovering, for example when etcd or kube-apiserver is under load or restarting. In that window, diagnostic `kubectl get node` calls may return errors such as `etcdserver: request timed out` or `502 Bad Gateway` and fail the CI job even though the cluster can recover shortly afterward.

Example error
```
E0505 03:17:44.603556    2966 memcache.go:265] "Unhandled Error" err="couldn't get current server API group list: an error on the server (\"<html>\\r\\n<head><title>502 Bad Gateway</title></head>\\r\\n<body>\\r\\n<center><h1>502 Bad Gateway</h1></center>\\r\\n<hr><center>nginx</center>\\r\\n</body>\\r\\n</html>\") has prevented the request from succeeding"
  .... has prevented the request from succeeding (get nodes)
```

The `virt-handler` readiness check also previously calculated the worker count only once before the retry loop. If that initial request failed and produced `0` workers, the check could incorrectly succeed with `0/0` ready handlers.

## What is the expected result?
1. Run the nested E2E bootstrap workflow.
2. If the nested cluster API temporarily fails during diagnostic output, the workflow logs a warning and continues collecting available information.
3. If worker nodes cannot be listed during `virt-handler` readiness checks, the workflow waits for the next retry instead of reporting success with `0/0` handlers.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: fix
summary: Make nested E2E bootstrap diagnostics tolerate temporary Kubernetes API failures.
impact_level: low
```