### PR TITLE
fix(module): skip unavailable usbip module packages

### DIFF
--- a/templates/virtualization-dra/nodegroupconfiguration-usbip.yaml
+++ b/templates/virtualization-dra/nodegroupconfiguration-usbip.yaml
@@ -25,28 +25,44 @@ spec:
     # See the License for the specific language governing permissions and
     # limitations under the License.
 
-    pkg=""
+    kernel_release="$(uname -r)"
     bundle="$(bb-is-bundle)"
+    module_dir="/lib/modules/${kernel_release}/kernel/drivers/usb/usbip"
+    modules=("usbip-core.ko" "usbip-host.ko" "vhci-hcd.ko")
+    packages=()
+
+    modules_exist=true
+    for module in "${modules[@]}"; do
+      if [[ ! -e "${module_dir}/${module}" && ! -e "${module_dir}/${module}.zst" ]]; then
+        modules_exist=false
+        break
+      fi
+    done
+
+    if [[ "$modules_exist" == "true" ]]; then
+      bb-log-info "usbip kernel modules already exist for kernel ${kernel_release}."
+      return 0
+    fi
 
     if bb-is-distro-like? "debian"; then
-    # Debian, Ubuntu, Astra (Debian-based): modules in linux-modules-extra-$(uname -r)
-    pkg="linux-modules-extra-$(uname -r)"
+      packages=("linux-modules-extra-${kernel_release}")
     elif bb-is-distro-like? "rhel" || bb-is-distro-like? "centos" || bb-is-distro-like? "fedora"; then
-    # RHEL, CentOS, Fedora, ROSA, REDOS: kernel-modules-extra (match by ID or ID_LIKE)
-    pkg="kernel-modules-extra"
+      packages=("kernel-modules-extra-${kernel_release}" "kernel-modules-extra")
     elif [[ "$bundle" == "altlinux" ]]; then
-    # Alt Linux
-    pkg="kernel-modules-extra"
+      packages=("kernel-modules-extra")
     else
-    bb-log-warn "Unsupported OS for usbip kernel modules: bundle=${bundle}. Skipping."
-    return 1
+      bb-log-warn "Unsupported OS for usbip kernel modules: bundle=${bundle}. Skipping."
+      return 0
     fi
 
-    if [[ -z "$pkg" ]]; then
-    bb-log-warn "Could not determine package for usbip kernel modules."
-    return 1
-    fi
+    for pkg in "${packages[@]}"; do
+      bb-log-info "Installing package for usbip kernel modules (usbip_core, usbip_host, vhci_hcd): ${pkg}"
+      if bb-pkg install "$pkg"; then
+        return 0
+      fi
+      bb-log-warn "Failed to install package for usbip kernel modules: ${pkg}"
+    done
 
-    bb-log-info "Installing package for usbip kernel modules (usbip_core, usbip_host, vhci_hcd): ${pkg}"
-    bb-pkg install "$pkg"
+    bb-log-warn "Could not install a package with usbip kernel modules for kernel ${kernel_release}."
+    return 0
 {{- end }}


### PR DESCRIPTION
## Description
Update the `virtualization-install-usbip-modules` NodeGroupConfiguration to handle missing USB/IP kernel module packages more safely.

The script now:
- checks whether `usbip-core`, `usbip-host`, and `vhci-hcd` modules already exist for the running kernel;
- tries a kernel-version-specific package first on RHEL-like distributions;
- falls back to the generic package name when available;
- logs a warning and exits successfully when no suitable package can be installed.

## Why do we need it, and what problem does it solve?
On some RHEL-like distributions, for example RED OS with kernel `6.12.56-1.red80.x86_64`, the generic `kernel-modules-extra` package is not available in enabled repositories. The previous bashible step failed and entered a retry loop, blocking node configuration.

This change prevents the NodeGroupConfiguration from failing endlessly when the package is unavailable, while still installing USB/IP modules where a matching package exists.

## What is the expected result?
1. Enable virtualization DRA USB support on a node where USB/IP modules are already present or can be installed.
2. Verify that the bashible step completes successfully.
3. On a node where the package is unavailable, verify that the step logs a warning and does not enter a retry loop.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: module
type: fix
summary: Prevent the USB/IP module installation step from retrying indefinitely when kernel module packages are unavailable.
impact_level: low
```
