### PR TITLE
fix(vm): cleanup cpu.features on KVVM after vmclass change

### DIFF
--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
@@ -152,6 +152,8 @@ func (b *KVVM) SetCPUModel(class *v1alpha2.VirtualMachineClass) error {
 		b.Resource.Spec.Template.Spec.Domain.CPU = &virtv1.CPU{}
 	}
 	cpu := b.Resource.Spec.Template.Spec.Domain.CPU
+	// Reset features to handle vmclass changes: only discovery type sets features.
+	cpu.Features = nil
 
 	switch class.Spec.CPU.Type {
 	case v1alpha2.CPUTypeHost:

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
@@ -410,22 +410,13 @@ func (h *SyncKvvmHandler) updateKVVM(ctx context.Context, s state.VirtualMachine
 		log.Info("Update internal virtual machine done", "name", newKVVM.Name)
 		log.Debug("Update internal virtual machine done", "name", newKVVM.Name, "kvvm", newKVVM)
 
-		// Add patches to remove fields with "omitempty" annotation.
-		jsonPatch := patch.JSONPatch{}
 		if domainMemory != nil {
+			jsonPatch := patch.JSONPatch{}
 			// Removing memory.maxGuest is not enough, replace memory.guest is needed to pass the vm-validator webhook.
 			jsonPatch.Append(
 				patch.WithRemove("/spec/template/spec/domain/memory/maxGuest"),
 				patch.WithReplace("/spec/template/spec/domain/memory/guest", domainMemory.Guest.String()),
 			)
-		}
-		//newCPU := newKVVM.Spec.Template.Spec.Domain.CPU
-		//if newCPU != nil && len(newCPU.Features) == 0 {
-		//	jsonPatch.Append(
-		//		patch.WithRemove("/spec/template/spec/domain/cpu/features"),
-		//	)
-		//}
-		if jsonPatch.Len() > 0 {
 			patchBytes, err := jsonPatch.Bytes()
 			if err != nil {
 				return fmt.Errorf("prepare json patch for internal virtual machine: %w", err)

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
@@ -410,13 +410,22 @@ func (h *SyncKvvmHandler) updateKVVM(ctx context.Context, s state.VirtualMachine
 		log.Info("Update internal virtual machine done", "name", newKVVM.Name)
 		log.Debug("Update internal virtual machine done", "name", newKVVM.Name, "kvvm", newKVVM)
 
+		// Add patches to remove fields with "omitempty" annotation.
+		jsonPatch := patch.JSONPatch{}
 		if domainMemory != nil {
-			jsonPatch := patch.JSONPatch{}
 			// Removing memory.maxGuest is not enough, replace memory.guest is needed to pass the vm-validator webhook.
 			jsonPatch.Append(
 				patch.WithRemove("/spec/template/spec/domain/memory/maxGuest"),
 				patch.WithReplace("/spec/template/spec/domain/memory/guest", domainMemory.Guest.String()),
 			)
+		}
+		newCPU := newKVVM.Spec.Template.Spec.Domain.CPU
+		if newCPU != nil && len(newCPU.Features) == 0 {
+			jsonPatch.Append(
+				patch.WithRemove("/spec/template/spec/domain/cpu/features"),
+			)
+		}
+		if jsonPatch.Len() > 0 {
 			patchBytes, err := jsonPatch.Bytes()
 			if err != nil {
 				return fmt.Errorf("prepare json patch for internal virtual machine: %w", err)

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
@@ -419,12 +419,12 @@ func (h *SyncKvvmHandler) updateKVVM(ctx context.Context, s state.VirtualMachine
 				patch.WithReplace("/spec/template/spec/domain/memory/guest", domainMemory.Guest.String()),
 			)
 		}
-		newCPU := newKVVM.Spec.Template.Spec.Domain.CPU
-		if newCPU != nil && len(newCPU.Features) == 0 {
-			jsonPatch.Append(
-				patch.WithRemove("/spec/template/spec/domain/cpu/features"),
-			)
-		}
+		//newCPU := newKVVM.Spec.Template.Spec.Domain.CPU
+		//if newCPU != nil && len(newCPU.Features) == 0 {
+		//	jsonPatch.Append(
+		//		patch.WithRemove("/spec/template/spec/domain/cpu/features"),
+		//	)
+		//}
 		if jsonPatch.Len() > 0 {
 			patchBytes, err := jsonPatch.Bytes()
 			if err != nil {


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->

- reset cpu.features when generate KVVM

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->

The problem occurs when VM started with Discovery type vmclass and then vmclass is changed to a non-Discovery type. - cpu.features are kept and they are passed to a nodeSelector for VM Pod. User may encounter unexpected Pod scheduling problems after vmclass change.


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->

No cpu.features in KVVM when change Discovery vmclass to a non-Discovery vmclass, e.g. Model.


**VM classes:**

```
vmclass/generic

  spec:
    cpu:
      model: Nehalem
      type: Model

vmclass/discovery

    cpu:
      discovery:
        nodeSelector: {}
      type: Discovery

```

**VM state**
```
$ kubectl get vm testvm -o jsonpath='{.spec.virtualMachineClassName}'
discovery

$ kubectl get intvirtvm testvm -o jsonpath='{"Model: "}{.spec.template.spec.domain.cpu.model}{"\n"}{"Features: "}{.spec.template.spec.domain.cpu.features }'

Model: qemu64
Features: [{"name":"aes","policy":"require"},....,{"name":"svm","policy":"optional"}]

$ kubectl patch vm testvm --type merge -p '{"spec":{"virtualMachineClassName":"generic"}}'
```

**Before:**

```
$ kubectl get intvirtvm testvm -o jsonpath='{"Model: "}{.spec.template.spec.domain.cpu.model}{"\n"}{"Features: "}{.spec.template.spec.domain.cpu.features }'

Model: Nehalem
Features: [{"name":"aes","policy":"require"},....,{"name":"svm","policy":"optional"}]

```

**After:**

```
$ kubectl get intvirtvm testvm -o jsonpath='{"Model: "}{.spec.template.spec.domain.cpu.model}{"\n"}{"Features: "}{.spec.template.spec.domain.cpu.features }'

Model: Nehalem
Features: 

```


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: vm
type: fix
summary: Fix possible scheduling problems after changing vmclass from Discovery type to Model type.
```
