### PR TITLE
chore(test): fix command to create generic-for-e2e vmclass

### DIFF
--- a/test/e2e/internal/precheck/vmc.go
+++ b/test/e2e/internal/precheck/vmc.go
@@ -125,7 +125,7 @@ func (c *vmcPrecheck) Run(ctx context.Context, f *framework.Framework) error {
 		cmds = append(cmds, cmdCopyGenericAsDefaultClass(defaultVMClassName))
 	}
 
-	return fmt.Errorf("%s=no to disable this precheck: %s. Run command to fix cluster: %s",
+	return fmt.Errorf("%s=no to disable this precheck. Cluster has issues: %s. Run command to fix: %s",
 		vmcModuleCheckEnvName,
 		strings.Join(issues, "; "),
 		strings.Join(cmds, " && "),

--- a/test/e2e/internal/precheck/vmc.go
+++ b/test/e2e/internal/precheck/vmc.go
@@ -30,9 +30,10 @@ import (
 
 const (
 	vmcModuleCheckEnvName = "VMC_PRECHECK"
-	defaultVMClassName    = "generic-for-e2e"
+	requiredVMClassName   = "generic-for-e2e"
 
-	vmClassVersion = "v1alpha3"
+	vmClassVersion         = "v1alpha3"
+	defaultClassAnnotation = "virtualmachineclass.virtualization.deckhouse.io/is-default-class"
 )
 
 // vmcPrecheck implements Precheck interface for VMC/VMClass.
@@ -61,55 +62,47 @@ func (c *vmcPrecheck) Run(ctx context.Context, f *framework.Framework) error {
 		return fmt.Errorf("%s=no to disable this precheck: list VirtualMachineClasses: %w", vmcModuleCheckEnvName, err)
 	}
 
-	var e2eClass map[string]interface{}
-	var defaultClass map[string]interface{}
+	var requiredClass map[string]interface{} // VMClass with requiredVMClassName
+	var defaultClass map[string]interface{}  // VMClass with is-default-class annotation
 
+	// Single pass through all VMClasses
 	for i := range vmClasses.Items {
 		vmClass := vmClasses.Items[i].Object
-		name, ok := vmClass["metadata"].(map[string]interface{})["name"].(string)
-		if !ok {
-			continue
-		}
 
-		if name == defaultVMClassName {
-			e2eClass = vmClass
-		}
-
-		// Check for default annotation
 		metadata, ok := vmClass["metadata"].(map[string]interface{})
 		if !ok {
 			continue
 		}
+
+		name, ok := metadata["name"].(string)
+		if !ok {
+			continue
+		}
+
+		// Check if this is the required e2e class
+		if name == requiredVMClassName {
+			requiredClass = vmClass
+		}
+
+		// Check for default annotation
 		annotations, ok := metadata["annotations"].(map[string]interface{})
 		if !ok {
 			continue
 		}
-		if _, ok := annotations["virtualmachineclass.virtualization.deckhouse.io/is-default-class"]; ok {
+		if _, isDefault := annotations[defaultClassAnnotation]; isDefault {
 			defaultClass = vmClass
 		}
 	}
 
-	// Helper to get name from vmClass
-	getVMClassName := func(m map[string]interface{}) string {
-		if m == nil {
-			return ""
-		}
-		metadata, ok := m["metadata"].(map[string]interface{})
-		if !ok {
-			return ""
-		}
-		name, _ := metadata["name"].(string)
-		return name
-	}
-
-	if e2eClass != nil && defaultClass != nil && getVMClassName(defaultClass) == defaultVMClassName {
-		// Everything is OK: correct default VMClass is present in the cluster.
+	// Check if everything is OK: required class exists AND it is the default
+	if requiredClass != nil && defaultClass != nil && getVMClassName(defaultClass) == requiredVMClassName {
 		return nil
 	}
 
-	issues := make([]string, 0)
-	cmds := make([]string, 0)
+	// Build issues and fix commands
+	var issues, cmds []string
 
+	// Handle default class issue
 	if defaultClass != nil {
 		issues = append(issues, fmt.Sprintf("cluster has wrong default vmclass %q", getVMClassName(defaultClass)))
 		cmds = append(cmds, cmdRemoveDefaultAnnotation(getVMClassName(defaultClass)))
@@ -117,12 +110,15 @@ func (c *vmcPrecheck) Run(ctx context.Context, f *framework.Framework) error {
 		issues = append(issues, "cluster has no default vmclass")
 	}
 
-	if e2eClass != nil {
-		issues = append(issues, fmt.Sprintf("e2e tests require vmclass %q to be default", defaultVMClassName))
-		cmds = append(cmds, cmdSetDefaultAnnotation(defaultVMClassName))
+	// Handle required class issue
+	if requiredClass != nil {
+		// Required class exists but is not default - just need to set annotation
+		issues = append(issues, fmt.Sprintf("e2e tests require vmclass %q to be default", requiredVMClassName))
+		cmds = append(cmds, cmdSetDefaultAnnotation(requiredVMClassName))
 	} else {
-		issues = append(issues, fmt.Sprintf("e2e tests require vmclass %q to present and be default", defaultVMClassName))
-		cmds = append(cmds, cmdCopyGenericAsDefaultClass(defaultVMClassName))
+		// Required class doesn't exist - need to create it
+		issues = append(issues, fmt.Sprintf("e2e tests require vmclass %q to present and be default", requiredVMClassName))
+		cmds = append(cmds, cmdCopyGenericAsDefaultClass(requiredVMClassName))
 	}
 
 	return fmt.Errorf("%s=no to disable this precheck. Cluster has issues: %s. Run command to fix: %s",
@@ -130,6 +126,19 @@ func (c *vmcPrecheck) Run(ctx context.Context, f *framework.Framework) error {
 		strings.Join(issues, "; "),
 		strings.Join(cmds, " && "),
 	)
+}
+
+// getVMClassName extracts name from VMClass object
+func getVMClassName(m map[string]interface{}) string {
+	if m == nil {
+		return ""
+	}
+	metadata, ok := m["metadata"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	name, _ := metadata["name"].(string)
+	return name
 }
 
 func cmdCopyGenericAsDefaultClass(targetVMClassName string) string {

--- a/test/e2e/internal/precheck/vmc.go
+++ b/test/e2e/internal/precheck/vmc.go
@@ -19,6 +19,7 @@ package precheck
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -101,29 +102,46 @@ func (c *vmcPrecheck) Run(ctx context.Context, f *framework.Framework) error {
 		return name
 	}
 
-	// Check if default VMClass exists and is correct
-	switch {
-	case e2eClass != nil && defaultClass != nil && getVMClassName(defaultClass) == defaultVMClassName:
-		// OK
-	case e2eClass != nil && defaultClass != nil:
-		return fmt.Errorf("%s=no to disable this precheck: cluster has wrong default class %q, e2e tests require %q to be default",
-			vmcModuleCheckEnvName, getVMClassName(defaultClass), defaultVMClassName)
-	case e2eClass == nil && defaultClass != nil:
-		return fmt.Errorf("%s=no to disable this precheck: cluster has wrong default class %q, e2e tests require %q to be default",
-			vmcModuleCheckEnvName, getVMClassName(defaultClass), defaultVMClassName)
-	case e2eClass != nil && defaultClass == nil:
-		return fmt.Errorf("%s=no to disable this precheck: cluster has no default class, e2e tests require %q to be default. Run: kubectl annotate vmclass/%s virtualmachineclass.virtualization.deckhouse.io/is-default-class=true",
-			vmcModuleCheckEnvName, defaultVMClassName, defaultVMClassName)
-	case e2eClass == nil && defaultClass == nil:
-		return fmt.Errorf("%s=no to disable this precheck: cluster has no default class and no %q class. Run: %s",
-			vmcModuleCheckEnvName, defaultVMClassName, cmdCopyGenericAsDefaultClass(defaultVMClassName))
+	if e2eClass != nil && defaultClass != nil && getVMClassName(defaultClass) == defaultVMClassName {
+		// Everything is OK: correct default VMClass is present in the cluster.
+		return nil
 	}
 
-	return nil
+	issues := make([]string, 0)
+	cmds := make([]string, 0)
+
+	if defaultClass != nil {
+		issues = append(issues, fmt.Sprintf("cluster has wrong default vmclass %q", getVMClassName(defaultClass)))
+		cmds = append(cmds, cmdRemoveDefaultAnnotation(getVMClassName(defaultClass)))
+	} else {
+		issues = append(issues, "cluster has no default vmclass")
+	}
+
+	if e2eClass != nil {
+		issues = append(issues, fmt.Sprintf("e2e tests require vmclass %q to be default", defaultVMClassName))
+		cmds = append(cmds, cmdSetDefaultAnnotation(defaultVMClassName))
+	} else {
+		issues = append(issues, fmt.Sprintf("e2e tests require vmclass %q to present and be default", defaultVMClassName))
+		cmds = append(cmds, cmdCopyGenericAsDefaultClass(defaultVMClassName))
+	}
+
+	return fmt.Errorf("%s=no to disable this precheck: %s. Run command to fix cluster: %s",
+		vmcModuleCheckEnvName,
+		strings.Join(issues, "; "),
+		strings.Join(cmds, " && "),
+	)
 }
 
 func cmdCopyGenericAsDefaultClass(targetVMClassName string) string {
 	return fmt.Sprintf(`kubectl get vmclass/generic -o json | jq 'del(.status) | del(.metadata) | .metadata = {"name":"%s","annotations":{"virtualmachineclass.virtualization.deckhouse.io/is-default-class":"true"}} ' | kubectl create -f -`, targetVMClassName)
+}
+
+func cmdRemoveDefaultAnnotation(targetVMClassName string) string {
+	return fmt.Sprintf(`kubectl annotate vmclass/%s virtualmachineclass.virtualization.deckhouse.io/is-default-class=-`, targetVMClassName)
+}
+
+func cmdSetDefaultAnnotation(targetVMClassName string) string {
+	return fmt.Sprintf(`kubectl annotate vmclass/%s virtualmachineclass.virtualization.deckhouse.io/is-default-class=true`, targetVMClassName)
 }
 
 // Register VMC precheck as common (runs for all tests).

--- a/test/e2e/internal/precheck/vmc.go
+++ b/test/e2e/internal/precheck/vmc.go
@@ -115,11 +115,15 @@ func (c *vmcPrecheck) Run(ctx context.Context, f *framework.Framework) error {
 		return fmt.Errorf("%s=no to disable this precheck: cluster has no default class, e2e tests require %q to be default. Run: kubectl annotate vmclass/%s virtualmachineclass.virtualization.deckhouse.io/is-default-class=true",
 			vmcModuleCheckEnvName, defaultVMClassName, defaultVMClassName)
 	case e2eClass == nil && defaultClass == nil:
-		return fmt.Errorf("%s=no to disable this precheck: cluster has no default class and no %q class. Run: kubectl get vmclass/generic -o json | jq 'del(.status) | .metadata.annotations = {\"virtualmachineclass.virtualization.deckhouse.io/is-default-class\":\"true\"}' | kubectl create -f -",
-			vmcModuleCheckEnvName, defaultVMClassName)
+		return fmt.Errorf("%s=no to disable this precheck: cluster has no default class and no %q class. Run: %s",
+			vmcModuleCheckEnvName, defaultVMClassName, cmdCopyGenericAsDefaultClass(defaultVMClassName))
 	}
 
 	return nil
+}
+
+func cmdCopyGenericAsDefaultClass(targetVMClassName string) string {
+	return fmt.Sprintf(`kubectl get vmclass/generic -o json | jq 'del(.status) | del(.metadata) | .metadata = {"name":"%s","annotations":{"virtualmachineclass.virtualization.deckhouse.io/is-default-class":"true"}} ' | kubectl create -f -`, targetVMClassName)
 }
 
 // Register VMC precheck as common (runs for all tests).


### PR DESCRIPTION
## Description

Fix command suggestion in default vmclass precheck.

## Why do we need it, and what problem does it solve?

Command was wrong.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->

Dev cluster admin can create copy of vmclass/generic and run e2e tests.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->
