### PR TITLE
fix(vd): allow ingress from virtualization namespace to importer pods

### DIFF
--- a/images/virtualization-artifact/pkg/common/network_policy/network_policy.go
+++ b/images/virtualization-artifact/pkg/common/network_policy/network_policy.go
@@ -52,8 +52,21 @@ func CreateNetworkPolicy(ctx context.Context, c client.Client, obj metav1.Object
 					},
 				},
 			},
+			Ingress: []netv1.NetworkPolicyIngressRule{
+				{
+					From: []netv1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"module": "virtualization",
+								},
+							},
+						},
+					},
+				},
+			},
 			Egress:      []netv1.NetworkPolicyEgressRule{{}},
-			PolicyTypes: []netv1.PolicyType{netv1.PolicyTypeEgress},
+			PolicyTypes: []netv1.PolicyType{netv1.PolicyTypeIngress, netv1.PolicyTypeEgress},
 		},
 	}
 


### PR DESCRIPTION
## Description
Allow ingress from virtualization namespace to importer pods


## Why do we need it, and what problem does it solve?
When a namespace has a restrictive NetworkPolicy (e.g. project isolation), the CDI controller from d8-virtualization cannot reach importer pods to fetch progress metrics via HTTP. As a result, DataVolume.Status.Progress stays N/A and VirtualDisk shows no intermediate progress.

Add an Ingress rule to the NetworkPolicy created for importer/DVCR pods, allowing incoming traffic from the namespace labeled module=virtualization. This enables the CDI controller to scrape progress metrics from importer pods even in isolated namespaces.


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: vd
type: fix
summary: Allow ingress from virtualization namespace to importer pods
```
