### PR TITLE
chore(ci): improve generate kubeconfig for nested cluster

### DIFF
--- a/test/dvp-static-cluster/scripts/gen-kubeconfig.sh
+++ b/test/dvp-static-cluster/scripts/gen-kubeconfig.sh
@@ -161,9 +161,19 @@ log_success "SA, Secrets and ClusterAuthorizationRule applied"
 
 kubeconfig_cert_cluster_section() {
   log_info "Set cluster config"
+
+  local api_host
+  if api_host=$(kubectl -n d8-user-authn get ing kubernetes-api -ojson 2>/dev/null | jq -r '.spec.rules[].host' | head -1) && [ -n "$api_host" ]; then
+    log_info "Found kubernetes-api ingress in d8-user-authn"
+  elif api_host=$(kubectl -n kube-system get ing kubernetes-api -ojson 2>/dev/null | jq -r '.spec.rules[].host' | head -1) && [ -n "$api_host" ]; then
+    log_info "Found kubernetes-api ingress in kube-system"
+  else
+    exit_with_error "kubernetes-api ingress not found in d8-user-authn or kube-system"
+  fi
+
   kubectl config set-cluster "${CLUSTER_NAME}" \
     --insecure-skip-tls-verify=true \
-    --server=https://"$(kubectl -n d8-user-authn get ing kubernetes-api -ojson | jq '.spec.rules[].host' -r)" \
+    --server=https://"${api_host}" \
     --kubeconfig="${FILE_NAME}"
 }
 


### PR DESCRIPTION
## Description
Update `gen-kubeconfig.sh` to search for the `kubernetes-api` ingress in `kube-system` as a fallback after `d8-user-authn`.

## Why do we need it, and what problem does it solve?
In Deckhouse 1.76, the `kubernetes-api` ingress moved to the `kube-system` namespace. Without the fallback, kubeconfig generation for nested clusters fails on newer Deckhouse versions.

## What is the expected result?
`gen-kubeconfig.sh` successfully generates kubeconfig on clusters where `kubernetes-api` ingress is located either in `d8-user-authn` or in `kube-system`.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: chore
summary: Support Kubernetes API ingress lookup in kube-system during nested cluster kubeconfig generation.
impact_level: low
```
