### PR TITLE
test: quote focus/label args in e2e precheck prepare

### DIFF
--- a/test/e2e/scripts/precheck-prepare.sh
+++ b/test/e2e/scripts/precheck-prepare.sh
@@ -19,17 +19,22 @@
 
 set -e
 
-# Build ginkgo command
-CMD="go tool ginkgo --json-report=/tmp/e2e-specs.json --dry-run --no-color"
+# Build ginkgo command. Use an array to preserve args with spaces.
+CMD=(
+  go tool ginkgo
+  --json-report=/tmp/e2e-specs.json
+  --dry-run
+  --no-color
+)
 
-# Add label filter based on environment variables
-if [ -n "$FOCUS" ]; then
-    CMD="$CMD --focus=$FOCUS"
-elif [ -n "$LABELS" ]; then
-    CMD="$CMD --label-filter=$LABELS"
+# Add filter based on environment variables.
+if [ -n "${FOCUS:-}" ]; then
+  CMD+=(--focus "$FOCUS")
+elif [ -n "${LABELS:-}" ]; then
+  CMD+=(--label-filter "$LABELS")
 fi
 
-# Run with suppressed stdout, but show stderr
-$CMD 2>&1 > /dev/null
+# Run with suppressed stdout, but show stderr.
+"${CMD[@]}" 2>&1 > /dev/null
 
 echo "Precheck prepare completed"

--- a/test/e2e/scripts/precheck-prepare_ci.sh
+++ b/test/e2e/scripts/precheck-prepare_ci.sh
@@ -19,10 +19,15 @@
 
 set -e
 
-# Build ginkgo command
-CMD="go tool ginkgo --json-report=/tmp/e2e-specs.json --dry-run --no-color"
+# Build ginkgo command. Use an array to preserve args with spaces.
+CMD=(
+  go tool ginkgo
+  --json-report=/tmp/e2e-specs.json
+  --dry-run
+  --no-color
+)
 
-# Run with suppressed stdout, but show stderr
-$CMD 2>&1 > /dev/null
+# Run with suppressed stdout, but show stderr.
+"${CMD[@]}" 2>&1 > /dev/null
 
 echo "Precheck prepare completed"


### PR DESCRIPTION
## Description
Fix `test/e2e` precheck prepare scripts: pass `FOCUS`/`LABELS` to ginkgo with proper quoting (values may contain spaces).

## Why do we need it, and what problem does it solve?
When `FOCUS` contains spaces, `precheck:prepare` could fail to generate `/tmp/e2e-specs.json`, causing `SynchronizedBeforeSuite` to fail early.

## What is the expected result?
Focused e2e runs with `FOCUS` containing spaces complete precheck preparation and do not fail due to missing `/tmp/e2e-specs.json`.

Steps:
- `FOCUS='when changes are applied manually' task -d test/e2e precheck:prepare`
- `FOCUS='when changes are applied manually' task -d test/e2e run`

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: test
type: fix
summary: "Fix e2e precheck prepare for focus/label filters containing spaces."
impact_level: low
```