### PR TITLE
fix(vm): failed hp pod mount

### DIFF
--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -3,7 +3,7 @@ firmware:
   libvirt: v10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: v1.6.2-v12n.37
+  3p-kubevirt: v1.6.2-v12n.38
   3p-containerized-data-importer: v1.60.3-v12n.19
   distribution: 2.8.3
 package:


### PR DESCRIPTION
## Description
Updates the `3p-kubevirt` component reference to the branch that contains the virt-handler hotplug mount fix.

The referenced KubeVirt change makes virt-handler skip stale hotplug `VolumeStatus` entries that are no longer present in `VMI.spec.volumes` during the mount phase.

## Why do we need it, and what problem does it solve?
When a hotplug disk is removed from a VM, KubeVirt can keep a stale `Ready` volume status for a disk that is already absent from `VMI.spec.volumes`. virt-handler then tries to mount this stale volume from an old hp pod path, fails before housekeeping/unmount is executed, and old `d8v-hp-*` pods remain running.

This update pulls the KubeVirt fix that prevents mount from processing removed hotplug volumes, allowing the normal unmount/status cleanup flow to continue.

## What is the expected result?
1. Remove a hotplug disk from a running VM.
2. Verify virt-handler does not fail while mounting stale hotplug status entries.
3. Verify stale hotplug volumes can transition to cleanup and old `d8v-hp-*` pods are deleted.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: core
type: fix
summary: Fix cleanup of stale hotplug attachment pods after removing VM disks.
impact_level: low
```
