### PR TITLE
test: improve flaky usb reconnection test

### DIFF
--- a/test/e2e/vm/usb.go
+++ b/test/e2e/vm/usb.go
@@ -19,6 +19,7 @@ package vm
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -91,7 +92,15 @@ var _ = Describe("VirtualMachineUSB", Label(precheck.PrecheckUSB), func() {
 		})
 
 		By("Mounting USB device", func() {
-			t.mountUSB()
+			GinkgoWriter.Println("Finding USB device")
+			mountDevice := t.findUSBMountDevice()
+			GinkgoWriter.Println("Found USB device:", mountDevice)
+
+			GinkgoWriter.Println("Formatting USB device")
+			t.formatUSBDevice(mountDevice)
+
+			GinkgoWriter.Println("Mounting USB device")
+			t.mountUSBDevice(mountDevice)
 		})
 
 		By("Writing data to USB device", func() {
@@ -115,7 +124,12 @@ var _ = Describe("VirtualMachineUSB", Label(precheck.PrecheckUSB), func() {
 		})
 
 		By("Remounting USB device after migration", func() {
-			t.mountUSB()
+			GinkgoWriter.Println("Finding USB device")
+			mountDevice := t.findUSBMountDevice()
+			GinkgoWriter.Println("Found USB device:", mountDevice)
+
+			GinkgoWriter.Println("Remounting USB device")
+			t.mountUSBDevice(mountDevice)
 		})
 
 		By("Verifying data persists after migration", func() {
@@ -182,6 +196,8 @@ func (t *VMUSBTest) GenerateEnvironmentResources() {
 		}
 	}
 	Expect(freeUSB).NotTo(BeNil(), "no free USB devices available")
+
+	GinkgoWriter.Println("Found free USB device:", freeUSB.Name)
 
 	t.NodeUSBDevice = freeUSB
 
@@ -255,11 +271,11 @@ func (t *VMUSBTest) verifyUSBTestData() {
 	Expect(result).To(ContainSubstring(t.testContent))
 }
 
-func (t *VMUSBTest) mountUSB() {
+func (t *VMUSBTest) findUSBMountDevice() string {
 	serial := t.NodeUSBDevice.Status.Attributes.Serial
 	Expect(serial).NotTo(BeEmpty(), "USB device serial must be set")
 
-	mountCmd := fmt.Sprintf(`
+	findDeviceCmd := fmt.Sprintf(`
 		usb_serial=%q
 		: > /tmp/usb-mount.err
 		for serial_file in /sys/bus/usb/devices/*/serial; do
@@ -293,20 +309,69 @@ func (t *VMUSBTest) mountUSB() {
 			exit 1
 		}
 
+		echo "$mount_device"
+	`, serial)
+
+	var mountDevice string
+
+	Eventually(func() error {
+		result, err := t.Framework.SSHCommand(
+			t.VM.Name,
+			t.VM.Namespace,
+			findDeviceCmd,
+			framework.WithSSHTimeout(framework.ShortTimeout),
+		)
+		if err != nil {
+			return err
+		}
+		mountDevice = strings.TrimSpace(result)
+		if mountDevice == "" {
+			return fmt.Errorf("empty mount device output")
+		}
+
+		return nil
+	}).WithTimeout(framework.MiddleTimeout).WithPolling(time.Second).Should(Succeed(), t.usbDiagnostics())
+
+	return mountDevice
+}
+
+func (t *VMUSBTest) formatUSBDevice(mountDevice string) {
+	formatCmd := fmt.Sprintf(`
+		: > /tmp/usb-mount.err
+		sudo mkfs.vfat -I %q 2>>/tmp/usb-mount.err
+	`, mountDevice)
+
+	Eventually(func() error {
+		_, err := t.Framework.SSHCommand(
+			t.VM.Name,
+			t.VM.Namespace,
+			formatCmd,
+			framework.WithSSHTimeout(framework.ShortTimeout),
+		)
+		return err
+	}).WithTimeout(framework.MiddleTimeout).WithPolling(time.Second).Should(Succeed(), t.usbDiagnostics())
+}
+
+func (t *VMUSBTest) mountUSBDevice(mountDevice string) {
+	mountCmd := fmt.Sprintf(`
+		: > /tmp/usb-mount.err
 		sudo mkdir -p /mnt/usb
 		if sudo mountpoint -q /mnt/usb; then
 			sudo umount /mnt/usb || true
 		fi
-		sudo mount -t auto "$mount_device" /mnt/usb 2>>/tmp/usb-mount.err || \
-			sudo mount -t vfat -o rw "$mount_device" /mnt/usb 2>>/tmp/usb-mount.err || \
-			sudo mount -o rw "$mount_device" /mnt/usb 2>>/tmp/usb-mount.err
+		sudo mount %q /mnt/usb 2>>/tmp/usb-mount.err
 		ls -la /mnt/usb
-	`, serial)
+	`, mountDevice)
 
 	Eventually(func() error {
-		_, err := t.Framework.SSHCommand(t.VM.Name, t.VM.Namespace, mountCmd, framework.WithSSHTimeout(framework.MiddleTimeout))
+		_, err := t.Framework.SSHCommand(
+			t.VM.Name,
+			t.VM.Namespace,
+			mountCmd,
+			framework.WithSSHTimeout(framework.MiddleTimeout),
+		)
 		return err
-	}).WithTimeout(framework.MiddleTimeout).WithPolling(time.Second).Should(Succeed(), t.usbDiagnostics())
+	}).WithTimeout(framework.LongTimeout).WithPolling(time.Second).Should(Succeed(), t.usbDiagnostics())
 }
 
 func (t *VMUSBTest) usbDiagnostics() string {


### PR DESCRIPTION
## Description
Refactor the flaky USB reconnection e2e test to improve reliability.

The monolithic `mountUSB()` function was split into three focused steps:
- `findUSBMountDevice()` — locates the block device path via `/sys/bus/usb/devices` with retries
- `formatUSBDevice(mountDevice)` — formats the device with `mkfs.vfat` before the first mount to ensure a clean filesystem
- `mountUSBDevice(mountDevice)` — mounts the located device directly by path (no multi-fallback `mount -t auto`)

Additional diagnostic `GinkgoWriter.Println` calls were added at key steps, and `LongTimeout` is now used for the mount step to handle slow environments.

## Why do we need it, and what problem does it solve?
The USB reconnection test was flaky because:
1. Device lookup and mounting were bundled in one shell script, making it hard to diagnose which step failed.
2. The mount command tried several fallback options (`-t auto`, `-t vfat`, no flag), masking root causes.
3. The device was not formatted before mounting, so an unclean or unformatted device could cause a mount failure on first use.

Splitting the steps, adding an explicit `mkfs.vfat` format, and increasing the mount timeout makes the test deterministic and easier to debug when it does fail.

## What is the expected result?
1. Run the `VirtualMachineUSB` e2e suite.
2. The test should consistently pass without flaky failures on the "Mounting USB device" and "Remounting USB device after migration" steps.
3. On failure, `GinkgoWriter` output clearly shows which step (find / format / mount) failed.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: test
type: fix
summary: Improve reliability of flaky USB reconnection e2e test by splitting mount logic into find, format, and mount steps.
impact_level: low
```
