### PR TITLE
chore(ci): update qemu to 10.2.2

### DIFF
--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -1,5 +1,5 @@
 firmware:
-  qemu: v9.2.0
+  qemu: v10.2.2
   libvirt: v10.9.0
   edk2: stable202411
 core:

--- a/images/qemu/patches/002-no-bootable-qmp.patch
+++ b/images/qemu/patches/002-no-bootable-qmp.patch
@@ -1,5 +1,5 @@
 diff --git a/hw/char/debugcon.c b/hw/char/debugcon.c
-index fdb04fe..0cf2325 100644
+index bb323adda5..dad74ca2db 100644
 --- a/hw/char/debugcon.c
 +++ b/hw/char/debugcon.c
 @@ -26,6 +26,7 @@
@@ -20,7 +20,7 @@ index fdb04fe..0cf2325 100644
  //#define DEBUG_DEBUGCON
 @@ -42,6 +44,9 @@ typedef struct DebugconState {
      MemoryRegion io;
-     CharBackend chr;
+     CharFrontend chr;
      uint32_t readback;
 +    bool watch_no_bootable_device;
 +    char match_buf[sizeof(DEBUGCON_NO_BOOTABLE_DEVICE) - 1];
@@ -64,20 +64,20 @@ index fdb04fe..0cf2325 100644
  }
  
  
-@@ -118,6 +145,8 @@ static Property debugcon_isa_properties[] = {
+@@ -118,6 +145,8 @@ static const Property debugcon_isa_properties[] = {
      DEFINE_PROP_UINT32("iobase", ISADebugconState, iobase, 0xe9),
      DEFINE_PROP_CHR("chardev",  ISADebugconState, state.chr),
      DEFINE_PROP_UINT32("readback", ISADebugconState, state.readback, 0xe9),
 +    DEFINE_PROP_BOOL("watch-no-bootable", ISADebugconState,
 +                     state.watch_no_bootable_device, false),
-     DEFINE_PROP_END_OF_LIST(),
  };
  
+ static void debugcon_isa_class_initfn(ObjectClass *klass, const void *data)
 diff --git a/qapi/control.json b/qapi/control.json
-index 336386f..e1e727e 100644
+index 9a5302193d..30301fcf73 100644
 --- a/qapi/control.json
 +++ b/qapi/control.json
-@@ -209,3 +209,13 @@
+@@ -211,3 +211,13 @@
        '*pretty': 'bool',
        'chardev': 'str'
    } }
@@ -92,7 +92,7 @@ index 336386f..e1e727e 100644
 +##
 +{ 'event': 'NO_BOOTABLE_DEVICE' }
 diff --git a/tests/qtest/qmp-test.c b/tests/qtest/qmp-test.c
-index 22957fa..9b4840e 100644
+index edf0886787..97a326aa54 100644
 --- a/tests/qtest/qmp-test.c
 +++ b/tests/qtest/qmp-test.c
 @@ -337,6 +337,25 @@ static void test_qmp_missing_any_arg(void)

