### PR TITLE
chore(ci): e2e report improve

### DIFF
--- a/.github/scripts/js/e2e/report/cluster-report.js
+++ b/.github/scripts/js/e2e/report/cluster-report.js
@@ -192,65 +192,46 @@ function findGinkgoOutput(config) {
   );
 }
 
-function parseGinkgoReportFile(rawReportPath, core) {
-  if (!rawReportPath) {
-    return {
-      metrics: zeroMetrics(),
-      failedTests: [],
-      failedTestDetails: [],
-      startedAt: null,
-      source: "empty",
-    };
-  }
-
-  core.info(`Found Ginkgo JSON report: ${rawReportPath}`);
-  try {
-    return {
-      ...parseGinkgoReport(fs.readFileSync(rawReportPath, "utf8")),
-      source: "ginkgo-json",
-    };
-  } catch (error) {
-    core.warning(
-      `Unable to parse Ginkgo JSON report ${rawReportPath}: ${error.message}`
-    );
-    return {
-      metrics: zeroMetrics(),
-      failedTests: [],
-      failedTestDetails: [],
-      startedAt: null,
-      source: "ginkgo-json-invalid",
-    };
-  }
+function emptyParsedReport(source) {
+  return {
+    metrics: zeroMetrics(),
+    failedTests: [],
+    failedTestDetails: [],
+    startedAt: null,
+    source,
+  };
 }
 
-function parseGinkgoOutputFile(outputPath, core) {
-  if (!outputPath) {
-    return {
-      metrics: zeroMetrics(),
-      failedTests: [],
-      failedTestDetails: [],
-      startedAt: null,
-      source: "empty",
-    };
+const ginkgoJsonSource = {
+  label: "Ginkgo JSON report",
+  okSource: "ginkgo-json",
+  invalidSource: "ginkgo-json-invalid",
+  parse: parseGinkgoReport,
+};
+
+const ginkgoOutputSource = {
+  label: "Ginkgo output log",
+  okSource: "ginkgo-output",
+  invalidSource: "ginkgo-output-invalid",
+  parse: parseGinkgoOutput,
+};
+
+function parseGinkgoFile(filePath, core, source) {
+  if (!filePath) {
+    return emptyParsedReport("empty");
   }
 
-  core.info(`Found Ginkgo output log: ${outputPath}`);
+  core.info(`Found ${source.label}: ${filePath}`);
   try {
     return {
-      ...parseGinkgoOutput(fs.readFileSync(outputPath, "utf8")),
-      source: "ginkgo-output",
+      ...source.parse(fs.readFileSync(filePath, "utf8")),
+      source: source.okSource,
     };
   } catch (error) {
     core.warning(
-      `Unable to parse Ginkgo output log ${outputPath}: ${error.message}`
+      `Unable to parse ${source.label} ${filePath}: ${error.message}`
     );
-    return {
-      metrics: zeroMetrics(),
-      failedTests: [],
-      failedTestDetails: [],
-      startedAt: null,
-      source: "ginkgo-output-invalid",
-    };
+    return emptyParsedReport(source.invalidSource);
   }
 }
 
@@ -260,8 +241,7 @@ function buildReportPayload({
   fallbackWorkflowRunUrl,
   branchName,
   parsedReport,
-  rawReportPath,
-  outputPath,
+  sourcePath,
 }) {
   const clusterStatus = buildClusterStatus(config.stageResults);
   const testStatus = buildTestStatus(
@@ -300,7 +280,7 @@ function buildReportPayload({
     metrics: parsedReport.metrics,
     failedTests: parsedReport.failedTests,
     failedTestDetails: parsedReport.failedTestDetails,
-    sourceReport: rawReportPath || outputPath,
+    sourceReport: sourcePath,
     reportSource: parsedReport.source,
   };
 }
@@ -368,6 +348,7 @@ async function buildClusterReport({ core, context, github, config } = {}) {
   const branchName = getBranchName(context);
   const rawReportPath = findGinkgoReport(resolvedConfig);
   const outputPath = rawReportPath ? null : findGinkgoOutput(resolvedConfig);
+  const sourcePath = rawReportPath || outputPath;
 
   if (!rawReportPath) {
     core.warning(
@@ -376,16 +357,15 @@ async function buildClusterReport({ core, context, github, config } = {}) {
   }
 
   const parsedReport = rawReportPath
-    ? parseGinkgoReportFile(rawReportPath, core)
-    : parseGinkgoOutputFile(outputPath, core);
+    ? parseGinkgoFile(rawReportPath, core, ginkgoJsonSource)
+    : parseGinkgoFile(outputPath, core, ginkgoOutputSource);
   const report = buildReportPayload({
     config: resolvedConfig,
     context,
     fallbackWorkflowRunUrl,
     branchName,
     parsedReport,
-    rawReportPath,
-    outputPath,
+    sourcePath,
   });
 
   try {

--- a/.github/scripts/js/e2e/report/cluster-report.js
+++ b/.github/scripts/js/e2e/report/cluster-report.js
@@ -87,17 +87,13 @@ function readClusterReportConfigFromEnv(env = process.env) {
   };
 }
 
+const requiredClusterReportConfigKeys = ["storageType", "reportsDir", "reportFile"];
+
 function requireClusterReportConfig(config) {
-  if (!config.storageType) {
-    throw new Error("buildClusterReport requires storageType");
-  }
-
-  if (!config.reportsDir) {
-    throw new Error("buildClusterReport requires reportsDir");
-  }
-
-  if (!config.reportFile) {
-    throw new Error("buildClusterReport requires reportFile");
+  for (const key of requiredClusterReportConfigKeys) {
+    if (!config[key]) {
+      throw new Error(`buildClusterReport requires ${key}`);
+    }
   }
 
   return { ...config };

--- a/.github/scripts/js/e2e/report/cluster-report.js
+++ b/.github/scripts/js/e2e/report/cluster-report.js
@@ -172,36 +172,6 @@ async function readStageJobUrlsFromApi(github, context, config, core) {
   return stageJobUrls;
 }
 
-function findGinkgoReport(config) {
-  const rawReportPattern = archivedReportPattern(config.storageType);
-
-  return findSingleMatchingFile(
-    config.reportsDir,
-    rawReportPattern,
-    "Ginkgo JSON report"
-  );
-}
-
-/**
- * Locates a single Ginkgo stdout/stderr fallback log for the configured
- * storage type. Used as a fallback report source when the primary
- * `e2e_report_*.json` file is missing (for example, when Ginkgo failed in
- * a suite setup node and produced no JSON report).
- *
- * @param {ClusterReportConfig} config Resolved cluster report config.
- * @returns {string|null} Path to the log file, or null when none exists.
- * @throws {Error} When more than one matching log file is found.
- */
-function findGinkgoOutput(config) {
-  const outputPattern = ginkgoOutputPattern(config.storageType);
-
-  return findSingleMatchingFile(
-    config.reportsDir,
-    outputPattern,
-    "Ginkgo output log"
-  );
-}
-
 /**
  * Builds a parsed-report payload used as a placeholder when no source data
  * is available, so the downstream report builder can keep working with a
@@ -231,6 +201,7 @@ const ginkgoJsonSource = {
   okSource: "ginkgo-json",
   invalidSource: "ginkgo-json-invalid",
   parse: parseGinkgoReport,
+  pattern: archivedReportPattern,
 };
 
 const ginkgoOutputSource = {
@@ -238,6 +209,7 @@ const ginkgoOutputSource = {
   okSource: "ginkgo-output",
   invalidSource: "ginkgo-output-invalid",
   parse: parseGinkgoOutput,
+  pattern: ginkgoOutputPattern,
 };
 
 /**
@@ -251,7 +223,25 @@ const ginkgoOutputSource = {
  *   failedTestDetails: Array<{name: string, reason: string}>,
  *   startedAt: string|null,
  * }} parse Parser function for the source content.
+ * @property {function(string): RegExp} pattern Builds the file-name regex for the source.
  */
+
+/**
+ * Locates a single Ginkgo source file (JSON report or stdout fallback log)
+ * for the configured storage type. Throws when more than one matching file
+ * exists; returns null when none is found.
+ *
+ * @param {ClusterReportConfig} config Resolved cluster report config.
+ * @param {GinkgoSourceDescriptor} source Source descriptor.
+ * @returns {string|null} Path to the source file, or null when none exists.
+ */
+function findGinkgoSource(config, source) {
+  return findSingleMatchingFile(
+    config.reportsDir,
+    source.pattern(config.storageType),
+    source.label
+  );
+}
 
 /**
  * Reads and parses a Ginkgo source file (JSON report or stdout log) using
@@ -400,9 +390,12 @@ async function buildClusterReport({ core, context, github, config } = {}) {
 
   const fallbackWorkflowRunUrl = getWorkflowRunUrl(context);
   const branchName = getBranchName(context);
-  const rawReportPath = findGinkgoReport(resolvedConfig);
-  const outputPath = rawReportPath ? null : findGinkgoOutput(resolvedConfig);
+  const rawReportPath = findGinkgoSource(resolvedConfig, ginkgoJsonSource);
+  const outputPath = rawReportPath
+    ? null
+    : findGinkgoSource(resolvedConfig, ginkgoOutputSource);
   const sourcePath = rawReportPath || outputPath;
+  const sourceDescriptor = rawReportPath ? ginkgoJsonSource : ginkgoOutputSource;
 
   if (!rawReportPath) {
     core.warning(
@@ -410,9 +403,7 @@ async function buildClusterReport({ core, context, github, config } = {}) {
     );
   }
 
-  const parsedReport = rawReportPath
-    ? parseGinkgoFile(rawReportPath, core, ginkgoJsonSource)
-    : parseGinkgoFile(outputPath, core, ginkgoOutputSource);
+  const parsedReport = parseGinkgoFile(sourcePath, core, sourceDescriptor);
   const report = buildReportPayload({
     config: resolvedConfig,
     context,

--- a/.github/scripts/js/e2e/report/cluster-report.js
+++ b/.github/scripts/js/e2e/report/cluster-report.js
@@ -182,6 +182,16 @@ function findGinkgoReport(config) {
   );
 }
 
+/**
+ * Locates a single Ginkgo stdout/stderr fallback log for the configured
+ * storage type. Used as a fallback report source when the primary
+ * `e2e_report_*.json` file is missing (for example, when Ginkgo failed in
+ * a suite setup node and produced no JSON report).
+ *
+ * @param {ClusterReportConfig} config Resolved cluster report config.
+ * @returns {string|null} Path to the log file, or null when none exists.
+ * @throws {Error} When more than one matching log file is found.
+ */
 function findGinkgoOutput(config) {
   const outputPattern = ginkgoOutputPattern(config.storageType);
 
@@ -192,6 +202,20 @@ function findGinkgoOutput(config) {
   );
 }
 
+/**
+ * Builds a parsed-report payload used as a placeholder when no source data
+ * is available, so the downstream report builder can keep working with a
+ * uniform shape.
+ *
+ * @param {string} source Source label to record on the placeholder.
+ * @returns {{
+ *   metrics: ReturnType<typeof zeroMetrics>,
+ *   failedTests: string[],
+ *   failedTestDetails: Array<{name: string, reason: string}>,
+ *   startedAt: null,
+ *   source: string,
+ * }} Empty parsed-report payload.
+ */
 function emptyParsedReport(source) {
   return {
     metrics: zeroMetrics(),
@@ -216,6 +240,36 @@ const ginkgoOutputSource = {
   parse: parseGinkgoOutput,
 };
 
+/**
+ * @typedef {Object} GinkgoSourceDescriptor
+ * @property {string} label Human-readable source name for log lines and warnings.
+ * @property {string} okSource Source tag stored on a successful parse result.
+ * @property {string} invalidSource Source tag stored when parsing fails.
+ * @property {function(string): {
+ *   metrics: ReturnType<typeof zeroMetrics>,
+ *   failedTests: string[],
+ *   failedTestDetails: Array<{name: string, reason: string}>,
+ *   startedAt: string|null,
+ * }} parse Parser function for the source content.
+ */
+
+/**
+ * Reads and parses a Ginkgo source file (JSON report or stdout log) using
+ * the provided source descriptor. Returns an empty placeholder when the
+ * file path is missing or the parser throws, so the caller always receives
+ * a consistent parsed-report shape.
+ *
+ * @param {string|null} filePath Path to the source file, or null/empty.
+ * @param {ClusterReportCore} core GitHub Actions core API.
+ * @param {GinkgoSourceDescriptor} source Source descriptor.
+ * @returns {{
+ *   metrics: ReturnType<typeof zeroMetrics>,
+ *   failedTests: string[],
+ *   failedTestDetails: Array<{name: string, reason: string}>,
+ *   startedAt: string|null,
+ *   source: string,
+ * }} Parsed report payload with a source tag.
+ */
 function parseGinkgoFile(filePath, core, source) {
   if (!filePath) {
     return emptyParsedReport("empty");

--- a/.github/scripts/js/e2e/report/cluster-report.js
+++ b/.github/scripts/js/e2e/report/cluster-report.js
@@ -183,6 +183,7 @@ function parseGinkgoReportFile(rawReportPath, core) {
     return {
       metrics: zeroMetrics(),
       failedTests: [],
+      failedTestDetails: [],
       startedAt: null,
       source: "empty",
     };
@@ -201,6 +202,7 @@ function parseGinkgoReportFile(rawReportPath, core) {
     return {
       metrics: zeroMetrics(),
       failedTests: [],
+      failedTestDetails: [],
       startedAt: null,
       source: "ginkgo-json-invalid",
     };
@@ -251,6 +253,7 @@ function buildReportPayload({
     startedAt: parsedReport.startedAt,
     metrics: parsedReport.metrics,
     failedTests: parsedReport.failedTests,
+    failedTestDetails: parsedReport.failedTestDetails,
     sourceReport: rawReportPath,
     reportSource: parsedReport.source,
   };

--- a/.github/scripts/js/e2e/report/cluster-report.js
+++ b/.github/scripts/js/e2e/report/cluster-report.js
@@ -13,12 +13,16 @@
 const fs = require("fs");
 
 const { findSingleMatchingFile } = require("./shared/fs-utils");
-const { parseGinkgoReport } = require("./shared/ginkgo-report-utils");
+const {
+  parseGinkgoOutput,
+  parseGinkgoReport,
+} = require("./shared/ginkgo-report-utils");
 const {
   archivedReportPattern,
   buildClusterStatus,
   buildReportSummary,
   buildTestStatus,
+  ginkgoOutputPattern,
   reportFileName,
   zeroMetrics,
 } = require("./shared/report-model");
@@ -178,6 +182,16 @@ function findGinkgoReport(config) {
   );
 }
 
+function findGinkgoOutput(config) {
+  const outputPattern = ginkgoOutputPattern(config.storageType);
+
+  return findSingleMatchingFile(
+    config.reportsDir,
+    outputPattern,
+    "Ginkgo output log"
+  );
+}
+
 function parseGinkgoReportFile(rawReportPath, core) {
   if (!rawReportPath) {
     return {
@@ -209,6 +223,37 @@ function parseGinkgoReportFile(rawReportPath, core) {
   }
 }
 
+function parseGinkgoOutputFile(outputPath, core) {
+  if (!outputPath) {
+    return {
+      metrics: zeroMetrics(),
+      failedTests: [],
+      failedTestDetails: [],
+      startedAt: null,
+      source: "empty",
+    };
+  }
+
+  core.info(`Found Ginkgo output log: ${outputPath}`);
+  try {
+    return {
+      ...parseGinkgoOutput(fs.readFileSync(outputPath, "utf8")),
+      source: "ginkgo-output",
+    };
+  } catch (error) {
+    core.warning(
+      `Unable to parse Ginkgo output log ${outputPath}: ${error.message}`
+    );
+    return {
+      metrics: zeroMetrics(),
+      failedTests: [],
+      failedTestDetails: [],
+      startedAt: null,
+      source: "ginkgo-output-invalid",
+    };
+  }
+}
+
 function buildReportPayload({
   config,
   context,
@@ -216,6 +261,7 @@ function buildReportPayload({
   branchName,
   parsedReport,
   rawReportPath,
+  outputPath,
 }) {
   const clusterStatus = buildClusterStatus(config.stageResults);
   const testStatus = buildTestStatus(
@@ -254,7 +300,7 @@ function buildReportPayload({
     metrics: parsedReport.metrics,
     failedTests: parsedReport.failedTests,
     failedTestDetails: parsedReport.failedTestDetails,
-    sourceReport: rawReportPath,
+    sourceReport: rawReportPath || outputPath,
     reportSource: parsedReport.source,
   };
 }
@@ -321,6 +367,7 @@ async function buildClusterReport({ core, context, github, config } = {}) {
   const fallbackWorkflowRunUrl = getWorkflowRunUrl(context);
   const branchName = getBranchName(context);
   const rawReportPath = findGinkgoReport(resolvedConfig);
+  const outputPath = rawReportPath ? null : findGinkgoOutput(resolvedConfig);
 
   if (!rawReportPath) {
     core.warning(
@@ -328,7 +375,9 @@ async function buildClusterReport({ core, context, github, config } = {}) {
     );
   }
 
-  const parsedReport = parseGinkgoReportFile(rawReportPath, core);
+  const parsedReport = rawReportPath
+    ? parseGinkgoReportFile(rawReportPath, core)
+    : parseGinkgoOutputFile(outputPath, core);
   const report = buildReportPayload({
     config: resolvedConfig,
     context,
@@ -336,6 +385,7 @@ async function buildClusterReport({ core, context, github, config } = {}) {
     branchName,
     parsedReport,
     rawReportPath,
+    outputPath,
   });
 
   try {

--- a/.github/scripts/js/e2e/report/cluster-report.test.js
+++ b/.github/scripts/js/e2e/report/cluster-report.test.js
@@ -608,6 +608,70 @@ describe("cluster-report", () => {
       ]);
     }));
 
+  test("parses real Ginkgo BeforeSuite failure stdout", async () =>
+    withTempDir(async (tempDir) => {
+      const outputPath = path.join(
+        tempDir,
+        "e2e_output_replicated_2026-05-14.log"
+      );
+      fs.writeFileSync(
+        outputPath,
+        [
+          "Will run 93 of 94 specs",
+          "------------------------------",
+          "[SynchronizedBeforeSuite]",
+          "/home/runner/work/virtualization/virtualization/test/e2e/e2e_test.go:44",
+          "PASS: all 94 specs have precheck labels",
+          "  STEP: Ensuring 12 precreated CVIs are available @ 05/14/26 13:57:36.142",
+          "  CVI \"v12n-e2e-testdata-iso\" exists but not ready (phase: Pending), waiting...",
+          "  [FAILED] in [SynchronizedBeforeSuite] - /home/runner/work/.../until.go:207 @ 05/14/26 14:02:37.61",
+          "[SynchronizedBeforeSuite] [FAILED] [307.964 seconds]",
+          "[SynchronizedBeforeSuite]",
+          "/home/runner/work/virtualization/virtualization/test/e2e/e2e_test.go:44",
+          "",
+          "  [FAILED] Timed out after 300.001s.",
+          "  The function passed to Eventually failed at /home/runner/work/.../until.go:205 with:",
+          "  object v12n-e2e-testdata-iso status.phase is Pending, expected Ready",
+          "  Expected",
+          "      <string>: Pending",
+          "  to equal",
+          "      <string>: Ready",
+          "------------------------------",
+          "[SynchronizedAfterSuite]",
+          "/home/runner/work/virtualization/virtualization/test/e2e/e2e_test.go:61",
+          "[SynchronizedAfterSuite] PASSED [3.649 seconds]",
+          "------------------------------",
+          "Summarizing 1 Failure:",
+          "  [FAIL] [SynchronizedBeforeSuite]",
+          "Ran 0 of 94 Specs in 311.615 seconds",
+          "FAIL! -- A BeforeSuite node failed so all tests were skipped.",
+        ].join("\n")
+      );
+
+      const reportFile = path.join(tempDir, "report.json");
+      const report = await buildClusterReport({
+        core: createCore(),
+        context: createContext(),
+        config: createClusterConfig({
+          reportsDir: tempDir,
+          reportFile,
+          stageResults: { "e2e-test": "failure" },
+        }),
+      });
+
+      expect(report.reportSource).toBe("ginkgo-output");
+      expect(report.failedTests).toEqual(["[SynchronizedBeforeSuite]"]);
+      const detail = report.failedTestDetails[0];
+      expect(detail.name).toBe("[SynchronizedBeforeSuite]");
+      expect(detail.reason).toContain("Timed out after 300.001s.");
+      expect(detail.reason).toContain(
+        "object v12n-e2e-testdata-iso status.phase is Pending, expected Ready"
+      );
+      // The plain "[SynchronizedBeforeSuite]" header that follows the
+      // "[FAILED] [307.964 seconds]" line must not leak into the reason.
+      expect(detail.reason.split("\n")[0]).not.toBe("[SynchronizedBeforeSuite]");
+    }));
+
   test("fails when multiple matching Ginkgo JSON reports exist", async () =>
     withTempDir(async (tempDir) => {
       const firstReportPath = path.join(

--- a/.github/scripts/js/e2e/report/cluster-report.test.js
+++ b/.github/scripts/js/e2e/report/cluster-report.test.js
@@ -507,6 +507,107 @@ describe("cluster-report", () => {
       expect(core.setOutput).toHaveBeenCalledWith("branch", "main");
     }));
 
+  test("captures suite-level failures from Ginkgo JSON", async () =>
+    withTempDir(async (tempDir) => {
+      const rawReportPath = path.join(
+        tempDir,
+        "e2e_report_replicated_2026-04-15.json"
+      );
+      fs.writeFileSync(
+        rawReportPath,
+        createGinkgoReport({
+          startedAt: "2026-04-15T09:30:44Z",
+          specs: [
+            createSpecReport({
+              leafNodeType: "SynchronizedBeforeSuite",
+              state: "failed",
+              failure: {
+                Message:
+                  "object v12n-e2e-testdata-iso status.phase is Pending, expected Ready",
+              },
+            }),
+          ],
+        })
+      );
+
+      const reportFile = path.join(tempDir, "report.json");
+      const report = await buildClusterReport({
+        core: createCore(),
+        context: createContext(),
+        config: createClusterConfig({
+          reportsDir: tempDir,
+          reportFile,
+          stageResults: {
+            "e2e-test": "failure",
+          },
+        }),
+      });
+
+      expect(report.reportKind).toBe("tests");
+      expect(report.status).toBe("failure");
+      expect(report.metrics).toMatchObject({
+        passed: 0,
+        failed: 0,
+        errors: 0,
+        total: 0,
+      });
+      expect(report.failedTestDetails).toEqual([
+        {
+          name: "[SynchronizedBeforeSuite]",
+          reason:
+            "object v12n-e2e-testdata-iso status.phase is Pending, expected Ready",
+        },
+      ]);
+    }));
+
+  test("uses Ginkgo output log when JSON report is missing", async () =>
+    withTempDir(async (tempDir) => {
+      const outputPath = path.join(
+        tempDir,
+        "e2e_output_replicated_2026-04-15.log"
+      );
+      fs.writeFileSync(
+        outputPath,
+        [
+          "[SynchronizedBeforeSuite] [FAILED] [307.964 seconds]",
+          "[FAILED] Timed out after 300.001s.",
+          "The function passed to Eventually failed with:",
+          "object v12n-e2e-testdata-iso status.phase is Pending, expected Ready",
+          "------------------------------",
+          "Summarizing 1 Failure:",
+          "  [FAIL] [SynchronizedBeforeSuite]",
+        ].join("\n")
+      );
+
+      const reportFile = path.join(tempDir, "report.json");
+      const report = await buildClusterReport({
+        core: createCore(),
+        context: createContext(),
+        config: createClusterConfig({
+          reportsDir: tempDir,
+          reportFile,
+          stageResults: {
+            "e2e-test": "failure",
+          },
+        }),
+      });
+
+      expect(report.reportKind).toBe("tests");
+      expect(report.status).toBe("failure");
+      expect(report.reportSource).toBe("ginkgo-output");
+      expect(report.sourceReport).toBe(outputPath);
+      expect(report.failedTestDetails).toEqual([
+        {
+          name: "[SynchronizedBeforeSuite]",
+          reason: [
+            "Timed out after 300.001s.",
+            "The function passed to Eventually failed with:",
+            "object v12n-e2e-testdata-iso status.phase is Pending, expected Ready",
+          ].join("\n"),
+        },
+      ]);
+    }));
+
   test("fails when multiple matching Ginkgo JSON reports exist", async () =>
     withTempDir(async (tempDir) => {
       const firstReportPath = path.join(

--- a/.github/scripts/js/e2e/report/cluster-report.test.js
+++ b/.github/scripts/js/e2e/report/cluster-report.test.js
@@ -11,30 +11,15 @@
 // limitations under the License.
 
 const fs = require("fs");
-const os = require("os");
 const path = require("path");
 
 const buildClusterReport = require("./cluster-report");
 const { readClusterReportConfigFromEnv } = require("./cluster-report");
 const { parseGinkgoReport } = require("./shared/ginkgo-report-utils");
 const { buildClusterStatus } = require("./shared/report-model");
+const { createCore, withTempDir } = require("./shared/test-utils");
 
-/**
- * Creates a mocked GitHub Actions core object for unit tests.
- *
- * @returns {{
- *   info: jest.Mock,
- *   warning: jest.Mock,
- *   setOutput: jest.Mock
- * }} Mocked core object.
- */
-function createCore() {
-  return {
-    info: jest.fn(),
-    warning: jest.fn(),
-    setOutput: jest.fn(),
-  };
-}
+const inTempDir = (testFn) => withTempDir("cluster-report-test", testFn);
 
 /**
  * Creates a minimal GitHub Actions context object for unit tests.
@@ -80,24 +65,6 @@ function createGithub(jobNames) {
       },
     },
   };
-}
-
-/**
- * Runs a test body inside a temporary directory and removes it afterwards.
- *
- * @template T
- * @param {function(string): (Promise<T>|T)} testFn Test body.
- * @returns {Promise<T>} Test result.
- */
-async function withTempDir(testFn) {
-  const tempDir = fs.mkdtempSync(
-    path.join(os.tmpdir(), "cluster-report-test-")
-  );
-  try {
-    return await testFn(tempDir);
-  } finally {
-    fs.rmSync(tempDir, { recursive: true, force: true });
-  }
 }
 
 /**
@@ -229,7 +196,7 @@ describe("cluster-report", () => {
   });
 
   test("builds report from explicit config without reading env", async () =>
-    withTempDir(async (tempDir) => {
+    inTempDir(async (tempDir) => {
       const reportFile = path.join(tempDir, "explicit-report.json");
 
       const report = await buildClusterReport({
@@ -264,7 +231,7 @@ describe("cluster-report", () => {
     }));
 
   test("builds report from environment config", async () =>
-    withTempDir(async (tempDir) => {
+    inTempDir(async (tempDir) => {
       const reportFile = path.join(tempDir, "env-report.json");
       process.env.STORAGE_TYPE = "replicated";
       process.env.PIPELINE_JOB_NAME = "E2E Pipeline (Replicated)";
@@ -301,7 +268,7 @@ describe("cluster-report", () => {
     }));
 
   test("reads stage results from env vars", async () =>
-    withTempDir(async (tempDir) => {
+    inTempDir(async (tempDir) => {
       const reportFile = path.join(tempDir, "env-report.json");
       process.env.STORAGE_TYPE = "nfs";
       process.env.PIPELINE_JOB_NAME = "E2E Pipeline (NFS)";
@@ -331,7 +298,7 @@ describe("cluster-report", () => {
     }));
 
   test("fetches job URLs from GitHub API", async () =>
-    withTempDir(async (tempDir) => {
+    inTempDir(async (tempDir) => {
       const reportFile = path.join(tempDir, "env-report.json");
       process.env.STORAGE_TYPE = "nfs";
       process.env.PIPELINE_JOB_NAME = "E2E Pipeline (NFS)";
@@ -368,7 +335,7 @@ describe("cluster-report", () => {
     }));
 
   test("works without github (no job URLs)", async () =>
-    withTempDir(async (tempDir) => {
+    inTempDir(async (tempDir) => {
       const reportFile = path.join(tempDir, "env-report.json");
       process.env.STORAGE_TYPE = "replicated";
       process.env.REPORTS_DIR = tempDir;
@@ -395,7 +362,7 @@ describe("cluster-report", () => {
     }));
 
   test("marks Ginkgo JSON with failed specs as failed", async () =>
-    withTempDir(async (tempDir) => {
+    inTempDir(async (tempDir) => {
       const rawReportPath = path.join(
         tempDir,
         "e2e_report_replicated_2026-04-15.json"
@@ -508,7 +475,7 @@ describe("cluster-report", () => {
     }));
 
   test("captures suite-level failures from Ginkgo JSON", async () =>
-    withTempDir(async (tempDir) => {
+    inTempDir(async (tempDir) => {
       const rawReportPath = path.join(
         tempDir,
         "e2e_report_replicated_2026-04-15.json"
@@ -561,7 +528,7 @@ describe("cluster-report", () => {
     }));
 
   test("uses Ginkgo output log when JSON report is missing", async () =>
-    withTempDir(async (tempDir) => {
+    inTempDir(async (tempDir) => {
       const outputPath = path.join(
         tempDir,
         "e2e_output_replicated_2026-04-15.log"
@@ -609,7 +576,7 @@ describe("cluster-report", () => {
     }));
 
   test("parses real Ginkgo BeforeSuite failure stdout", async () =>
-    withTempDir(async (tempDir) => {
+    inTempDir(async (tempDir) => {
       const outputPath = path.join(
         tempDir,
         "e2e_output_replicated_2026-05-14.log"
@@ -673,7 +640,7 @@ describe("cluster-report", () => {
     }));
 
   test("fails when multiple matching Ginkgo JSON reports exist", async () =>
-    withTempDir(async (tempDir) => {
+    inTempDir(async (tempDir) => {
       const firstReportPath = path.join(
         tempDir,
         "nested",
@@ -721,7 +688,7 @@ describe("cluster-report", () => {
     }));
 
   test("falls back to missing-report status when raw Ginkgo JSON is invalid", async () =>
-    withTempDir(async (tempDir) => {
+    inTempDir(async (tempDir) => {
       const rawReportPath = path.join(
         tempDir,
         "e2e_report_replicated_2026-04-15.json"
@@ -755,7 +722,7 @@ describe("cluster-report", () => {
     }));
 
   test("throws a descriptive error when writing the cluster report fails", async () =>
-    withTempDir(async (tempDir) => {
+    inTempDir(async (tempDir) => {
       const reportFile = path.join(tempDir, "report.json");
       const config = createClusterConfig({
         reportsDir: tempDir,
@@ -868,7 +835,7 @@ describe("cluster-report", () => {
   });
 
   test("reports configure-sdn as the failed pre-E2E phase", async () =>
-    withTempDir(async (tempDir) => {
+    inTempDir(async (tempDir) => {
       const reportFile = path.join(tempDir, "report.json");
       const config = createClusterConfig({
         reportsDir: tempDir,
@@ -903,7 +870,7 @@ describe("cluster-report", () => {
     }));
 
   test("marks missing artifacts when test stage is successful but no reports were found", async () =>
-    withTempDir(async (tempDir) => {
+    inTempDir(async (tempDir) => {
       const reportFile = path.join(tempDir, "report.json");
       const config = createClusterConfig({
         reportsDir: tempDir,
@@ -928,7 +895,7 @@ describe("cluster-report", () => {
     }));
 
   test("keeps cancelled test stage when no reports were found", async () =>
-    withTempDir(async (tempDir) => {
+    inTempDir(async (tempDir) => {
       const reportFile = path.join(tempDir, "report.json");
       const config = createClusterConfig({
         reportsDir: tempDir,
@@ -956,7 +923,7 @@ describe("cluster-report", () => {
     }));
 
   test("keeps failed test stage when no reports were found", async () =>
-    withTempDir(async (tempDir) => {
+    inTempDir(async (tempDir) => {
       const reportFile = path.join(tempDir, "report.json");
       const config = createClusterConfig({
         reportsDir: tempDir,

--- a/.github/scripts/js/e2e/report/cluster-report.test.js
+++ b/.github/scripts/js/e2e/report/cluster-report.test.js
@@ -480,10 +480,13 @@ describe("cluster-report", () => {
         {
           name: "[It] Suite fails & burns [Slow]",
           reason: "failed to execute command sudo lsblk: signal: killed",
+          message:
+            "Unexpected error:\n    <*fmt.wrapError | 0xc000f24540>:\n    failed to execute command sudo lsblk: signal: killed\noccurred",
         },
         {
           name: "[It] Other errors <loudly>",
           reason: "timed out waiting for VM to become ready",
+          message: "timed out waiting for VM to become ready",
         },
       ]);
       expect(report.reportSource).toBe("ginkgo-json");

--- a/.github/scripts/js/e2e/report/cluster-report.test.js
+++ b/.github/scripts/js/e2e/report/cluster-report.test.js
@@ -479,14 +479,12 @@ describe("cluster-report", () => {
       expect(report.failedTestDetails).toEqual([
         {
           name: "[It] Suite fails & burns [Slow]",
-          reason: "failed to execute command sudo lsblk: signal: killed",
-          message:
+          reason:
             "Unexpected error:\n    <*fmt.wrapError | 0xc000f24540>:\n    failed to execute command sudo lsblk: signal: killed\noccurred",
         },
         {
           name: "[It] Other errors <loudly>",
           reason: "timed out waiting for VM to become ready",
-          message: "timed out waiting for VM to become ready",
         },
       ]);
       expect(report.reportSource).toBe("ginkgo-json");

--- a/.github/scripts/js/e2e/report/cluster-report.test.js
+++ b/.github/scripts/js/e2e/report/cluster-report.test.js
@@ -419,11 +419,18 @@ describe("cluster-report", () => {
               leafNodeText: "fails & burns",
               state: "failed",
               leafNodeLabels: ["Slow"],
+              failure: {
+                Message:
+                  "Unexpected error:\n    <*fmt.wrapError | 0xc000f24540>:\n    failed to execute command sudo lsblk: signal: killed\noccurred",
+              },
             }),
             createSpecReport({
               containerHierarchyTexts: ["Other"],
               leafNodeText: "errors <loudly>",
               state: "timedout",
+              failure: {
+                Message: "timed out waiting for VM to become ready",
+              },
             }),
             createSpecReport({
               leafNodeText: "skipped",
@@ -463,11 +470,21 @@ describe("cluster-report", () => {
         errors: 1,
         skipped: 1,
         total: 4,
-        successRate: 25,
+        successRate: 33.33,
       });
       expect(report.failedTests).toEqual([
         "[It] Suite fails & burns [Slow]",
         "[It] Other errors <loudly>",
+      ]);
+      expect(report.failedTestDetails).toEqual([
+        {
+          name: "[It] Suite fails & burns [Slow]",
+          reason: "failed to execute command sudo lsblk: signal: killed",
+        },
+        {
+          name: "[It] Other errors <loudly>",
+          reason: "timed out waiting for VM to become ready",
+        },
       ]);
       expect(report.reportSource).toBe("ginkgo-json");
       expect(report.sourceReport).toBe(rawReportPath);
@@ -675,7 +692,7 @@ describe("cluster-report", () => {
       errors: 0,
       skipped: 34,
       total: 131,
-      successRate: 68.7,
+      successRate: 92.78,
     });
     expect(parsed.startedAt).toBe("2026-04-28T03:11:27.708387575Z");
     expect(parsed.failedTests).toHaveLength(7);

--- a/.github/scripts/js/e2e/report/messenger-report.test.js
+++ b/.github/scripts/js/e2e/report/messenger-report.test.js
@@ -129,6 +129,7 @@ describe("messenger-report", () => {
             {
               name: "[It] fails",
               reason: "command timed out",
+              message: "Unexpected error:\ncommand timed out\noccurred",
             },
           ],
         })
@@ -171,7 +172,23 @@ describe("messenger-report", () => {
       );
       expect(result.message).not.toContain("### Failed tests");
       expect(result.threadMessages).toEqual([
-        "### Failed tests\n\n**replicated**\n\n| Tests | Reason |\n|---|---|\n| fails | command timed out |",
+        [
+          "### Failed tests",
+          "",
+          "**replicated**",
+          "",
+          "| Tests | Reason |",
+          "|---|---|",
+          "| fails | command timed out |",
+          "",
+          "**Details**",
+          "",
+          "_fails_",
+          "",
+          "```text",
+          "Unexpected error:\ncommand timed out\noccurred",
+          "```",
+        ].join("\n"),
       ]);
     }));
 

--- a/.github/scripts/js/e2e/report/messenger-report.test.js
+++ b/.github/scripts/js/e2e/report/messenger-report.test.js
@@ -175,7 +175,7 @@ describe("messenger-report", () => {
         [
           "### Failed tests",
           "",
-          "**replicated**",
+          "**[replicated](https://example.invalid/replicated)**",
           "",
           "| Tests | Reason |",
           "|---|---|",
@@ -306,8 +306,8 @@ describe("messenger-report", () => {
       const result = await renderMessengerReport({ core: createCore() });
 
       expect(result.threadMessages).toEqual([
-        "### Failed tests\n\n**replicated**\n\n| Tests | Reason |\n|---|---|\n| replicated | — |",
-        "**nfs**\n\n| Tests | Reason |\n|---|---|\n| nfs | — |",
+        "### Failed tests\n\n**[replicated](https://example.invalid/replicated)**\n\n| Tests | Reason |\n|---|---|\n| replicated | — |",
+        "**[nfs](https://example.invalid/nfs)**\n\n| Tests | Reason |\n|---|---|\n| nfs | — |",
       ]);
     }));
 
@@ -351,7 +351,7 @@ describe("messenger-report", () => {
         [
           "### Failed tests",
           "",
-          "**nfs**",
+          "**[nfs](https://example.invalid/nfs)**",
           "",
           "| Tests | Reason |",
           "|---|---|",
@@ -551,7 +551,7 @@ describe("messenger-report", () => {
       expect(JSON.parse(global.fetch.mock.calls[1][1].body)).toEqual({
         channel_id: "channel-id",
         message:
-          "### Failed tests\n\n**replicated**\n\n| Tests | Reason |\n|---|---|\n| fails | — |",
+          "### Failed tests\n\n**[replicated](https://example.invalid/replicated)**\n\n| Tests | Reason |\n|---|---|\n| fails | — |",
         root_id: "root-post-id",
       });
     }));

--- a/.github/scripts/js/e2e/report/messenger-report.test.js
+++ b/.github/scripts/js/e2e/report/messenger-report.test.js
@@ -11,46 +11,13 @@
 // limitations under the License.
 
 const fs = require("fs");
-const os = require("os");
 const path = require("path");
 
 const renderMessengerReport = require("./messenger-report");
 const { readMessengerConfigFromEnv } = require("./messenger/config");
+const { createCore, withTempDir } = require("./shared/test-utils");
 
-/**
- * Creates a mocked GitHub Actions core object for unit tests.
- *
- * @returns {{
- *   info: jest.Mock,
- *   warning: jest.Mock,
- *   setOutput: jest.Mock
- * }} Mocked core object.
- */
-function createCore() {
-  return {
-    info: jest.fn(),
-    warning: jest.fn(),
-    setOutput: jest.fn(),
-  };
-}
-
-/**
- * Runs a test body inside a temporary directory and removes it afterwards.
- *
- * @template T
- * @param {function(string): (Promise<T>|T)} testFn Test body.
- * @returns {Promise<T>} Test result.
- */
-async function withTempDir(testFn) {
-  const tempDir = fs.mkdtempSync(
-    path.join(os.tmpdir(), "messenger-report-test-")
-  );
-  try {
-    return await testFn(tempDir);
-  } finally {
-    fs.rmSync(tempDir, { recursive: true, force: true });
-  }
-}
+const inTempDir = (testFn) => withTempDir("messenger-report-test", testFn);
 
 describe("messenger-report", () => {
   afterEach(() => {
@@ -106,7 +73,7 @@ describe("messenger-report", () => {
   });
 
   test("renders test results, stage failures, and per-cluster thread replies", async () =>
-    withTempDir(async (tempDir) => {
+    inTempDir(async (tempDir) => {
       fs.writeFileSync(
         path.join(tempDir, "e2e_report_replicated.json"),
         JSON.stringify({
@@ -184,7 +151,7 @@ describe("messenger-report", () => {
     }));
 
   test("creates artifact-missing entry for absent cluster report", async () =>
-    withTempDir(async (tempDir) => {
+    inTempDir(async (tempDir) => {
       process.env.REPORTS_DIR = tempDir;
       process.env.EXPECTED_STORAGE_TYPES = '["replicated"]';
 
@@ -198,7 +165,7 @@ describe("messenger-report", () => {
     }));
 
   test("warns and skips report files that are missing storageType/cluster fields", async () =>
-    withTempDir(async (tempDir) => {
+    inTempDir(async (tempDir) => {
       fs.writeFileSync(
         path.join(tempDir, "e2e_report_corrupt.json"),
         JSON.stringify({
@@ -248,7 +215,7 @@ describe("messenger-report", () => {
     }));
 
   test("splits failed tests into separate thread messages per cluster", async () =>
-    withTempDir(async (tempDir) => {
+    inTempDir(async (tempDir) => {
       fs.writeFileSync(
         path.join(tempDir, "e2e_report_replicated.json"),
         JSON.stringify({
@@ -303,7 +270,7 @@ describe("messenger-report", () => {
     }));
 
   test("groups failed tests by top-level describe name", async () =>
-    withTempDir(async (tempDir) => {
+    inTempDir(async (tempDir) => {
       fs.writeFileSync(
         path.join(tempDir, "e2e_report_nfs.json"),
         JSON.stringify({
@@ -353,7 +320,7 @@ describe("messenger-report", () => {
     }));
 
   test("renders cluster status from downloaded report artifact", async () =>
-    withTempDir(async (tempDir) => {
+    inTempDir(async (tempDir) => {
       fs.writeFileSync(
         path.join(tempDir, "e2e_report_replicated.json"),
         JSON.stringify({
@@ -398,7 +365,7 @@ describe("messenger-report", () => {
     }));
 
   test("shows branch line for non-main branches", async () =>
-    withTempDir(async (tempDir) => {
+    inTempDir(async (tempDir) => {
       fs.writeFileSync(
         path.join(tempDir, "e2e_report_replicated.json"),
         JSON.stringify({
@@ -437,7 +404,7 @@ describe("messenger-report", () => {
     }));
 
   test("renders missing test report status from downloaded report artifact", async () =>
-    withTempDir(async (tempDir) => {
+    inTempDir(async (tempDir) => {
       fs.writeFileSync(
         path.join(tempDir, "e2e_report_replicated.json"),
         JSON.stringify({
@@ -480,7 +447,7 @@ describe("messenger-report", () => {
     }));
 
   test("posts main report and per-cluster failed tests thread via Loop API", async () =>
-    withTempDir(async (tempDir) => {
+    inTempDir(async (tempDir) => {
       fs.writeFileSync(
         path.join(tempDir, "e2e_report_replicated.json"),
         JSON.stringify({
@@ -548,7 +515,7 @@ describe("messenger-report", () => {
     }));
 
   test("warns when Loop API returns an empty response body (no post id)", async () =>
-    withTempDir(async (tempDir) => {
+    inTempDir(async (tempDir) => {
       fs.writeFileSync(
         path.join(tempDir, "e2e_report_replicated.json"),
         JSON.stringify({
@@ -595,7 +562,7 @@ describe("messenger-report", () => {
     }));
 
   test("warns when Loop API returns a non-JSON response body (no post id)", async () =>
-    withTempDir(async (tempDir) => {
+    inTempDir(async (tempDir) => {
       fs.writeFileSync(
         path.join(tempDir, "e2e_report_replicated.json"),
         JSON.stringify({
@@ -645,7 +612,7 @@ describe("messenger-report", () => {
     }));
 
   test("logs readable Loop API errors for failed responses", async () =>
-    withTempDir(async (tempDir) => {
+    inTempDir(async (tempDir) => {
       fs.writeFileSync(
         path.join(tempDir, "e2e_report_replicated.json"),
         JSON.stringify({

--- a/.github/scripts/js/e2e/report/messenger-report.test.js
+++ b/.github/scripts/js/e2e/report/messenger-report.test.js
@@ -128,8 +128,7 @@ describe("messenger-report", () => {
           failedTestDetails: [
             {
               name: "[It] fails",
-              reason: "command timed out",
-              message: "Unexpected error:\ncommand timed out\noccurred",
+              reason: "Unexpected error:\ncommand timed out\noccurred",
             },
           ],
         })
@@ -179,15 +178,7 @@ describe("messenger-report", () => {
           "",
           "| Tests | Reason |",
           "|---|---|",
-          "| fails | command timed out |",
-          "",
-          "**Details**",
-          "",
-          "_fails_",
-          "",
-          "```text",
-          "Unexpected error:\ncommand timed out\noccurred",
-          "```",
+          "| fails | Unexpected error: command timed out occurred |",
         ].join("\n"),
       ]);
     }));

--- a/.github/scripts/js/e2e/report/messenger-report.test.js
+++ b/.github/scripts/js/e2e/report/messenger-report.test.js
@@ -93,7 +93,9 @@ describe("messenger-report", () => {
         LOOP_API_BASE_URL: "https://loop.example.invalid",
         // LOOP_CHANNEL_ID and LOOP_TOKEN intentionally absent
       })
-    ).toThrow("LOOP_CHANNEL_ID, LOOP_TOKEN, and LOOP_API_BASE_URL are required");
+    ).toThrow(
+      "LOOP_CHANNEL_ID, LOOP_TOKEN, and LOOP_API_BASE_URL are required"
+    );
   });
 
   test("uses default configured clusters when env override is absent", () => {
@@ -123,6 +125,12 @@ describe("messenger-report", () => {
             successRate: 80,
           },
           failedTests: ["[It] fails"],
+          failedTestDetails: [
+            {
+              name: "[It] fails",
+              reason: "command timed out",
+            },
+          ],
         })
       );
 
@@ -154,15 +162,16 @@ describe("messenger-report", () => {
 
       expect(result.message).toContain("### Test results");
       expect(result.message).toContain(
-        "| [replicated](https://example.invalid/replicated) | 12 | 2 | 1 | 0 | 15 | 80.00% |"
+        "| [replicated](https://example.invalid/replicated) | 12 | 2 | 1 | 15 | 80.00% |"
       );
+      expect(result.message).not.toContain("⚠️ Errors");
       expect(result.message).toContain("### Cluster failures");
       expect(result.message).toContain(
         "- [nfs](https://example.invalid/nfs): CONFIGURE SDN"
       );
       expect(result.message).not.toContain("### Failed tests");
       expect(result.threadMessages).toEqual([
-        "### Failed tests\n\n**replicated**\n\n| Test group |\n|---|\n| fails |",
+        "### Failed tests\n\n**replicated**\n\n| Tests | Reason |\n|---|---|\n| fails | command timed out |",
       ]);
     }));
 
@@ -280,8 +289,8 @@ describe("messenger-report", () => {
       const result = await renderMessengerReport({ core: createCore() });
 
       expect(result.threadMessages).toEqual([
-        "### Failed tests\n\n**replicated**\n\n| Test group |\n|---|\n| replicated |",
-        "**nfs**\n\n| Test group |\n|---|\n| nfs |",
+        "### Failed tests\n\n**replicated**\n\n| Tests | Reason |\n|---|---|\n| replicated | — |",
+        "**nfs**\n\n| Tests | Reason |\n|---|---|\n| nfs | — |",
       ]);
     }));
 
@@ -327,10 +336,10 @@ describe("messenger-report", () => {
           "",
           "**nfs**",
           "",
-          "| Test group |",
-          "|---|",
-          "| VirtualMachineOperationRestore |",
-          "| VirtualMachineAdditionalNetworkInterfaces |",
+          "| Tests | Reason |",
+          "|---|---|",
+          "| VirtualMachineOperationRestore | — |",
+          "| VirtualMachineAdditionalNetworkInterfaces | — |",
         ].join("\n"),
       ]);
     }));
@@ -525,7 +534,7 @@ describe("messenger-report", () => {
       expect(JSON.parse(global.fetch.mock.calls[1][1].body)).toEqual({
         channel_id: "channel-id",
         message:
-          "### Failed tests\n\n**replicated**\n\n| Test group |\n|---|\n| fails |",
+          "### Failed tests\n\n**replicated**\n\n| Tests | Reason |\n|---|---|\n| fails | — |",
         root_id: "root-post-id",
       });
     }));

--- a/.github/scripts/js/e2e/report/messenger/loop-client.js
+++ b/.github/scripts/js/e2e/report/messenger/loop-client.js
@@ -17,19 +17,17 @@
  */
 
 /**
- * @typedef {Object} LoopPostRequest
+ * @typedef {Object} LoopCredentials
  * @property {string} apiUrl
  * @property {string} channelId
  * @property {string} token
- * @property {string} message
- * @property {string} [rootId]
  */
 
 /**
  * @typedef {Object} LoopPublishParams
  * @property {string} message
  * @property {string[]} threadMessages
- * @property {{ apiUrl: string, channelId: string, token: string }} loop
+ * @property {LoopCredentials} loop
  */
 
 /**
@@ -58,22 +56,21 @@ function parseLoopApiPayload(responseText, core) {
 /**
  * Sends a single post to Loop and returns the parsed API payload.
  *
- * @param {LoopPostRequest} request Loop API request payload.
+ * @param {LoopCredentials} loop Loop API credentials.
+ * @param {string} message Post body.
+ * @param {string} [rootId] Optional thread root id for reply posts.
  * @param {LoopClientCore} core GitHub core API.
  * @returns {Promise<Record<string, any>>} Parsed Loop API response.
  */
-async function postToLoopApi(
-  { apiUrl, channelId, token, message, rootId },
-  core
-) {
-  const response = await fetch(apiUrl, {
+async function postToLoopApi(loop, message, rootId, core) {
+  const response = await fetch(loop.apiUrl, {
     method: "POST",
     headers: {
-      Authorization: `Bearer ${token}`,
+      Authorization: `Bearer ${loop.token}`,
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      channel_id: channelId,
+      channel_id: loop.channelId,
       message,
       ...(rootId ? { root_id: rootId } : {}),
     }),
@@ -99,15 +96,7 @@ async function postToLoopApi(
  * @returns {Promise<void>}
  */
 async function makeThreadedReportInLoop({ message, threadMessages, loop }, core) {
-  const rootPost = await postToLoopApi(
-    {
-      apiUrl: loop.apiUrl,
-      channelId: loop.channelId,
-      token: loop.token,
-      message,
-    },
-    core
-  );
+  const rootPost = await postToLoopApi(loop, message, undefined, core);
 
   if (!rootPost.id) {
     throw new Error(
@@ -116,16 +105,7 @@ async function makeThreadedReportInLoop({ message, threadMessages, loop }, core)
   }
 
   for (const replyMessage of threadMessages) {
-    await postToLoopApi(
-      {
-        apiUrl: loop.apiUrl,
-        channelId: loop.channelId,
-        token: loop.token,
-        message: replyMessage,
-        rootId: rootPost.id,
-      },
-      core
-    );
+    await postToLoopApi(loop, replyMessage, rootPost.id, core);
   }
 }
 

--- a/.github/scripts/js/e2e/report/messenger/markdown.js
+++ b/.github/scripts/js/e2e/report/messenger/markdown.js
@@ -217,21 +217,13 @@ function getFailedTestEntries(report) {
     return report.failedTestDetails.map((test) => ({
       name: test.name,
       reason: test.reason,
-      message: test.message,
     }));
   }
 
   return (report.failedTests || []).map((testName) => ({
     name: testName,
     reason: "",
-    message: "",
   }));
-}
-
-function sanitizeCodeBlock(value) {
-  return String(value || "")
-    .replace(/```/g, "`\u200b``")
-    .trim();
 }
 
 function summarizeFailedTestGroups(failedTestEntries) {
@@ -243,24 +235,16 @@ function summarizeFailedTestGroups(failedTestEntries) {
     if (!groups.has(groupName)) {
       groups.set(groupName, {
         reasons: new Set(),
-        details: [],
       });
     }
 
     const group = groups.get(groupName);
     group.reasons.add(reason);
-    if (test.message) {
-      group.details.push({
-        name: groupName,
-        message: test.message,
-      });
-    }
   }
 
   return Array.from(groups, ([name, group]) => ({
     name,
-    reason: Array.from(group.reasons).join("<br>"),
-    details: group.details,
+    reason: Array.from(group.reasons).join("; "),
   }));
 }
 
@@ -278,20 +262,6 @@ function renderFailedTestsThreadMessage(report) {
       lines.push(
         `| ${sanitizeCell(group.name)} | ${sanitizeCell(group.reason)} |`
       );
-    }
-
-    const details = failedGroups.flatMap((group) => group.details || []);
-    if (details.length > 0) {
-      lines.push("");
-      lines.push("**Details**");
-      for (const detail of details) {
-        lines.push("");
-        lines.push(`_${sanitizeListItem(detail.name)}_`);
-        lines.push("");
-        lines.push("```text");
-        lines.push(sanitizeCodeBlock(detail.message));
-        lines.push("```");
-      }
     }
   } else {
     lines.push(

--- a/.github/scripts/js/e2e/report/messenger/markdown.js
+++ b/.github/scripts/js/e2e/report/messenger/markdown.js
@@ -265,8 +265,7 @@ function summarizeFailedTestGroups(failedTestEntries) {
 }
 
 function renderFailedTestsThreadMessage(report) {
-  const clusterName = sanitizeListItem(report.cluster || report.storageType);
-  const lines = [`**${clusterName}**`];
+  const lines = [`**${formatClusterLink(report)}**`];
 
   if (Array.isArray(report.failedTests) && report.failedTests.length > 0) {
     const failedGroups = summarizeFailedTestGroups(

--- a/.github/scripts/js/e2e/report/messenger/markdown.js
+++ b/.github/scripts/js/e2e/report/messenger/markdown.js
@@ -86,8 +86,8 @@ function renderTestResultsSection(testsReports) {
     lines.push("");
     lines.push(
       hasGinkgoErrors
-        ? "| Cluster | ✅ Passed | ⏭️ Skipped | ❌ Failed | ⚠️ Errors | Total | Success Rate |"
-        : "| Cluster | ✅ Passed | ⏭️ Skipped | ❌ Failed | Total | Success Rate |"
+        ? "| :dvp: Cluster | ✅ Passed | ⏭️ Skipped | ❌ Failed | ⚠️ Errors | 📊 Total | 📈 Success Rate |"
+        : "| :dvp: Cluster | ✅ Passed | ⏭️ Skipped | ❌ Failed | 📊 Total | 📈 Success Rate |"
     );
     lines.push(
       hasGinkgoErrors

--- a/.github/scripts/js/e2e/report/messenger/markdown.js
+++ b/.github/scripts/js/e2e/report/messenger/markdown.js
@@ -44,23 +44,14 @@ function formatClusterLink(report) {
 }
 
 function splitReportsBySection(orderedReports) {
-  const testsReports = orderedReports.filter(
-    (report) => isTestResultReport(report) && getReportClusterKey(report)
-  );
-  const stageFailureReports = orderedReports.filter(
-    (report) => isClusterFailureReport(report) && getReportClusterKey(report)
-  );
-  const missingReports = orderedReports.filter(
-    (report) =>
-      isMissingReport(report) &&
-      !isClusterFailureReport(report) &&
-      getReportClusterKey(report)
-  );
+  const reports = orderedReports.filter(getReportClusterKey);
 
   return {
-    testsReports,
-    stageFailureReports,
-    missingReports,
+    testsReports: reports.filter(isTestResultReport),
+    stageFailureReports: reports.filter(isClusterFailureReport),
+    missingReports: reports.filter(
+      (report) => isMissingReport(report) && !isClusterFailureReport(report)
+    ),
   };
 }
 
@@ -174,52 +165,47 @@ function renderTestResultsSection(testsReports) {
   return ["### Test results", "", ...rows, ""];
 }
 
-function renderClusterFailuresSection(stageFailureReports) {
-  const lines = [];
-
-  if (stageFailureReports.length > 0) {
-    lines.push("### Cluster failures");
-    lines.push("");
-
-    for (const report of stageFailureReports) {
-      lines.push(
-        `- ${formatClusterLink(report)}: ${sanitizeListItem(
-          (report.clusterStatus && report.clusterStatus.message) ||
-            report.statusMessage ||
-            report.failedStageLabel ||
-            report.failedStage
-        )}`
-      );
-    }
-
-    lines.push("");
+/**
+ * Renders a `### <title>` section followed by a bullet list of
+ * `- <cluster link>: <message>` rows, one per report. Returns an empty
+ * array when there are no reports so callers can spread the result into
+ * the main message without conditional logic.
+ *
+ * @param {string} title Section heading text (without the leading `### `).
+ * @param {Array<Record<string, any>>} reports Reports to render.
+ * @param {function(Record<string, any>): string} getMessage Extracts the
+ *   per-cluster message string from a report.
+ * @returns {string[]} Markdown lines for the section.
+ */
+function renderBulletSection(title, reports, getMessage) {
+  if (reports.length === 0) {
+    return [];
   }
 
-  return lines;
+  const bullets = reports.map(
+    (report) =>
+      `- ${formatClusterLink(report)}: ${sanitizeListItem(getMessage(report))}`
+  );
+
+  return [`### ${title}`, "", ...bullets, ""];
 }
 
-function renderMissingReportsSection(missingReports) {
-  const lines = [];
+function getClusterFailureMessage(report) {
+  return (
+    (report.clusterStatus && report.clusterStatus.message) ||
+    report.statusMessage ||
+    report.failedStageLabel ||
+    report.failedStage
+  );
+}
 
-  if (missingReports.length > 0) {
-    lines.push("### Missing reports");
-    lines.push("");
-
-    for (const report of missingReports) {
-      lines.push(
-        `- ${formatClusterLink(report)}: ${sanitizeListItem(
-          report.statusMessage ||
-            (report.testStatus && report.testStatus.message) ||
-            (report.clusterStatus && report.clusterStatus.message) ||
-            report.failedStageLabel
-        )}`
-      );
-    }
-
-    lines.push("");
-  }
-
-  return lines;
+function getMissingReportMessage(report) {
+  return (
+    report.statusMessage ||
+    (report.testStatus && report.testStatus.message) ||
+    (report.clusterStatus && report.clusterStatus.message) ||
+    report.failedStageLabel
+  );
 }
 
 /**
@@ -236,8 +222,16 @@ function buildMainMessage(orderedReports) {
     `## :dvp: DVP | E2E on nested clusters | ${reportDate}`,
     "",
     ...renderBranchLine(orderedReports),
-    ...renderClusterFailuresSection(stageFailureReports),
-    ...renderMissingReportsSection(missingReports),
+    ...renderBulletSection(
+      "Cluster failures",
+      stageFailureReports,
+      getClusterFailureMessage
+    ),
+    ...renderBulletSection(
+      "Missing reports",
+      missingReports,
+      getMissingReportMessage
+    ),
     ...renderTestResultsSection(testsReports),
   ];
 

--- a/.github/scripts/js/e2e/report/messenger/markdown.js
+++ b/.github/scripts/js/e2e/report/messenger/markdown.js
@@ -74,48 +74,84 @@ function renderBranchLine(orderedReports) {
     : [];
 }
 
-function renderTestResultsSection(testsReports) {
-  const lines = [];
+// Test-results table columns. Each column declares its header, its alignment
+// for the markdown separator row, and how to render the value for a cluster.
+// The "Errors" column is included only when at least one cluster reported
+// Ginkgo errors, so successful runs stay compact.
+function buildTestResultsColumns(hasGinkgoErrors) {
+  const columns = [
+    {
+      header: ":dvp: Cluster",
+      align: "---",
+      value: (report) => formatClusterLink(report),
+    },
+    {
+      header: "✅ Passed",
+      align: "---:",
+      value: (_report, metrics) => metrics.passed || 0,
+    },
+    {
+      header: "⏭️ Skipped",
+      align: "---:",
+      value: (_report, metrics) => metrics.skipped || 0,
+    },
+    {
+      header: "❌ Failed",
+      align: "---:",
+      value: (_report, metrics) => metrics.failed || 0,
+    },
+  ];
 
-  if (testsReports.length > 0) {
-    const hasGinkgoErrors = testsReports.some(
-      (report) => Number((report.metrics || {}).errors || 0) > 0
-    );
-
-    lines.push("### Test results");
-    lines.push("");
-    lines.push(
-      hasGinkgoErrors
-        ? "| :dvp: Cluster | ✅ Passed | ⏭️ Skipped | ❌ Failed | ⚠️ Errors | 📊 Total | 📈 Success Rate |"
-        : "| :dvp: Cluster | ✅ Passed | ⏭️ Skipped | ❌ Failed | 📊 Total | 📈 Success Rate |"
-    );
-    lines.push(
-      hasGinkgoErrors
-        ? "|---|---:|---:|---:|---:|---:|---:|"
-        : "|---|---:|---:|---:|---:|---:|"
-    );
-
-    for (const report of testsReports) {
-      const metrics = report.metrics || {};
-      lines.push(
-        hasGinkgoErrors
-          ? `| ${formatClusterLink(report)} | ${metrics.passed || 0} | ${
-              metrics.skipped || 0
-            } | ${metrics.failed || 0} | ${metrics.errors || 0} | ${
-              metrics.total || 0
-            } | ${formatRate(metrics.successRate)} |`
-          : `| ${formatClusterLink(report)} | ${metrics.passed || 0} | ${
-              metrics.skipped || 0
-            } | ${metrics.failed || 0} | ${metrics.total || 0} | ${formatRate(
-              metrics.successRate
-            )} |`
-      );
-    }
-
-    lines.push("");
+  if (hasGinkgoErrors) {
+    columns.push({
+      header: "⚠️ Errors",
+      align: "---:",
+      value: (_report, metrics) => metrics.errors || 0,
+    });
   }
 
-  return lines;
+  columns.push(
+    {
+      header: "📊 Total",
+      align: "---:",
+      value: (_report, metrics) => metrics.total || 0,
+    },
+    {
+      header: "📈 Success Rate",
+      align: "---:",
+      value: (_report, metrics) => formatRate(metrics.successRate),
+    }
+  );
+
+  return columns;
+}
+
+function buildMarkdownRow(cells) {
+  return `| ${cells.join(" | ")} |`;
+}
+
+function renderTestResultsSection(testsReports) {
+  if (testsReports.length === 0) {
+    return [];
+  }
+
+  const hasGinkgoErrors = testsReports.some(
+    (report) => Number((report.metrics || {}).errors || 0) > 0
+  );
+  const columns = buildTestResultsColumns(hasGinkgoErrors);
+  const rows = [
+    buildMarkdownRow(columns.map((column) => column.header)),
+    buildMarkdownRow(columns.map((column) => column.align)),
+  ];
+
+  for (const report of testsReports) {
+    const metrics = report.metrics || {};
+    rows.push(
+      buildMarkdownRow(columns.map((column) => column.value(report, metrics)))
+    );
+  }
+
+  return ["### Test results", "", ...rows, ""];
 }
 
 function renderClusterFailuresSection(stageFailureReports) {
@@ -234,20 +270,16 @@ function getFailedTestEntries(report) {
   }));
 }
 
-function summarizeFailedTestGroups(failedTestEntries) {
+function summarizeFailedTestGroups(report) {
   const groups = new Map();
 
-  for (const test of failedTestEntries) {
+  for (const test of getFailedTestEntries(report)) {
     const groupName = getFailedTestGroupName(test.name);
     const reason = sanitizeListItem(test.reason) || "—";
     if (!groups.has(groupName)) {
-      groups.set(groupName, {
-        reasons: new Set(),
-      });
+      groups.set(groupName, { reasons: new Set() });
     }
-
-    const group = groups.get(groupName);
-    group.reasons.add(reason);
+    groups.get(groupName).reasons.add(reason);
   }
 
   return Array.from(groups, ([name, group]) => ({
@@ -260,9 +292,7 @@ function renderFailedTestsThreadMessage(report) {
   const lines = [`**${formatClusterLink(report)}**`];
 
   if (Array.isArray(report.failedTests) && report.failedTests.length > 0) {
-    const failedGroups = summarizeFailedTestGroups(
-      getFailedTestEntries(report)
-    );
+    const failedGroups = summarizeFailedTestGroups(report);
     lines.push("");
     lines.push("| Tests | Reason |");
     lines.push("|---|---|");

--- a/.github/scripts/js/e2e/report/messenger/markdown.js
+++ b/.github/scripts/js/e2e/report/messenger/markdown.js
@@ -86,10 +86,8 @@ function renderBranchLine(orderedReports) {
 /**
  * Builds the column descriptors for the test-results markdown table.
  *
- * Each column declares its header, its alignment for the markdown
- * separator row, and how to render the value for a cluster. The "Errors"
- * column is included only when at least one cluster reported Ginkgo
- * errors, so successful runs stay compact.
+ * The "Errors" column is included only when at least one cluster reported
+ * Ginkgo errors, so successful runs stay compact.
  *
  * @param {boolean} hasGinkgoErrors Whether any cluster reported Ginkgo errors.
  * @returns {TestResultsColumn[]} Ordered list of columns to render.

--- a/.github/scripts/js/e2e/report/messenger/markdown.js
+++ b/.github/scripts/js/e2e/report/messenger/markdown.js
@@ -201,12 +201,20 @@ function hasFailedTests(report) {
 }
 
 function getFailedTestGroupName(testName) {
-  const normalizedName = sanitizeListItem(testName).replace(
-    /^\[[^\]]+\]\s*/,
-    ""
-  );
-  const [groupName] = normalizedName.split(/\s+/, 1);
-  return groupName || "Unknown";
+  const sanitizedName = sanitizeListItem(testName);
+  const leadingTagMatch = sanitizedName.match(/^\[([^\]]+)\]\s*(.*)$/);
+  const leadingTag = leadingTagMatch ? leadingTagMatch[1].trim() : "";
+  const remainder = leadingTagMatch ? leadingTagMatch[2].trim() : sanitizedName;
+
+  // Suite-level entries such as "[SynchronizedBeforeSuite]" or
+  // "[SynchronizedAfterSuite]" have no body after the leading tag.
+  // In that case the tag itself is the most informative group name.
+  if (!remainder) {
+    return leadingTag || "Unknown";
+  }
+
+  const [groupName] = remainder.split(/\s+/, 1);
+  return groupName || leadingTag || "Unknown";
 }
 
 function getFailedTestEntries(report) {

--- a/.github/scripts/js/e2e/report/messenger/markdown.js
+++ b/.github/scripts/js/e2e/report/messenger/markdown.js
@@ -78,21 +78,37 @@ function renderTestResultsSection(testsReports) {
   const lines = [];
 
   if (testsReports.length > 0) {
+    const hasGinkgoErrors = testsReports.some(
+      (report) => Number((report.metrics || {}).errors || 0) > 0
+    );
+
     lines.push("### Test results");
     lines.push("");
     lines.push(
-      "| Cluster | ✅ Passed | ⏭️ Skipped | ❌ Failed | ⚠️ Errors | Total | Success Rate |"
+      hasGinkgoErrors
+        ? "| Cluster | ✅ Passed | ⏭️ Skipped | ❌ Failed | ⚠️ Errors | Total | Success Rate |"
+        : "| Cluster | ✅ Passed | ⏭️ Skipped | ❌ Failed | Total | Success Rate |"
     );
-    lines.push("|---|---:|---:|---:|---:|---:|---:|");
+    lines.push(
+      hasGinkgoErrors
+        ? "|---|---:|---:|---:|---:|---:|---:|"
+        : "|---|---:|---:|---:|---:|---:|"
+    );
 
     for (const report of testsReports) {
       const metrics = report.metrics || {};
       lines.push(
-        `| ${formatClusterLink(report)} | ${metrics.passed || 0} | ${
-          metrics.skipped || 0
-        } | ${metrics.failed || 0} | ${metrics.errors || 0} | ${
-          metrics.total || 0
-        } | ${formatRate(metrics.successRate)} |`
+        hasGinkgoErrors
+          ? `| ${formatClusterLink(report)} | ${metrics.passed || 0} | ${
+              metrics.skipped || 0
+            } | ${metrics.failed || 0} | ${metrics.errors || 0} | ${
+              metrics.total || 0
+            } | ${formatRate(metrics.successRate)} |`
+          : `| ${formatClusterLink(report)} | ${metrics.passed || 0} | ${
+              metrics.skipped || 0
+            } | ${metrics.failed || 0} | ${metrics.total || 0} | ${formatRate(
+              metrics.successRate
+            )} |`
       );
     }
 
@@ -193,8 +209,39 @@ function getFailedTestGroupName(testName) {
   return groupName || "Unknown";
 }
 
-function summarizeFailedTestGroups(failedTests) {
-  return [...new Set(failedTests.map(getFailedTestGroupName))];
+function getFailedTestEntries(report) {
+  if (
+    Array.isArray(report.failedTestDetails) &&
+    report.failedTestDetails.length > 0
+  ) {
+    return report.failedTestDetails.map((test) => ({
+      name: test.name,
+      reason: test.reason,
+    }));
+  }
+
+  return (report.failedTests || []).map((testName) => ({
+    name: testName,
+    reason: "",
+  }));
+}
+
+function summarizeFailedTestGroups(failedTestEntries) {
+  const groups = new Map();
+
+  for (const test of failedTestEntries) {
+    const groupName = getFailedTestGroupName(test.name);
+    const reason = sanitizeListItem(test.reason) || "—";
+    if (!groups.has(groupName)) {
+      groups.set(groupName, new Set());
+    }
+    groups.get(groupName).add(reason);
+  }
+
+  return Array.from(groups, ([name, reasons]) => ({
+    name,
+    reason: Array.from(reasons).join("<br>"),
+  }));
 }
 
 function renderFailedTestsThreadMessage(report) {
@@ -202,12 +249,16 @@ function renderFailedTestsThreadMessage(report) {
   const lines = [`**${clusterName}**`];
 
   if (Array.isArray(report.failedTests) && report.failedTests.length > 0) {
-    const failedGroups = summarizeFailedTestGroups(report.failedTests);
+    const failedGroups = summarizeFailedTestGroups(
+      getFailedTestEntries(report)
+    );
     lines.push("");
-    lines.push("| Test group |");
-    lines.push("|---|");
-    for (const groupName of failedGroups) {
-      lines.push(`| ${sanitizeCell(groupName)} |`);
+    lines.push("| Tests | Reason |");
+    lines.push("|---|---|");
+    for (const group of failedGroups) {
+      lines.push(
+        `| ${sanitizeCell(group.name)} | ${sanitizeCell(group.reason)} |`
+      );
     }
   } else {
     lines.push(

--- a/.github/scripts/js/e2e/report/messenger/markdown.js
+++ b/.github/scripts/js/e2e/report/messenger/markdown.js
@@ -74,10 +74,26 @@ function renderBranchLine(orderedReports) {
     : [];
 }
 
-// Test-results table columns. Each column declares its header, its alignment
-// for the markdown separator row, and how to render the value for a cluster.
-// The "Errors" column is included only when at least one cluster reported
-// Ginkgo errors, so successful runs stay compact.
+/**
+ * @typedef {Object} TestResultsColumn
+ * @property {string} header Column header text rendered in the markdown row.
+ * @property {string} align Column alignment for the markdown separator row
+ *   (for example, "---" or "---:").
+ * @property {function(Record<string, any>, Record<string, any>): (string|number)} value
+ *   Cell renderer that receives the cluster report and its metrics object.
+ */
+
+/**
+ * Builds the column descriptors for the test-results markdown table.
+ *
+ * Each column declares its header, its alignment for the markdown
+ * separator row, and how to render the value for a cluster. The "Errors"
+ * column is included only when at least one cluster reported Ginkgo
+ * errors, so successful runs stay compact.
+ *
+ * @param {boolean} hasGinkgoErrors Whether any cluster reported Ginkgo errors.
+ * @returns {TestResultsColumn[]} Ordered list of columns to render.
+ */
 function buildTestResultsColumns(hasGinkgoErrors) {
   const columns = [
     {
@@ -126,6 +142,12 @@ function buildTestResultsColumns(hasGinkgoErrors) {
   return columns;
 }
 
+/**
+ * Joins a list of cells into a single markdown table row.
+ *
+ * @param {Array<string|number>} cells Ordered cell values for one row.
+ * @returns {string} Markdown row string framed with pipe characters.
+ */
 function buildMarkdownRow(cells) {
   return `| ${cells.join(" | ")} |`;
 }
@@ -270,6 +292,16 @@ function getFailedTestEntries(report) {
   }));
 }
 
+/**
+ * Aggregates failed test entries from a cluster report into a deduplicated
+ * list of "group" rows for the failed-tests thread message. Tests are
+ * grouped by the first word of their leaf node text (or by the leading
+ * Ginkgo tag for suite-level failures); reasons for the same group are
+ * deduplicated and joined with "; ".
+ *
+ * @param {Record<string, any>} report Cluster report payload.
+ * @returns {Array<{name: string, reason: string}>} Group rows for the thread table.
+ */
 function summarizeFailedTestGroups(report) {
   const groups = new Map();
 

--- a/.github/scripts/js/e2e/report/messenger/markdown.js
+++ b/.github/scripts/js/e2e/report/messenger/markdown.js
@@ -217,13 +217,21 @@ function getFailedTestEntries(report) {
     return report.failedTestDetails.map((test) => ({
       name: test.name,
       reason: test.reason,
+      message: test.message,
     }));
   }
 
   return (report.failedTests || []).map((testName) => ({
     name: testName,
     reason: "",
+    message: "",
   }));
+}
+
+function sanitizeCodeBlock(value) {
+  return String(value || "")
+    .replace(/```/g, "`\u200b``")
+    .trim();
 }
 
 function summarizeFailedTestGroups(failedTestEntries) {
@@ -233,14 +241,26 @@ function summarizeFailedTestGroups(failedTestEntries) {
     const groupName = getFailedTestGroupName(test.name);
     const reason = sanitizeListItem(test.reason) || "—";
     if (!groups.has(groupName)) {
-      groups.set(groupName, new Set());
+      groups.set(groupName, {
+        reasons: new Set(),
+        details: [],
+      });
     }
-    groups.get(groupName).add(reason);
+
+    const group = groups.get(groupName);
+    group.reasons.add(reason);
+    if (test.message) {
+      group.details.push({
+        name: groupName,
+        message: test.message,
+      });
+    }
   }
 
-  return Array.from(groups, ([name, reasons]) => ({
+  return Array.from(groups, ([name, group]) => ({
     name,
-    reason: Array.from(reasons).join("<br>"),
+    reason: Array.from(group.reasons).join("<br>"),
+    details: group.details,
   }));
 }
 
@@ -259,6 +279,20 @@ function renderFailedTestsThreadMessage(report) {
       lines.push(
         `| ${sanitizeCell(group.name)} | ${sanitizeCell(group.reason)} |`
       );
+    }
+
+    const details = failedGroups.flatMap((group) => group.details || []);
+    if (details.length > 0) {
+      lines.push("");
+      lines.push("**Details**");
+      for (const detail of details) {
+        lines.push("");
+        lines.push(`_${sanitizeListItem(detail.name)}_`);
+        lines.push("");
+        lines.push("```text");
+        lines.push(sanitizeCodeBlock(detail.message));
+        lines.push("```");
+      }
     }
   } else {
     lines.push(

--- a/.github/scripts/js/e2e/report/shared/fs-utils.test.js
+++ b/.github/scripts/js/e2e/report/shared/fs-utils.test.js
@@ -11,30 +11,16 @@
 // limitations under the License.
 
 const fs = require("fs");
-const os = require("os");
 const path = require("path");
 
 const { listMatchingFiles } = require("./fs-utils");
+const { withTempDir } = require("./test-utils");
 
-/**
- * Runs a test body inside a temporary directory and removes it afterwards.
- *
- * @template T
- * @param {function(string): (Promise<T>|T)} testFn Test body.
- * @returns {Promise<T>} Test result.
- */
-async function withTempDir(testFn) {
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fs-utils-test-"));
-  try {
-    return await testFn(tempDir);
-  } finally {
-    fs.rmSync(tempDir, { recursive: true, force: true });
-  }
-}
+const inTempDir = (testFn) => withTempDir("fs-utils-test", testFn);
 
 describe("fs-utils", () => {
   test("returns sorted matching files recursively", async () =>
-    withTempDir((tempDir) => {
+    inTempDir((tempDir) => {
       const nestedDir = path.join(tempDir, "nested");
       fs.mkdirSync(nestedDir, { recursive: true });
       fs.writeFileSync(path.join(tempDir, "b.json"), "{}\n");
@@ -48,7 +34,7 @@ describe("fs-utils", () => {
     }));
 
   test("throws a descriptive error when a directory cannot be scanned", async () =>
-    withTempDir((tempDir) => {
+    inTempDir((tempDir) => {
       const readdirSpy = jest
         .spyOn(fs, "readdirSync")
         .mockImplementation(() => {

--- a/.github/scripts/js/e2e/report/shared/ginkgo-report-utils.js
+++ b/.github/scripts/js/e2e/report/shared/ginkgo-report-utils.js
@@ -246,6 +246,14 @@ const reasonStopPrefixes = [
 
 const maxReasonLines = 6;
 
+/**
+ * Detects the first suite-level Ginkgo node that failed in the given stdout.
+ * Returns the suite node name (for example, "SynchronizedBeforeSuite") or
+ * an empty string when there is no suite failure marker in the output.
+ *
+ * @param {string} output Raw Ginkgo stdout/stderr content.
+ * @returns {string} Suite node name or "" when no failure was detected.
+ */
 function findFailedSuiteNode(output) {
   const match = output.match(suiteNodePattern);
   if (!match) {
@@ -269,6 +277,19 @@ function isReasonNoiseLine(line, suiteHeader, failedMarker) {
   );
 }
 
+/**
+ * Extracts a short human-readable failure reason for a failed suite-level
+ * node from Ginkgo stdout. Walks the failure block starting at the
+ * "[<SuiteNode>] [FAILED]" marker, skipping section headers and source
+ * file locations, and stops at the next suite/report section or summary
+ * footer. The result is at most `maxReasonLines` non-empty lines joined
+ * with a newline, or a generic fallback string when nothing meaningful
+ * was found.
+ *
+ * @param {string} output Raw Ginkgo stdout/stderr content.
+ * @param {string} suiteNodeType Suite node name returned by `findFailedSuiteNode`.
+ * @returns {string} Multi-line reason string for the failed suite node.
+ */
 function extractFailureReasonFromOutput(output, suiteNodeType) {
   const suiteHeader = `[${suiteNodeType}]`;
   const failedMarker = `${suiteHeader} [FAILED]`;
@@ -297,6 +318,21 @@ function extractFailureReasonFromOutput(output, suiteNodeType) {
   return reasonLines.join("\n") || "Ginkgo suite setup failed";
 }
 
+/**
+ * Parses raw Ginkgo stdout/stderr output as a fallback report source for
+ * cases when the JSON report is missing. Currently surfaces only
+ * suite-level failures (BeforeSuite/AfterSuite); regular spec metrics are
+ * left at zero because per-spec accounting cannot be reliably recovered
+ * from plain text.
+ *
+ * @param {string} outputContent Raw Ginkgo output content.
+ * @returns {{
+ *   metrics: GinkgoMetrics,
+ *   failedTests: string[],
+ *   failedTestDetails: Array<{name: string, reason: string}>,
+ *   startedAt: null,
+ * }} Parsed fallback payload.
+ */
 function parseGinkgoOutput(outputContent) {
   const output = String(outputContent || "");
   const suiteNodeType = findFailedSuiteNode(output);

--- a/.github/scripts/js/e2e/report/shared/ginkgo-report-utils.js
+++ b/.github/scripts/js/e2e/report/shared/ginkgo-report-utils.js
@@ -113,47 +113,12 @@ function getMetricKeyForState(state) {
   return "errors";
 }
 
-function isGenericFailureLine(line) {
-  return (
-    line === "Unexpected error:" ||
-    line === "occurred" ||
-    /^<[^>]+>:?$/.test(line) ||
-    line === "{" ||
-    line === "}"
-  );
-}
-
-function getFailureMessage(specReport) {
-  const failure = (specReport && specReport.Failure) || {};
-  return String(failure.Message || failure.ForwardedPanic || "").trim();
-}
-
-function truncateReason(reason) {
-  const maxLength = 300;
-  return reason.length > maxLength
-    ? `${reason.slice(0, maxLength - 1).trimEnd()}…`
-    : reason;
-}
-
-/**
- * Extracts a compact human-readable failure reason from a Ginkgo spec report.
- *
- * @param {Record<string, any>} specReport Raw Ginkgo spec report entry.
- * @returns {string} Failure reason.
- */
 function formatFailureReason(specReport) {
-  const message = getFailureMessage(specReport);
-  const lines = message
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean);
-  const reason = lines.find((line) => !isGenericFailureLine(line));
-
-  if (reason) {
-    return truncateReason(reason);
-  }
-
-  return truncateReason(String(specReport.State || "failed").trim());
+  const failure = (specReport && specReport.Failure) || {};
+  return (
+    String(failure.Message || failure.ForwardedPanic || "").trim() ||
+    String(specReport.State || "failed").trim()
+  );
 }
 
 /**
@@ -164,7 +129,7 @@ function formatFailureReason(specReport) {
  * @returns {{
  *   metrics: GinkgoMetrics,
  *   failedTests: string[],
- *   failedTestDetails: Array<{name: string, reason: string, message: string}>,
+ *   failedTestDetails: Array<{name: string, reason: string}>,
  *   startedAt: string|null
  * }} Parsed report payload.
  */
@@ -197,7 +162,6 @@ function parseGinkgoReport(jsonContent) {
           failedTestDetails.push({
             name: specName,
             reason: formatFailureReason(specReport),
-            message: getFailureMessage(specReport),
           });
         }
       }

--- a/.github/scripts/js/e2e/report/shared/ginkgo-report-utils.js
+++ b/.github/scripts/js/e2e/report/shared/ginkgo-report-utils.js
@@ -121,6 +121,25 @@ function formatFailureReason(specReport) {
   );
 }
 
+function isSuiteNodeFailure(specReport) {
+  const leafNodeType = String(specReport && specReport.LeafNodeType).trim();
+  const metricKey = getMetricKeyForState(specReport && specReport.State);
+
+  return leafNodeType !== "It" && (metricKey === "failed" || metricKey === "errors");
+}
+
+function buildFailureDetail(specReport) {
+  const specName = formatSpecName(specReport);
+  if (!specName) {
+    return null;
+  }
+
+  return {
+    name: specName,
+    reason: formatFailureReason(specReport),
+  };
+}
+
 /**
  * Parses a Ginkgo JSON report into metrics and failed test names used by the
  * markdown report.
@@ -143,6 +162,15 @@ function parseGinkgoReport(jsonContent) {
 
   for (const suite of suites) {
     for (const specReport of toArray(suite && suite.SpecReports)) {
+      if (isSuiteNodeFailure(specReport)) {
+        const failureDetail = buildFailureDetail(specReport);
+        if (failureDetail) {
+          failedTests.push(failureDetail.name);
+          failedTestDetails.push(failureDetail);
+        }
+        continue;
+      }
+
       // SpecReports can contain suite-level setup/teardown entries
       // (BeforeSuite, AfterSuite, etc.) in addition to regular specs.
       // `Specify` is a pure alias for `It` and serializes to the same
@@ -156,13 +184,10 @@ function parseGinkgoReport(jsonContent) {
       metrics[metricKey] += 1;
 
       if (metricKey === "failed" || metricKey === "errors") {
-        const specName = formatSpecName(specReport);
-        if (specName) {
-          failedTests.push(specName);
-          failedTestDetails.push({
-            name: specName,
-            reason: formatFailureReason(specReport),
-          });
+        const failureDetail = buildFailureDetail(specReport);
+        if (failureDetail) {
+          failedTests.push(failureDetail.name);
+          failedTestDetails.push(failureDetail);
         }
       }
     }
@@ -189,6 +214,72 @@ function parseGinkgoReport(jsonContent) {
   };
 }
 
+function extractFailedSuiteNode(output) {
+  const failedNodeMatch =
+    output.match(/\[(SynchronizedBeforeSuite|BeforeSuite|SynchronizedAfterSuite|AfterSuite)\]\s+\[FAILED\]/) ||
+    output.match(/\[FAIL\]\s+\[(SynchronizedBeforeSuite|BeforeSuite|SynchronizedAfterSuite|AfterSuite)\]/);
+
+  return failedNodeMatch ? failedNodeMatch[1] : "";
+}
+
+function extractFailureReasonFromOutput(output, suiteNodeType) {
+  const failedMarker = `[${suiteNodeType}] [FAILED]`;
+  const failedIndex = output.indexOf(failedMarker);
+  const failureBlock = failedIndex >= 0 ? output.slice(failedIndex) : output;
+  const lines = failureBlock.split(/\r?\n/);
+  const reasonLines = [];
+
+  for (const line of lines) {
+    const trimmedLine = line.trim();
+    if (!trimmedLine) {
+      continue;
+    }
+
+    if (
+      trimmedLine.startsWith("------------------------------") ||
+      trimmedLine.startsWith("[SynchronizedAfterSuite]") ||
+      trimmedLine.startsWith("[ReportAfterSuite]") ||
+      trimmedLine.startsWith("Summarizing ")
+    ) {
+      break;
+    }
+
+    if (trimmedLine.startsWith(failedMarker) || trimmedLine.startsWith("/")) {
+      continue;
+    }
+
+    reasonLines.push(trimmedLine.replace(/^\[FAILED\]\s*/, ""));
+    if (reasonLines.length >= 6) {
+      break;
+    }
+  }
+
+  return reasonLines.join("\n") || "Ginkgo suite setup failed";
+}
+
+function parseGinkgoOutput(outputContent) {
+  const output = String(outputContent || "");
+  const metrics = zeroMetrics();
+  const suiteNodeType = extractFailedSuiteNode(output);
+  const failedTests = [];
+  const failedTestDetails = [];
+
+  if (suiteNodeType) {
+    const name = `[${suiteNodeType}]`;
+    const reason = extractFailureReasonFromOutput(output, suiteNodeType);
+    failedTests.push(name);
+    failedTestDetails.push({ name, reason });
+  }
+
+  return {
+    metrics,
+    failedTests,
+    failedTestDetails,
+    startedAt: null,
+  };
+}
+
 module.exports = {
+  parseGinkgoOutput,
   parseGinkgoReport,
 };

--- a/.github/scripts/js/e2e/report/shared/ginkgo-report-utils.js
+++ b/.github/scripts/js/e2e/report/shared/ginkgo-report-utils.js
@@ -123,6 +123,11 @@ function isGenericFailureLine(line) {
   );
 }
 
+function getFailureMessage(specReport) {
+  const failure = (specReport && specReport.Failure) || {};
+  return String(failure.Message || failure.ForwardedPanic || "").trim();
+}
+
 function truncateReason(reason) {
   const maxLength = 300;
   return reason.length > maxLength
@@ -137,8 +142,7 @@ function truncateReason(reason) {
  * @returns {string} Failure reason.
  */
 function formatFailureReason(specReport) {
-  const failure = (specReport && specReport.Failure) || {};
-  const message = String(failure.Message || failure.ForwardedPanic || "");
+  const message = getFailureMessage(specReport);
   const lines = message
     .split(/\r?\n/)
     .map((line) => line.trim())
@@ -160,7 +164,7 @@ function formatFailureReason(specReport) {
  * @returns {{
  *   metrics: GinkgoMetrics,
  *   failedTests: string[],
- *   failedTestDetails: Array<{name: string, reason: string}>,
+ *   failedTestDetails: Array<{name: string, reason: string, message: string}>,
  *   startedAt: string|null
  * }} Parsed report payload.
  */
@@ -193,6 +197,7 @@ function parseGinkgoReport(jsonContent) {
           failedTestDetails.push({
             name: specName,
             reason: formatFailureReason(specReport),
+            message: getFailureMessage(specReport),
           });
         }
       }

--- a/.github/scripts/js/e2e/report/shared/ginkgo-report-utils.js
+++ b/.github/scripts/js/e2e/report/shared/ginkgo-report-utils.js
@@ -113,6 +113,45 @@ function getMetricKeyForState(state) {
   return "errors";
 }
 
+function isGenericFailureLine(line) {
+  return (
+    line === "Unexpected error:" ||
+    line === "occurred" ||
+    /^<[^>]+>:?$/.test(line) ||
+    line === "{" ||
+    line === "}"
+  );
+}
+
+function truncateReason(reason) {
+  const maxLength = 300;
+  return reason.length > maxLength
+    ? `${reason.slice(0, maxLength - 1).trimEnd()}…`
+    : reason;
+}
+
+/**
+ * Extracts a compact human-readable failure reason from a Ginkgo spec report.
+ *
+ * @param {Record<string, any>} specReport Raw Ginkgo spec report entry.
+ * @returns {string} Failure reason.
+ */
+function formatFailureReason(specReport) {
+  const failure = (specReport && specReport.Failure) || {};
+  const message = String(failure.Message || failure.ForwardedPanic || "");
+  const lines = message
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const reason = lines.find((line) => !isGenericFailureLine(line));
+
+  if (reason) {
+    return truncateReason(reason);
+  }
+
+  return truncateReason(String(specReport.State || "failed").trim());
+}
+
 /**
  * Parses a Ginkgo JSON report into metrics and failed test names used by the
  * markdown report.
@@ -121,6 +160,7 @@ function getMetricKeyForState(state) {
  * @returns {{
  *   metrics: GinkgoMetrics,
  *   failedTests: string[],
+ *   failedTestDetails: Array<{name: string, reason: string}>,
  *   startedAt: string|null
  * }} Parsed report payload.
  */
@@ -128,6 +168,7 @@ function parseGinkgoReport(jsonContent) {
   const suites = toArray(JSON.parse(jsonContent));
   const metrics = zeroMetrics();
   const failedTests = [];
+  const failedTestDetails = [];
   const startedAt =
     suites.find((suite) => suite && suite.StartTime)?.StartTime || null;
 
@@ -149,19 +190,32 @@ function parseGinkgoReport(jsonContent) {
         const specName = formatSpecName(specReport);
         if (specName) {
           failedTests.push(specName);
+          failedTestDetails.push({
+            name: specName,
+            reason: formatFailureReason(specReport),
+          });
         }
       }
     }
   }
 
+  const completedSpecs = metrics.passed + metrics.failed + metrics.errors;
   metrics.successRate =
-    metrics.total > 0
-      ? Number(((metrics.passed / metrics.total) * 100).toFixed(2))
+    completedSpecs > 0
+      ? Number(((metrics.passed / completedSpecs) * 100).toFixed(2))
       : 0;
 
   return {
     metrics,
     failedTests: Array.from(new Set(failedTests)),
+    failedTestDetails: Array.from(
+      new Map(
+        failedTestDetails.map((test) => [
+          `${test.name}\u0000${test.reason}`,
+          test,
+        ])
+      ).values()
+    ),
     startedAt,
   };
 }

--- a/.github/scripts/js/e2e/report/shared/ginkgo-report-utils.js
+++ b/.github/scripts/js/e2e/report/shared/ginkgo-report-utils.js
@@ -121,11 +121,15 @@ function formatFailureReason(specReport) {
   );
 }
 
-function isSuiteNodeFailure(specReport) {
-  const leafNodeType = String(specReport && specReport.LeafNodeType).trim();
-  const metricKey = getMetricKeyForState(specReport && specReport.State);
+const failureStates = new Set(["failed", "errors"]);
 
-  return leafNodeType !== "It" && (metricKey === "failed" || metricKey === "errors");
+function isSuiteNodeFailure(specReport) {
+  const leafNodeType = String((specReport && specReport.LeafNodeType) || "").trim();
+  if (!leafNodeType || leafNodeType === "It") {
+    return false;
+  }
+
+  return failureStates.has(getMetricKeyForState(specReport && specReport.State));
 }
 
 function buildFailureDetail(specReport) {
@@ -183,7 +187,7 @@ function parseGinkgoReport(jsonContent) {
       const metricKey = getMetricKeyForState(specReport.State);
       metrics[metricKey] += 1;
 
-      if (metricKey === "failed" || metricKey === "errors") {
+      if (failureStates.has(metricKey)) {
         const failureDetail = buildFailureDetail(specReport);
         if (failureDetail) {
           failedTests.push(failureDetail.name);
@@ -214,42 +218,66 @@ function parseGinkgoReport(jsonContent) {
   };
 }
 
-function extractFailedSuiteNode(output) {
-  const failedNodeMatch =
-    output.match(/\[(SynchronizedBeforeSuite|BeforeSuite|SynchronizedAfterSuite|AfterSuite)\]\s+\[FAILED\]/) ||
-    output.match(/\[FAIL\]\s+\[(SynchronizedBeforeSuite|BeforeSuite|SynchronizedAfterSuite|AfterSuite)\]/);
+const suiteNodeTypes = [
+  "SynchronizedBeforeSuite",
+  "BeforeSuite",
+  "SynchronizedAfterSuite",
+  "AfterSuite",
+];
 
-  return failedNodeMatch ? failedNodeMatch[1] : "";
+const suiteNodePattern = new RegExp(
+  `\\[(?:FAIL\\]\\s+\\[)?(${suiteNodeTypes.join("|")})\\](?:\\s+\\[FAILED\\])?`
+);
+
+// Lines that mark the end of the failure block in Ginkgo stdout. Anything
+// after these belongs to the next suite section or the summary footer.
+const reasonStopPrefixes = [
+  "------------------------------",
+  "[SynchronizedAfterSuite]",
+  "[ReportAfterSuite]",
+  "Summarizing ",
+];
+
+const maxReasonLines = 6;
+
+function findFailedSuiteNode(output) {
+  const match = output.match(suiteNodePattern);
+  if (!match) {
+    return "";
+  }
+
+  // Make sure we only treat the match as a failure when [FAILED] is involved.
+  return match[0].includes("FAIL") ? match[1] : "";
+}
+
+function isReasonStopLine(line) {
+  return reasonStopPrefixes.some((prefix) => line.startsWith(prefix));
+}
+
+function isReasonNoiseLine(line, failedMarker) {
+  return line.startsWith(failedMarker) || line.startsWith("/");
 }
 
 function extractFailureReasonFromOutput(output, suiteNodeType) {
   const failedMarker = `[${suiteNodeType}] [FAILED]`;
   const failedIndex = output.indexOf(failedMarker);
   const failureBlock = failedIndex >= 0 ? output.slice(failedIndex) : output;
-  const lines = failureBlock.split(/\r?\n/);
   const reasonLines = [];
 
-  for (const line of lines) {
-    const trimmedLine = line.trim();
-    if (!trimmedLine) {
+  for (const rawLine of failureBlock.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) {
       continue;
     }
-
-    if (
-      trimmedLine.startsWith("------------------------------") ||
-      trimmedLine.startsWith("[SynchronizedAfterSuite]") ||
-      trimmedLine.startsWith("[ReportAfterSuite]") ||
-      trimmedLine.startsWith("Summarizing ")
-    ) {
+    if (isReasonStopLine(line)) {
       break;
     }
-
-    if (trimmedLine.startsWith(failedMarker) || trimmedLine.startsWith("/")) {
+    if (isReasonNoiseLine(line, failedMarker)) {
       continue;
     }
 
-    reasonLines.push(trimmedLine.replace(/^\[FAILED\]\s*/, ""));
-    if (reasonLines.length >= 6) {
+    reasonLines.push(line.replace(/^\[FAILED\]\s*/, ""));
+    if (reasonLines.length >= maxReasonLines) {
       break;
     }
   }
@@ -259,24 +287,23 @@ function extractFailureReasonFromOutput(output, suiteNodeType) {
 
 function parseGinkgoOutput(outputContent) {
   const output = String(outputContent || "");
-  const metrics = zeroMetrics();
-  const suiteNodeType = extractFailedSuiteNode(output);
-  const failedTests = [];
-  const failedTestDetails = [];
-
-  if (suiteNodeType) {
-    const name = `[${suiteNodeType}]`;
-    const reason = extractFailureReasonFromOutput(output, suiteNodeType);
-    failedTests.push(name);
-    failedTestDetails.push({ name, reason });
-  }
-
-  return {
-    metrics,
-    failedTests,
-    failedTestDetails,
+  const suiteNodeType = findFailedSuiteNode(output);
+  const result = {
+    metrics: zeroMetrics(),
+    failedTests: [],
+    failedTestDetails: [],
     startedAt: null,
   };
+
+  if (!suiteNodeType) {
+    return result;
+  }
+
+  const name = `[${suiteNodeType}]`;
+  const reason = extractFailureReasonFromOutput(output, suiteNodeType);
+  result.failedTests.push(name);
+  result.failedTestDetails.push({ name, reason });
+  return result;
 }
 
 module.exports = {

--- a/.github/scripts/js/e2e/report/shared/ginkgo-report-utils.js
+++ b/.github/scripts/js/e2e/report/shared/ginkgo-report-utils.js
@@ -225,8 +225,14 @@ const suiteNodeTypes = [
   "AfterSuite",
 ];
 
+// Match Ginkgo failure markers for suite-level nodes in two forms:
+//   1. "[<SuiteNode>] [FAILED]"   — main failure line in the stdout body.
+//   2. "[FAIL] [<SuiteNode>]"     — line from the "Summarizing N Failure:" footer.
+// Both forms guarantee that the matched suite node actually failed, so we
+// never confuse them with the plain "[<SuiteNode>]" section header.
+const suiteNodeAlternatives = suiteNodeTypes.join("|");
 const suiteNodePattern = new RegExp(
-  `\\[(?:FAIL\\]\\s+\\[)?(${suiteNodeTypes.join("|")})\\](?:\\s+\\[FAILED\\])?`
+  `(?:\\[(${suiteNodeAlternatives})\\]\\s+\\[FAILED\\])|(?:\\[FAIL\\]\\s+\\[(${suiteNodeAlternatives})\\])`
 );
 
 // Lines that mark the end of the failure block in Ginkgo stdout. Anything
@@ -246,20 +252,26 @@ function findFailedSuiteNode(output) {
     return "";
   }
 
-  // Make sure we only treat the match as a failure when [FAILED] is involved.
-  return match[0].includes("FAIL") ? match[1] : "";
+  // The pattern has two alternatives, so the captured node name is in
+  // either group 1 ("[X] [FAILED]") or group 2 ("[FAIL] [X]").
+  return match[1] || match[2] || "";
 }
 
 function isReasonStopLine(line) {
   return reasonStopPrefixes.some((prefix) => line.startsWith(prefix));
 }
 
-function isReasonNoiseLine(line, failedMarker) {
-  return line.startsWith(failedMarker) || line.startsWith("/");
+function isReasonNoiseLine(line, suiteHeader, failedMarker) {
+  return (
+    line === suiteHeader ||
+    line.startsWith(failedMarker) ||
+    line.startsWith("/")
+  );
 }
 
 function extractFailureReasonFromOutput(output, suiteNodeType) {
-  const failedMarker = `[${suiteNodeType}] [FAILED]`;
+  const suiteHeader = `[${suiteNodeType}]`;
+  const failedMarker = `${suiteHeader} [FAILED]`;
   const failedIndex = output.indexOf(failedMarker);
   const failureBlock = failedIndex >= 0 ? output.slice(failedIndex) : output;
   const reasonLines = [];
@@ -272,7 +284,7 @@ function extractFailureReasonFromOutput(output, suiteNodeType) {
     if (isReasonStopLine(line)) {
       break;
     }
-    if (isReasonNoiseLine(line, failedMarker)) {
+    if (isReasonNoiseLine(line, suiteHeader, failedMarker)) {
       continue;
     }
 

--- a/.github/scripts/js/e2e/report/shared/report-model.js
+++ b/.github/scripts/js/e2e/report/shared/report-model.js
@@ -33,6 +33,17 @@ function archivedReportPattern(storageType) {
   return new RegExp(`^e2e_report_${escaped}_.*\\.json$`);
 }
 
+/**
+ * Returns a regex that matches Ginkgo stdout/stderr fallback logs,
+ * e.g. `e2e_output_replicated_2026-04-15.log`.
+ * @param {string} storageType
+ * @returns {RegExp}
+ */
+function ginkgoOutputPattern(storageType) {
+  const escaped = storageType.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^e2e_output_${escaped}_.*\\.log$`);
+}
+
 const stageMessage = {
   "bootstrap": "BOOTSTRAP CLUSTER",
   "configure-sdn": "CONFIGURE SDN",
@@ -142,7 +153,7 @@ function buildTestStatus(
 
   const normalizedResult = normalizeJobResult(testResult);
 
-  if (reportSource === "ginkgo-json") {
+  if (reportSource === "ginkgo-json" || reportSource === "ginkgo-output") {
     const hasReportedFailures =
       Number(metrics.failed || 0) > 0 || Number(metrics.errors || 0) > 0;
     const status =
@@ -276,6 +287,7 @@ module.exports = {
   buildReportSummary,
   buildStatusMessage,
   buildTestStatus,
+  ginkgoOutputPattern,
   isClusterFailureReport,
   isMissingReport,
   isTestResultReport,

--- a/.github/scripts/js/e2e/report/shared/report-model.js
+++ b/.github/scripts/js/e2e/report/shared/report-model.js
@@ -81,28 +81,21 @@ function zeroMetrics() {
   };
 }
 
+// Status → template used by buildStatusMessage. The "%s" placeholder is
+// replaced with stageLabel; any status not listed here falls through to
+// the generic "failure" rendering.
+const statusMessageTemplates = {
+  success: "✅ %s",
+  cancelled: "⚠️ %s CANCELLED",
+  skipped: "⚠️ %s SKIPPED",
+  missing: "⚠️ %s",
+  "not-run": "⚠️ %s NOT RUN",
+  failure: "❌ %s FAILED",
+};
+
 function buildStatusMessage(status, stageLabel) {
-  if (status === "success") {
-    return `✅ ${stageLabel}`;
-  }
-
-  if (status === "cancelled") {
-    return `⚠️ ${stageLabel} CANCELLED`;
-  }
-
-  if (status === "skipped") {
-    return `⚠️ ${stageLabel} SKIPPED`;
-  }
-
-  if (status === "missing") {
-    return `⚠️ ${stageLabel}`;
-  }
-
-  if (status === "not-run") {
-    return `⚠️ ${stageLabel} NOT RUN`;
-  }
-
-  return `❌ ${stageLabel} FAILED`;
+  const template = statusMessageTemplates[status] || statusMessageTemplates.failure;
+  return template.replace("%s", stageLabel);
 }
 
 function normalizeJobResult(resultValue) {

--- a/.github/scripts/js/e2e/report/shared/report-model.js
+++ b/.github/scripts/js/e2e/report/shared/report-model.js
@@ -109,21 +109,18 @@ function normalizeJobResult(resultValue) {
 
 function buildClusterStatus(stageResults) {
   for (const stageName of clusterSetupStages) {
+    // normalizeJobResult only ever returns success/cancelled/skipped/failure,
+    // so once we know it isn't success, stageResult is already the final
+    // status name we want to propagate.
     const stageResult = normalizeJobResult(stageResults[stageName]);
     if (stageResult !== "success") {
       const stageLabel = stageMessage[stageName] || stageName;
-      const status =
-        stageResult === "cancelled"
-          ? "cancelled"
-          : stageResult === "skipped"
-            ? "skipped"
-            : "failure";
       return {
-        status,
+        status: stageResult,
         stage: stageName,
         stageLabel,
         message: buildStatusMessage(stageResult, stageLabel),
-        reason: `cluster-stage-${status}`,
+        reason: `cluster-stage-${stageResult}`,
       };
     }
   }

--- a/.github/scripts/js/e2e/report/shared/report-model.js
+++ b/.github/scripts/js/e2e/report/shared/report-model.js
@@ -14,6 +14,17 @@
 const REPORT_FILE_PATTERN = /^e2e_report_.*\.json$/;
 
 /**
+ * Escapes characters with special meaning in a regex literal so the value
+ * can be safely interpolated into `new RegExp(...)`.
+ *
+ * @param {string} value Raw string to escape.
+ * @returns {string} Regex-safe string.
+ */
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
  * Returns the canonical report file name for a given storage type.
  * @param {string} storageType
  * @returns {string}
@@ -29,8 +40,7 @@ function reportFileName(storageType) {
  * @returns {RegExp}
  */
 function archivedReportPattern(storageType) {
-  const escaped = storageType.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return new RegExp(`^e2e_report_${escaped}_.*\\.json$`);
+  return new RegExp(`^e2e_report_${escapeRegExp(storageType)}_.*\\.json$`);
 }
 
 /**
@@ -40,8 +50,7 @@ function archivedReportPattern(storageType) {
  * @returns {RegExp}
  */
 function ginkgoOutputPattern(storageType) {
-  const escaped = storageType.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return new RegExp(`^e2e_output_${escaped}_.*\\.log$`);
+  return new RegExp(`^e2e_output_${escapeRegExp(storageType)}_.*\\.log$`);
 }
 
 const stageMessage = {

--- a/.github/scripts/js/e2e/report/shared/test-utils.js
+++ b/.github/scripts/js/e2e/report/shared/test-utils.js
@@ -1,0 +1,54 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+/**
+ * Creates a mocked GitHub Actions core object for unit tests.
+ *
+ * @returns {{
+ *   info: jest.Mock,
+ *   warning: jest.Mock,
+ *   setOutput: jest.Mock
+ * }} Mocked core object.
+ */
+function createCore() {
+  return {
+    info: jest.fn(),
+    warning: jest.fn(),
+    setOutput: jest.fn(),
+  };
+}
+
+/**
+ * Runs a test body inside a temporary directory and removes it afterwards.
+ *
+ * @template T
+ * @param {string} prefix Temporary directory name prefix.
+ * @param {function(string): (Promise<T>|T)} testFn Test body.
+ * @returns {Promise<T>} Test result.
+ */
+async function withTempDir(prefix, testFn) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `${prefix}-`));
+  try {
+    return await testFn(tempDir);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+module.exports = {
+  createCore,
+  withTempDir,
+};

--- a/.github/workflows/e2e-reusable-pipeline.yml
+++ b/.github/workflows/e2e-reusable-pipeline.yml
@@ -1445,6 +1445,7 @@ jobs:
         run: |
           DATE=$(date +"%Y-%m-%d")
           e2e_report_file="e2e_report_${CSI}_${DATE}.json"
+          e2e_output_file="e2e_output_${CSI}_${DATE}.log"
           FOCUS="${{ inputs.e2e_focus_tests }}"
 
           cp -a legacy/testdata /tmp/testdata
@@ -1473,8 +1474,8 @@ jobs:
             GINKGO_ARGS+=(--focus="$FOCUS")
           fi
 
-          go tool ginkgo "${GINKGO_ARGS[@]}"
-          GINKGO_EXIT_CODE=$?
+          go tool ginkgo "${GINKGO_ARGS[@]}" 2>&1 | tee "$e2e_output_file"
+          GINKGO_EXIT_CODE=${PIPESTATUS[0]}
           set -e
 
           echo "[INFO] Exit code: $GINKGO_EXIT_CODE"
@@ -1488,6 +1489,7 @@ jobs:
           name: e2e-test-results-${{ inputs.storage_type }}-${{ github.run_id }}-${{ inputs.date_start }}
           path: |
             test/e2e/e2e_report_*.json
+            test/e2e/e2e_output_*.log
           if-no-files-found: ignore
           overwrite: true
           retention-days: 3

--- a/test/e2e/internal/framework/ssh.go
+++ b/test/e2e/internal/framework/ssh.go
@@ -91,7 +91,7 @@ func (f *Framework) SSHCommand(vmName, vmNamespace, command string, options ...S
 	})
 
 	if !res.WasSuccess() {
-		return "", fmt.Errorf("failed to execute command %s: %w: %s", command, res.Error(), res.StdErr())
+		return "", fmt.Errorf("failed to execute command %s: %s: %s", command, res.Error().Error(), res.StdErr())
 	}
 
 	return res.StdOut(), nil


### PR DESCRIPTION
## Description

Improve the E2E messenger report generated by CI and reorganize the
report scripts so the same logic is easier to follow.

User-facing changes:

- Add a `Reason` column to the failed-tests thread table and rename
  `Test group` to `Tests`.
- Link cluster names in failed-tests thread replies to the matching
  workflow/job URL.
- Hide the `Errors` column in the main test-results table when there
  are no Ginkgo errors.
- Calculate `Success Rate` from executed specs only:
  `passed / (passed + failed + errors)`.
- Add table header emojis to the main report.
- Use the full Ginkgo `Failure.Message` text as the failed-test reason.
- Stop wrapping `*exec.ExitError` with `%w` in
  `test/e2e/internal/framework/ssh.go` so Ginkgo no longer dumps Go
  internals into the report when an SSH command fails.
- Capture Ginkgo stdout/stderr in the reusable pipeline and parse it as
  a fallback report source so suite-level failures such as
  `SynchronizedBeforeSuite` are still surfaced when the JSON report is
  missing or contains only setup failure data.

Internal refactors (no behavior change, covered by existing tests):

- Move the shared `withTempDir` / `createCore` jest helpers into
  `shared/test-utils.js` to remove duplication across three test files.
- Extract `escapeRegExp` in `shared/report-model.js`; consolidate
  `buildStatusMessage` into a status → template lookup table; remove a
  redundant ternary in `buildClusterStatus`.
- Unify the Ginkgo source lookup (`findGinkgoReport` /
  `findGinkgoOutput` → one `findGinkgoSource`) and call
  `parseGinkgoFile` once with the descriptor picked up front.
- Iterate over a list of required keys in
  `requireClusterReportConfig` instead of three identical `if` blocks.
- Pre-filter cluster reports once by storage key and merge
  `renderClusterFailuresSection` / `renderMissingReportsSection` into
  a single `renderBulletSection` helper. Output stays byte-identical;
  verified by existing `messenger-report` tests.
- Pass the `loop` credentials object as-is to `postToLoopApi` so the
  two call sites collapse to one-liners.

## Why do we need it, and what problem does it solve?

The current E2E notification thread only lists failed test groups and
does not show why a test failed. This forces engineers to open CI
artifacts and logs even for simple failures.

The main report also counted skipped specs in the `Success Rate`
denominator, which made Ginkgo runs look worse than the executed-spec
result. SSH command failures contained noisy Go internals in
`Failure.Message` because `*exec.ExitError` was wrapped with `%w`.

When E2E fails in `SynchronizedBeforeSuite`, Ginkgo may skip all specs
and the JSON report may be absent or contain no regular test failures.
Previously the messenger report could only show a generic storage
failure (for example `nfs` with `E2E TEST FAILED`), without the actual
setup failure reason. The pipeline now captures Ginkgo stdout into
`e2e_output_<storage>_<date>.log` and the report parses suite-level
failures out of it as a fallback.

The follow-up refactors remove duplicated helpers, collapse parallel
branches, and replace inline regex/`if`-chain logic with declarative
data, making the report scripts easier to read and extend without
changing the rendered output.

## What is the expected result?

1. Run the E2E report generation with a Ginkgo JSON report containing
   failed specs.
2. Check the main messenger report:
   - the `Errors` column is hidden when all error counts are zero;
   - `Success Rate` is calculated without skipped specs;
   - table headers include emojis.
3. Check the failed-tests thread:
   - cluster names are links;
   - the table has `Tests` and `Reason` columns;
   - `Reason` contains the Ginkgo `Failure.Message` text.
4. SSH command failures are rendered as useful text instead of dumping
   `*exec.ExitError` internals.
5. If Ginkgo fails in `SynchronizedBeforeSuite` and no JSON report is
   created, the report is still generated from the captured Ginkgo
   output and the failed-tests thread shows the suite-level failure
   reason. Suite-level failures do not change spec metrics such as
   passed, failed, errors, or total.
6. The jest suite under `.github/scripts/js/e2e/report/` still passes
   (37 tests) and `tmp/test-ci/report/run.sh` produces the same
   markdown for the bundled fixtures.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: fix
summary: Improve E2E messenger report failure reasons, suite setup failure reporting, and success-rate calculation.
impact_level: low
```