### PR TITLE
fix(ci): fix resolve external ip address for dhctl bootstrap

### DIFF
--- a/test/dvp-static-cluster/Taskfile.yaml
+++ b/test/dvp-static-cluster/Taskfile.yaml
@@ -160,6 +160,32 @@ tasks:
         kubectl -n {{ .NAMESPACE }} get all -l infra=jump-host || true
         kubectl -n {{ .NAMESPACE }} delete all -l infra=jump-host || true
 
+  discover-jumphost-ext-ip:
+    desc: Discover jump-host external IP
+    silent: true
+    cmds:
+      - |
+        for attempt in 1 2 3; do
+          ip=$(
+            kubectl -n {{ .NAMESPACE }} exec deployment/jump-host -- sh -c '
+              dig @resolver4.opendns.com myip.opendns.com A +short +time=2 +tries=1 2>/dev/null
+              dig @1.1.1.1 whoami.cloudflare CH TXT +short +time=2 +tries=1 2>/dev/null
+              dig @ns1.google.com o-o.myaddr.l.google.com TXT +short +time=2 +tries=1 2>/dev/null
+              dig @ns1-1.akamaitech.net whoami.akamai.net A +short +time=2 +tries=1 2>/dev/null
+            ' | tr -d '"' | awk '/^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$/ { print; exit }'
+          )
+
+          if [ -n "$ip" ]; then
+            echo "$ip"
+            exit 0
+          fi
+
+          sleep "$attempt"
+        done
+
+        echo "failed to discover jump-host external IP" >&2
+        exit 1
+
   dhctl-bootstrap:
     desc: Bootstrap DKP over DVP
     deps:
@@ -170,14 +196,14 @@ tasks:
         sh: yq eval '.storageType' values.yaml
       start_time:
         sh: date +%s
-      JUMPHOST_EXT_IP:
-        sh: kubectl -n {{ .NAMESPACE }} exec deployment/jump-host -- dig @resolver4.opendns.com myip.opendns.com +short
       JUMPHOST_NODEPORT:
         sh: kubectl -n {{ .NAMESPACE }} get svc jump-host -o json | jq '.spec.ports[] | select(.port==2222) | .nodePort'
       MASTER_NODE_IP:
         sh: kubectl -n {{ .NAMESPACE }} get vm {{.prefix}}-master-0 -o jsonpath="{.status.ipAddress}"
     cmds:
       - |
+        JUMPHOST_EXT_IP="$(task discover-jumphost-ext-ip)"
+
         docker run --pull=always \
         -v "{{ .TMP_DIR }}/config.yaml:/config.yaml" \
         -v "{{ .SSH_DIR }}:/tmp/.ssh/" \
@@ -189,7 +215,7 @@ tasks:
             --ssh-host={{ .MASTER_NODE_IP }} \
             --ssh-user={{ .DEFAULT_USER }} \
               --ssh-bastion-port={{ .JUMPHOST_NODEPORT }} \
-              --ssh-bastion-host={{ .JUMPHOST_EXT_IP }} \
+              --ssh-bastion-host="$JUMPHOST_EXT_IP" \
               --ssh-bastion-user=user \
             {{.CLI_ARGS}}
       - |


### PR DESCRIPTION
## Description

Fix resolving the external jump-host IP used by `dhctl bootstrap` in the static DVP cluster e2e pipeline.

## Why do we need it, and what problem does it solve?

The previous implementation used a single `dig @resolver4.opendns.com myip.opendns.com +short` call from the jump-host pod and passed its raw output directly to `--ssh-bastion-host`.

When `dig` printed diagnostic output such as `;; communications error ...` before the IP address, that text was substituted into the generated shell command. Bash then failed before `dhctl` started because `;;` is only valid in a `case` clause.

This change makes IP discovery more resilient by querying several external DNS-based IP discovery services and accepting only the first line that matches an IPv4 address.

## What is the expected result?

`dhctl-bootstrap` gets a clean IPv4 value for `--ssh-bastion-host` or fails early with a clear error if the jump-host external IP cannot be discovered.

## Validation

- `task --list` successfully parses `test/dvp-static-cluster/Taskfile.yaml` and shows the new `discover-jumphost-ext-ip` task.
- `git diff --check -- test/dvp-static-cluster/Taskfile.yaml` passed.
- Linter diagnostics for `test/dvp-static-cluster/Taskfile.yaml` are clean.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```yaml
section: ci
type: fix
summary: Make static DVP cluster dhctl bootstrap external IP discovery resilient to DNS diagnostic output.
```