### PR TITLE
fix(rbac): allow listing nodes for VM migration

### DIFF
--- a/templates/rbacv2/use/capabilities/execute_virtualmachine_operations.yaml
+++ b/templates/rbacv2/use/capabilities/execute_virtualmachine_operations.yaml
@@ -18,3 +18,10 @@ rules:
   - patch
   - delete
   - deletecollection
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+  - watch

--- a/templates/user-authz-cluster-roles.yaml
+++ b/templates/user-authz-cluster-roles.yaml
@@ -87,6 +87,13 @@ rules:
   - deletecollection
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
## Description

Grant virtualization users permission to list and watch Kubernetes Nodes when executing virtual machine operations.

The Console migration dialog checks `canI({ resource: 'nodes' }, ['list', 'watch'])` before enabling the "Migrate to the selected node" option and uses the node list to build available migration targets.

## Why do we need it, and what problem does it solve?

Users with VM operation permissions could initiate migration to an arbitrary node, but the Console disabled migration to a selected node with a "Not enough rights" tooltip because the role did not include Node list/watch permissions.

This fix aligns virtualization RBAC with the Console permission check and allows eligible users to select a target node for VM migration.

## What is the expected result?

1. Open a running VM migration dialog in Console as a user with virtualization operation permissions.
2. Verify that "Migrate to the selected node" is enabled outside CE edition.
3. Select an available target node and start migration.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: module
type: fix
summary: Allow users with VM operation permissions to select a target node for virtual machine migration in Console.
impact_level: low
```
