### PR TITLE
fix(core): bump kubevirt to prevent hotplug mount leaks on failed migration cleanup

### DIFF
--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -3,7 +3,7 @@ firmware:
   libvirt: v10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: v1.6.2-v12n.34
+  3p-kubevirt: v1.6.2-v12n.35
   3p-containerized-data-importer: v1.60.3-v12n.19
   distribution: 2.8.3
 package:


### PR DESCRIPTION
## Description
Bump bundled KubeVirt to a version that includes an upstream fix for hotplug volume cleanup during migration cleanup.

The upstream change switches cleanup logic from `Unmount()` to `UnmountAll()` for this path.

## Why do we need it, and what problem does it solve?
Failed migration with hotplug volumes can leave stale mounts on the target node.

The reason is that `Unmount()` removes only volumes absent in the VMI spec, while migration cleanup must unmount all hotplug volumes. This causes mount leaks and may affect subsequent operations on the node.

## What is the expected result?
1. Run migration for a VMI with hotplug volumes and reproduce a failed migration.
2. Wait for cleanup on the target node.
3. Verify that no stale hotplug mounts remain after cleanup.
4. Verify repeated migration attempts are not affected by leftover mounts.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: core
type: fix
summary: "Prevent hotplug volume mount leaks on failed migration cleanup by bumping KubeVirt."
impact_level: low
```
