### PR TITLE
docs: add CRD examples

### DIFF
--- a/crds/clustervirtualimages.yaml
+++ b/crds/clustervirtualimages.yaml
@@ -58,6 +58,16 @@ spec:
             With this resource in the cluster, a container image is created and stored in a dedicated Deckhouse Virtualization Container Registry (DVCR).
 
             **Note:** The `metadata.name` field must comply with [Kubernetes object naming conventions](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) and must not exceed 48 characters.
+          x-examples:
+            - apiVersion: virtualization.deckhouse.io/v1alpha2
+              kind: ClusterVirtualImage
+              metadata:
+                name: ubuntu-24-04
+              spec:
+                dataSource:
+                  type: HTTP
+                  http:
+                    url: https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img
           properties:
             apiVersion:
               description: |-

--- a/crds/nodeusbdevices.yaml
+++ b/crds/nodeusbdevices.yaml
@@ -47,6 +47,13 @@ spec:
             Represents a USB device discovered on a specific node in the cluster.
             This resource is created automatically by the DRA (Dynamic Resource Allocation) system
             when a USB device is detected on a node.
+          x-examples:
+            - apiVersion: virtualization.deckhouse.io/v1alpha2
+              kind: NodeUSBDevice
+              metadata:
+                name: logitech-webcam
+              spec:
+                assignedNamespace: my-project
           properties:
             apiVersion:
               description: |-

--- a/crds/virtualdisks.yaml
+++ b/crds/virtualdisks.yaml
@@ -64,11 +64,16 @@ spec:
             - apiVersion: virtualization.deckhouse.io/v1alpha2
               kind: VirtualDisk
               metadata:
-                name: blank-disk
+                name: linux-vm-root
               spec:
                 persistentVolumeClaim:
                   storageClassName: rv-thin-r2
-                  size: 100Mi
+                  size: 10Gi
+                dataSource:
+                  type: ObjectRef
+                  objectRef:
+                    kind: VirtualImage
+                    name: ubuntu-24-04
           properties:
             apiVersion:
               description: |-

--- a/crds/virtualdisks.yaml
+++ b/crds/virtualdisks.yaml
@@ -60,6 +60,15 @@ spec:
             Once a VirtualDisk is created, the following fields in `.spec.persistentVolumeClaim` can be changed: `size` and `storageClassName`. All other fields are immutable.
 
             **Note:** The `metadata.name` field must comply with [Kubernetes object naming conventions](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) and must not exceed 60 characters.
+          x-examples:
+            - apiVersion: virtualization.deckhouse.io/v1alpha2
+              kind: VirtualDisk
+              metadata:
+                name: blank-disk
+              spec:
+                persistentVolumeClaim:
+                  storageClassName: rv-thin-r2
+                  size: 100Mi
           properties:
             apiVersion:
               description: |-

--- a/crds/virtualdisksnapshots.yaml
+++ b/crds/virtualdisksnapshots.yaml
@@ -29,6 +29,14 @@ spec:
             Provides a resource for creating snapshots of existing virtual disks, which can be used as data sources for generating new virtual disks.
 
             When running, a VolumeSnapshot resource is created.
+          x-examples:
+            - apiVersion: virtualization.deckhouse.io/v1alpha2
+              kind: VirtualDiskSnapshot
+              metadata:
+                name: linux-vm-root-snapshot
+              spec:
+                requiredConsistency: true
+                virtualDiskName: linux-vm-root
           required:
             - spec
           properties:

--- a/crds/virtualimages.yaml
+++ b/crds/virtualimages.yaml
@@ -61,6 +61,17 @@ spec:
             With this resource in the cluster, a container image is created and stored in a dedicated Deckhouse Virtualization Container Registry (DVCR) or PVC, with the data filled in from the source.
 
             **Note:** The `metadata.name` field must comply with [Kubernetes object naming conventions](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) and must not exceed 49 characters.
+          x-examples:
+            - apiVersion: virtualization.deckhouse.io/v1alpha2
+              kind: VirtualImage
+              metadata:
+                name: ubuntu-24-04
+              spec:
+                storage: ContainerRegistry
+                dataSource:
+                  type: HTTP
+                  http:
+                    url: https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img
           properties:
             apiVersion:
               description: |-

