### PR TITLE
feat(ci): add step for switch modules to maintenance mode

### DIFF
--- a/.github/workflows/e2e-reusable-pipeline.yml
+++ b/.github/workflows/e2e-reusable-pipeline.yml
@@ -1230,6 +1230,16 @@ jobs:
           echo "[INFO] Checking virt-handler pods "
           virt_handler_ready
 
+          echo "[INFO] Switch virtualization module to maintenance mode"
+          kubectl patch mc virtualization --type merge --patch '{"spec":{"maintenance":"NoResourceReconciliation"}}'
+          if [[ "${{ inputs.storage_type }}" == "replicated" ]]; then
+            echo "[INFO] Switch sds-replicated-volume module to maintenance mode"
+            kubectl patch mc sds-replicated-volume --type merge --patch '{"spec":{"maintenance":"NoResourceReconciliation"}}'
+          elif [[ "${{ inputs.storage_type }}" == "nfs" ]]; then
+            echo "[INFO] Switch csi-nfs module to maintenance mode"
+            kubectl patch mc csi-nfs --type merge --patch '{"spec":{"maintenance":"NoResourceReconciliation"}}'
+          fi
+
   e2e-test:
     name: E2E test
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
Add step in CI pipeline to switch modules to maintenance mode before running e2e tests.

## Why do we need it, and what problem does it solve?
During e2e tests execution, module components may be rolled out (due to image updates, config changes, etc.), which disrupts test runs. This change prevents module rollouts by switching modules to maintenance mode before tests start.

## What is the expected result?
1. Modules are in maintenance mode before e2e tests run
2. No unexpected module rollouts during tests
3. Stable and reliable e2e test execution

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!--
  /!\ See CONTRIBUTING.md for more details. /!\
-->
```changes
section: ci
type: feature
summary: Add step to switch modules to maintenance mode before e2e tests.
```