### PR TITLE
chore(ci): harden nested e2e module setup

### DIFF
--- a/.github/scripts/bash/e2e/apply-clusternetworks.sh
+++ b/.github/scripts/bash/e2e/apply-clusternetworks.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/scripts/bash/e2e/common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+manifest="$(mktemp)"
+trap 'rm -f "$manifest"' EXIT
+
+cat > "$manifest"
+
+count=12
+delay=10
+
+for i in $(seq 1 "$count"); do
+  echo "[INFO] Apply ClusterNetworks attempt ${i}/${count}"
+  if kubectl apply -f "$manifest"; then
+    exit 0
+  fi
+
+  if [ "$i" -lt "$count" ]; then
+    echo "[WARN] Failed to apply ClusterNetworks, retrying in ${delay} seconds..."
+    kubectl -n d8-sdn get endpoints controller-sdn-admission || true
+    kubectl get clusternetworks.network.deckhouse.io || true
+    sleep "$delay"
+  fi
+done
+
+echo "[ERROR] Failed to apply ClusterNetworks after ${count} attempts"
+kubectl -n d8-sdn get pods,svc,endpoints || true
+kubectl get clusternetworks.network.deckhouse.io || true
+exit 1

--- a/.github/scripts/bash/e2e/common.sh
+++ b/.github/scripts/bash/e2e/common.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+on_error() {
+  local exit_code=$?
+  echo "[ERROR] Command failed with exit code ${exit_code} at line ${BASH_LINENO[0]}: ${BASH_COMMAND}" >&2
+}
+
+require_env() {
+  local name="$1"
+
+  if [ -z "${!name:-}" ]; then
+    echo "[ERROR] Required environment variable is not set: ${name}" >&2
+    exit 1
+  fi
+}
+
+trap on_error ERR