--- a/crds/virtualmachineblockdeviceattachments.yaml
+++ b/crds/virtualmachineblockdeviceattachments.yaml
@@ -50,6 +50,16 @@ spec:
           description: |-
             VirtualMachineBlockDeviceAttachment provides a hot plug for attaching a disk to a virtual machine.
             Disks are always attached using the SCSI bus, regardless of the enableParavirtualization setting.
+          x-examples:
+            - apiVersion: virtualization.deckhouse.io/v1alpha2
+              kind: VirtualMachineBlockDeviceAttachment
+              metadata:
+                name: attach-blank-disk
+              spec:
+                blockDeviceRef:
+                  kind: VirtualDisk
+                  name: blank-disk
+                virtualMachineName: linux-vm
           properties:
             apiVersion:
               description: |-

--- a/crds/virtualmachineclasses.yaml
+++ b/crds/virtualmachineclasses.yaml
@@ -44,6 +44,14 @@ spec:
           description: |-
             VirtualMachineClass resource describes CPU requirements, node placement, and sizing policy for VM resources.
             A resource cannot be deleted as long as it is used in one of the VMs.
+          x-examples:
+            - apiVersion: virtualization.deckhouse.io/v1alpha2
+              kind: VirtualMachineClass
+              metadata:
+                name: host
+              spec:
+                cpu:
+                  type: Host
           properties:
             apiVersion:
               description: |-

--- a/crds/virtualmachineipaddresses.yaml
+++ b/crds/virtualmachineipaddresses.yaml
@@ -22,6 +22,14 @@ spec:
         openAPIV3Schema:
           description: |
             Defines the IP address for a virtual machine.
+          x-examples:
+            - apiVersion: virtualization.deckhouse.io/v1alpha2
+              kind: VirtualMachineIPAddress
+              metadata:
+                name: linux-vm-custom-ip
+              spec:
+                type: Static
+                staticIP: 10.66.20.77
           properties:
             apiVersion:
               type: string

--- a/crds/virtualmachineipaddresses.yaml
+++ b/crds/virtualmachineipaddresses.yaml
@@ -28,8 +28,7 @@ spec:
               metadata:
                 name: linux-vm-custom-ip
               spec:
-                type: Static
-                staticIP: 10.66.20.77
+                type: Auto
           properties:
             apiVersion:
               type: string

--- a/crds/virtualmachineoperations.yaml
+++ b/crds/virtualmachineoperations.yaml
@@ -48,6 +48,14 @@ spec:
           description:
             VirtualMachineOperation enables declarative management of virtual
             machine state changes.
+          x-examples:
+            - apiVersion: virtualization.deckhouse.io/v1alpha2
+              kind: VirtualMachineOperation
+              metadata:
+                generateName: restart-linux-vm-
+              spec:
+                virtualMachineName: linux-vm
+                type: Restart
           properties:
             apiVersion:
               description: |-

--- a/crds/virtualmachinerestores.yaml
+++ b/crds/virtualmachinerestores.yaml
@@ -40,14 +40,6 @@ spec:
           description:
             VirtualMachineRestore provides a resource for restoring a virtual
             machine and all associated resources from a snapshot.
-          x-examples:
-            - apiVersion: virtualization.deckhouse.io/v1alpha2
-              kind: VirtualMachineRestore
-              metadata:
-                name: restore-linux-vm
-              spec:
-                virtualMachineSnapshotName: linux-vm-snapshot
-                restoreMode: Safe
           properties:
             apiVersion:
               description: |-

--- a/crds/virtualmachinerestores.yaml
+++ b/crds/virtualmachinerestores.yaml
@@ -47,6 +47,7 @@ spec:
                 name: restore-linux-vm
               spec:
                 virtualMachineSnapshotName: linux-vm-snapshot
+                restoreMode: Safe
           properties:
             apiVersion:
               description: |-

--- a/crds/virtualmachinerestores.yaml
+++ b/crds/virtualmachinerestores.yaml
@@ -40,6 +40,13 @@ spec:
           description:
             VirtualMachineRestore provides a resource for restoring a virtual
             machine and all associated resources from a snapshot.
+          x-examples:
+            - apiVersion: virtualization.deckhouse.io/v1alpha2
+              kind: VirtualMachineRestore
+              metadata:
+                name: restore-linux-vm
+              spec:
+                virtualMachineSnapshotName: linux-vm-snapshot
           properties:
             apiVersion:
               description: |-

