### PR TITLE
fix(vm): preserve spec.blockDeviceRefs order in hotplug handler

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm/internal/hotplug_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/hotplug_handler.go
@@ -94,7 +94,8 @@ func (h *HotplugHandler) Handle(ctx context.Context, s state.VirtualMachineState
 	var errs []error
 
 	// 1. Hotplugging
-	for key := range specDevices {
+	for _, bd := range current.Spec.BlockDeviceRefs {
+		key := nameKindKey{kind: bd.Kind, name: bd.Name}
 		volName := generateVolumeName(key)
 		if _, onKVVM := kvvmDevices[key]; onKVVM {
 			continue


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Iterate over `Spec.BlockDeviceRefs` slice instead of map when hotplugging to preserve hotplug order.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