--- a/.github/scripts/bash/e2e/configure-virtualization.sh
+++ b/.github/scripts/bash/e2e/configure-virtualization.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/scripts/bash/e2e/common.sh
+source "${SCRIPT_DIR}/common.sh"
+# shellcheck source=.github/scripts/bash/e2e/deckhouse.sh
+source "${SCRIPT_DIR}/deckhouse.sh"
+
+require_env DEV_REGISTRY_DOCKER_CFG
+require_env NESTED_STORAGE_CLASS_NAME
+require_env VIRTUALIZATION_TAG
+
+kubectl_apply_with_retry() {
+  local count=20
+  local delay=10
+  local manifest
+  manifest="$(mktemp)"
+  cat > "$manifest"
+
+  for i in $(seq 1 "$count"); do
+    echo "[INFO] kubectl apply attempt ${i}/${count}"
+    if kubectl apply -f "$manifest"; then
+      rm -f "$manifest"
+      return 0
+    fi
+
+    if [ "$i" -lt "$count" ]; then
+      echo "[WARN] kubectl apply failed, retrying in ${delay}s"
+      show_deckhouse_state
+      sleep "$delay"
+    fi
+  done
+
+  echo "[ERROR] kubectl apply failed after ${count} attempts"
+  rm -f "$manifest"
+  return 1
+}
+
+show_modulesource_status() {
+  local ms_json
+  local phase
+  local message
+
+  if ! ms_json="$(kubectl get ms deckhouse-dev -o json 2>/dev/null)"; then
+    echo "[DEBUG] ModuleSource deckhouse-dev is not found"
+    return 0
+  fi
+
+  phase="$(jq -r '.status.phase // "unknown"' <<< "$ms_json")"
+  message="$(jq -r '.status.message // ""' <<< "$ms_json")"
+
+  echo "[DEBUG] ModuleSource deckhouse-dev phase: ${phase}"
+  if echo "$message" | grep -Eqi '401 Unauthorized|Auth failed'; then
+    echo "[DEBUG] ModuleSource deckhouse-dev problem: registry authentication failed (401 Unauthorized)"
+  fi
+}
+
+wait_for_modulesource_active() {
+  local count=30
+  local delay=10
+  local ms_json
+  local phase
+  local message
+
+  for i in $(seq 1 "$count"); do
+    ms_json="$(kubectl get ms deckhouse-dev -o json 2>/dev/null || true)"
+    phase="$(jq -r '.status.phase // "unknown"' <<< "$ms_json" 2>/dev/null || true)"
+    message="$(jq -r '.status.message // ""' <<< "$ms_json" 2>/dev/null || true)"
+
+    echo "[INFO] Wait for ModuleSource deckhouse-dev to be Active ${i}/${count}, phase=${phase:-unknown}"
+    if echo "$message" | grep -Eqi '401 Unauthorized|Auth failed'; then
+      echo "[INFO] ModuleSource deckhouse-dev problem: registry authentication failed (401 Unauthorized)"
+    fi
+
+    if [ "$phase" = "Active" ]; then
+      echo "[SUCCESS] ModuleSource deckhouse-dev is Active"
+      kubectl get ms deckhouse-dev -o wide
+      return 0
+    fi
+
+    if echo "$message" | grep -Eqi '401 Unauthorized|Auth failed'; then
+      echo "[ERROR] ModuleSource deckhouse-dev registry authentication failed. Check DEV_REGISTRY_DOCKER_CFG credentials." >&2
+      return 1
+    fi
+
+    if (( i % 5 == 0 )); then
+      show_deckhouse_state
+    fi
+
+    if [ "$i" -lt "$count" ]; then
+      sleep "$delay"
+    fi
+  done
+
+  echo "[ERROR] ModuleSource deckhouse-dev did not become Active"
+  show_modulesource_status
+  show_deckhouse_state
+  return 1
+}
+
+wait_for_virtualization_dev_source() {
+  local count=60
+  local delay=10
+  local available_sources
+
+  for i in $(seq 1 "$count"); do
+    available_sources="$(kubectl get modules virtualization -o json 2>/dev/null | jq -r '.properties.availableSources // [] | join(",")' || true)"
+    echo "[INFO] Wait for virtualization module source deckhouse-dev ${i}/${count}, availableSources=${available_sources:-none}"
+
+    if echo ",${available_sources}," | grep -q ",deckhouse-dev,"; then
+      echo "[SUCCESS] deckhouse-dev is available for virtualization module"
+      kubectl get modules virtualization -o wide
+      return 0
+    fi
+
+    if (( i % 5 == 0 )); then
+      echo "[DEBUG] Show ModuleSource"
+      show_modulesource_status
+      echo "[DEBUG] Show virtualization module"
+      kubectl get modules virtualization -o yaml || true
+      show_deckhouse_state
+    fi
+
+    if [ "$i" -lt "$count" ]; then
+      sleep "$delay"
+    fi
+  done
+
+  echo "[ERROR] deckhouse-dev did not become available for virtualization module"
+  show_modulesource_status
+  kubectl get modules virtualization -o yaml || true
+  return 1
+}
+
+apply_module_source() {
+  local registry
+  registry="$(base64 -d <<< "$DEV_REGISTRY_DOCKER_CFG" | jq '.auths | to_entries | .[] | .key' -r)"
+
+  echo "[INFO] Apply ModuleSource dev config"
+  kubectl_apply_with_retry <<EOF
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  name: deckhouse-dev
+spec:
+  registry:
+    ca: ""
+    dockerCfg: "${DEV_REGISTRY_DOCKER_CFG}"
+    repo: "${registry}/sys/deckhouse-oss/modules"
+    scheme: HTTPS
+EOF
+}
+
+apply_virtualization_module_config() {
+  echo "[INFO] Apply Virtualization module config"
+  kubectl_apply_with_retry <<EOF
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: virtualization
+spec:
+  enabled: true
+  settings:
+    dvcr:
+      storage:
+        persistentVolumeClaim:
+          size: 10Gi
+          storageClassName: ${NESTED_STORAGE_CLASS_NAME}
+        type: PersistentVolumeClaim
+    virtualMachineCIDRs:
+      - 192.168.10.0/24
+  source: deckhouse-dev
+  version: 1
+---
+apiVersion: deckhouse.io/v1alpha2
+kind: ModulePullOverride
+metadata:
+  name: virtualization
+spec:
+  imageTag: ${VIRTUALIZATION_TAG}
+  scanInterval: 120h
+EOF
+}
+
+show_virtualization_config() {
+  echo "[INFO] Show ModuleSource"
+  kubectl get ms
+
+  echo "[INFO] Show module config virtualization info"
+  kubectl get mc virtualization
+
+  echo "[INFO] Show ModulePullOverride virtualization info"
+  kubectl get mpo virtualization
+}
+
+apply_module_source
+wait_for_modulesource_active
+wait_for_deckhouse_queue
+wait_for_virtualization_dev_source
+wait_for_deckhouse_queue
+apply_virtualization_module_config
+show_virtualization_config

