### PR TITLE
fix(vm): bump 3p-kubevirt to fix migration failure for filesystem-backed hotplug disks

### DIFF
--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -3,7 +3,7 @@ firmware:
   libvirt: v10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: v1.6.2-v12n.38
+  3p-kubevirt: v1.6.2-v12n.39
   3p-containerized-data-importer: v1.60.3-v12n.19
   distribution: 2.8.3
 package:


### PR DESCRIPTION
## Description
Bump `3p-kubevirt` version with two fixes for hotplug disks on filesystem volumes:
- Fix incorrect path to the hotplug disk image, which prevented real volume size detection.
- Fix missing real-size check when creating a qcow2 image on the migration target for filesystem-backed hotplug disks.

https://github.com/deckhouse/3p-kubevirt/pull/119

## Why do we need it, and what problem does it solve?
During VM migration, the target disk was created with incorrect size for filesystem-backed hotplug volumes. Since source and target disk sizes must match, migration was failing.

## What is the expected result?
1. Attach a filesystem-backed hotplug disk to a VM.
2. Trigger a migration.
3. Migration completes successfully.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: vm
type: fix
summary: "Fix VM migration failure caused by incorrect target disk size for filesystem-backed hotplug volumes."
```
