### PR TITLE
chore(ci): add unit test js/python scripts

### DIFF
--- a/.github/workflows/dev_module_build.yml
+++ b/.github/workflows/dev_module_build.yml
@@ -325,6 +325,52 @@ jobs:
           task virtualization-controller:init
           task virtualization-controller:test:unit
 
+  test_scripts_js:
+    runs-on: ubuntu-22.04
+    name: Run JS unit tests
+    env:
+      NODE_VERSION: "24"
+    steps:
+      - name: Set up Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: "${{ env.NODE_VERSION }}"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Install JS dependencies
+        working-directory: .github/scripts/js
+        run: npm install
+
+      - name: Run JS unit tests
+        working-directory: .github/scripts/js
+        run: npm test
+
+  test_scripts_python:
+    runs-on: ubuntu-22.04
+    name: Run Python unit tests
+    env:
+      PYTHON_VERSION: "3.12"
+    steps:
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: "${{ env.PYTHON_VERSION }}"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Install Python dependencies
+        working-directory: .github/scripts/python
+        run: pip install -r requirements.txt
+
+      - name: Run Python unit tests
+        working-directory: .github/scripts/python
+        run: python -m unittest discover -p '*_test.py' -v
+
   dev_setup_build:
     runs-on: ${{ fromJSON(needs.set_vars.outputs.runner_type)}}
     name: Build and Push images


### PR DESCRIPTION
## Description
Adds CI coverage for scripts under `.github/scripts` in `dev_module_build.yml`:

- `Run JS scripts unit tests` runs `.github/scripts/js` tests with Node.js 24 and `npm install && npm test`.
- `Run Python scripts unit tests` runs `.github/scripts/python` tests with Python 3.12 and `python -m unittest discover`.

Both jobs are independent and run alongside the existing lint/test jobs on the workflow's existing triggers.

## Why do we need it, and what problem does it solve?
The repository already contains unit tests for the GitHub helper scripts, but the dev module build workflow did not execute them. As a result, regressions in CI/e2e helper scripts could be merged without being caught before those scripts are used by other workflows.

This PR makes those tests visible as regular GitHub Actions checks.

## What is the expected result?
For every `dev_module_build.yml` run, GitHub Actions starts two additional checks:

- `Run JS unit tests`
- `Run Python unit tests`

The PR is expected to pass only when the JS Jest tests and Python unittest suite for `.github/scripts` pass.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes. Not required: CI-only change.
- [x] Changes were tested in the Kubernetes cluster manually. Not required: CI-only change.

## Changelog entries

```changes
section: ci
type: chore
summary: Run GitHub scripts unit tests in the dev module build workflow.
```