--- a/.github/scripts/bash/e2e/deckhouse.sh
+++ b/.github/scripts/bash/e2e/deckhouse.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+show_deckhouse_state() {
+  echo "[DEBUG] Show deckhouse pods"
+  kubectl -n d8-system get pods -l app=deckhouse -o wide || true
+  echo "[DEBUG] Show queue (first 25 lines)"
+  d8 s queue list | head -n25 || true
+}
+
+wait_for_deckhouse_queue() {
+  local count=60
+  local delay=10
+  local queue_count
+
+  for i in $(seq 1 "$count"); do
+    queue_count="$(d8 s queue list | grep -Po '([0-9]+)(?= active)' || true)"
+    echo "[INFO] Wait until Deckhouse queue is empty ${i}/${count}, active=${queue_count:-unknown}"
+
+    if [ "$queue_count" = "0" ]; then
+      echo "[SUCCESS] Deckhouse queue is empty"
+      return 0
+    fi
+
+    if (( i % 5 == 0 )); then
+      show_deckhouse_state
+    fi
+
+    if [ "$i" -lt "$count" ]; then
+      sleep "$delay"
+    fi
+  done
+
+  echo "[ERROR] Deckhouse queue is not empty"
+  show_deckhouse_state
+  return 1
+}

--- a/.github/scripts/bash/e2e/enable-sdn.sh
+++ b/.github/scripts/bash/e2e/enable-sdn.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/scripts/bash/e2e/common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+show_sdn_state() {
+  echo "[DEBUG] Module sdn"
+  kubectl get modules sdn -o wide || true
+  echo "[DEBUG] ModuleConfig sdn"
+  kubectl get mc sdn -o yaml || true
+  echo "[DEBUG] d8-sdn resources"
+  kubectl -n d8-sdn get pods,deploy,ds,svc,endpoints || true
+}
+
+apply_sdn_module_config() {
+  local count=12
+  local delay=10
+
+  for i in $(seq 1 "$count"); do
+    echo "[INFO] Apply SDN ModuleConfig attempt ${i}/${count}"
+    if kubectl apply -f - <<'EOF'
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: sdn
+spec:
+  enabled: true
+EOF
+    then
+      echo "[SUCCESS] SDN ModuleConfig applied"
+      kubectl get mc sdn
+      return 0
+    fi
+
+    if [ "$i" -lt "$count" ]; then
+      echo "[WARN] Failed to apply SDN ModuleConfig, retrying in ${delay} seconds..."
+      show_sdn_state
+      sleep "$delay"
+    fi
+  done
+
+  echo "[ERROR] Failed to apply SDN ModuleConfig after ${count} attempts"
+  show_sdn_state
+  d8 s logs | tail -n 100 || true
+  return 1
+}
+
+wait_for_sdn_module() {
+  local count=60
+  local delay=5
+  local phase
+
+  for i in $(seq 1 "$count"); do
+    phase="$(kubectl get modules sdn -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+    echo "[INFO] Wait for modules/sdn to be Ready ${i}/${count}, phase=${phase:-unknown}"
+
+    if [ "$phase" = "Ready" ]; then
+      kubectl get modules sdn -o wide
+      return 0
+    fi
+
+    if (( i % 5 == 0 )); then
+      show_sdn_state
+    fi
+
+    if [ "$i" -lt "$count" ]; then
+      sleep "$delay"
+    fi
+  done
+
+  echo "[ERROR] modules/sdn is not Ready"
+  show_sdn_state
+  d8 s logs | tail -n 100 || true
+  return 1
+}
+
+wait_for_sdn_workloads() {
+  echo "[INFO] Wait for sdn deployments to be ready, timeout: 300s"
+  kubectl -n d8-sdn wait --for=condition=Available deploy --all --timeout 300s
+  echo "[INFO] Wait for sdn daemonset agent to be ready, timeout: 300s"
+  kubectl -n d8-sdn rollout status daemonset agent --timeout=300s
+}
+
+wait_for_sdn_admission_endpoint() {
+  local count=60
+  local delay=5
+  local endpoints
+
+  for i in $(seq 1 "$count"); do
+    endpoints="$(kubectl -n d8-sdn get endpoints controller-sdn-admission -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null || true)"
+    echo "[INFO] Wait for controller-sdn-admission endpoints ${i}/${count}, endpoints=${endpoints:-none}"
+
+    if [ -n "$endpoints" ]; then
+      kubectl -n d8-sdn get svc,endpoints controller-sdn-admission
+      return 0
+    fi
+
+    if (( i % 5 == 0 )); then
+      show_sdn_state
+    fi
+
+    if [ "$i" -lt "$count" ]; then
+      sleep "$delay"
+    fi
+  done
+
+  echo "[ERROR] controller-sdn-admission endpoints are not ready"
+  show_sdn_state
+  return 1
+}
+
+echo "[INFO] Enable SDN"
+apply_sdn_module_config
+wait_for_sdn_module
+wait_for_sdn_workloads
+wait_for_sdn_admission_endpoint
+echo "[SUCCESS] Done"

