### PR TITLE
feat(vmop): record virt-handler shutdown as migration failure reason

### DIFF
--- a/api/core/v1alpha2/vmopcondition/condition.go
+++ b/api/core/v1alpha2/vmopcondition/condition.go
@@ -98,6 +98,14 @@ const (
 	// ReasonTargetDiskError indicates that target disk attachment failed.
 	ReasonTargetDiskError ReasonCompleted = "TargetDiskError"
 
+	// ReasonTargetHandlerShutdown indicates that virt-handler on the target node
+	// was shut down during the live migration, breaking the migration proxy channel.
+	ReasonTargetHandlerShutdown ReasonCompleted = "TargetHandlerShutdown"
+
+	// ReasonSourceHandlerShutdown indicates that virt-handler on the source node
+	// was shut down during the live migration, breaking the migration proxy channel.
+	ReasonSourceHandlerShutdown ReasonCompleted = "SourceHandlerShutdown"
+
 	// ReasonTargetPreparing indicates that target pod is being prepared.
 	ReasonTargetPreparing ReasonCompleted = "TargetPreparing"
 

--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -3,7 +3,7 @@ firmware:
   libvirt: v10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: v1.6.2-v12n.34
+  3p-kubevirt: feat/virt-handler/handler-shutdown-migration-reason
   3p-containerized-data-importer: v1.60.3-v12n.19
   distribution: 2.8.3
 package:

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -9,7 +9,7 @@
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
 final: false
 fromImage: builder/src
-fromCacheVersion: 21-05-3"
+fromCacheVersion: 21-05-5"
 secrets:
 - id: SOURCE_REPO
   value: {{ $.SOURCE_REPO }}
@@ -45,7 +45,7 @@ packages:
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: false
 fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alt-1.25" "builder/golang-alt-svace-1.25" }}
-fromCacheVersion: 21-05-3"
+fromCacheVersion: 21-05-5"
 mount:
 {{- include "mount points for golang builds" . }}
 secrets:

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -9,7 +9,7 @@
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
 final: false
 fromImage: builder/src
-fromCacheVersion: 21-05-5"
+fromCacheVersion: 21-05-6"
 secrets:
 - id: SOURCE_REPO
   value: {{ $.SOURCE_REPO }}
@@ -45,7 +45,7 @@ packages:
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: false
 fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alt-1.25" "builder/golang-alt-svace-1.25" }}
-fromCacheVersion: 21-05-5"
+fromCacheVersion: 21-05-6"
 mount:
 {{- include "mount points for golang builds" . }}
 secrets:

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -9,6 +9,7 @@
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
 final: false
 fromImage: builder/src
+fromCacheVersion: 21-05"
 secrets:
 - id: SOURCE_REPO
   value: {{ $.SOURCE_REPO }}
@@ -44,6 +45,7 @@ packages:
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: false
 fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alt-1.25" "builder/golang-alt-svace-1.25" }}
+fromCacheVersion: 21-05"
 mount:
 {{- include "mount points for golang builds" . }}
 secrets:

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -9,7 +9,7 @@
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
 final: false
 fromImage: builder/src
-fromCacheVersion: 21-05"
+fromCacheVersion: 21-05-3"
 secrets:
 - id: SOURCE_REPO
   value: {{ $.SOURCE_REPO }}
@@ -45,7 +45,7 @@ packages:
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: false
 fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alt-1.25" "builder/golang-alt-svace-1.25" }}
-fromCacheVersion: 21-05"
+fromCacheVersion: 21-05-3"
 mount:
 {{- include "mount points for golang builds" . }}
 secrets:

--- a/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle.go
@@ -527,6 +527,9 @@ func (h LifecycleHandler) getFailedReason(mig *virtv1.VirtualMachineInstanceMigr
 		if state.AbortRequested || state.AbortStatus == virtv1.MigrationAbortSucceeded {
 			return vmopcondition.ReasonAborted
 		}
+		if reason := vmopcondition.ReasonCompleted(state.FailureReason); reason == vmopcondition.ReasonTargetHandlerShutdown || reason == vmopcondition.ReasonSourceHandlerShutdown {
+			return reason
+		}
 		if strings.Contains(strings.ToLower(state.FailureReason), "converg") || strings.Contains(strings.ToLower(state.FailureReason), "progress") {
 			return vmopcondition.ReasonNotConverging
 		}
@@ -548,7 +551,7 @@ func (h LifecycleHandler) getFailedReason(mig *virtv1.VirtualMachineInstanceMigr
 func (h LifecycleHandler) getFailedMessage(reason vmopcondition.ReasonCompleted, mig *virtv1.VirtualMachineInstanceMigration) string {
 	base := "Migration failed"
 	switch reason {
-	case vmopcondition.ReasonAborted:
+	case vmopcondition.ReasonAborted, vmopcondition.ReasonTargetHandlerShutdown, vmopcondition.ReasonSourceHandlerShutdown:
 		base = "Migration aborted"
 	case vmopcondition.ReasonNotConverging:
 		base = "Migration did not converge"

--- a/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle_test.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle_test.go
@@ -362,9 +362,33 @@ var _ = Describe("LifecycleHandler", func() {
 				&virtv1.VirtualMachineInstanceMigration{Status: virtv1.VirtualMachineInstanceMigrationStatus{Conditions: []virtv1.VirtualMachineInstanceMigrationCondition{{Type: virtv1.VirtualMachineInstanceMigrationFailed, Reason: "VolumeAttach", Message: "csi volume attach failed"}}}},
 				vmopcondition.ReasonTargetDiskError,
 			),
+			Entry("target virt-handler shutdown from failure reason",
+				&virtv1.VirtualMachineInstanceMigration{Status: virtv1.VirtualMachineInstanceMigrationStatus{MigrationState: &virtv1.VirtualMachineInstanceMigrationState{FailureReason: vmopcondition.ReasonTargetHandlerShutdown.String()}}},
+				vmopcondition.ReasonTargetHandlerShutdown,
+			),
+			Entry("source virt-handler shutdown from failure reason",
+				&virtv1.VirtualMachineInstanceMigration{Status: virtv1.VirtualMachineInstanceMigrationStatus{MigrationState: &virtv1.VirtualMachineInstanceMigrationState{FailureReason: vmopcondition.ReasonSourceHandlerShutdown.String()}}},
+				vmopcondition.ReasonSourceHandlerShutdown,
+			),
 			Entry("generic failed reason",
 				&virtv1.VirtualMachineInstanceMigration{},
 				vmopcondition.ReasonFailed,
+			),
+		)
+
+		DescribeTable("should render handler-shutdown failure message", func(reason vmopcondition.ReasonCompleted, mig *virtv1.VirtualMachineInstanceMigration, expected string) {
+			h := LifecycleHandler{}
+			Expect(h.getFailedMessage(reason, mig)).To(Equal(expected))
+		},
+			Entry("target shutdown",
+				vmopcondition.ReasonTargetHandlerShutdown,
+				&virtv1.VirtualMachineInstanceMigration{Status: virtv1.VirtualMachineInstanceMigrationStatus{MigrationState: &virtv1.VirtualMachineInstanceMigrationState{TargetNode: "worker-1", FailureReason: vmopcondition.ReasonTargetHandlerShutdown.String()}}},
+				"Migration aborted: TargetHandlerShutdown",
+			),
+			Entry("source shutdown",
+				vmopcondition.ReasonSourceHandlerShutdown,
+				&virtv1.VirtualMachineInstanceMigration{Status: virtv1.VirtualMachineInstanceMigrationStatus{MigrationState: &virtv1.VirtualMachineInstanceMigrationState{SourceNode: "master-0", FailureReason: vmopcondition.ReasonSourceHandlerShutdown.String()}}},
+				"Migration aborted: SourceHandlerShutdown",
 			),
 		)
 

--- a/images/virtualization-artifact/pkg/monitoring/metrics/vmop/data_metric.go
+++ b/images/virtualization-artifact/pkg/monitoring/metrics/vmop/data_metric.go
@@ -42,12 +42,14 @@ var successfulTerminalReasons = map[string]struct{}{
 }
 
 var failedTerminalReasons = map[string]struct{}{
-	vmopcondition.ReasonOperationFailed.String():     {},
-	vmopcondition.ReasonFailed.String():              {},
-	vmopcondition.ReasonAborted.String():             {},
-	vmopcondition.ReasonNotConverging.String():       {},
-	vmopcondition.ReasonTargetUnschedulable.String(): {},
-	vmopcondition.ReasonTargetDiskError.String():     {},
+	vmopcondition.ReasonOperationFailed.String():       {},
+	vmopcondition.ReasonFailed.String():                {},
+	vmopcondition.ReasonAborted.String():               {},
+	vmopcondition.ReasonNotConverging.String():         {},
+	vmopcondition.ReasonTargetUnschedulable.String():   {},
+	vmopcondition.ReasonTargetDiskError.String():       {},
+	vmopcondition.ReasonTargetHandlerShutdown.String(): {},
+	vmopcondition.ReasonSourceHandlerShutdown.String(): {},
 }
 
 // DO NOT mutate VirtualMachineOperation!


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section:
type:
summary:
```
