### PR TITLE
chore(ci): update qemu build with optional ht

### DIFF
--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -1,9 +1,10 @@
 firmware:
-  qemu: v9.2.0
+  qemu: v10.2.2
   libvirt: v10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: v1.6.2-v12n.34
+  # 3p-kubevirt: fix/migration/drop-ht-feature
+  3p-kubevirt: v1.6.2-v12n.31
   3p-containerized-data-importer: v1.60.3-v12n.19
   distribution: 2.8.3
 package:

--- a/images/qemu/patches/002-no-bootable-qmp.patch
+++ b/images/qemu/patches/002-no-bootable-qmp.patch
@@ -1,5 +1,5 @@
 diff --git a/hw/char/debugcon.c b/hw/char/debugcon.c
-index fdb04fe..0cf2325 100644
+index bb323adda5..dad74ca2db 100644
 --- a/hw/char/debugcon.c
 +++ b/hw/char/debugcon.c
 @@ -26,6 +26,7 @@
@@ -20,7 +20,7 @@ index fdb04fe..0cf2325 100644
  //#define DEBUG_DEBUGCON
 @@ -42,6 +44,9 @@ typedef struct DebugconState {
      MemoryRegion io;
-     CharBackend chr;
+     CharFrontend chr;
      uint32_t readback;
 +    bool watch_no_bootable_device;
 +    char match_buf[sizeof(DEBUGCON_NO_BOOTABLE_DEVICE) - 1];
@@ -64,20 +64,20 @@ index fdb04fe..0cf2325 100644
  }
  
  
-@@ -118,6 +145,8 @@ static Property debugcon_isa_properties[] = {
+@@ -118,6 +145,8 @@ static const Property debugcon_isa_properties[] = {
      DEFINE_PROP_UINT32("iobase", ISADebugconState, iobase, 0xe9),
      DEFINE_PROP_CHR("chardev",  ISADebugconState, state.chr),
      DEFINE_PROP_UINT32("readback", ISADebugconState, state.readback, 0xe9),
 +    DEFINE_PROP_BOOL("watch-no-bootable", ISADebugconState,
 +                     state.watch_no_bootable_device, false),
-     DEFINE_PROP_END_OF_LIST(),
  };
  
+ static void debugcon_isa_class_initfn(ObjectClass *klass, const void *data)
 diff --git a/qapi/control.json b/qapi/control.json
-index 336386f..e1e727e 100644
+index 9a5302193d..30301fcf73 100644
 --- a/qapi/control.json
 +++ b/qapi/control.json
-@@ -209,3 +209,13 @@
+@@ -211,3 +211,13 @@
        '*pretty': 'bool',
        'chardev': 'str'
    } }
@@ -92,7 +92,7 @@ index 336386f..e1e727e 100644
 +##
 +{ 'event': 'NO_BOOTABLE_DEVICE' }
 diff --git a/tests/qtest/qmp-test.c b/tests/qtest/qmp-test.c
-index 22957fa..9b4840e 100644
+index edf0886787..97a326aa54 100644
 --- a/tests/qtest/qmp-test.c
 +++ b/tests/qtest/qmp-test.c
 @@ -337,6 +337,25 @@ static void test_qmp_missing_any_arg(void)

--- a/images/qemu/werf.inc.yaml
+++ b/images/qemu/werf.inc.yaml
@@ -226,7 +226,6 @@ shell:
       --block-drv-ro-whitelist="vdi,vmdk,vhdx,vpc,https" \
       --disable-alsa \
       --disable-auth-pam \
-      --disable-avx512bw \
       --disable-block-drv-whitelist-in-tools \
       --disable-bochs \
       --disable-bpf \

--- a/images/qemu/werf.inc.yaml
+++ b/images/qemu/werf.inc.yaml
@@ -226,7 +226,6 @@ shell:
       --block-drv-ro-whitelist="vdi,vmdk,vhdx,vpc,https" \
       --disable-alsa \
       --disable-auth-pam \
-      --disable-avx2 \
       --disable-avx512bw \
       --disable-block-drv-whitelist-in-tools \
       --disable-bochs \