--- a/crds/virtualmachines.yaml
+++ b/crds/virtualmachines.yaml
@@ -49,20 +49,7 @@ spec:
                   size: 1Gi
                 provisioning:
                   type: UserData
-                  userData: |
-                    #cloud-config
-                    package_update: true
-                    packages:
-                      - qemu-guest-agent
-                    runcmd:
-                      - systemctl enable --now qemu-guest-agent.service
-                    ssh_pwauth: true
-                    users:
-                      - name: cloud
-                        passwd: "$6$rounds=4096$saltsalt$fPmUsbjAuA7mnQNTajQM6ClhesyG0.yyQhvahas02ejfMAq1ykBo1RquzS0R6GgdIDlvS.kbUwDablGZKZcTP/"
-                        shell: /bin/bash
-                        sudo: ALL=(ALL) NOPASSWD:ALL
-                        lock_passwd: false
+                  userData: <USER_DATA>
                 blockDeviceRefs:
                   - kind: VirtualDisk
                     name: linux-vm-root

--- a/crds/virtualmachines.yaml
+++ b/crds/virtualmachines.yaml
@@ -47,6 +47,22 @@ spec:
                   coreFraction: 10%
                 memory:
                   size: 1Gi
+                provisioning:
+                  type: UserData
+                  userData: |
+                    #cloud-config
+                    package_update: true
+                    packages:
+                      - qemu-guest-agent
+                    runcmd:
+                      - systemctl enable --now qemu-guest-agent.service
+                    ssh_pwauth: true
+                    users:
+                      - name: cloud
+                        passwd: "$6$rounds=4096$saltsalt$fPmUsbjAuA7mnQNTajQM6ClhesyG0.yyQhvahas02ejfMAq1ykBo1RquzS0R6GgdIDlvS.kbUwDablGZKZcTP/"
+                        shell: /bin/bash
+                        sudo: ALL=(ALL) NOPASSWD:ALL
+                        lock_passwd: false
                 blockDeviceRefs:
                   - kind: VirtualDisk
                     name: linux-vm-root

--- a/crds/virtualmachines.yaml
+++ b/crds/virtualmachines.yaml
@@ -35,6 +35,21 @@ spec:
             - `.spec.runPolicy`.
 
             **Note:** The `metadata.name` field must comply with [Kubernetes object naming conventions](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) and must not exceed 63 characters.
+          x-examples:
+            - apiVersion: virtualization.deckhouse.io/v1alpha2
+              kind: VirtualMachine
+              metadata:
+                name: linux-vm
+              spec:
+                virtualMachineClassName: generic
+                cpu:
+                  cores: 1
+                  coreFraction: 10%
+                memory:
+                  size: 1Gi
+                blockDeviceRefs:
+                  - kind: VirtualDisk
+                    name: linux-vm-root
           required:
             - spec
           properties:

--- a/crds/virtualmachinesnapshotoperations.yaml
+++ b/crds/virtualmachinesnapshotoperations.yaml
@@ -48,10 +48,10 @@ spec:
             - apiVersion: virtualization.deckhouse.io/v1alpha2
               kind: VirtualMachineSnapshotOperation
               metadata:
-                name: <vmsop-name>
+                name: vmsop-name
               spec:
                 type: CreateVirtualMachine
-                virtualMachineSnapshotName: <name of the VM snapshot from which to clone>
+                virtualMachineSnapshotName: vm-snapshot-clone
                 createVirtualMachine:
                   mode: DryRun | Strict | BestEffort
                   nameReplacements: []

--- a/crds/virtualmachinesnapshotoperations.yaml
+++ b/crds/virtualmachinesnapshotoperations.yaml
@@ -54,8 +54,8 @@ spec:
                 virtualMachineSnapshotName: <name of the VM snapshot from which to clone>
                 createVirtualMachine:
                   mode: DryRun | Strict | BestEffort
-                  nameReplacements: [ ]
-                  customization: { }
+                  nameReplacements: []
+                  customization: {}
           properties:
             apiVersion:
               description: |-

--- a/crds/virtualmachinesnapshotoperations.yaml
+++ b/crds/virtualmachinesnapshotoperations.yaml
@@ -48,21 +48,14 @@ spec:
             - apiVersion: virtualization.deckhouse.io/v1alpha2
               kind: VirtualMachineSnapshotOperation
               metadata:
-                name: clone-linux-vm-from-snapshot
+                name: <vmsop-name>
               spec:
                 type: CreateVirtualMachine
