### PR TITLE
fix(disks, images): allow provisioning traffic in isolated projects

### DIFF
--- a/images/virtualization-artifact/pkg/common/network_policy/network_policy.go
+++ b/images/virtualization-artifact/pkg/common/network_policy/network_policy.go
@@ -19,14 +19,24 @@ package networkpolicy
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/deckhouse/virtualization-controller/pkg/common/annotations"
 	"github.com/deckhouse/virtualization-controller/pkg/common/object"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/supplements"
+)
+
+const (
+	moduleNamespaceLabelName = "module"
+	moduleVirtualization     = "virtualization"
+
+	provisioningMetricsPort = 8443
+	uploaderPort            = 8444
 )
 
 func CreateNetworkPolicy(ctx context.Context, c client.Client, obj metav1.Object, sup supplements.DataVolumeSupplement, finalizer string) error {
@@ -52,13 +62,53 @@ func CreateNetworkPolicy(ctx context.Context, c client.Client, obj metav1.Object
 					},
 				},
 			},
+			Ingress: []netv1.NetworkPolicyIngressRule{
+				{
+					From: []netv1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									moduleNamespaceLabelName: moduleVirtualization,
+								},
+							},
+						},
+					},
+					Ports: []netv1.NetworkPolicyPort{
+						tcpPort(provisioningMetricsPort),
+					},
+				},
+				{
+					From: []netv1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									annotations.HeritageLabel: annotations.HeritageValue,
+								},
+							},
+						},
+					},
+					Ports: []netv1.NetworkPolicyPort{
+						tcpPort(uploaderPort),
+					},
+				},
+			},
 			Egress:      []netv1.NetworkPolicyEgressRule{{}},
-			PolicyTypes: []netv1.PolicyType{netv1.PolicyTypeEgress},
+			PolicyTypes: []netv1.PolicyType{netv1.PolicyTypeIngress, netv1.PolicyTypeEgress},
 		},
 	}
 
 	err := c.Create(ctx, &networkPolicy)
 	return client.IgnoreAlreadyExists(err)
+}
+
+func tcpPort(port int) netv1.NetworkPolicyPort {
+	protocol := corev1.ProtocolTCP
+	targetPort := intstr.FromInt(port)
+
+	return netv1.NetworkPolicyPort{
+		Protocol: &protocol,
+		Port:     &targetPort,
+	}
 }
 
 func GetNetworkPolicy(ctx context.Context, client client.Client, legacyName types.NamespacedName, sup supplements.Generator) (*netv1.NetworkPolicy, error) {


### PR DESCRIPTION
## Description
Allow the virtualization controller to scrape provisioning metrics and Deckhouse-managed components to reach uploader pods in isolated projects.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: disks, images
type: fix
summary: allow provisioning traffic in isolated projects
```