--- a/.github/workflows/e2e-reusable-pipeline.yml
+++ b/.github/workflows/e2e-reusable-pipeline.yml
@@ -629,15 +629,9 @@ jobs:
           fi
       - name: Enable SDN
         run: |
-          echo "[INFO] Enable SDN"
-          d8 system module enable sdn
-          echo "[INFO] Wait for sdn modules to be ready, timeout: 300s"
-          kubectl wait --for=jsonpath='{.status.phase}'=Ready modules sdn --timeout=300s
-          echo "[INFO] Wait for sdn deployments to be ready, timeout: 300s"
-          kubectl -n d8-sdn wait --for=condition=Available deploy --all --timeout 300s
-          echo "[INFO] Wait for sdn daemonset agent to be ready, timeout: 300s"
-          kubectl -n d8-sdn rollout status daemonset agent --timeout=300s
-          echo "[SUCCESS] Done"
+          # Keep SDN enable and readiness checks in a script because this step needs
+          # several retries around Deckhouse webhooks and detailed SDN diagnostics.
+          bash .github/scripts/bash/e2e/enable-sdn.sh
 
       - name: Wait for nodenetworkinterfaces to be ready
         run: |
@@ -696,7 +690,9 @@ jobs:
 
           kubectl get nodenetworkinterface -l nic-group=extra
 
-          cat <<'EOF' | kubectl apply -f -
+          # Use a retry wrapper because ClusterNetwork admission can race with the
+          # SDN webhook endpoint right after the module becomes Ready.
+          cat <<'EOF' | bash .github/scripts/bash/e2e/apply-clusternetworks.sh
           ---
           apiVersion: network.deckhouse.io/v1alpha1
           kind: ClusterNetwork
@@ -1073,87 +1069,14 @@ jobs:
           kubectl config use-context nested-e2e-nested-sa
 
       - name: Configure Virtualization
+        env:
+          DEV_REGISTRY_DOCKER_CFG: ${{ secrets.DEV_REGISTRY_DOCKER_CFG }}
+          NESTED_STORAGE_CLASS_NAME: ${{ inputs.nested_storageclass_name }}
+          VIRTUALIZATION_TAG: ${{ env.VIRTUALIZATION_TAG }}
         run: |