@@ -267,7 +266,7 @@ shell:
       --disable-linux-user \
       --disable-lto \
       --disable-lzfse \
-      --disable-membarrier \
+      --enable-membarrier \
       --disable-module-upgrades \
       --disable-multiprocess \
       --disable-netmap \
@@ -332,7 +331,7 @@ shell:
       --enable-pie \
       --enable-rbd \
       --enable-rdma \
-      --enable-seccomp \
+      --disable-seccomp \
       --enable-selinux \
       --enable-slirp \
       --enable-snappy \

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -12,6 +12,7 @@ fromImage: builder/src
 secrets:
 - id: SOURCE_REPO
   value: {{ $.SOURCE_REPO }}
+# fromCacheVersion: remove unconditionally
 shell:
   install:
   - |

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
@@ -50,6 +50,7 @@ const (
 
 	// GenericCPUModel specifies the base CPU model for Features and Discovery CPU model types.
 	GenericCPUModel = "qemu64"
+	HTCPUFeature    = "ht"
 
 	MaxMemorySizeForHotplug      = 256 * 1024 * 1024 * 1024 // 256 Gi (safely limit to not overlap somewhat conservative 38 bit physical address space)
 	EnableMemoryHotplugThreshold = 1 * 1024 * 1024 * 1024   // 1 Gi (no hotplug for VMs with less than 1Gi)
@@ -162,12 +163,13 @@ func (b *KVVM) SetCPUModel(class *v1alpha2.VirtualMachineClass) error {
 		cpu.Model = virtv1.CPUModeHostPassthrough
 	case v1alpha2.CPUTypeModel:
 		cpu.Model = class.Spec.CPU.Model
+		cpu.Features = []virtv1.CPUFeature{{Name: HTCPUFeature, Policy: "optional"}}
 	case v1alpha2.CPUTypeDiscovery, v1alpha2.CPUTypeFeatures:
 		cpu.Model = GenericCPUModel
-		l := len(class.Status.CpuFeatures.Enabled)
-		features := make([]virtv1.CPUFeature, l, l+1)
+		features := make([]virtv1.CPUFeature, 0, len(class.Status.CpuFeatures.Enabled)+2)
 		hasSvm := false
-		for i, feature := range class.Status.CpuFeatures.Enabled {
+		hasHT := false
+		for _, feature := range class.Status.CpuFeatures.Enabled {
 			policy := "require"
 			if feature == "invtsc" {
 				policy = "optional"
@@ -175,13 +177,19 @@ func (b *KVVM) SetCPUModel(class *v1alpha2.VirtualMachineClass) error {
 			if feature == "svm" {
 				hasSvm = true
 			}
-			features[i] = virtv1.CPUFeature{
+			if feature == HTCPUFeature {
+				hasHT = true
+			}
+			features = append(features, virtv1.CPUFeature{
 				Name:   feature,
 				Policy: policy,
-			}
+			})
 		}
 		if !hasSvm {
 			features = append(features, virtv1.CPUFeature{Name: "svm", Policy: "optional"})
+		}
+		if !hasHT {
+			features = append(features, virtv1.CPUFeature{Name: HTCPUFeature, Policy: "optional"})
 		}
 		cpu.Features = features
 	default:

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_test.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_test.go
@@ -22,6 +22,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	virtv1 "kubevirt.io/api/core/v1"
 
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
@@ -222,6 +223,89 @@ func TestApplyPVNodeAffinity(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestSetCPUModel(t *testing.T) {
+	name := "test-name"
+	namespace := "test-namespace"
+
+	t.Run("should add optional ht feature for model cpu", func(t *testing.T) {
+		builder := NewEmptyKVVM(types.NamespacedName{Name: name, Namespace: namespace}, KVVMOptions{})
+		class := &v1alpha2.VirtualMachineClass{
+			Spec: v1alpha2.VirtualMachineClassSpec{
+				CPU: v1alpha2.CPU{Type: v1alpha2.CPUTypeModel, Model: "Nehalem"},
+			},
+		}
+
+		if err := builder.SetCPUModel(class); err != nil {
+			t.Fatalf("SetCPUModel() failed: %v", err)
+		}
+
+		features := builder.Resource.Spec.Template.Spec.Domain.CPU.Features
+		if !containsCPUFeature(features, virtv1.CPUFeature{Name: HTCPUFeature, Policy: "optional"}) {
+			t.Fatalf("expected optional ht feature to be added for model cpu, got %#v", features)
+		}
+	})
+
+	t.Run("should add optional ht feature for discovery cpu", func(t *testing.T) {
+		builder := NewEmptyKVVM(types.NamespacedName{Name: name, Namespace: namespace}, KVVMOptions{})
+		class := &v1alpha2.VirtualMachineClass{
+			Spec: v1alpha2.VirtualMachineClassSpec{
+				CPU: v1alpha2.CPU{Type: v1alpha2.CPUTypeDiscovery},
+			},
+			Status: v1alpha2.VirtualMachineClassStatus{
+				CpuFeatures: v1alpha2.CpuFeatures{Enabled: []string{"aes"}},
+			},
+		}
+
+		if err := builder.SetCPUModel(class); err != nil {
+			t.Fatalf("SetCPUModel() failed: %v", err)
+		}
+
+		features := builder.Resource.Spec.Template.Spec.Domain.CPU.Features
+		if !containsCPUFeature(features, virtv1.CPUFeature{Name: HTCPUFeature, Policy: "optional"}) {
+			t.Fatalf("expected optional ht feature to be added, got %#v", features)
+		}
+	})
+
+	t.Run("should keep existing ht feature policy when already present", func(t *testing.T) {
+		builder := NewEmptyKVVM(types.NamespacedName{Name: name, Namespace: namespace}, KVVMOptions{})
+		class := &v1alpha2.VirtualMachineClass{
+			Spec: v1alpha2.VirtualMachineClassSpec{
+				CPU: v1alpha2.CPU{Type: v1alpha2.CPUTypeFeatures},
+			},
+			Status: v1alpha2.VirtualMachineClassStatus{
+				CpuFeatures: v1alpha2.CpuFeatures{Enabled: []string{"vmx", HTCPUFeature}},
+			},
+		}
+
+		if err := builder.SetCPUModel(class); err != nil {
+			t.Fatalf("SetCPUModel() failed: %v", err)
+		}
+
+		features := builder.Resource.Spec.Template.Spec.Domain.CPU.Features
+		htCount := 0
+		for _, feature := range features {
+			if feature.Name == HTCPUFeature {
+				htCount++
+				if feature.Policy != "require" {
+					t.Fatalf("expected existing ht policy to stay require, got %#v", feature)
+				}
+			}
+		}
+		if htCount != 1 {
+			t.Fatalf("expected exactly one ht feature, got %#v", features)
+		}
+	})
+}
+
+func containsCPUFeature(features []virtv1.CPUFeature, expected virtv1.CPUFeature) bool {
+	for _, feature := range features {
+		if feature == expected {
+			return true
+		}
+	}
+	return false
 }
 
 func TestSetOsType(t *testing.T) {


### PR DESCRIPTION
## Description
Update QEMU to 10.2.2, enable AVX2 and membarrier in the QEMU build configuration, disable seccomp support, and keep HT CPU feature handling optional in VM CPU model generation.

## Why do we need it, and what problem does it solve?
This PR follows the same direction as PR #2339 for the QEMU build rework, but uses optional HT handling instead of required HT in the virtualization artifact. That lets us evaluate the updated QEMU build together with a less strict CPU feature policy for migration-related behavior.

## What is the expected result?
1. Build the QEMU image.
2. Verify the configure step enables AVX2 and membarrier.
3. Verify seccomp is disabled.
4. Verify generated VM CPU definitions include the `ht` feature with `optional` policy for model and discovery/features flows when HT is absent.
5. Confirm unit tests for CPU feature generation pass.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: chore
summary: "Update QEMU build configuration and add an optional HT CPU feature variant for migration-related checks."
impact_level: low
```
