### PR TITLE
test(vd): verify VirtualDisk readiness after VM is running

### DIFF
--- a/test/e2e/blockdevice/virtual_disk_provisioning.go
+++ b/test/e2e/blockdevice/virtual_disk_provisioning.go
@@ -59,7 +59,7 @@ var _ = Describe("VirtualDiskProvisioning", Label(precheck.NoPrecheck), func() {
 		)
 
 		By("Creating VirtualImage from precreated CVI", func() {
-			vi = object.NewGeneratedVIFromCVI("vi-", f.Namespace().Name, object.PrecreatedCVIAlpineUEFI)
+			vi = object.NewGeneratedVIFromCVI("vi-", f.Namespace().Name, object.PrecreatedCVIAlpineBIOS)
 
 			err := f.CreateWithDeferredDeletion(ctx, vi)
 			Expect(err).NotTo(HaveOccurred())
@@ -106,7 +106,7 @@ var _ = Describe("VirtualDiskProvisioning", Label(precheck.NoPrecheck), func() {
 			vm *v1alpha2.VirtualMachine
 		)
 		By("Creating VirtualImage", func() {
-			vi = object.NewGeneratedVIFromCVI("vi-", f.Namespace().Name, object.PrecreatedCVIAlpineUEFI)
+			vi = object.NewGeneratedVIFromCVI("vi-", f.Namespace().Name, object.PrecreatedCVIAlpineBIOS)
 			err := f.CreateWithDeferredDeletion(ctx, vi)
 			Expect(err).NotTo(HaveOccurred())
 		})

--- a/test/e2e/blockdevice/virtual_disk_provisioning.go
+++ b/test/e2e/blockdevice/virtual_disk_provisioning.go
@@ -113,10 +113,6 @@ var _ = Describe("VirtualDiskProvisioning", Label(precheck.NoPrecheck), func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		By("Waiting for VirtualDisk to be ready", func() {
-			util.UntilObjectPhase(ctx, string(v1alpha2.DiskReady), framework.LongTimeout, vd)
-		})
-
 		By("Creating VirtualMachine and waiting for VirtualMachine to be ready", func() {
 			vm := object.NewMinimalVM("vm-", f.Namespace().Name, vmbuilder.WithBlockDeviceRefs(v1alpha2.BlockDeviceSpecRef{
 				Kind: v1alpha2.VirtualDiskKind,
@@ -126,6 +122,10 @@ var _ = Describe("VirtualDiskProvisioning", Label(precheck.NoPrecheck), func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			util.UntilObjectPhase(ctx, string(v1alpha2.MachineRunning), framework.LongTimeout, vm)
+		})
+
+		By("Waiting for VirtualDisk to be ready", func() {
+			util.UntilObjectPhase(ctx, string(v1alpha2.DiskReady), framework.LongTimeout, vd)
 		})
 	})
 
@@ -138,10 +138,6 @@ var _ = Describe("VirtualDiskProvisioning", Label(precheck.NoPrecheck), func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		By("Waiting for VirtualDisk to be ready", func() {
-			util.UntilObjectPhase(ctx, string(v1alpha2.DiskReady), framework.LongTimeout, vd)
-		})
-
 		By("Creating VirtualMachine and waiting for VirtualMachine to be ready", func() {
 			vm := object.NewMinimalVM("vm-", f.Namespace().Name, vmbuilder.WithBlockDeviceRefs(v1alpha2.BlockDeviceSpecRef{
 				Kind: v1alpha2.VirtualDiskKind,
@@ -151,6 +147,10 @@ var _ = Describe("VirtualDiskProvisioning", Label(precheck.NoPrecheck), func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			util.UntilObjectPhase(ctx, string(v1alpha2.MachineRunning), framework.LongTimeout, vm)
+		})
+
+		By("Waiting for VirtualDisk to be ready", func() {
+			util.UntilObjectPhase(ctx, string(v1alpha2.DiskReady), framework.LongTimeout, vd)
 		})
 	})
 
@@ -163,10 +163,6 @@ var _ = Describe("VirtualDiskProvisioning", Label(precheck.NoPrecheck), func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		By("Waiting for VirtualDisk to be ready", func() {
-			util.UntilObjectPhase(ctx, string(v1alpha2.DiskReady), framework.LongTimeout, vd)
-		})
-
 		By("Creating VirtualMachine and waiting for VirtualMachine to be ready", func() {
 			vm := object.NewMinimalVM("vm-", f.Namespace().Name, vmbuilder.WithBlockDeviceRefs(v1alpha2.BlockDeviceSpecRef{
 				Kind: v1alpha2.VirtualDiskKind,
@@ -176,6 +172,10 @@ var _ = Describe("VirtualDiskProvisioning", Label(precheck.NoPrecheck), func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			util.UntilObjectPhase(ctx, string(v1alpha2.MachineRunning), framework.LongTimeout, vm)
+		})
+
+		By("Waiting for VirtualDisk to be ready", func() {
+			util.UntilObjectPhase(ctx, string(v1alpha2.DiskReady), framework.LongTimeout, vd)
 		})
 	})
 })

--- a/test/e2e/blockdevice/virtual_disk_provisioning.go
+++ b/test/e2e/blockdevice/virtual_disk_provisioning.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/ptr"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	vdbuilder "github.com/deckhouse/virtualization-controller/pkg/builder/vd"
 	vmbuilder "github.com/deckhouse/virtualization-controller/pkg/builder/vm"
@@ -75,7 +76,7 @@ var _ = Describe("VirtualDiskProvisioning", Label(precheck.NoPrecheck), func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		By("Creating VirtualMachine", func() {
+		By("Creating VirtualMachine and waiting for VirtualMachine to be running", func() {
 			vm = object.NewMinimalVM("vm-", f.Namespace().Name, vmbuilder.WithBlockDeviceRefs(
 				v1alpha2.BlockDeviceSpecRef{
 					Kind: v1alpha2.VirtualDiskKind,
@@ -85,6 +86,12 @@ var _ = Describe("VirtualDiskProvisioning", Label(precheck.NoPrecheck), func() {
 
 			err := f.CreateWithDeferredDeletion(ctx, vm)
 			Expect(err).NotTo(HaveOccurred())
+
+			util.UntilObjectPhase(ctx, string(v1alpha2.MachineRunning), framework.LongTimeout, vm)
+		})
+
+		By("Waiting for guest agent to be ready", func() {
+			util.UntilVMAgentReady(ctx, crclient.ObjectKeyFromObject(vm), framework.LongTimeout)
 		})
 
 		By("Waiting for VirtualDisk to be ready", func() {
@@ -96,6 +103,7 @@ var _ = Describe("VirtualDiskProvisioning", Label(precheck.NoPrecheck), func() {
 		var (
 			vi *v1alpha2.VirtualImage
 			vd *v1alpha2.VirtualDisk
+			vm *v1alpha2.VirtualMachine
 		)
 		By("Creating VirtualImage", func() {
 			vi = object.NewGeneratedVIFromCVI("vi-", f.Namespace().Name, object.PrecreatedCVIAlpineUEFI)
@@ -113,8 +121,8 @@ var _ = Describe("VirtualDiskProvisioning", Label(precheck.NoPrecheck), func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		By("Creating VirtualMachine and waiting for VirtualMachine to be ready", func() {
-			vm := object.NewMinimalVM("vm-", f.Namespace().Name, vmbuilder.WithBlockDeviceRefs(v1alpha2.BlockDeviceSpecRef{
+		By("Creating VirtualMachine and waiting for VirtualMachine to be running", func() {
+			vm = object.NewMinimalVM("vm-", f.Namespace().Name, vmbuilder.WithBlockDeviceRefs(v1alpha2.BlockDeviceSpecRef{
 				Kind: v1alpha2.VirtualDiskKind,
 				Name: vd.Name,
 			}))
@@ -122,6 +130,10 @@ var _ = Describe("VirtualDiskProvisioning", Label(precheck.NoPrecheck), func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			util.UntilObjectPhase(ctx, string(v1alpha2.MachineRunning), framework.LongTimeout, vm)
+		})
+
+		By("Waiting for guest agent to be ready", func() {
+			util.UntilVMAgentReady(ctx, crclient.ObjectKeyFromObject(vm), framework.LongTimeout)
 		})
 
 		By("Waiting for VirtualDisk to be ready", func() {
@@ -130,7 +142,10 @@ var _ = Describe("VirtualDiskProvisioning", Label(precheck.NoPrecheck), func() {
 	})
 
 	It("verifies that a VirtualDisk is provisioned successfully from a ClusterVirtualImage", func() {
-		var vd *v1alpha2.VirtualDisk
+		var (
+			vd *v1alpha2.VirtualDisk
+			vm *v1alpha2.VirtualMachine
+		)
 
 		By("Creating VirtualDisk", func() {
 			vd = object.NewVDFromCVI("vd", f.Namespace().Name, object.PrecreatedCVIAlpineBIOS, vdbuilder.WithSize(ptr.To(resource.MustParse("350Mi"))))
@@ -138,8 +153,8 @@ var _ = Describe("VirtualDiskProvisioning", Label(precheck.NoPrecheck), func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		By("Creating VirtualMachine and waiting for VirtualMachine to be ready", func() {
-			vm := object.NewMinimalVM("vm-", f.Namespace().Name, vmbuilder.WithBlockDeviceRefs(v1alpha2.BlockDeviceSpecRef{
+		By("Creating VirtualMachine and waiting for VirtualMachine to be running", func() {
+			vm = object.NewMinimalVM("vm-", f.Namespace().Name, vmbuilder.WithBlockDeviceRefs(v1alpha2.BlockDeviceSpecRef{
 				Kind: v1alpha2.VirtualDiskKind,
 				Name: vd.Name,
 			}))
@@ -147,6 +162,10 @@ var _ = Describe("VirtualDiskProvisioning", Label(precheck.NoPrecheck), func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			util.UntilObjectPhase(ctx, string(v1alpha2.MachineRunning), framework.LongTimeout, vm)
+		})
+
+		By("Waiting for guest agent to be ready", func() {
+			util.UntilVMAgentReady(ctx, crclient.ObjectKeyFromObject(vm), framework.LongTimeout)
 		})
 
 		By("Waiting for VirtualDisk to be ready", func() {
@@ -155,7 +174,10 @@ var _ = Describe("VirtualDiskProvisioning", Label(precheck.NoPrecheck), func() {
 	})
 
 	It("verifies that a VirtualDisk is provisioned successfully from a http", func() {
-		var vd *v1alpha2.VirtualDisk
+		var (
+			vd *v1alpha2.VirtualDisk
+			vm *v1alpha2.VirtualMachine
+		)
 
 		By("Creating VirtualDisk", func() {
 			vd = object.NewHTTPVDAlpineBIOS("vd", f.Namespace().Name, vdbuilder.WithSize(ptr.To(resource.MustParse("350Mi"))))
@@ -163,8 +185,8 @@ var _ = Describe("VirtualDiskProvisioning", Label(precheck.NoPrecheck), func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		By("Creating VirtualMachine and waiting for VirtualMachine to be ready", func() {
-			vm := object.NewMinimalVM("vm-", f.Namespace().Name, vmbuilder.WithBlockDeviceRefs(v1alpha2.BlockDeviceSpecRef{
+		By("Creating VirtualMachine and waiting for VirtualMachine to be running", func() {
+			vm = object.NewMinimalVM("vm-", f.Namespace().Name, vmbuilder.WithBlockDeviceRefs(v1alpha2.BlockDeviceSpecRef{
 				Kind: v1alpha2.VirtualDiskKind,
 				Name: vd.Name,
 			}))
@@ -172,6 +194,10 @@ var _ = Describe("VirtualDiskProvisioning", Label(precheck.NoPrecheck), func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			util.UntilObjectPhase(ctx, string(v1alpha2.MachineRunning), framework.LongTimeout, vm)
+		})
+
+		By("Waiting for guest agent to be ready", func() {
+			util.UntilVMAgentReady(ctx, crclient.ObjectKeyFromObject(vm), framework.LongTimeout)
 		})
 
 		By("Waiting for VirtualDisk to be ready", func() {


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
This PR updates the `VirtualDiskProvisioning` e2e tests to verify disk readiness after the VirtualMachine is running.

Changes made:
- Reordered test steps: now the test first creates a VirtualMachine and waits for it to reach "Running" phase, then verifies the VirtualDisk is "Ready"

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
The default storage class may not have `VolumeBindingMode=Immediate`, which means PVCs are bound using `WaitForFirstConsumer` mode. In this mode, PVC is not bound until a Pod consumes it, which can cause e2e tests to fail or timeout when they try to verify disk provisioning without a consumer (VM).

By using an immediate storage class, PVCs are bound immediately when the VirtualDisk is created, allowing the test to verify disk readiness without needing to create a VirtualMachine.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
The test should pass regardless of the storage class volume binding mode, as long as the VirtualMachine can be started successfully with the attached disk.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: test
type: chore
summary: "Verify VirtualDisk readiness after VirtualMachine is running."
impact_level: low
```