--- a/images/qemu/patches/003-revert-nehalem-ht-feature.patch
+++ b/images/qemu/patches/003-revert-nehalem-ht-feature.patch
@@ -1,0 +1,30 @@
+diff --git a/target/i386/cpu.c b/target/i386/cpu.c
+index 78308a82a0..05da8abdd5 100644
+@@ -7908,6 +7908,7 @@
+         }
+         *edx = env->features[FEAT_1_EDX];
+         if (threads_per_pkg > 1) {
++            *edx |= CPUID_HT;
+             uint32_t num;
+ 
+             /*
+@@ -8976,19 +8977,12 @@
+         }
+     }
+ 
+-    if (x86_threads_per_pkg(&env->topo_info) > 1) {
+-        env->features[FEAT_1_EDX] |= CPUID_HT;
+-
+         /*
+          * The Linux kernel checks for the CMPLegacy bit and
+          * discards multiple thread information if it is set.
+          * So don't set it here for Intel (and other processors
+          * following Intel's behavior) to make Linux guests happy.
+          */
+-        if (!IS_INTEL_CPU(env) && !IS_ZHAOXIN_CPU(env)) {
+-            env->features[FEAT_8000_0001_ECX] |= CPUID_EXT3_CMP_LEG;
+-        }
+-    }
+ 
+     if (!cpu->pdcm_on_even_without_pmu) {
+         /* PDCM is fixed1 bit for TDX */

--- a/images/qemu/patches/README.md
+++ b/images/qemu/patches/README.md
@@ -41,3 +41,18 @@ Effect:
 - When enabled, QEMU watches the debug console output and emits `NO_BOOTABLE_DEVICE` after the
   full marker string is received.
 - The patch also adds a qtest that verifies the event is generated.
+
+## 003-revert-nehalem-ht-feature.patch
+
+Reverts upstream QEMU commit
+[`c6bd2dd63420`](https://github.com/qemu/qemu/commit/c6bd2dd63420), which changed x86 HT reporting
+behavior between QEMU `9.2.0` and `10.2.2`.
+
+Why this patch is kept:
+
+- The upstream change breaks live migration for VMs that use CPU models where HT is not explicitly
+  enabled.
+- In our environment this especially affects older modeled CPUs such as Nehalem, where guest-visible
+  HT reporting changes across QEMU versions.
+- We need to preserve the pre-`c6bd2dd63420` behavior from QEMU `9.2.0` so migration compatibility
+  is not lost when updating to QEMU `10.2.2`.

--- a/images/qemu/werf.inc.yaml
+++ b/images/qemu/werf.inc.yaml
@@ -219,7 +219,8 @@ shell:
 
     ./configure \
       --target-list="x86_64-softmmu" \
-      --extra-cflags="-march=x86-64-v2" \
+      --extra-cflags="-march=x86-64-v2 -mno-avx2 -mno-fma" \
+      --extra-cxxflags="-march=x86-64-v2 -mno-avx2 -mno-fma" \
       --with-pkgversion="-dvp" \
       --with-coroutine=ucontext \
       --tls-priority="@QEMU,SYSTEM" \

--- a/images/qemu/werf.inc.yaml
+++ b/images/qemu/werf.inc.yaml
@@ -226,8 +226,6 @@ shell:
       --block-drv-ro-whitelist="vdi,vmdk,vhdx,vpc,https" \
       --disable-alsa \
       --disable-auth-pam \
-      --disable-avx2 \
-      --disable-avx512bw \
       --disable-block-drv-whitelist-in-tools \
       --disable-bochs \
       --disable-bpf \
@@ -267,7 +265,7 @@ shell:
       --disable-linux-user \
       --disable-lto \
       --disable-lzfse \
-      --disable-membarrier \
+      --enable-membarrier \
       --disable-module-upgrades \
       --disable-multiprocess \
       --disable-netmap \
@@ -332,7 +330,7 @@ shell:
       --enable-pie \
       --enable-rbd \
       --enable-rdma \
-      --enable-seccomp \
+      --disable-seccomp \
       --enable-selinux \
       --enable-slirp \
       --enable-snappy \

--- a/images/qemu/werf.inc.yaml
+++ b/images/qemu/werf.inc.yaml
@@ -219,6 +219,7 @@ shell:
 
     ./configure \
       --target-list="x86_64-softmmu" \
+      --extra-cflags="-march=x86-64-v2" \
       --with-pkgversion="-dvp" \
       --with-coroutine=ucontext \
       --tls-priority="@QEMU,SYSTEM" \

--- a/images/qemu/werf.inc.yaml
+++ b/images/qemu/werf.inc.yaml
@@ -219,8 +219,6 @@ shell:
 
     ./configure \
       --target-list="x86_64-softmmu" \
-      --extra-cflags="-march=x86-64-v2 -mno-avx2 -mno-fma" \
-      --extra-cxxflags="-march=x86-64-v2 -mno-avx2 -mno-fma" \
       --with-pkgversion="-dvp" \
       --with-coroutine=ucontext \
       --tls-priority="@QEMU,SYSTEM" \

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -12,7 +12,6 @@ fromImage: builder/src
 secrets:
 - id: SOURCE_REPO
   value: {{ $.SOURCE_REPO }}
-# fromCacheVersion: remove unconditionally
 shell:
   install:
   - |

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -12,6 +12,7 @@ fromImage: builder/src
 secrets:
 - id: SOURCE_REPO
   value: {{ $.SOURCE_REPO }}
+# fromCacheVersion: remove unconditionally
 shell:
   install:
   - |


### PR DESCRIPTION
## Description
Update QEMU to 10.2.2 and keep the QEMU patch set aligned with that version by rebasing the no-bootable-device QMP patch and restoring the Nehalem HT feature patch.

## Why do we need it, and what problem does it solve?
The repository still uses QEMU 9.2.0 while the QEMU-related patches need to be aligned with newer upstream sources. This PR updates the QEMU version to 10.2.2, fixes the `002-no-bootable-qmp.patch` context for the new source tree, and restores `003-revert-nehalem-ht-feature.patch` that was removed in commit `811e762b736aede0212f6ae5795d8dff5b8d2d81`.

## What is the expected result?
1. Build the QEMU image with QEMU `v10.2.2` sources.
2. Verify `002-no-bootable-qmp.patch` applies successfully during the build.
3. Verify `003-revert-nehalem-ht-feature.patch` is present in the patch set.
4. Confirm the QEMU source tree is patched successfully and the image build proceeds without the previous patch-apply failure.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: chore
summary: "Update QEMU to 10.2.2 and align QEMU patches with the new source version."
impact_level: low
```
