### PR TITLE
chore(test): fix postcleanup precheck

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -101,14 +101,18 @@ FOCUS="ComplexTest" POST_CLEANUP=no task run
 
 ### PostCleanUp option
 
-POST_CLEANUP defines an environment variable used to explicitly request the deletion of created/used resources.
+`POST_CLEANUP` defines an environment variable used to explicitly request the deletion of created/used resources.
+
+Valid values:
+- `yes` or "" (empty) - perform cleanup after tests (default)
+- `no` - skip cleanup after tests
 
 You can also control cleanup behavior via the `isCleanupNeeded` field in `default_config.yaml`:
 ```yaml
 isCleanupNeeded: true  # default: cleanup enabled
 ```
 
-The POST_CLEANUP environment variable takes precedence over the YAML config.
+The `POST_CLEANUP` environment variable takes precedence over the YAML config.
 
 For example, run a test in no-cleanup mode:
 ```bash

--- a/test/e2e/internal/config/cleanup.go
+++ b/test/e2e/internal/config/cleanup.go
@@ -18,18 +18,18 @@ package config
 
 import (
 	"fmt"
-	"log"
 	"os"
 )
-
-// PostCleanUpEnv defines an environment variable used to explicitly request the deletion of created/used resources.
-const PostCleanUpEnv = "POST_CLEANUP"
 
 // PrecreatedCVICleanupEnv defines an environment variable to explicitly enable deletion of precreated CVIs after the suite.
 //
 // By default, precreated CVIs are not deleted: they are shared across runs and may be reused.
 // Set PRECREATED_CVI_CLEANUP=yes to delete them after the suite; unset, empty, or "no" means no deletion.
 const PrecreatedCVICleanupEnv = "PRECREATED_CVI_CLEANUP"
+
+// PostCleanupEnv defines an environment variable used to explicitly request the deletion of created/used resources.
+// Valid values: "yes", "no", or "" (default = yes).
+const PostCleanupEnv = "POST_CLEANUP"
 
 func CheckPrecreatedCVICleanupOption() error {
 	env := os.Getenv(PrecreatedCVICleanupEnv)
@@ -45,22 +45,4 @@ func CheckPrecreatedCVICleanupOption() error {
 // Default (unset, empty, or "no"): precreated CVIs are not deleted after the suite.
 func IsPrecreatedCVICleanupNeeded() bool {
 	return os.Getenv(PrecreatedCVICleanupEnv) == "yes"
-}
-
-func CheckWithPostCleanUpOption() error {
-	env := os.Getenv(PostCleanUpEnv)
-	switch env {
-	case "yes", "no", "":
-		return nil
-	default:
-		log.Printf(
-			"Usual behaviour for tests is to make post cleanup (when %[1]s is not set or equal to 'yes'). Use %[1]s=no to skip post cleanup after tests.\n",
-			PostCleanUpEnv,
-		)
-		return fmt.Errorf("invalid value for the %s env: %q", PostCleanUpEnv, env)
-	}
-}
-
-func IsCleanUpNeeded() bool {
-	return os.Getenv(PostCleanUpEnv) != "no"
 }

--- a/test/e2e/internal/config/config.go
+++ b/test/e2e/internal/config/config.go
@@ -133,7 +133,7 @@ type HelperImages struct {
 
 func (c *Config) setEnvs() error {
 	// isCleanupNeeded: env var has priority over yaml config
-	if e, ok := os.LookupEnv("POST_CLEANUP"); ok {
+	if e, ok := os.LookupEnv(PostCleanupEnv); ok {
 		c.IsCleanupNeeded = e != "no"
 	}
 	// ClusterTransport

--- a/test/e2e/internal/precheck/postcleanup.go
+++ b/test/e2e/internal/precheck/postcleanup.go
@@ -23,11 +23,15 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 
+	"github.com/deckhouse/virtualization/test/e2e/internal/config"
 	"github.com/deckhouse/virtualization/test/e2e/internal/framework"
 )
 
 const (
-	postCleanupPrecheckEnvName = "POST_CLEANUP"
+	// POST_CLEANUP_PRECHECK controls whether the precheck runs.
+	// Precheck validates that POST_CLEANUP has a valid value.
+	// Set to "no" to disable precheck execution.
+	postCleanupPrecheckEnvName = "POST_CLEANUP_PRECHECK"
 )
 
 // postcleanupPrecheck implements Precheck interface for postcleanup option.
@@ -44,13 +48,13 @@ func (c *postcleanupPrecheck) Run(ctx context.Context, f *framework.Framework) e
 		return nil
 	}
 
-	// Validate POST_CLEANUP env var
-	env := os.Getenv(postCleanupPrecheckEnvName)
+	// Validate POST_CLEANUP env var (controls cleanup behavior)
+	env := os.Getenv(config.PostCleanupEnv)
 	switch env {
 	case "yes", "no", "":
 		// valid values
 	default:
-		return fmt.Errorf("invalid value for the %s env: %q (allowed: \"\", \"yes\", \"no\")", postCleanupPrecheckEnvName, env)
+		return fmt.Errorf("invalid value for the %s env: %q (allowed: \"\", \"yes\", \"no\")", config.PostCleanupEnv, env)
 	}
 
 	return nil

--- a/test/e2e/legacy/legacy.go
+++ b/test/e2e/legacy/legacy.go
@@ -66,9 +66,6 @@ func Init() error {
 }
 
 func configure() (err error) {
-	if err = config.CheckWithPostCleanUpOption(); err != nil {
-		return err
-	}
 	if err = config.CheckPrecreatedCVICleanupOption(); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Fixes the postcleanup precheck system in e2e tests:

- Renamed `POST_CLEANUP` to `POST_CLEANUP_PRECHECK` to control precheck execution separately
- `POST_CLEANUP` now only controls cleanup behavior and is validated by the precheck
- Removed duplicate validation (`CheckWithPostCleanUpOption`) from legacy package
- Added `PostCleanupEnv` constant in config package to avoid duplication
- Updated README with valid `POST_CLEANUP` values

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
The postcleanup precheck had several issues:

1. **Duplicate validation**: Both `config.CheckWithPostCleanUpOption()` in legacy package and the precheck performed the same validation of `POST_CLEANUP` environment variable
2. **Confusing naming**: The same variable `POST_CLEANUP` was used both to control precheck execution and to control cleanup behavior, making it unclear which functionality is being configured
3. **Unused functions**: `IsCleanUpNeeded()` was not used by any test after config field was added

The fix separates concerns:
- `POST_CLEANUP_PRECHECK` - controls whether the precheck runs
- `POST_CLEANUP` - controls whether cleanup is performed after tests

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
- Precheck validates `POST_CLEANUP` has valid values (`"yes"`, `"no"`, `""`)
- Users can disable precheck with `POST_CLEANUP_PRECHECK=no`
- Users can control cleanup with `POST_CLEANUP=no`
- No duplicate validation code

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: test
type: chore
summary: "Fix postcleanup precheck: rename POST_CLEANUP to POST_CLEANUP_PRECHECK, remove duplicate validation from legacy package."
```
