### PR TITLE
chore(ci): increase timeout for e2e test on nested cluster

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -427,7 +427,7 @@ jobs:
       deckhouse_channel: alpha
       default_user: cloud
       go_version: "1.25.9"
-      e2e_timeout: "3.5h"
+      e2e_timeout: "5h"
       date_start: ${{ needs.set-vars.outputs.date_start }}
       randuuid4c: ${{ needs.set-vars.outputs.randuuid4c }}
       cluster_config_workers_memory: "9Gi"
@@ -453,7 +453,7 @@ jobs:
       deckhouse_channel: alpha
       default_user: cloud
       go_version: "1.24.13"
-      e2e_timeout: "3.5h"
+      e2e_timeout: "5h"
       date_start: ${{ needs.set-vars.outputs.date_start }}
       randuuid4c: ${{ needs.set-vars.outputs.randuuid4c }}
       cluster_config_workers_memory: "9Gi"


### PR DESCRIPTION
## Description
Increase the e2e timeout for nested cluster jobs in `.github/workflows/e2e-matrix.yml` from `3.5h` to `5h`.

## Why do we need it, and what problem does it solve?
Nested cluster e2e runs take longer than the current timeout in CI and may be interrupted before the test flow finishes. This causes unstable results and reruns even when the environment is still progressing normally. Increasing the timeout gives nested cluster jobs enough time to complete and reduces false-negative failures caused by CI timeout limits.

## What is the expected result?
1. Run nested cluster e2e jobs in CI.
2. Verify jobs for both configured Kubernetes versions use the updated `5h` timeout.
3. Confirm long-running nested cluster e2e executions are no longer terminated by the previous `3.5h` timeout.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: chore
summary: "Increase timeout for nested cluster e2e jobs from 3.5h to 5h."
impact_level: low
```
