### PR TITLE
fix(ci): apply cr in nested cluster

### DIFF
--- a/.github/workflows/e2e-reusable-pipeline.yml
+++ b/.github/workflows/e2e-reusable-pipeline.yml
@@ -971,10 +971,35 @@ jobs:
 
       - name: Configure Virtualization
         run: |
+          kubectl_apply_with_retry() {
+            local count=6
+            local delay=10
+            local manifest
+            manifest="$(mktemp)"
+            cat > "$manifest"
+
+            for i in $(seq 1 "$count"); do
+              echo "[INFO] kubectl apply attempt ${i}/${count}"
+              if kubectl apply -f "$manifest"; then
+                rm -f "$manifest"
+                return 0
+              fi
+
+              if [ "$i" -lt "$count" ]; then
+                echo "[WARN] kubectl apply failed, retrying in ${delay}s"
+                sleep "$delay"
+              fi
+            done
+
+            echo "[ERROR] kubectl apply failed after ${count} attempts"
+            rm -f "$manifest"
+            return 1
+          }
+
           REGISTRY=$(base64 -d <<< "${{secrets.DEV_REGISTRY_DOCKER_CFG}}" | jq '.auths | to_entries | .[] | .key' -r)
 
           echo "[INFO] Apply ModuleSource dev config"
-          kubectl apply -f -<<EOF
+          kubectl_apply_with_retry <<EOF
           apiVersion: deckhouse.io/v1alpha1
           kind: ModuleSource
           metadata:
@@ -990,7 +1015,7 @@ jobs:
           kubectl wait --for=jsonpath='{.status.phase}'=Active ms deckhouse-dev --timeout=300s
 
           echo "[INFO] Apply Virtualization module config"
-          kubectl apply -f -<<EOF
+          kubectl_apply_with_retry <<EOF
           apiVersion: deckhouse.io/v1alpha1
           kind: ModuleConfig
           metadata:


### PR DESCRIPTION
## Description
Add retry logic around `kubectl apply` calls in the nested E2E `Configure Virtualization` step.

The workflow now writes the manifest received from stdin to a temporary file and retries the same `kubectl apply` command several times before failing. This covers transient Kubernetes API or DNS failures while applying `ModuleSource`, `ModuleConfig`, and `ModulePullOverride` resources.

## Why do we need it, and what problem does it solve?
The nested E2E pipeline can fail during Virtualization configuration when `kubectl apply` cannot reach the cluster API long enough to download the OpenAPI schema. This is a transient infrastructure/connectivity issue, but it currently fails the whole CI run immediately.

Example failure:

```text
[INFO] Apply ModuleSource dev config
error: error validating "STDIN": error validating data: failed to download openapi: Get "https://api.nightly-e2e-replicated-077b199-b827.e2e.virtlab.flant.com/openapi/v2?timeout=32s": dial tcp: lookup api.nightly-e2e-replicated-077b199-b827.e2e.virtlab.flant.com on 127.0.0.53:53: read udp 127.0.0.1:46600->127.0.0.53:53: i/o timeout; if you choose to ignore these errors, turn validation off with --validate=false
Error: Process completed with exit code 1.
```

Retrying the apply operation gives the nested cluster a chance to recover from short DNS/API hiccups without disabling manifest validation.

## What is the expected result?
1. Run the nested E2E workflow.
2. Trigger or encounter a short DNS/API outage during the `Configure Virtualization` step.
3. Verify that the workflow retries `kubectl apply` instead of failing on the first transient error.
4. Confirm the job continues once the apply command succeeds.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: fix
summary: Retry applying Virtualization configuration in nested E2E workflow.
impact_level: low
```