### PR TITLE
test(test): simplify lsblk size lookup

### DIFF
--- a/test/e2e/internal/util/block_device.go
+++ b/test/e2e/internal/util/block_device.go
@@ -112,18 +112,21 @@ func GetBlockDeviceLsblkSize(ctx context.Context, f *framework.Framework, vm *v1
 	serial, ok := GetBlockDeviceSerialNumber(ctx, vm, bdKind, bdName)
 	Expect(ok).To(BeTrue(), fmt.Sprintf("failed to get block device %s/%s serial number", bdKind, bdName))
 
-	devicePath, err := GetBlockDeviceBySerial(f, vm, serial)
-	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to get device %s/%s by serial", bdKind, bdName))
-
-	cmdOut, err := f.SSHCommand(vm.Name, vm.Namespace, fmt.Sprintf("sudo lsblk --json -o SIZE %s", devicePath))
-	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to get lsblk size for block device %s/%s", bdKind, bdName))
+	cmdOut, err := f.SSHCommand(vm.Name, vm.Namespace, "sudo lsblk --nodeps --json -o SERIAL,SIZE")
+	Expect(err).NotTo(HaveOccurred())
 
 	var disks Disks
 	err = json.Unmarshal([]byte(cmdOut), &disks)
 	Expect(err).NotTo(HaveOccurred(), "failed to parse lsblk output")
-	Expect(disks.BlockDevices).NotTo(BeEmpty(), "lsblk output does not contain block devices")
 
-	return resource.MustParse(strings.TrimSpace(disks.BlockDevices[0].Size))
+	for _, blockDevice := range disks.BlockDevices {
+		if blockDevice.Serial == serial {
+			return resource.MustParse(strings.TrimSpace(blockDevice.Size))
+		}
+	}
+
+	Fail(fmt.Sprintf("lsblk output does not contain block device with serial %s", serial))
+	return resource.Quantity{}
 }
 
 func GetBlockDeviceBySerial(f *framework.Framework, vm *v1alpha2.VirtualMachine, serial string) (string, error) {
@@ -243,7 +246,8 @@ type Disks struct {
 
 // BlockDevice represents a single block device in the lsblk JSON output.
 type BlockDevice struct {
-	Name string `json:"name"`
-	Size string `json:"size"`
-	Type string `json:"type"`
+	Name   string `json:"name"`
+	Serial string `json:"serial"`
+	Size   string `json:"size"`
+	Type   string `json:"type"`
 }


### PR DESCRIPTION
## Description

Simplify disk size lookup in the `VirtualDiskResizing` e2e test.

The test now uses a single `lsblk --nodeps --json -o SERIAL,SIZE` call and selects the required block device by serial from JSON output, instead of first resolving the device path and then running a second `lsblk` command for size.

## Why do we need it, and what problem does it solve?

`VirtualDiskResizing` could fail while probing disk sizes because the previous implementation executed multiple SSH commands with `lsblk`/`grep`/`awk`. Under hotplug/resize activity this made the check more fragile and increased the chance of timeout-related `signal: killed` errors.

Using one simple JSON-based `lsblk` call reduces the amount of SSH work and avoids shell parsing for device path lookup.

## What is the expected result?

1. Run `VirtualDiskResizing` e2e test.
2. Verify disk size checks find the expected devices by serial.
3. Verify `test/e2e` lint reports no issues.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: test
type: fix
summary: Simplify VirtualDiskResizing disk size checks to reduce SSH command flakiness.
impact_level: low
```