-          kubectl_apply_with_retry() {
-            local count=6
-            local delay=10
-            local manifest
-            manifest="$(mktemp)"
-            cat > "$manifest"
-
-            for i in $(seq 1 "$count"); do
-              echo "[INFO] kubectl apply attempt ${i}/${count}"
-              if kubectl apply -f "$manifest"; then
-                rm -f "$manifest"
-                return 0
-              fi
-
-              if [ "$i" -lt "$count" ]; then
-                echo "[WARN] kubectl apply failed, retrying in ${delay}s"
-                sleep "$delay"
-              fi
-            done
-
-            echo "[ERROR] kubectl apply failed after ${count} attempts"
-            rm -f "$manifest"
-            return 1
-          }
-
-          REGISTRY=$(base64 -d <<< "${{secrets.DEV_REGISTRY_DOCKER_CFG}}" | jq '.auths | to_entries | .[] | .key' -r)
-
-          echo "[INFO] Apply ModuleSource dev config"
-          kubectl_apply_with_retry <<EOF
-          apiVersion: deckhouse.io/v1alpha1
-          kind: ModuleSource
-          metadata:
-            name: deckhouse-dev
-          spec:
-            registry:
-              ca: ""
-              dockerCfg: "${{secrets.DEV_REGISTRY_DOCKER_CFG}}"
-              repo: "${REGISTRY}/sys/deckhouse-oss/modules"
-              scheme: HTTPS
-          EOF
-
-          kubectl wait --for=jsonpath='{.status.phase}'=Active ms deckhouse-dev --timeout=300s
-
-          echo "[INFO] Apply Virtualization module config"
-          kubectl_apply_with_retry <<EOF
-          apiVersion: deckhouse.io/v1alpha1
-          kind: ModuleConfig
-          metadata:
-            name: virtualization
-          spec:
-            enabled: true
-            settings:
-              dvcr:
-                storage:
-                  persistentVolumeClaim:
-                    size: 10Gi
-                    storageClassName: ${{ inputs.nested_storageclass_name }}
-                  type: PersistentVolumeClaim
-              virtualMachineCIDRs:
-                - 192.168.10.0/24
-            source: deckhouse-dev
-            version: 1
-          ---
-          apiVersion: deckhouse.io/v1alpha2
-          kind: ModulePullOverride
-          metadata:
-            name: virtualization
-          spec:
-            imageTag: ${{ env.VIRTUALIZATION_TAG }}
-            scanInterval: 120h
-          EOF
-
-          echo "[INFO] Show ModuleSource"
-          kubectl get ms
-
-          echo "[INFO] Show module config virtualization info"
-          kubectl get mc virtualization
-
-          echo "[INFO] Show ModulePullOverride virtualization info"
-          kubectl get mpo virtualization
+          # Keep virtualization configuration in a script because it waits for
+          # Deckhouse queue/source propagation before applying ModuleConfig.
+          bash .github/scripts/bash/e2e/configure-virtualization.sh
       - name: Wait for Virtualization to be ready
         run: |
           d8_queue_list() {


### PR DESCRIPTION
## Description
This PR hardens the nested e2e setup flow by moving module setup logic from the reusable workflow into dedicated bash helpers under `.github/scripts/bash/e2e`.

The new helpers cover:
- `enable-sdn.sh`: SDN ModuleConfig creation, module readiness, workloads, and SDN admission endpoint readiness.
- `apply-clusternetworks.sh`: retry wrapper for ClusterNetwork apply while SDN admission becomes ready.
- `configure-virtualization.sh`: ModuleSource creation, Deckhouse queue waits, `deckhouse-dev` source propagation, and Virtualization ModuleConfig/ModulePullOverride apply.
- `common.sh` and `deckhouse.sh`: shared error/env handling and Deckhouse diagnostics/queue wait helpers.

Shell scripts are checked with `shellcheck -x` and `bash -n`.

## Why do we need it, and what problem does it solve?
Nested e2e setup can fail while Deckhouse is still processing module changes after bootstrap. One observed failure happened when `virtualization` was configured with `source: deckhouse-dev` before that source was available for the module.

Another failure mode is invalid registry credentials for `deckhouse-dev`: Deckhouse reports a registry authentication problem in `ModuleSource.status.message`, and the later admission failure can look like an unavailable source. The new script checks `ModuleSource` state first and reports a safe `401 Unauthorized` classification without printing the full status message or `dockerCfg` contents.

## What is the expected result?
Rerunning the nested e2e workflow should be more stable during module setup:
- SDN setup waits for module/workload/admission readiness before ClusterNetwork configuration.
- ClusterNetwork apply retries while the SDN admission endpoint is becoming ready.
- Virtualization setup waits for `deckhouse-dev` ModuleSource, empty Deckhouse queue, and source propagation before applying the module config.
- CI logs include actionable diagnostics for module setup and registry authentication failures without leaking credentials.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ci
type: fix
summary: "Harden nested e2e module setup against Deckhouse module propagation and admission readiness races."
```