### PR TITLE
fix(ci): cloudinit alpine ssh credentials

### DIFF
--- a/test/dvp-static-cluster/charts/infra/templates/_cloudinit.tpl
+++ b/test/dvp-static-cluster/charts/infra/templates/_cloudinit.tpl
@@ -63,6 +63,7 @@ final_message: "\U0001F525\U0001F525\U0001F525 The system is finally up, after $
 
 {{- define "cloudinit.alpine" -}}
 #cloud-config
+ssh_pwauth: true
 package_update: true
 packages:
   - tmux
@@ -78,7 +79,7 @@ users:
     chpasswd: {expire: False}
     lock_passwd: false
     ssh_authorized_keys:
-      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFzMcx+aKT7jfkaeQrDdsKfeuSqX/4bqR4Z6IaDsiAFI user@default
+      - {{ .Values.discovered.publicSSHKey }}
 disk_setup:
   /dev/sdc:
     table_type: mbr


### PR DESCRIPTION
## Description
Update Alpine cloud-init configuration used by the static e2e test cluster:

- enable SSH password authentication with `ssh_pwauth: true`;
- use the discovered public SSH key from chart values instead of a hardcoded default key.

## Why do we need it, and what problem does it solve?
The nested/static cluster e2e infrastructure provisions Alpine VMs and then connects to them over SSH. The previous cloud-init template used a hardcoded SSH public key and did not explicitly enable password authentication, which could make VM SSH access fail when tests rely on dynamically discovered credentials.

This change makes Alpine VM SSH credentials match the test environment configuration and restores reliable SSH access for e2e jobs.

## What is the expected result?
1. Deploy the static cluster test infrastructure with a discovered public SSH key in chart values.
2. Provision an Alpine VM using the cloud-init template.
3. Verify that the discovered SSH key is present for the `user` account and SSH access to the VM works in the e2e environment.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: fix
summary: use discovered SSH credentials for Alpine VMs in static cluster e2e infrastructure.
impact_level: low
```
