### PR TITLE
fix(vm): fix vm pod placement for local disks with hotplug volumes

### DIFF
--- a/images/virtualization-artifact/pkg/common/vd/vd.go
+++ b/images/virtualization-artifact/pkg/common/vd/vd.go
@@ -18,6 +18,7 @@ package vd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -27,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/deckhouse/virtualization-controller/pkg/common/object"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization-controller/pkg/featuregates"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
@@ -73,6 +75,53 @@ func StorageClassChanged(vd *v1alpha2.VirtualDisk) bool {
 	}
 
 	return *specSc != "" && statusSc != ""
+}
+
+type VirtualDiskStorageClassResolver interface {
+	GetModuleStorageClass(ctx context.Context) (*storagev1.StorageClass, error)
+	GetDefaultStorageClass(ctx context.Context) (*storagev1.StorageClass, error)
+}
+
+// ResolveStorageClassName resolves storage class name for a VirtualDisk
+// with the same precedence as VD handlers:
+// 1. vd.Status.StorageClassName
+// 2. vd.Spec.PersistentVolumeClaim.StorageClass
+// 3. module default storage class (if resolver is provided)
+// 4. cluster default storage class (if resolver is provided)
+func ResolveStorageClassName(ctx context.Context, vd *v1alpha2.VirtualDisk, resolver VirtualDiskStorageClassResolver) (string, error) {
+	if vd == nil {
+		return "", nil
+	}
+
+	if vd.Status.StorageClassName != "" {
+		return vd.Status.StorageClassName, nil
+	}
+
+	if vd.Spec.PersistentVolumeClaim.StorageClass != nil && *vd.Spec.PersistentVolumeClaim.StorageClass != "" {
+		return *vd.Spec.PersistentVolumeClaim.StorageClass, nil
+	}
+
+	if resolver == nil {
+		return "", nil
+	}
+
+	moduleStorageClass, err := resolver.GetModuleStorageClass(ctx)
+	if err != nil {
+		return "", err
+	}
+	if moduleStorageClass != nil {
+		return moduleStorageClass.Name, nil
+	}
+
+	defaultStorageClass, err := resolver.GetDefaultStorageClass(ctx)
+	if err != nil && !errors.Is(err, service.ErrDefaultStorageClassNotFound) {
+		return "", err
+	}
+	if defaultStorageClass != nil {
+		return defaultStorageClass.Name, nil
+	}
+
+	return "", fmt.Errorf("storage class for VirtualDisk %q cannot be determined", vd.Name)
 }
 
 func ValidateVirtualImageStorageClassProvisionerCompatibility(ctx context.Context, vd *v1alpha2.VirtualDisk, client client.Client) error {

--- a/images/virtualization-artifact/pkg/controller/indexer/indexer.go
+++ b/images/virtualization-artifact/pkg/controller/indexer/indexer.go
@@ -71,6 +71,7 @@ const (
 
 	IndexFieldEventByInvolvedObjectName        = "involvedObject.name"
 	IndexFieldEventByInvolvedObjectKind        = "involvedObject.kind"
+	IndexFieldPVByStorageClass                 = "spec.storageClassName"
 	IndexFieldUSBDeviceByName                  = "metadata.name"
 	IndexFieldNodeUSBDeviceByAssignedNamespace = "spec.assignedNamespace"
 
@@ -104,6 +105,7 @@ var IndexGetters = []IndexGetter{
 	IndexVMIPLeaseByVMIP,
 	IndexEventByInvolvedObjectName,
 	IndexEventByInvolvedObjectKind,
+	IndexPVByStorageClass,
 }
 
 var IndexGettersUSB = []IndexGetter{

--- a/images/virtualization-artifact/pkg/controller/indexer/pv_indexer.go
+++ b/images/virtualization-artifact/pkg/controller/indexer/pv_indexer.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package indexer
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func IndexPVByStorageClass() (obj client.Object, field string, extractValue client.IndexerFunc) {
+	return &corev1.PersistentVolume{}, IndexFieldPVByStorageClass, func(object client.Object) []string {
+		pv, ok := object.(*corev1.PersistentVolume)
+		if !ok || pv == nil || pv.Spec.StorageClassName == "" {
+			return nil
+		}
+		return []string{pv.Spec.StorageClassName}
+	}
+}

--- a/images/virtualization-artifact/pkg/controller/vd/internal/validator/vi_pvc_storage_class_provisioner_compatibility_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/validator/vi_pvc_storage_class_provisioner_compatibility_validator.go
@@ -18,8 +18,6 @@ package validator
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"reflect"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -27,7 +25,6 @@ import (
 
 	commonvd "github.com/deckhouse/virtualization-controller/pkg/common/vd"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
-	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	intsvc "github.com/deckhouse/virtualization-controller/pkg/controller/vd/internal/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vd/internal/source"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
@@ -47,7 +44,7 @@ func NewVirtualImagePVCStorageClassValidator(client client.Client, scService *in
 }
 
 func (v *VirtualImagePVCStorageClassValidator) ValidateCreate(ctx context.Context, vd *v1alpha2.VirtualDisk) (admission.Warnings, error) {
-	scName, err := v.extractVDStorageClassName(ctx, vd)
+	scName, err := commonvd.ResolveStorageClassName(ctx, vd, v.scService)
 	if err != nil {
 		return nil, err
 	}
@@ -69,34 +66,4 @@ func (v *VirtualImagePVCStorageClassValidator) ValidateUpdate(ctx context.Contex
 	}
 
 	return nil, commonvd.ValidateVirtualImageStorageClassProvisionerCompatibility(ctx, newVD, v.client)
-}
-
-func (v *VirtualImagePVCStorageClassValidator) extractVDStorageClassName(ctx context.Context, vd *v1alpha2.VirtualDisk) (string, error) {
-	if vd.Status.StorageClassName != "" {
-		return vd.Status.StorageClassName, nil
-	}
-
-	if vd.Spec.PersistentVolumeClaim.StorageClass != nil {
-		return *vd.Spec.PersistentVolumeClaim.StorageClass, nil
-	}
-
-	moduleStorageClass, err := v.scService.GetModuleStorageClass(ctx)
-	if err != nil {
-		return "", err
-	}
-
-	if moduleStorageClass != nil {
-		return moduleStorageClass.Name, nil
-	}
-
-	defaultStorageClass, err := v.scService.GetDefaultStorageClass(ctx)
-	if err != nil && !errors.Is(err, service.ErrDefaultStorageClassNotFound) {
-		return "", err
-	}
-
-	if defaultStorageClass != nil {
-		return defaultStorageClass.Name, nil
-	}
-
-	return "", fmt.Errorf("storage class for VirtualDisk %q cannot be determined", vd.Name)
 }

--- a/images/virtualization-artifact/pkg/controller/vm/internal/state/state.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/state/state.go
@@ -579,6 +579,12 @@ func (s *state) nodeAffinityTermsFromUnboundPVC(ctx context.Context, kind v1alph
 	if err != nil {
 		return nil, fmt.Errorf("resolve StorageClass for %s/%s: %w", kind, name, err)
 	}
+	// During migration we intentionally do not trust VD status storage class for target PVC,
+	// because it can still point to the source PVC class while the source VM pod is running.
+	// In this case use target PVC storage class if it is already set.
+	if storageClassName == "" && pvc.Spec.StorageClassName != nil {
+		storageClassName = *pvc.Spec.StorageClassName
+	}
 	if storageClassName == "" {
 		return nil, nil
 	}

--- a/images/virtualization-artifact/pkg/controller/vm/internal/state/state.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/state/state.go
@@ -512,7 +512,10 @@ func (s *state) resolveStorageClassName(ctx context.Context, kind v1alpha2.Block
 		}
 		// During migration, status.StorageClassName can still point to the old PVC's class.
 		// Avoid using it for the target PVC; rely on target PVC fields instead.
-		if vd.Status.MigrationState.TargetPVC == pvcName {
+		migrating, _ := conditions.GetCondition(vdcondition.MigratingType, vd.Status.Conditions)
+		if migrating.Status == metav1.ConditionTrue &&
+			conditions.IsLastUpdated(migrating, vd) &&
+			vd.Status.MigrationState.TargetPVC == pvcName {
 			return "", nil
 		}
 		return commonvd.ResolveStorageClassName(ctx, vd, nil)
@@ -590,7 +593,7 @@ func (s *state) nodeAffinityTermsFromUnboundPVC(ctx context.Context, kind v1alph
 	}
 
 	var pvList corev1.PersistentVolumeList
-	if err := s.client.List(ctx, &pvList); err != nil {
+	if err := s.client.List(ctx, &pvList, client.MatchingFields{indexer.IndexFieldPVByStorageClass: storageClassName}); err != nil {
 		return nil, fmt.Errorf("list PVs: %w", err)
 	}
 
@@ -642,7 +645,7 @@ func (s *state) nodeAffinityTermsFromStorageClassTopology(ctx context.Context, s
 		Name string `json:"name"`
 	}
 	if err := yaml.Unmarshal([]byte(lvgParam), &lvgs); err != nil {
-		return nil, nil
+		return nil, err
 	}
 
 	var nodeNames []string

--- a/images/virtualization-artifact/pkg/controller/vm/internal/state/state.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/state/state.go
@@ -21,17 +21,22 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	virtv1 "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 
 	"github.com/deckhouse/virtualization-controller/pkg/common/annotations"
 	kvvmutil "github.com/deckhouse/virtualization-controller/pkg/common/kvvm"
 	"github.com/deckhouse/virtualization-controller/pkg/common/nodeaffinity"
 	"github.com/deckhouse/virtualization-controller/pkg/common/object"
+	commonvd "github.com/deckhouse/virtualization-controller/pkg/common/vd"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/indexer"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/powerstate"
@@ -410,7 +415,7 @@ func (s *state) PVNodeAffinityTerms(ctx context.Context) ([]corev1.NodeSelectorT
 			continue
 		}
 
-		terms, err := s.pvNodeAffinityTermsForPVC(ctx, pvcName, namespace)
+		terms, err := s.pvNodeAffinityTermsForPVC(ctx, ref.Kind, ref.Name, pvcName, namespace)
 		if err != nil {
 			return nil, fmt.Errorf("get PV node affinity for PVC %s: %w", pvcName, err)
 		}
@@ -495,19 +500,63 @@ func (s *state) resolvePVCName(ctx context.Context, kind v1alpha2.BlockDeviceKin
 	}
 }
 
-func (s *state) pvNodeAffinityTermsForPVC(ctx context.Context, pvcName, namespace string) ([]corev1.NodeSelectorTerm, error) {
+func (s *state) resolveStorageClassName(ctx context.Context, kind v1alpha2.BlockDeviceKind, name, pvcName string) (string, error) {
+	switch kind {
+	case v1alpha2.DiskDevice:
+		vd, err := s.VirtualDisk(ctx, name)
+		if err != nil {
+			return "", err
+		}
+		if vd == nil {
+			return "", nil
+		}
+		// During migration, status.StorageClassName can still point to the old PVC's class.
+		// Avoid using it for the target PVC; rely on target PVC fields instead.
+		if vd.Status.MigrationState.TargetPVC == pvcName {
+			return "", nil
+		}
+		return commonvd.ResolveStorageClassName(ctx, vd, nil)
+	case v1alpha2.ImageDevice:
+		vi, err := s.VirtualImage(ctx, name)
+		if err != nil {
+			return "", err
+		}
+		if vi == nil {
+			return "", nil
+		}
+		if vi.Status.StorageClassName != "" {
+			return vi.Status.StorageClassName, nil
+		}
+		if vi.Spec.PersistentVolumeClaim.StorageClass != nil {
+			return *vi.Spec.PersistentVolumeClaim.StorageClass, nil
+		}
+		return "", nil
+	default:
+		return "", nil
+	}
+}
+
+func (s *state) pvNodeAffinityTermsForPVC(ctx context.Context, kind v1alpha2.BlockDeviceKind, name, pvcName, namespace string) ([]corev1.NodeSelectorTerm, error) {
 	pvc, err := object.FetchObject(ctx, types.NamespacedName{
 		Name: pvcName, Namespace: namespace,
 	}, s.client, &corev1.PersistentVolumeClaim{})
 	if err != nil {
 		return nil, err
 	}
-	if pvc == nil || pvc.Spec.VolumeName == "" {
+	if pvc == nil {
 		return nil, nil
 	}
 
+	if pvc.Spec.VolumeName != "" {
+		return s.nodeAffinityTermsFromBoundPV(ctx, pvc.Spec.VolumeName)
+	}
+
+	return s.nodeAffinityTermsFromUnboundPVC(ctx, kind, name, pvcName, pvc)
+}
+
+func (s *state) nodeAffinityTermsFromBoundPV(ctx context.Context, pvName string) ([]corev1.NodeSelectorTerm, error) {
 	pv, err := object.FetchObject(ctx, types.NamespacedName{
-		Name: pvc.Spec.VolumeName,
+		Name: pvName,
 	}, s.client, &corev1.PersistentVolume{})
 	if err != nil {
 		return nil, err
@@ -520,6 +569,120 @@ func (s *state) pvNodeAffinityTermsForPVC(ctx context.Context, pvcName, namespac
 		return pv.Spec.NodeAffinity.Required.NodeSelectorTerms, nil
 	}
 	return nil, nil
+}
+
+// nodeAffinityTermsFromUnboundPVC determines node affinity for an unbound PVC by:
+// 1. Looking for pre-provisioned Available PVs (static provisioning case).
+// 2. If none found, deriving topology from StorageClass + LVMVolumeGroup (dynamic provisioning case).
+func (s *state) nodeAffinityTermsFromUnboundPVC(ctx context.Context, kind v1alpha2.BlockDeviceKind, name, pvcName string, pvc *corev1.PersistentVolumeClaim) ([]corev1.NodeSelectorTerm, error) {
+	storageClassName, err := s.resolveStorageClassName(ctx, kind, name, pvcName)
+	if err != nil {
+		return nil, fmt.Errorf("resolve StorageClass for %s/%s: %w", kind, name, err)
+	}
+	if storageClassName == "" {
+		return nil, nil
+	}
+
+	var pvList corev1.PersistentVolumeList
+	if err := s.client.List(ctx, &pvList); err != nil {
+		return nil, fmt.Errorf("list PVs: %w", err)
+	}
+
+	var allTerms []corev1.NodeSelectorTerm
+	for i := range pvList.Items {
+		pv := &pvList.Items[i]
+		if pv.Status.Phase != corev1.VolumeAvailable {
+			continue
+		}
+		if pv.Spec.StorageClassName != storageClassName {
+			continue
+		}
+		if pv.Spec.NodeAffinity == nil || pv.Spec.NodeAffinity.Required == nil {
+			continue
+		}
+		allTerms = append(allTerms, pv.Spec.NodeAffinity.Required.NodeSelectorTerms...)
+	}
+
+	if len(allTerms) > 0 {
+		return allTerms, nil
+	}
+
+	return s.nodeAffinityTermsFromStorageClassTopology(ctx, storageClassName)
+}
+
+const (
+	localCSIProvisioner  = "local.csi.storage.deckhouse.io"
+	lvmVolumeGroupsParam = "local.csi.storage.deckhouse.io/lvm-volume-groups"
+)
+
+// nodeAffinityTermsFromStorageClassTopology resolves node topology for dynamic provisioning
+// by reading the StorageClass parameters and looking up LVMVolumeGroup resources to determine
+// which nodes can provision volumes for this StorageClass.
+func (s *state) nodeAffinityTermsFromStorageClassTopology(ctx context.Context, storageClassName string) ([]corev1.NodeSelectorTerm, error) {
+	sc, err := object.FetchObject(ctx, types.NamespacedName{Name: storageClassName}, s.client, &storagev1.StorageClass{})
+	if err != nil {
+		return nil, fmt.Errorf("get StorageClass %s: %w", storageClassName, err)
+	}
+	if sc == nil || sc.Provisioner != localCSIProvisioner {
+		return nil, nil
+	}
+
+	lvgParam, ok := sc.Parameters[lvmVolumeGroupsParam]
+	if !ok || lvgParam == "" {
+		return nil, nil
+	}
+
+	var lvgs []struct {
+		Name string `json:"name"`
+	}
+	if err := yaml.Unmarshal([]byte(lvgParam), &lvgs); err != nil {
+		return nil, nil
+	}
+
+	var nodeNames []string
+	for _, lvg := range lvgs {
+		nodeName, err := s.getNodeNameFromLVMVolumeGroup(ctx, lvg.Name)
+		if err != nil {
+			return nil, err
+		}
+		if nodeName != "" {
+			nodeNames = append(nodeNames, nodeName)
+		}
+	}
+
+	if len(nodeNames) == 0 {
+		return nil, nil
+	}
+
+	return []corev1.NodeSelectorTerm{{
+		MatchExpressions: []corev1.NodeSelectorRequirement{{
+			Key:      corev1.LabelHostname,
+			Operator: corev1.NodeSelectorOpIn,
+			Values:   nodeNames,
+		}},
+	}}, nil
+}
+
+var lvmVolumeGroupGVK = schema.GroupVersionKind{
+	Group:   "storage.deckhouse.io",
+	Version: "v1alpha1",
+	Kind:    "LVMVolumeGroup",
+}
+
+func (s *state) getNodeNameFromLVMVolumeGroup(ctx context.Context, name string) (string, error) {
+	lvg := &unstructured.Unstructured{}
+	lvg.SetGroupVersionKind(lvmVolumeGroupGVK)
+
+	err := s.client.Get(ctx, types.NamespacedName{Name: name}, lvg)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("get LVMVolumeGroup %s: %w", name, err)
+	}
+
+	nodeName, _, _ := unstructured.NestedString(lvg.Object, "spec", "local", "nodeName")
+	return nodeName, nil
 }
 
 func (s *state) USBDevice(ctx context.Context, name string) (*v1alpha2.USBDevice, error) {

--- a/images/virtualization-artifact/pkg/controller/vm/internal/state/state_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/state/state_test.go
@@ -569,6 +569,48 @@ var _ = Describe("PVNodeAffinityTerms", func() {
 			"affinity should follow the migration target PVC's PV (node-2), not the source PVC's PV (node-1)")
 	})
 
+	It("should use target PVC storage class for unbound target PVC during migration", func() {
+		vm := makeVM(v1alpha2.BlockDeviceSpecRef{Kind: v1alpha2.DiskDevice, Name: "local-disk"})
+
+		vd := makeVD("local-disk", "pvc-source")
+		vd.Generation = 1
+		vd.Status.StorageClassName = "source-sc"
+		vd.Status.Conditions = []metav1.Condition{{
+			Type:               vdcondition.MigratingType.String(),
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: 1,
+			Reason:             "Migrating",
+		}}
+		vd.Status.MigrationState = v1alpha2.VirtualDiskMigrationState{
+			SourcePVC: "pvc-source",
+			TargetPVC: "pvc-target",
+		}
+
+		pvcSource := makePVC("pvc-source", "pv-source")
+		pvSource := makePV("pv-source", nodeAffinityTerm(node1))
+		pvSource.Spec.StorageClassName = "source-sc"
+		pvSource.Status.Phase = corev1.VolumeBound
+
+		targetSC := "target-sc"
+		pvcTarget := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "pvc-target", Namespace: ns},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				StorageClassName: &targetSC,
+			},
+		}
+		pvAvailTarget := makePV("pv-target-avail", nodeAffinityTerm(node2))
+		pvAvailTarget.Spec.StorageClassName = "target-sc"
+		pvAvailTarget.Status.Phase = corev1.VolumeAvailable
+
+		s := buildState(vm, vd, pvcSource, pvSource, pvcTarget, pvAvailTarget)
+		ctx := logger.ToContext(context.TODO(), slog.Default())
+		terms, err := s.PVNodeAffinityTerms(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(terms).To(HaveLen(1))
+		Expect(terms[0].MatchExpressions[0].Values).To(ConsistOf(node2),
+			"affinity for unbound target PVC should use target storage class, not source VD status class")
+	})
+
 	It("should fall back to source PVC when migration condition is False (e.g. reverted)", func() {
 		vm := makeVM(v1alpha2.BlockDeviceSpecRef{Kind: v1alpha2.DiskDevice, Name: "local-disk"})
 

--- a/images/virtualization-artifact/pkg/controller/vm/internal/state/state_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/state/state_test.go
@@ -24,8 +24,11 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	virtv1 "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -148,6 +151,7 @@ var _ = Describe("PVNodeAffinityTerms", func() {
 		v1alpha2.AddToScheme,
 		virtv1.AddToScheme,
 		corev1.AddToScheme,
+		storagev1.AddToScheme,
 	} {
 		err := f(scheme)
 		Expect(err).NotTo(HaveOccurred())
@@ -305,7 +309,7 @@ var _ = Describe("PVNodeAffinityTerms", func() {
 		Expect(terms[0].MatchExpressions[0].Values).To(ConsistOf(node2))
 	})
 
-	It("should skip new WFFC disks where PVC is pending (no PV yet)", func() {
+	It("should skip unbound PVC when no available PVs match and SC is not local CSI", func() {
 		vm := makeVM(
 			v1alpha2.BlockDeviceSpecRef{Kind: v1alpha2.DiskDevice, Name: "bound-disk"},
 			v1alpha2.BlockDeviceSpecRef{Kind: v1alpha2.DiskDevice, Name: "pending-disk"},
@@ -315,17 +319,189 @@ var _ = Describe("PVNodeAffinityTerms", func() {
 		pvBound := makePV("pv-bound", nodeAffinityTerm(node1))
 
 		vdPending := makeVD("pending-disk", "pvc-pending")
+		vdPending.Status.StorageClassName = "some-other-storage"
 		pvcPending := &corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{Name: "pvc-pending", Namespace: ns},
-			Spec:       corev1.PersistentVolumeClaimSpec{}, // no VolumeName yet
+		}
+		otherSC := &storagev1.StorageClass{
+			ObjectMeta:  metav1.ObjectMeta{Name: "some-other-storage"},
+			Provisioner: "some-other-provisioner",
 		}
 
-		s := buildState(vm, vdBound, pvcBound, pvBound, vdPending, pvcPending)
+		s := buildState(vm, vdBound, pvcBound, pvBound, vdPending, pvcPending, otherSC)
 		ctx := logger.ToContext(context.TODO(), slog.Default())
 		terms, err := s.PVNodeAffinityTerms(ctx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(terms).To(HaveLen(1))
 		Expect(terms[0].MatchExpressions[0].Values).To(ConsistOf(node1))
+	})
+
+	It("should derive node affinity from LVMVolumeGroup for local CSI dynamic provisioning", func() {
+		vm := makeVM(v1alpha2.BlockDeviceSpecRef{Kind: v1alpha2.DiskDevice, Name: "local-disk"})
+		vd := makeVD("local-disk", "pvc-local")
+		vd.Status.StorageClassName = "local-storage-class-thin"
+		pvcLocal := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "pvc-local", Namespace: ns},
+		}
+		localSC := &storagev1.StorageClass{
+			ObjectMeta:  metav1.ObjectMeta{Name: "local-storage-class-thin"},
+			Provisioner: localCSIProvisioner,
+			Parameters: map[string]string{
+				lvmVolumeGroupsParam: "- name: vg-data-node-1\n  thin:\n    poolName: thin-data\n",
+			},
+		}
+		lvg := &unstructured.Unstructured{}
+		lvg.SetGroupVersionKind(schema.GroupVersionKind{
+			Group: "storage.deckhouse.io", Version: "v1alpha1", Kind: "LVMVolumeGroup",
+		})
+		lvg.SetName("vg-data-node-1")
+		_ = unstructured.SetNestedField(lvg.Object, node1, "spec", "local", "nodeName")
+
+		s := buildState(vm, vd, pvcLocal, localSC, lvg)
+		ctx := logger.ToContext(context.TODO(), slog.Default())
+		terms, err := s.PVNodeAffinityTerms(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(terms).To(HaveLen(1))
+		Expect(terms[0].MatchExpressions).To(HaveLen(1))
+		Expect(terms[0].MatchExpressions[0].Key).To(Equal(corev1.LabelHostname))
+		Expect(terms[0].MatchExpressions[0].Values).To(ConsistOf(node1))
+	})
+
+	It("should intersect bound PV terms with LVMVolumeGroup topology", func() {
+		vm := makeVM(
+			v1alpha2.BlockDeviceSpecRef{Kind: v1alpha2.DiskDevice, Name: "bound-disk"},
+			v1alpha2.BlockDeviceSpecRef{Kind: v1alpha2.DiskDevice, Name: "local-disk"},
+		)
+		vdBound := makeVD("bound-disk", "pvc-bound")
+		pvcBound := makePVC("pvc-bound", "pv-bound")
+		pvBound := makePV("pv-bound", nodeAffinityTerm(node1, node2))
+
+		vdLocal := makeVD("local-disk", "pvc-local")
+		vdLocal.Status.StorageClassName = "local-storage-class-thin"
+		pvcLocal := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "pvc-local", Namespace: ns},
+		}
+		localSC := &storagev1.StorageClass{
+			ObjectMeta:  metav1.ObjectMeta{Name: "local-storage-class-thin"},
+			Provisioner: localCSIProvisioner,
+			Parameters: map[string]string{
+				lvmVolumeGroupsParam: "- name: vg-data-node-1\n  thin:\n    poolName: thin-data\n",
+			},
+		}
+		lvg := &unstructured.Unstructured{}
+		lvg.SetGroupVersionKind(schema.GroupVersionKind{
+			Group: "storage.deckhouse.io", Version: "v1alpha1", Kind: "LVMVolumeGroup",
+		})
+		lvg.SetName("vg-data-node-1")
+		_ = unstructured.SetNestedField(lvg.Object, node1, "spec", "local", "nodeName")
+
+		s := buildState(vm, vdBound, pvcBound, pvBound, vdLocal, pvcLocal, localSC, lvg)
+		ctx := logger.ToContext(context.TODO(), slog.Default())
+		terms, err := s.PVNodeAffinityTerms(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(terms).NotTo(BeEmpty())
+	})
+
+	It("should collect node affinity from available PVs for unbound WFFC PVC", func() {
+		vm := makeVM(v1alpha2.BlockDeviceSpecRef{Kind: v1alpha2.DiskDevice, Name: "wffc-disk"})
+		vd := makeVD("wffc-disk", "pvc-wffc")
+		vd.Status.StorageClassName = "local-storage"
+		pvcWFFC := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "pvc-wffc", Namespace: ns},
+		}
+
+		pvAvail1 := makePV("pv-avail-1", nodeAffinityTerm(node1))
+		pvAvail1.Spec.StorageClassName = "local-storage"
+		pvAvail1.Status.Phase = corev1.VolumeAvailable
+
+		pvAvail2 := makePV("pv-avail-2", nodeAffinityTerm(node2))
+		pvAvail2.Spec.StorageClassName = "local-storage"
+		pvAvail2.Status.Phase = corev1.VolumeAvailable
+
+		pvBound := makePV("pv-bound-other", nodeAffinityTerm(node3))
+		pvBound.Spec.StorageClassName = "local-storage"
+		pvBound.Status.Phase = corev1.VolumeBound
+
+		s := buildState(vm, vd, pvcWFFC, pvAvail1, pvAvail2, pvBound)
+		ctx := logger.ToContext(context.TODO(), slog.Default())
+		terms, err := s.PVNodeAffinityTerms(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(terms).To(HaveLen(2), "should have terms from 2 available PVs (not the bound one)")
+	})
+
+	It("should use VirtualDisk status storage class when PVC storage class is empty", func() {
+		vm := makeVM(v1alpha2.BlockDeviceSpecRef{Kind: v1alpha2.DiskDevice, Name: "wffc-disk"})
+		vd := makeVD("wffc-disk", "pvc-wffc")
+		vd.Status.StorageClassName = "local-storage"
+		pvcWFFC := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "pvc-wffc", Namespace: ns},
+		}
+
+		pvAvail := makePV("pv-avail-1", nodeAffinityTerm(node2))
+		pvAvail.Spec.StorageClassName = "local-storage"
+		pvAvail.Status.Phase = corev1.VolumeAvailable
+
+		s := buildState(vm, vd, pvcWFFC, pvAvail)
+		ctx := logger.ToContext(context.TODO(), slog.Default())
+		terms, err := s.PVNodeAffinityTerms(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(terms).To(HaveLen(1))
+		Expect(terms[0].MatchExpressions).To(HaveLen(1))
+		Expect(terms[0].MatchExpressions[0].Values).To(ConsistOf(node2))
+	})
+
+	It("should use VirtualDisk spec storage class when PVC and status storage classes are empty", func() {
+		vm := makeVM(v1alpha2.BlockDeviceSpecRef{Kind: v1alpha2.DiskDevice, Name: "wffc-disk"})
+		vd := makeVD("wffc-disk", "pvc-wffc")
+		sc := "local-storage"
+		vd.Spec.PersistentVolumeClaim.StorageClass = &sc
+		pvcWFFC := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "pvc-wffc", Namespace: ns},
+		}
+
+		pvAvail := makePV("pv-avail-1", nodeAffinityTerm(node3))
+		pvAvail.Spec.StorageClassName = "local-storage"
+		pvAvail.Status.Phase = corev1.VolumeAvailable
+
+		s := buildState(vm, vd, pvcWFFC, pvAvail)
+		ctx := logger.ToContext(context.TODO(), slog.Default())
+		terms, err := s.PVNodeAffinityTerms(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(terms).To(HaveLen(1))
+		Expect(terms[0].MatchExpressions).To(HaveLen(1))
+		Expect(terms[0].MatchExpressions[0].Values).To(ConsistOf(node3))
+	})
+
+	It("should intersect available PV terms with bound disk terms", func() {
+		vm := makeVM(
+			v1alpha2.BlockDeviceSpecRef{Kind: v1alpha2.DiskDevice, Name: "bound-disk"},
+			v1alpha2.BlockDeviceSpecRef{Kind: v1alpha2.DiskDevice, Name: "wffc-disk"},
+		)
+
+		vdBound := makeVD("bound-disk", "pvc-bound")
+		pvcBound := makePVC("pvc-bound", "pv-bound")
+		pvBound := makePV("pv-bound", nodeAffinityTerm(node1, node2))
+
+		vdWFFC := makeVD("wffc-disk", "pvc-wffc")
+		vdWFFC.Status.StorageClassName = "local-storage"
+		pvcWFFC := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "pvc-wffc", Namespace: ns},
+		}
+		pvAvail1 := makePV("pv-avail-1", nodeAffinityTerm(node2))
+		pvAvail1.Spec.StorageClassName = "local-storage"
+		pvAvail1.Status.Phase = corev1.VolumeAvailable
+
+		pvAvail2 := makePV("pv-avail-2", nodeAffinityTerm(node3))
+		pvAvail2.Spec.StorageClassName = "local-storage"
+		pvAvail2.Status.Phase = corev1.VolumeAvailable
+
+		s := buildState(vm, vdBound, pvcBound, pvBound, vdWFFC, pvcWFFC, pvAvail1, pvAvail2)
+		ctx := logger.ToContext(context.TODO(), slog.Default())
+		terms, err := s.PVNodeAffinityTerms(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		// bound-disk allows node1,node2; wffc-disk allows node2,node3
+		// intersection (cross-product) should yield terms matching node2
+		Expect(terms).NotTo(BeEmpty())
 	})
 
 	It("should collect PV nodeAffinity from VirtualImage with PVC storage", func() {

--- a/images/virtualization-artifact/pkg/controller/vm/internal/state/state_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/state/state_test.go
@@ -213,10 +213,12 @@ var _ = Describe("PVNodeAffinityTerms", func() {
 		allObjs := []client.Object{vm}
 		allObjs = append(allObjs, objs...)
 		vmbdaIndexObj, vmbdaIndexField, vmbdaIndexFn := indexer.IndexVMBDAByVM()
+		pvByStorageClassIndexObj, pvByStorageClassIndexField, pvByStorageClassIndexFn := indexer.IndexPVByStorageClass()
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithObjects(allObjs...).
 			WithIndex(vmbdaIndexObj, vmbdaIndexField, vmbdaIndexFn).
+			WithIndex(pvByStorageClassIndexObj, pvByStorageClassIndexField, pvByStorageClassIndexFn).
 			Build()
 		namespacedName := types.NamespacedName{Name: vm.Name, Namespace: vm.Namespace}
 		vmResource := reconciler.NewResource(namespacedName, fakeClient, vmFactoryByVM(vm), vmStatusGetter)

--- a/templates/virtualization-controller/rbac-for-us.yaml
+++ b/templates/virtualization-controller/rbac-for-us.yaml
@@ -96,6 +96,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - storage.deckhouse.io
+  resources:
+  - lvmvolumegroups
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - nodes


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Fixes VM pod placement for VMs using local disks together with hotplug disks.

Previously, a VM with hotplugable disks could be scheduled or migrated to a node where its local disk was not available. This happened because the virt-launcher pod did not receive the required affinity rules for local disk placement.

This PR ensures that the necessary affinity is properly applied to virt-launcher, so VMs with local disks are placed only on nodes where the required local storage is available.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

