### PR TITLE
chore(ci): update timeout for nested e2e bootstrap

### DIFF
--- a/.github/workflows/e2e-reusable-pipeline.yml
+++ b/.github/workflows/e2e-reusable-pipeline.yml
@@ -313,7 +313,7 @@ jobs:
 
           task dhctl-bootstrap
           echo "[SUCCESS] Done"
-        timeout-minutes: 45
+        timeout-minutes: 60
       - name: Bootstrap cluster [show-connection-info]
         working-directory: ${{ env.SETUP_CLUSTER_TYPE_PATH }}
         run: |

--- a/.github/workflows/e2e-reusable-pipeline.yml
+++ b/.github/workflows/e2e-reusable-pipeline.yml
@@ -313,7 +313,7 @@ jobs:
 
           task dhctl-bootstrap
           echo "[SUCCESS] Done"
-        timeout-minutes: 30
+        timeout-minutes: 45
       - name: Bootstrap cluster [show-connection-info]
         working-directory: ${{ env.SETUP_CLUSTER_TYPE_PATH }}
         run: |


### PR DESCRIPTION
## Description
Increase the timeout for the nested E2E cluster bootstrap step in the reusable pipeline from 30 to 60 minutes.

## Why do we need it, and what problem does it solve?
Nested cluster bootstrap may take longer than 30 minutes in matrix E2E runs. In such cases the workflow fails because of the bootstrap step timeout even though the cluster setup is still progressing normally.

Increasing the timeout reduces false-negative CI failures for nested E2E jobs.

## What is the expected result?
1. Run the nested E2E matrix workflow.
2. Verify that the reusable pipeline allows up to 60 minutes for the `Bootstrap cluster [dhctl-bootstrap]` step.
3. Confirm that replicated and NFS jobs use the updated timeout.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.



