### PR TITLE
fix(ci): wait for release site

### DIFF
--- a/.github/workflows/release_module_release-channels.yml
+++ b/.github/workflows/release_module_release-channels.yml
@@ -463,17 +463,17 @@ jobs:
         env:
           input_check_only: ${{ inputs.check_only }}
         run: |
-          # When check_only is true, we don't want to wait 120 seconds
+          # When check_only is true, we don't want to wait before checking
           # because we just want to check the version we're interested in on the website
           if [ $input_check_only = false ]; then
-            echo "Waiting for site to update (versions are usually updated within 2 minutes)..."
-            sleep 120
+            echo "Waiting for site to update (versions are usually updated within 5 minutes)..."
+            sleep 300
           fi
 
-          echo "Test that version deployed on site, retrying 5 times with delay of 60 seconds"
+          echo "Test that version deployed on site, retrying 10 times with delay of 60 seconds"
           CHANNEL=$input_channel \
           VERSION=$input_version \
-          COUNT=5 \
+          COUNT=10 \
           task -d tools/moduleversions check:releases
       - name: Check version on site ${{ matrix.check }}
         if: ${{ matrix.check == 'documentation' && always() }}


### PR DESCRIPTION
## Description
Increase the release-site validation window in the production deploy workflow:
- wait 5 minutes before checking `releases.deckhouse.io`;
- retry the releases check 10 times with a 60 second delay.

## Why do we need it, and what problem does it solve?
`releases.deckhouse.io` can lag behind the module deploy. The previous window, 2 minutes before the check plus 5 retry attempts, was too short and could fail while the released module version was still propagating to the site.

## What is the expected result?
Run the prod deploy workflow for a newly promoted module version. The release-site check waits longer and passes once the selected channel is updated on `releases.deckhouse.io`; it still fails if the version never appears there.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ci
type: fix
summary: Increase release site validation wait time to reduce CI flakes while module versions propagate.
```