-                virtualMachineSnapshotName: linux-vm-snapshot
+                virtualMachineSnapshotName: <name of the VM snapshot from which to clone>
                 createVirtualMachine:
-                  mode: Strict
-                  nameReplacement:
-                    - from:
-                        kind: VirtualMachine
-                        name: linux-vm
-                      to: linux-vm-clone
-                    - from:
-                        kind: VirtualDisk
-                        name: linux-vm-root
-                      to: linux-vm-clone-root
+                  mode: DryRun | Strict | BestEffort
+                  nameReplacements: [ ]
+                  customization: { }
           properties:
             apiVersion:
               description: |-

--- a/crds/virtualmachinesnapshotoperations.yaml
+++ b/crds/virtualmachinesnapshotoperations.yaml
@@ -48,15 +48,21 @@ spec:
             - apiVersion: virtualization.deckhouse.io/v1alpha2
               kind: VirtualMachineSnapshotOperation
               metadata:
-                name: clone-database-from-snapshot
+                name: clone-linux-vm-from-snapshot
               spec:
                 type: CreateVirtualMachine
-                virtualMachineSnapshotName: database-snapshot
+                virtualMachineSnapshotName: linux-vm-snapshot
                 createVirtualMachine:
                   mode: Strict
-                  customization:
-                    namePrefix: clone-
-                    nameSuffix: -prod
+                  nameReplacement:
+                    - from:
+                        kind: VirtualMachine
+                        name: linux-vm
+                      to: linux-vm-clone
+                    - from:
+                        kind: VirtualDisk
+                        name: linux-vm-root
+                      to: linux-vm-clone-root
           properties:
             apiVersion:
               description: |-

--- a/crds/virtualmachinesnapshotoperations.yaml
+++ b/crds/virtualmachinesnapshotoperations.yaml
@@ -44,6 +44,19 @@ spec:
           description:
             VirtualMachineSnapshotOperation enables declarative management
             of virtual machine snapshot state changes.
+          x-examples:
+            - apiVersion: virtualization.deckhouse.io/v1alpha2
+              kind: VirtualMachineSnapshotOperation
+              metadata:
+                name: clone-database-from-snapshot
+              spec:
+                type: CreateVirtualMachine
+                virtualMachineSnapshotName: database-snapshot
+                createVirtualMachine:
+                  mode: Strict
+                  customization:
+                    namePrefix: clone-
+                    nameSuffix: -prod
           properties:
             apiVersion:
               description: |-

--- a/crds/virtualmachinesnapshotoperations.yaml
+++ b/crds/virtualmachinesnapshotoperations.yaml
@@ -48,14 +48,21 @@ spec:
             - apiVersion: virtualization.deckhouse.io/v1alpha2
               kind: VirtualMachineSnapshotOperation
               metadata:
-                name: vmsop-name
+                name: clone-linux-vm-from-snapshot
               spec:
                 type: CreateVirtualMachine
-                virtualMachineSnapshotName: vm-snapshot-clone
+                virtualMachineSnapshotName: linux-vm-snapshot
                 createVirtualMachine:
-                  mode: DryRun | Strict | BestEffort
-                  nameReplacements: []
-                  customization: {}
+                  mode: Strict
+                  nameReplacement:
+                    - from:
+                        kind: VirtualMachine
+                        name: linux-vm
+                      to: linux-vm-clone
+                    - from:
+                        kind: VirtualDisk
+                        name: linux-vm-root
+                      to: linux-vm-clone-root
           properties:
             apiVersion:
               description: |-

--- a/crds/virtualmachinesnapshots.yaml
+++ b/crds/virtualmachinesnapshots.yaml
@@ -41,6 +41,15 @@ spec:
           description:
             VirtualMachineSnapshot provides a resource for creating snapshots
             of virtual machines.
+          x-examples:
+            - apiVersion: virtualization.deckhouse.io/v1alpha2
+              kind: VirtualMachineSnapshot
+              metadata:
+                name: linux-vm-snapshot
+              spec:
+                virtualMachineName: linux-vm
+                requiredConsistency: true
+                keepIPAddress: Never
           properties:
             apiVersion:
               description: |-


### PR DESCRIPTION
## Description
Added `x-examples` to CRD files.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: docs
type: docs
summary: "Added `x-examples` field to CRD files."
impact_level: low
```
