### PR TITLE
test: temporary disable VirtualMachineOperationRestore

### DIFF
--- a/test/e2e/vmop/restore.go
+++ b/test/e2e/vmop/restore.go
@@ -84,7 +84,7 @@ var _ = Describe("VirtualMachineOperationRestore", label.Slow(), Label(precheck.
 
 		t := newRestoreTest(f)
 		if !t.IsStorageClassAvailableForTest(t.VM) {
-			Skip("Storage class is not available for test")
+			Skip("Temporary skip on sds-replicated-volume until snapshot functionality is fixed")
 		}
 
 		By("Environment preparation", func() {
@@ -536,10 +536,5 @@ func (t *restoreModeTest) IsStorageClassAvailableForTest(vm *v1alpha2.VirtualMac
 	sc, err := legacy.GetDefaultStorageClass()
 	Expect(err).NotTo(HaveOccurred())
 
-	if sc.Provisioner != "replicated.csi.storage.deckhouse.io" {
-		return true
-	}
-
-	placementCount, ok := sc.Parameters["replicated.csi.storage.deckhouse.io/placementCount"]
-	return ok && placementCount == "1"
+	return sc.Provisioner != framework.SDSReplicatedVolume
 }


### PR DESCRIPTION
## Description
Temporarily skip `VirtualMachineOperationRestore` on `sds-replicated-volume`.

## Why do we need it, and what problem does it solve?
The test is currently unstable on the existing replicated storage implementation because of snapshot-related issues. We are waiting for the new replicated implementation, so the test is skipped for this storage class for now.

## What is the expected result?
`VirtualMachineOperationRestore` is skipped on `sds-replicated-volume` and continues to run on other storage classes.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
```changes
section: test
type: chore
summary: Temporarily skip VirtualMachineOperationRestore on sds-replicated-volume while waiting for the new replicated implementation.
impact_level: low
```