### PR TITLE
chore(ci): fix e2e resources archiving

### DIFF
--- a/.github/workflows/dev_module_build.yml
+++ b/.github/workflows/dev_module_build.yml
@@ -664,7 +664,7 @@ jobs:
         with:
           name: resources_from_failed_tests
           retention-days: 2
-          path: ${{ runner.temp }}/e2e_failed__*
+          path: ${{ runner.temp }}/e2e_failed/
           if-no-files-found: ignore
 
       - name: Cleanup E2E resources on cancel

--- a/.github/workflows/e2e-reusable-pipeline.yml
+++ b/.github/workflows/e2e-reusable-pipeline.yml
@@ -1503,7 +1503,7 @@ jobs:
         if: always() && steps.e2e-report.outcome != 'skipped'
         with:
           name: resources_from_failed_tests-${{ env.STORAGE_TYPE }}-${{ env.E2E_START_TIME }}
-          path: ${{ runner.temp }}/e2e_failed__*
+          path: ${{ runner.temp }}/e2e_failed/
           if-no-files-found: ignore
           retention-days: 3
 


### PR DESCRIPTION
## Description
Fix the artifact upload path for archived E2E resource dumps in CI workflows.

## Why do we need it, and what problem does it solve?
The workflows archive failed E2E resources into the `${{ runner.temp }}/e2e_failed/` directory, but the upload steps were looking for `${{ runner.temp }}/e2e_failed__*`.
Because of this mismatch, archived dumps from failed or cancelled E2E runs were not uploaded as workflow artifacts, which made debugging harder.

## What is the expected result?
1. Run an E2E workflow that produces failed resource dumps.
2. Verify the workflow uploads artifacts from `${{ runner.temp }}/e2e_failed/`.
3. Confirm archived E2E resource dumps are available in the workflow artifacts for investigation.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: chore
summary: "Fix archived E2E resource dump artifact uploads in CI workflows."
impact_level: low
```
