### PR TITLE
fix(core): better handling VMs with osType=Windows

### DIFF
--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -3,7 +3,7 @@ firmware:
   libvirt: v10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: v1.6.2-v12n.32
+  3p-kubevirt: v1.6.2-v12n.33
   3p-containerized-data-importer: v1.60.3-v12n.19
   distribution: 2.8.3
 package:


### PR DESCRIPTION

## Description
<!---
  Describe your changes with technical details.
-->

1) More stable TSC labels to handle VMs with reenlightenment feature (mostly Windows guests).

See: https://github.com/deckhouse/3p-kubevirt/pull/109

2) Prevent stale labels with empty values on Nodes.

See: https://github.com/deckhouse/kube-api-rewriter/pull/7 (merged by #2351)

3) Another supportive PR: clenup cpu.features when Dicovery vmclass changed to non-Discovery

See: #2352 



## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->

CPU frequency drifts on Nodes may lead to "Unschedulable" and non-migratable VMs.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->

VMs with Windows guests starts and migrates.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: core
type: fix
summary: "Better handling Windows guests: start and migration should work in clusters with frequent CPU frequencies drifts"
```
