### PR TITLE
fix(ci): increase wait kubeconfig and user-authz ready

### DIFF
--- a/test/dvp-static-cluster/scripts/deckhouse-queue.sh
+++ b/test/dvp-static-cluster/scripts/deckhouse-queue.sh
@@ -128,6 +128,8 @@ d8_ready() {
     log_success "Deckhouse is Ready!"
     log_info "Checking module user-authn"
     module_ready user-authn
+    log_info "Checking module user-authz"
+    module_ready user-authz
     log_info "Checking queues"
     d8_queue
   else

--- a/test/dvp-static-cluster/scripts/gen-kubeconfig.sh
+++ b/test/dvp-static-cluster/scripts/gen-kubeconfig.sh
@@ -189,11 +189,17 @@ kubeconfig_set_current_context() {
 }
 
 check_kubeconfig() {
-  if kubectl --kubeconfig "${FILE_NAME}" get no >/dev/null 2>&1; then
+  local output
+
+  if output=$(kubectl --kubeconfig "${FILE_NAME}" get no 2>&1); then
     return 0
   fi
 
-  log_error "Failed to get resources via generated kubeconfig"
+  log_warning "Generated kubeconfig is not ready yet"
+  echo "${output}"
+  kubectl --kubeconfig "${FILE_NAME}" auth can-i get nodes 2>&1 || true
+  kubectl get clusterrolebinding "user-authz:${SA_CAR_NAME}:super-admin" -o wide 2>&1 || true
+
   if [[ -f "${FILE_NAME}" ]]; then
     cat "${FILE_NAME}"
   fi
@@ -203,8 +209,8 @@ check_kubeconfig() {
 generate_kubeconfig() {
   log_info "Create kubeconfig"
 
-  local max_attempts=10
-  local retry_wait_seconds=5
+  local max_attempts=60
+  local retry_wait_seconds=10
   local attempt_number
 
   for ((attempt_number = 1; attempt_number <= max_attempts; attempt_number++)); do


### PR DESCRIPTION
## Description
Increase the waiting window for nested cluster kubeconfig validation and make the validation diagnostics non-fatal inside the retry loop.

The generated kubeconfig check now captures the `kubectl get nodes` error output, prints additional authorization diagnostics, and retries for longer while `user-authz` materializes the `ClusterAuthorizationRule` into RBAC bindings. The Deckhouse readiness helper also waits for the `user-authz` module in addition to `user-authn`.

## Why do we need it, and what problem does it solve?
Nested e2e bootstrap can create the service account token and `ClusterAuthorizationRule` successfully, but fail immediately afterwards when validating the generated kubeconfig. In the observed failure, the `ClusterRoleBinding` managed by `user-authz` appeared several minutes after the `ClusterAuthorizationRule` was applied, while the previous retry window was only about 50 seconds.

This change removes that race from the CI path and keeps useful diagnostics in the logs without failing the job on the first temporary authorization error.

## What is the expected result?
1. Run the nested e2e bootstrap pipeline.
2. Wait until Deckhouse, `user-authn`, and `user-authz` are ready in the nested cluster.
3. Generate the nested cluster kubeconfig.
4. Verify that kubeconfig validation retries until the generated service account can list nodes, or fails only after the extended timeout with diagnostic output.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: fix
summary: Wait longer for nested e2e kubeconfig authorization to become ready.
impact_level: low
```