### PR TITLE
fix(vm): create pvc disk.img for hotplug volumes on migration target

### DIFF
--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -3,7 +3,7 @@ firmware:
   libvirt: v10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: v1.6.2-v12n.33
+  3p-kubevirt: v1.6.2-v12n.34
   3p-containerized-data-importer: v1.60.3-v12n.19
   distribution: 2.8.3
 package:


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Bump KubeVirt version in Deckhouse Virtualization to include our upstream fork fix for migration target hotplug volume handling.

The fix enables `disk.img` creation for filesystem hotplug PVCs on migration target before mount.


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
Live migration of VMs with filesystem hotplug PVCs could fail on target with:
`.../disk.img: no such file or directory`.

Reason: migration target path did not create `disk.img` when needed.

After this bump, migration target uses the fixed behavior and migration succeeds for this case.


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
1. Deploy virtualization with updated KubeVirt.
2. Run a VM with filesystem hotplug RWO PVC.
3. Start live migration.
4. Confirm migration succeeds and no `disk.img` mount errors appear in target `virt-handler` logs.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

