### PR TITLE
revert(vd): revert allowing ingress from virtualization namespace to uploader pods

### DIFF
--- a/images/virtualization-artifact/pkg/common/network_policy/network_policy.go
+++ b/images/virtualization-artifact/pkg/common/network_policy/network_policy.go
@@ -52,21 +52,8 @@ func CreateNetworkPolicy(ctx context.Context, c client.Client, obj metav1.Object
 					},
 				},
 			},
-			Ingress: []netv1.NetworkPolicyIngressRule{
-				{
-					From: []netv1.NetworkPolicyPeer{
-						{
-							NamespaceSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									"module": "virtualization",
-								},
-							},
-						},
-					},
-				},
-			},
 			Egress:      []netv1.NetworkPolicyEgressRule{{}},
-			PolicyTypes: []netv1.PolicyType{netv1.PolicyTypeIngress, netv1.PolicyTypeEgress},
+			PolicyTypes: []netv1.PolicyType{netv1.PolicyTypeEgress},
 		},
 	}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Reverts the changes introduced in commit 67b70fa886a43fb5e503cd97b71c9cdf1aa3c24b which added an Ingress rule to NetworkPolicy for uploader pods.

The original fix added an Ingress rule allowing traffic only from namespaces labeled with `module: virtualization`. This was intended to allow the CDI controller to scrape progress metrics from importer pods in isolated namespaces. However, this breaks the e2e DataExport test because the uploader pod is accessed via the Ingress controller, which is located in a different namespace (e.g., d8-ingress-nginx) with label `module: ingress-nginx`.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
The e2e test `DataExports exports VirtualDisk and VirtualDiskSnapshot, then restores data via upload` fails with the following error:

```
failed to sync virtual disk data source upload: failed to get upload server status: Get "https://virtualization.example.com/upload/...": context deadline exceeded
```

The request flow in the test:
1. Test sends HTTP request to the Ingress URL
2. Request hits the Ingress controller pod (in d8-ingress-nginx namespace)
3. Ingress controller proxies the request to the uploader pod
4. NetworkPolicy blocks this because the source namespace has `module: ingress-nginx` label, not `module: virtualization`

The fix reverts the Ingress rule addition, restoring the previous behavior where only Egress policy was applied.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
The e2e test `DataExports` should pass after this revert.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: core
type: chore
summary: "Reverted NetworkPolicy Ingress rule that broke e2e DataExport test. The Ingress rule was blocking traffic from ingress controller namespaces."
impact_level: low
```
