### PR TITLE
feat(cli): add multi lifecycle operations with label-selector and confirmation prompt

### DIFF
--- a/src/cli/internal/cmd/lifecycle/evict.go
+++ b/src/cli/internal/cmd/lifecycle/evict.go
@@ -28,7 +28,6 @@ func NewEvictCommand() *cobra.Command {
 		Use:     "evict (VirtualMachine)",
 		Short:   "Evict a virtual machine.",
 		Example: lifecycle.Usage(),
-		Args:    templates.ExactArgs("evict", 1),
 		RunE:    lifecycle.Run,
 	}
 	AddCommandLineArgs(cmd.Flags(), &lifecycle.opts)

--- a/src/cli/internal/cmd/lifecycle/lifecycle.go
+++ b/src/cli/internal/cmd/lifecycle/lifecycle.go
@@ -90,6 +90,7 @@ type Options struct {
 	Force        bool
 	WaitComplete bool
 	CreateOnly   bool
+	All          bool
 	Timeout      time.Duration
 }
 
@@ -102,40 +103,79 @@ func (l *Lifecycle) Run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	name, namespace, err := l.getNameNamespace(defaultNamespace, args)
-	key := types.NamespacedName{Namespace: namespace, Name: name}
-	if err != nil {
-		return err
+
+	if len(args) > 0 && l.opts.All {
+		return fmt.Errorf("cannot use --all flag with specific keys")
 	}
+
+	var keys []types.NamespacedName
+	if l.opts.All {
+		keys, err = l.getVirtualMachines(cmd.Context(), defaultNamespace, client)
+		if err != nil {
+			return fmt.Errorf("failed to get virtual machines in namespace %q: %w", defaultNamespace, err)
+		}
+	} else {
+		keys, err = l.getNamespacedNames(defaultNamespace, args)
+		if err != nil {
+			return fmt.Errorf("failed to parse keys: %w", err)
+		}
+	}
+
+	if len(keys) == 0 {
+		return fmt.Errorf("no one virtual machine found for execute command")
+	}
+
 	forceSet := cmd.Flags().Changed(forceFlag)
-	mgr := l.getManager(client, forceSet)
+	mgr := l.getManager(client, forceSet, len(keys) > 1)
 
 	ctx, cancel := context.WithTimeout(context.Background(), l.opts.Timeout)
 	defer cancel()
-	var msg string
+
 	switch l.cmd {
 	case Stop:
-		cmd.Printf("Stopping virtual machine %q\n", key.String())
-		msg, err = mgr.Stop(ctx, name, namespace)
+		for _, key := range keys {
+			cmd.Printf("Stopping virtual machine %q\n", key.String())
+			msg, err := mgr.Stop(ctx, key.Name, key.Namespace)
+			l.handleMsgError(cmd, msg, err)
+		}
 	case Start:
-		cmd.Printf("Starting virtual machine %q\n", key.String())
-		msg, err = mgr.Start(ctx, name, namespace)
+		for _, key := range keys {
+			cmd.Printf("Starting virtual machine %q\n", key.String())
+			msg, err := mgr.Start(ctx, key.Name, key.Namespace)
+			l.handleMsgError(cmd, msg, err)
+		}
 	case Restart:
-		cmd.Printf("Restarting virtual machine %q\n", key.String())
-		msg, err = mgr.Restart(ctx, name, namespace)
+		for _, key := range keys {
+			cmd.Printf("Restarting virtual machine %q\n", key.String())
+			msg, err := mgr.Restart(ctx, key.Name, key.Namespace)
+			l.handleMsgError(cmd, msg, err)
+		}
 	case Evict:
-		cmd.Printf("Evicting virtual machine %q\n", key.String())
-		msg, err = mgr.Evict(ctx, name, namespace)
+		for _, key := range keys {
+			cmd.Printf("Evicting virtual machine %q\n", key.String())
+			msg, err := mgr.Evict(ctx, key.Name, key.Namespace)
+			l.handleMsgError(cmd, msg, err)
+		}
 	case Migrate:
-		cmd.Printf("Migrating virtual machine %q\n", key.String())
-		msg, err = mgr.Migrate(ctx, name, namespace, l.migrationOpts.TargetNodeName)
+		for _, key := range keys {
+			cmd.Printf("Migrating virtual machine %q\n", key.String())
+			msg, err := mgr.Migrate(ctx, key.Name, key.Namespace, l.migrationOpts.TargetNodeName)
+			l.handleMsgError(cmd, msg, err)
+		}
 	default:
 		return fmt.Errorf("invalid command %q", l.cmd)
 	}
+
+	return nil
+}
+
+func (l *Lifecycle) handleMsgError(cmd *cobra.Command, msg string, err error) {
 	if msg != "" {
-		cmd.Printf("%s", msg)
+		cmd.Printf("%s\n", msg)
 	}
-	return err
+	if err != nil {
+		cmd.Printf("Error: %s\n", err.Error())
+	}
 }
 
 func (l *Lifecycle) Usage() string {
@@ -157,18 +197,44 @@ func (l *Lifecycle) Usage() string {
 	return usage
 }
 
-func (l *Lifecycle) getNameNamespace(defaultNamespace string, args []string) (string, string, error) {
-	namespace, name, err := templates.ParseTarget(args[0])
+func (l *Lifecycle) getNamespacedName(defaultNamespace, arg string) (types.NamespacedName, error) {
+	namespace, name, err := templates.ParseTarget(arg)
 	if err != nil {
-		return "", "", err
+		return types.NamespacedName{}, err
 	}
 	if namespace == "" {
 		namespace = defaultNamespace
 	}
-	return name, namespace, nil
+	return types.NamespacedName{Namespace: namespace, Name: name}, nil
 }
 
-func (l *Lifecycle) getManager(client kubeclient.Client, forceSet bool) Manager {
+func (l *Lifecycle) getNamespacedNames(defaultNamespace string, args []string) ([]types.NamespacedName, error) {
+	var keys []types.NamespacedName
+	for _, arg := range args {
+		key, err := l.getNamespacedName(defaultNamespace, arg)
+		if err != nil {
+			return nil, err
+		}
+		keys = append(keys, key)
+	}
+	return keys, nil
+}
+
+func (l *Lifecycle) getVirtualMachines(ctx context.Context, namespace string, client kubeclient.Client) ([]types.NamespacedName, error) {
+	vmList, err := client.VirtualMachines(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	var keys []types.NamespacedName
+	for _, vm := range vmList.Items {
+		keys = append(keys, types.NamespacedName{Namespace: vm.Namespace, Name: vm.Name})
+	}
+
+	return keys, nil
+}
+
+func (l *Lifecycle) getManager(client kubeclient.Client, forceSet, severalVms bool) Manager {
 	var forcePtr *bool
 	if forceSet {
 		forcePtr = ptr.To(l.opts.Force)
@@ -176,7 +242,7 @@ func (l *Lifecycle) getManager(client kubeclient.Client, forceSet bool) Manager 
 
 	return vmop.New(
 		client,
-		vmop.WithCreateOnly(l.opts.CreateOnly),
+		vmop.WithCreateOnly(l.opts.CreateOnly || severalVms),
 		vmop.WithWaitComplete(l.opts.WaitComplete),
 		vmop.WithForce(forcePtr),
 	)
@@ -219,6 +285,7 @@ const (
 	forceFlag, forceFlagShort           = "force", "f"
 	waitFlag, waitFlagShort             = "wait", "w"
 	createOnlyFlag, createOnlyFlagShort = "create-only", "c"
+	allFlag, allFlagShort               = "all", "a"
 	timeoutFlag, timeoutFlagShort       = "timeout", "t"
 )
 
@@ -229,6 +296,8 @@ func AddCommandLineArgs(flagset *pflag.FlagSet, opts *Options) {
 		"Set this flag to wait for the operation to complete.")
 	flagset.BoolVarP(&opts.CreateOnly, createOnlyFlag, createOnlyFlagShort, opts.CreateOnly,
 		"Set this flag to only create the action without status warnings or notifications.")
+	flagset.BoolVarP(&opts.All, allFlag, allFlagShort, opts.All,
+		"Set this flag to apply the action to all VMs.")
 	flagset.DurationVarP(&opts.Timeout, timeoutFlag, timeoutFlagShort, opts.Timeout,
 		"Set this flag to change the timeout.")
 }

--- a/src/cli/internal/cmd/lifecycle/lifecycle.go
+++ b/src/cli/internal/cmd/lifecycle/lifecycle.go
@@ -17,9 +17,12 @@ limitations under the License.
 package lifecycle
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 	"time"
 
@@ -29,6 +32,7 @@ import (
 	"golang.org/x/text/language"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 
@@ -72,10 +76,13 @@ type Lifecycle struct {
 	cmd           Command
 	opts          Options
 	migrationOpts MigrationOpts
+
+	resultErr error
 }
 
 func DefaultOptions() Options {
 	return Options{
+		Confirm:      os.Getenv(confirmEnv) == "yes",
 		Force:        false,
 		WaitComplete: false,
 		CreateOnly:   false,
@@ -87,11 +94,27 @@ func DefaultOptions() Options {
 // although in reality, it is `false`. This flag should be refactored.
 // Consider changing it to a `silence` flag, which could be useful in scripting.
 type Options struct {
+	Confirm      bool
 	Force        bool
 	WaitComplete bool
 	CreateOnly   bool
 	All          bool
+	Selector     map[string]string
 	Timeout      time.Duration
+}
+
+func (o *Options) validate(args []string) error {
+	if len(args) > 0 && o.All {
+		return fmt.Errorf("cannot use --all flag with specific keys")
+	}
+	if len(args) > 0 && len(o.Selector) > 0 {
+		return fmt.Errorf("cannot use --label-selector flag with specific keys")
+	}
+	if o.All && len(o.Selector) > 0 {
+		return fmt.Errorf("cannot use --all and --label-selector flags together")
+	}
+
+	return nil
 }
 
 type MigrationOpts struct {
@@ -104,17 +127,27 @@ func (l *Lifecycle) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if len(args) > 0 && l.opts.All {
-		return fmt.Errorf("cannot use --all flag with specific keys")
+	if err = l.opts.validate(args); err != nil {
+		return err
 	}
 
 	var keys []types.NamespacedName
-	if l.opts.All {
-		keys, err = l.getVirtualMachines(cmd.Context(), defaultNamespace, client)
+
+	switch {
+	case l.opts.All:
+		keys, err = l.getVirtualMachines(cmd.Context(), defaultNamespace, client, metav1.ListOptions{})
 		if err != nil {
 			return fmt.Errorf("failed to get virtual machines in namespace %q: %w", defaultNamespace, err)
 		}
-	} else {
+	case len(l.opts.Selector) > 0:
+		selector := labels.SelectorFromSet(l.opts.Selector).String()
+		opts := metav1.ListOptions{LabelSelector: selector}
+
+		keys, err = l.getVirtualMachines(cmd.Context(), defaultNamespace, client, opts)
+		if err != nil {
+			return fmt.Errorf("failed to get virtual machines in namespace %q with selector: %q: %w", defaultNamespace, selector, err)
+		}
+	default:
 		keys, err = l.getNamespacedNames(defaultNamespace, args)
 		if err != nil {
 			return fmt.Errorf("failed to parse keys: %w", err)
@@ -134,39 +167,79 @@ func (l *Lifecycle) Run(cmd *cobra.Command, args []string) error {
 	switch l.cmd {
 	case Stop:
 		for _, key := range keys {
-			cmd.Printf("Stopping virtual machine %q\n", key.String())
-			msg, err := mgr.Stop(ctx, key.Name, key.Namespace)
-			l.handleMsgError(cmd, msg, err)
+			l.withConfirm(cmd, Stop, key, func() {
+				cmd.Printf("Stopping virtual machine %q\n", key.String())
+				msg, err := mgr.Stop(ctx, key.Name, key.Namespace)
+				l.handleMsgError(cmd, msg, err)
+			})
 		}
 	case Start:
 		for _, key := range keys {
-			cmd.Printf("Starting virtual machine %q\n", key.String())
-			msg, err := mgr.Start(ctx, key.Name, key.Namespace)
-			l.handleMsgError(cmd, msg, err)
+			l.withConfirm(cmd, Start, key, func() {
+				cmd.Printf("Starting virtual machine %q\n", key.String())
+				msg, err := mgr.Start(ctx, key.Name, key.Namespace)
+				l.handleMsgError(cmd, msg, err)
+			})
 		}
 	case Restart:
 		for _, key := range keys {
-			cmd.Printf("Restarting virtual machine %q\n", key.String())
-			msg, err := mgr.Restart(ctx, key.Name, key.Namespace)
-			l.handleMsgError(cmd, msg, err)
+			l.withConfirm(cmd, Restart, key, func() {
+				cmd.Printf("Restarting virtual machine %q\n", key.String())
+				msg, err := mgr.Restart(ctx, key.Name, key.Namespace)
+				l.handleMsgError(cmd, msg, err)
+			})
 		}
 	case Evict:
 		for _, key := range keys {
-			cmd.Printf("Evicting virtual machine %q\n", key.String())
-			msg, err := mgr.Evict(ctx, key.Name, key.Namespace)
-			l.handleMsgError(cmd, msg, err)
+			l.withConfirm(cmd, Evict, key, func() {
+				cmd.Printf("Evicting virtual machine %q\n", key.String())
+				msg, err := mgr.Evict(ctx, key.Name, key.Namespace)
+				l.handleMsgError(cmd, msg, err)
+			})
 		}
 	case Migrate:
 		for _, key := range keys {
-			cmd.Printf("Migrating virtual machine %q\n", key.String())
-			msg, err := mgr.Migrate(ctx, key.Name, key.Namespace, l.migrationOpts.TargetNodeName)
-			l.handleMsgError(cmd, msg, err)
+			targetNodeName := l.migrationOpts.TargetNodeName
+
+			if err := l.validateNodeName(cmd, key.Name, targetNodeName); err != nil {
+				l.handleMsgError(cmd, "", err)
+				continue
+			}
+
+			l.withConfirm(cmd, Migrate, key, func() {
+				cmd.Printf("Migrating virtual machine %q\n", key.String())
+				msg, err := mgr.Migrate(ctx, key.Name, key.Namespace, targetNodeName)
+				l.handleMsgError(cmd, msg, err)
+			})
 		}
 	default:
 		return fmt.Errorf("invalid command %q", l.cmd)
 	}
 
-	return nil
+	return l.resultErr
+}
+
+func (l *Lifecycle) withConfirm(cmd *cobra.Command, command Command, key types.NamespacedName, fn func()) {
+	if l.opts.Confirm {
+		fn()
+		return
+	}
+
+	cmd.Printf("Are you sure you want to execute command %q for virtual machine %q? [y/N] ", command, key.String())
+	reader := bufio.NewReader(cmd.InOrStdin())
+	answer, err := reader.ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		cmd.PrintErrf("Error: failed to read confirmation: %s\n", err)
+		return
+	}
+
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	if answer != "y" && answer != "yes" {
+		cmd.Printf("Skipping virtual machine %q\n", key.String())
+		return
+	}
+
+	fn()
 }
 
 func (l *Lifecycle) handleMsgError(cmd *cobra.Command, msg string, err error) {
@@ -175,6 +248,10 @@ func (l *Lifecycle) handleMsgError(cmd *cobra.Command, msg string, err error) {
 	}
 	if err != nil {
 		cmd.Printf("Error: %s\n", err.Error())
+
+		if l.resultErr == nil {
+			l.resultErr = fmt.Errorf("something went wrong: %w", err)
+		}
 	}
 }
 
@@ -220,8 +297,8 @@ func (l *Lifecycle) getNamespacedNames(defaultNamespace string, args []string) (
 	return keys, nil
 }
 
-func (l *Lifecycle) getVirtualMachines(ctx context.Context, namespace string, client kubeclient.Client) ([]types.NamespacedName, error) {
-	vmList, err := client.VirtualMachines(namespace).List(ctx, metav1.ListOptions{})
+func (l *Lifecycle) getVirtualMachines(ctx context.Context, namespace string, client kubeclient.Client, opts metav1.ListOptions) ([]types.NamespacedName, error) {
+	vmList, err := client.VirtualMachines(namespace).List(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -248,7 +325,7 @@ func (l *Lifecycle) getManager(client kubeclient.Client, forceSet, severalVms bo
 	)
 }
 
-func (l *Lifecycle) ValidateNodeName(cmd *cobra.Command, vmName, targetNodeName string) error {
+func (l *Lifecycle) validateNodeName(cmd *cobra.Command, vmName, targetNodeName string) error {
 	if !cmd.Flags().Changed("target-node-name") {
 		return nil
 	}
@@ -282,22 +359,30 @@ func (l *Lifecycle) ValidateNodeName(cmd *cobra.Command, vmName, targetNodeName 
 }
 
 const (
+	confirmFlag, confirmFlagShort       = "yes", "y"
 	forceFlag, forceFlagShort           = "force", "f"
 	waitFlag, waitFlagShort             = "wait", "w"
 	createOnlyFlag, createOnlyFlagShort = "create-only", "c"
-	allFlag, allFlagShort               = "all", "a"
+	allFlag                             = "all"
+	selectorFlag, selectorFlagShort     = "label-selector", "l"
 	timeoutFlag, timeoutFlagShort       = "timeout", "t"
+
+	confirmEnv = "D8_VIRTUALIZATION_LIFECYCLE_CONFIRM"
 )
 
 func AddCommandLineArgs(flagset *pflag.FlagSet, opts *Options) {
+	flagset.BoolVarP(&opts.Confirm, confirmFlag, confirmFlagShort, opts.Confirm,
+		"Set this flag to confirm the action without prompting for confirmation.")
 	flagset.BoolVarP(&opts.Force, forceFlag, forceFlagShort, opts.Force,
 		"Set this flag to force the operation.")
 	flagset.BoolVarP(&opts.WaitComplete, waitFlag, waitFlagShort, opts.WaitComplete,
 		"Set this flag to wait for the operation to complete.")
 	flagset.BoolVarP(&opts.CreateOnly, createOnlyFlag, createOnlyFlagShort, opts.CreateOnly,
 		"Set this flag to only create the action without status warnings or notifications.")
-	flagset.BoolVarP(&opts.All, allFlag, allFlagShort, opts.All,
+	flagset.BoolVar(&opts.All, allFlag, opts.All,
 		"Set this flag to apply the action to all VMs.")
+	flagset.StringToStringVarP(&opts.Selector, selectorFlag, selectorFlagShort, opts.Selector,
+		"Set this flag to apply the action to VMs with the specified labels.")
 	flagset.DurationVarP(&opts.Timeout, timeoutFlag, timeoutFlagShort, opts.Timeout,
 		"Set this flag to change the timeout.")
 }

--- a/src/cli/internal/cmd/lifecycle/migrate.go
+++ b/src/cli/internal/cmd/lifecycle/migrate.go
@@ -29,15 +29,7 @@ func NewMigrateCommand() *cobra.Command {
 		Use:     "migrate (VirtualMachine)",
 		Short:   "Migrate a virtual machine.",
 		Example: lifecycle.Usage(),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			vmName := args[0]
-			err := lifecycle.ValidateNodeName(cmd, vmName, lifecycle.migrationOpts.TargetNodeName)
-			if err != nil {
-				return err
-			}
-			return nil
-		},
-		RunE: lifecycle.Run,
+		RunE:    lifecycle.Run,
 	}
 	AddCommandLineArgs(cmd.Flags(), &lifecycle.opts)
 	AddCommandLineMigrationArgs(cmd.Flags(), &lifecycle.migrationOpts)

--- a/src/cli/internal/cmd/lifecycle/migrate.go
+++ b/src/cli/internal/cmd/lifecycle/migrate.go
@@ -29,7 +29,6 @@ func NewMigrateCommand() *cobra.Command {
 		Use:     "migrate (VirtualMachine)",
 		Short:   "Migrate a virtual machine.",
 		Example: lifecycle.Usage(),
-		Args:    templates.ExactArgs("migrate", 1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			vmName := args[0]
 			err := lifecycle.ValidateNodeName(cmd, vmName, lifecycle.migrationOpts.TargetNodeName)

--- a/src/cli/internal/cmd/lifecycle/restart.go
+++ b/src/cli/internal/cmd/lifecycle/restart.go
@@ -28,7 +28,6 @@ func NewRestartCommand() *cobra.Command {
 		Use:     "restart (VirtualMachine)",
 		Short:   "Restart a virtual machine.",
 		Example: lifecycle.Usage(),
-		Args:    templates.ExactArgs("restart", 1),
 		RunE:    lifecycle.Run,
 	}
 	AddCommandLineArgs(cmd.Flags(), &lifecycle.opts)

--- a/src/cli/internal/cmd/lifecycle/start.go
+++ b/src/cli/internal/cmd/lifecycle/start.go
@@ -28,7 +28,6 @@ func NewStartCommand() *cobra.Command {
 		Use:     "start (VirtualMachine)",
 		Short:   "Start a virtual machine.",
 		Example: lifecycle.Usage(),
-		Args:    templates.ExactArgs("start", 1),
 		RunE:    lifecycle.Run,
 	}
 	AddCommandLineArgs(cmd.Flags(), &lifecycle.opts)

--- a/src/cli/internal/cmd/lifecycle/stop.go
+++ b/src/cli/internal/cmd/lifecycle/stop.go
@@ -28,7 +28,6 @@ func NewStopCommand() *cobra.Command {
 		Use:     "stop (VirtualMachine)",
 		Short:   "Stop a virtual machine.",
 		Example: lifecycle.Usage(),
-		Args:    templates.ExactArgs("stop", 1),
 		RunE:    lifecycle.Run,
 	}
 	AddCommandLineArgs(cmd.Flags(), &lifecycle.opts)


### PR DESCRIPTION
## Description
Add support for multi-target lifecycle operations, label-selector targeting, and confirmation prompts in the CLI (`d8v`).

- Lifecycle commands (`start`, `stop`, `restart`, `evict`, `migrate`) now accept multiple VM names as arguments.
- New `--all` flag applies the operation to all VMs in the current namespace.
- New `--label-selector` / `-l` flag filters target VMs by label set (e.g. `--label-selector env=prod,tier=frontend`).
- New `--yes` / `-y` flag skips interactive confirmation; without it, each VM requires explicit `y/yes` confirmation before the action is executed. The `D8_VIRTUALIZATION_LIFECYCLE_CONFIRM=yes` environment variable has the same effect as `--yes`.
- `--all` and `--label-selector` are mutually exclusive; both are incompatible with positional VM name arguments.
- When operating on multiple VMs, `--create-only` is implicitly forced to prevent blocking on each individual operation.
- Errors and messages per VM are printed inline instead of aborting the whole batch.

## Why do we need it, and what problem does it solve?
Previously, lifecycle commands only accepted a single VM name, requiring users to run the command repeatedly for each VM.  
This is inconvenient in scenarios like draining a node, performing maintenance, or bulk-testing VM lifecycle behaviour.  
The `--all` flag and multi-argument support eliminate the need for shell loops.  
The `--label-selector` flag allows targeting a logical group of VMs without listing each one explicitly.  
The confirmation prompt prevents accidental bulk operations, while `--yes` keeps scripting ergonomic.

## What is the expected result?
1. Run `d8v stop vm1 vm2 vm3` — all three VMs are stopped (with per-VM confirmation).
2. Run `d8v restart --all --yes` — all VMs in the current namespace are restarted without prompting.
3. Run `d8v stop --label-selector env=prod` — stops all VMs matching the label, with per-VM confirmation.
4. Run `d8v start --all vm1` — command returns an error: cannot use `--all` with specific keys.
5. Run `d8v start --all --label-selector env=prod` — command returns an error: cannot use both flags together.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: core
type: feature
summary: "CLI lifecycle commands (start, stop, restart, evict, migrate) now support multiple VM targets, --all flag, --label-selector flag for label-based targeting, and --yes flag for non-interactive confirmation."
```
