### PR TITLE
test: add PostCleanup precheck

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -97,7 +97,7 @@ task runp
 ### Debugging options
 
 - Use the FOCUS environment variable to run a specific test.
-- Set POST_CLEANUP=no to disable cleanup after tests.
+- Set POST_CLEANUP=no to disable cleanup after tests (takes precedence over isCleanupNeeded in config).
 - Set LABELS to run tests with specific label(https://onsi.github.io/ginkgo/#spec-labels).
 - Manage timeouts for new e2e tests (not for legacy tests) using env variables `E2E_SHORT_TIMEOUT`, `E2E_MIDDLE_TIMEOUT`, `E2E_LONG_TIMEOUT` and `E2E_MAX_TIMEOUT`.
 
@@ -109,6 +109,13 @@ FOCUS="ComplexTest" POST_CLEANUP=no task run
 ### PostCleanUp option
 
 POST_CLEANUP defines an environment variable used to explicitly request the deletion of created/used resources.
+
+You can also control cleanup behavior via the `isCleanupNeeded` field in `default_config.yaml`:
+```yaml
+isCleanupNeeded: true  # default: cleanup enabled
+```
+
+The POST_CLEANUP environment variable takes precedence over the YAML config.
 
 For example, run a test in no-cleanup mode:
 ```bash

--- a/test/e2e/default_config.yaml
+++ b/test/e2e/default_config.yaml
@@ -1,5 +1,7 @@
 namespaceSuffix: "e2e"
 
+isCleanupNeeded: true
+
 clusterTransport:
   kubeConfig: ""
   token: ""

--- a/test/e2e/internal/config/config.go
+++ b/test/e2e/internal/config/config.go
@@ -39,7 +39,7 @@ func GetConfig() (*Config, error) {
 	}
 	data, err := os.ReadFile(cfg)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read config file %q: %w", cfg, err)
 	}
 	var conf Config
 
@@ -76,7 +76,9 @@ type Config struct {
 	LogFilter        []string         `yaml:"logFilter"`
 	CleanupResources []string         `yaml:"cleanupResources"`
 	RegexpLogFilter  []regexp.Regexp  `yaml:"regexpLogFilter"`
-	StorageClass     StorageClass
+	IsCleanupNeeded  bool             `yaml:"isCleanupNeeded"`
+
+	StorageClass StorageClass
 }
 
 type TestData struct {
@@ -130,6 +132,10 @@ type HelperImages struct {
 }
 
 func (c *Config) setEnvs() error {
+	// isCleanupNeeded: env var has priority over yaml config
+	if e, ok := os.LookupEnv("POST_CLEANUP"); ok {
+		c.IsCleanupNeeded = e != "no"
+	}
 	// ClusterTransport
 	if e, ok := os.LookupEnv("E2E_CLUSTERTRANSPORT_KUBECONFIG"); ok {
 		c.ClusterTransport.KubeConfig = e

--- a/test/e2e/internal/framework/framework.go
+++ b/test/e2e/internal/framework/framework.go
@@ -30,8 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/deckhouse/virtualization/test/e2e/internal/config"
 )
 
 const (
@@ -74,7 +72,7 @@ func (f *Framework) Before() {
 func (f *Framework) After() {
 	GinkgoHelper()
 
-	if config.IsCleanUpNeeded() {
+	if GetConfig().IsCleanupNeeded {
 		defer func() {
 			if f.namespace != nil {
 				By("Cleanup: delete namespace")

--- a/test/e2e/internal/precheck/labels.go
+++ b/test/e2e/internal/precheck/labels.go
@@ -42,6 +42,9 @@ const (
 	// PrecheckUSB - test requires USB device with dummy_hcd to be configured.
 	PrecheckUSB = "usb-precheck"
 
+	// PrecheckPostCleanup - test requires postcleanup to be configured.
+	PrecheckPostCleanup = "postcleanup-precheck"
+
 	// NoPrecheck - test doesn't require any prechecks.
 	// Use this label for tests that don't depend on cluster configuration.
 	NoPrecheck = "no-precheck"
@@ -57,6 +60,7 @@ func KnownPrecheckLabels() []string {
 		PrecheckSnapshot,
 		PrecheckVirtualization,
 		PrecheckUSB,
+		PrecheckPostCleanup,
 		NoPrecheck,
 	}
 }

--- a/test/e2e/internal/precheck/postcleanup.go
+++ b/test/e2e/internal/precheck/postcleanup.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package precheck
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+
+	"github.com/deckhouse/virtualization/test/e2e/internal/framework"
+)
+
+const (
+	postCleanupPrecheckEnvName = "POST_CLEANUP"
+)
+
+// postcleanupPrecheck implements Precheck interface for postcleanup option.
+// This is a common precheck that runs for all tests.
+type postcleanupPrecheck struct{}
+
+func (c *postcleanupPrecheck) Label() string {
+	return PrecheckPostCleanup
+}
+
+func (c *postcleanupPrecheck) Run(ctx context.Context, f *framework.Framework) error {
+	if !isCheckEnabled(postCleanupPrecheckEnvName) {
+		_, _ = GinkgoWriter.Write([]byte("PostCleanup precheck is disabled.\n"))
+		return nil
+	}
+
+	// Validate POST_CLEANUP env var
+	env := os.Getenv(postCleanupPrecheckEnvName)
+	switch env {
+	case "yes", "no", "":
+		// valid values
+	default:
+		return fmt.Errorf("invalid value for the %s env: %q (allowed: \"\", \"yes\", \"no\")", postCleanupPrecheckEnvName, env)
+	}
+
+	return nil
+}
+
+// Register postcleanup precheck as common (runs for all tests).
+func init() {
+	RegisterPrecheck(&postcleanupPrecheck{}, true)
+}

--- a/test/e2e/legacy/complex.go
+++ b/test/e2e/legacy/complex.go
@@ -54,7 +54,7 @@ var _ = Describe("ComplexTest", Ordered, label.Legacy(), Label(precheck.NoPreche
 	})
 
 	AfterAll(func() {
-		if config.IsCleanUpNeeded() {
+		if conf.IsCleanupNeeded {
 			DeleteTestCaseResources(ns, ResourcesToDelete{
 				KustomizationDir: conf.TestData.ComplexTest,
 			})

--- a/test/e2e/legacy/image_hotplug.go
+++ b/test/e2e/legacy/image_hotplug.go
@@ -78,7 +78,7 @@ var _ = Describe("ImageHotplug", Ordered, label.Legacy(), Label(precheck.NoPrech
 	})
 
 	AfterAll(func() {
-		if config.IsCleanUpNeeded() {
+		if conf.IsCleanupNeeded {
 			DeleteTestCaseResources(ns, ResourcesToDelete{
 				KustomizationDir: conf.TestData.ImageHotplug,
 			})

--- a/test/e2e/legacy/legacy.go
+++ b/test/e2e/legacy/legacy.go
@@ -157,7 +157,7 @@ func NewBeforeProcess1Body() {
 }
 
 func NewAfterAllProcessBody() {
-	if config.IsCleanUpNeeded() {
+	if conf.IsCleanupNeeded {
 		Expect(Cleanup()).To(Succeed())
 	}
 }

--- a/test/e2e/legacy/vd_snapshots.go
+++ b/test/e2e/legacy/vd_snapshots.go
@@ -79,7 +79,7 @@ var _ = Describe("VirtualDiskSnapshots", Ordered, label.Legacy(), Label(precheck
 	})
 
 	AfterAll(func() {
-		if config.IsCleanUpNeeded() {
+		if conf.IsCleanupNeeded {
 			DeleteTestCaseResources(ns, ResourcesToDelete{
 				KustomizationDir: conf.TestData.VdSnapshots,
 			})

--- a/test/e2e/legacy/vm_disk_resizing.go
+++ b/test/e2e/legacy/vm_disk_resizing.go
@@ -29,7 +29,6 @@ import (
 	virtv1 "kubevirt.io/api/core/v1"
 
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
-	cfg "github.com/deckhouse/virtualization/test/e2e/internal/config"
 	"github.com/deckhouse/virtualization/test/e2e/internal/d8"
 	"github.com/deckhouse/virtualization/test/e2e/internal/framework"
 	kc "github.com/deckhouse/virtualization/test/e2e/internal/kubectl"
@@ -62,7 +61,7 @@ var _ = Describe("VirtualDiskResizing", Ordered, label.Legacy(), Label(precheck.
 	})
 
 	AfterAll(func() {
-		if cfg.IsCleanUpNeeded() {
+		if conf.IsCleanupNeeded {
 			DeleteTestCaseResources(ns, ResourcesToDelete{
 				KustomizationDir: conf.TestData.DiskResizing,
 			})
@@ -170,7 +169,7 @@ var _ = Describe("VirtualDiskResizing", Ordered, label.Legacy(), Label(precheck.
 				go func() {
 					defer GinkgoRecover()
 					defer wg.Done()
-					ResizeDisks(addedSize, conf, ns, vds...)
+					ResizeDisks(addedSize, ns, vds...)
 				}()
 				wg.Wait()
 			})
@@ -270,7 +269,7 @@ func WaitBlockDeviceRefsAttached(namespace string, vms ...string) {
 	}).WithTimeout(Timeout).WithPolling(Interval).Should(Succeed())
 }
 
-func ResizeDisks(addedSize *resource.Quantity, config *cfg.Config, ns string, virtualDisks ...string) {
+func ResizeDisks(addedSize *resource.Quantity, ns string, virtualDisks ...string) {
 	GinkgoHelper()
 	wg := &sync.WaitGroup{}
 	for _, vd := range virtualDisks {

--- a/test/e2e/legacy/vm_evacuation.go
+++ b/test/e2e/legacy/vm_evacuation.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
-	"github.com/deckhouse/virtualization/test/e2e/internal/config"
 	"github.com/deckhouse/virtualization/test/e2e/internal/framework"
 	kc "github.com/deckhouse/virtualization/test/e2e/internal/kubectl"
 	"github.com/deckhouse/virtualization/test/e2e/internal/label"
@@ -67,7 +66,7 @@ var _ = Describe("VirtualMachineEvacuation", Ordered, label.Legacy(), Label(prec
 		if CurrentSpecReport().Failed() {
 			SaveTestCaseDump(testCaseLabel, CurrentSpecReport().LeafNodeText, ns)
 		}
-		if config.IsCleanUpNeeded() {
+		if conf.IsCleanupNeeded {
 			DeleteTestCaseResources(ns, ResourcesToDelete{
 				KustomizationDir: conf.TestData.VMEvacuation,
 			})

--- a/test/e2e/legacy/vm_migration_cancel.go
+++ b/test/e2e/legacy/vm_migration_cancel.go
@@ -26,7 +26,6 @@ import (
 	virtv1 "kubevirt.io/api/core/v1"
 
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
-	"github.com/deckhouse/virtualization/test/e2e/internal/config"
 	"github.com/deckhouse/virtualization/test/e2e/internal/d8"
 	"github.com/deckhouse/virtualization/test/e2e/internal/framework"
 	kc "github.com/deckhouse/virtualization/test/e2e/internal/kubectl"
@@ -62,7 +61,7 @@ var _ = Describe("VirtualMachineCancelMigration", Ordered, label.Legacy(), Label
 		if CurrentSpecReport().Failed() {
 			SaveTestCaseDump(testCaseLabel, CurrentSpecReport().LeafNodeText, ns)
 		}
-		if config.IsCleanUpNeeded() {
+		if conf.IsCleanupNeeded {
 			DeleteTestCaseResources(ns, ResourcesToDelete{
 				KustomizationDir: conf.TestData.VMMigrationCancel,
 			})

--- a/test/e2e/suite_cvi.go
+++ b/test/e2e/suite_cvi.go
@@ -49,7 +49,7 @@ func bootstrapPrecreatedCVIs() {
 func cleanupPrecreatedCVIs() {
 	GinkgoHelper()
 
-	if !config.IsCleanUpNeeded() || !config.IsPrecreatedCVICleanupNeeded() {
+	if !framework.GetConfig().IsCleanupNeeded || !config.IsPrecreatedCVICleanupNeeded() {
 		return
 	}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Add PostCleanup precheck to the e2e test framework and integrate it with the Config struct.

Changes include:
- Add `IsCleanupNeeded` field to `Config` struct in `test/e2e/internal/config/config.go`
- Add default value `isCleanupNeeded: true` in `test/e2e/default_config.yaml`
- Create new `postcleanup` precheck in `test/e2e/internal/precheck/postcleanup.go` that validates the `POST_CLEANUP` environment variable
- Add `PrecheckPostCleanup` label to `test/e2e/internal/precheck/labels.go`
- Refactor legacy test files to use `conf.IsCleanupNeeded` instead of the old `config.IsCleanUpNeeded()` function
- Refactor `framework.go` and `suite_cvi.go` to use `GetConfig().IsCleanupNeeded`
- Update `test/e2e/README.md` to document the new configuration option

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
The e2e test framework previously used the `config.IsCleanUpNeeded()` function that directly read the `POST_CLEANUP` environment variable without considering the YAML configuration. This change:

1. Moves cleanup configuration to the Config struct, making it consistent with other configuration options
2. Adds a proper precheck that validates the `POST_CLEANUP` environment variable before running tests
3. Provides better documentation for users about how to control cleanup behavior

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
- Tests continue to work with the default cleanup behavior (enabled)
- Users can disable cleanup via `POST_CLEANUP=no` environment variable (takes precedence over YAML)
- Users can configure default cleanup behavior via `isCleanupNeeded` field in `default_config.yaml`
- All legacy tests and framework use the same configuration source


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: test
type: chore
summary: "Add PostCleanup precheck and IsCleanupNeeded config option for e2e tests."
impact_level: low
```
