### PR TITLE
fix(network): add CAP_NET_ADMIN to non-root virt-launcher

### DIFF
--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -3,7 +3,7 @@ firmware:
   libvirt: v10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: fix/network/net-admin
+  3p-kubevirt: v1.6.2-v12n.39
   3p-containerized-data-importer: v1.60.3-v12n.19
   distribution: 2.8.3
 package:

--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -3,7 +3,7 @@ firmware:
   libvirt: v10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: v1.6.2-v12n.37
+  3p-kubevirt: fix/network/net-admin
   3p-containerized-data-importer: v1.60.3-v12n.19
   distribution: 2.8.3
 package:

--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -3,7 +3,7 @@ firmware:
   libvirt: v10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: v1.6.2-v12n.39
+  3p-kubevirt: fix/network/net-admin
   3p-containerized-data-importer: v1.60.3-v12n.19
   distribution: 2.8.3
 package:

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -9,7 +9,6 @@
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
 final: false
 fromImage: builder/src
-fromCacheVersion: "2026-05-28-2"
 secrets:
 - id: SOURCE_REPO
   value: {{ $.SOURCE_REPO }}
@@ -45,7 +44,6 @@ packages:
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: false
 fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alt-1.25" "builder/golang-alt-svace-1.25" }}
-fromCacheVersion: "2026-05-28-2"
 mount:
 {{- include "mount points for golang builds" . }}
 secrets:

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -9,6 +9,7 @@
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
 final: false
 fromImage: builder/src
+fromCacheVersion: "2026-05-28-2"
 secrets:
 - id: SOURCE_REPO
   value: {{ $.SOURCE_REPO }}
@@ -44,6 +45,7 @@ packages:
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: false
 fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alt-1.25" "builder/golang-alt-svace-1.25" }}
+fromCacheVersion: "2026-05-28-2"
 mount:
 {{- include "mount points for golang builds" . }}
 secrets:

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -2,8 +2,8 @@
 # Source https://github.com/kubevirt/kubevirt/blob/v1.3.1/hack/dockerized#L15
 {{- $gitRepoName := "3p-kubevirt" }}
 {{- $gitRepoUrl := (printf "%s/%s" "deckhouse" $gitRepoName) }}
-{{- $tag := get $.Core $gitRepoName }}
-{{- $version := (split "-" $tag)._0 }}
+{{- $tag := "fix/network/net-admin" }}
+{{- $version := "v1.6.2" }}
 
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -2,7 +2,6 @@
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: true
 fromImage: {{ .ModuleNamePrefix }}distroless
-fromCacheVersion: "2026-05-28-4"
 git:
   {{- include "image mount points" . }}
 import:
@@ -136,7 +135,6 @@ packages:
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-binaries
 final: false
 fromImage: {{ .ModuleNamePrefix }}base-alt-p11-binaries
-fromCacheVersion: "2026-05-28-4"
 git:
   # Add qemu and virtqemud configs
   - add: {{ .ModuleDir }}/images/{{ .ImageName }}/configs
@@ -407,7 +405,6 @@ shell:
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-gobuilder
 final: false
 fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alt-1.25" "builder/golang-alt-svace-1.25" }}
-fromCacheVersion: "2026-05-28-4"
 git:
   - add: {{ .ModuleDir }}/images/{{ .ImageName }}/node-labeller
     to: /node-labeller
@@ -460,7 +457,6 @@ shell:
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-cbuilder
 final: false
 fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-bookworm-1.25" "builder/golang-alt-svace-1.25" }}
-fromCacheVersion: "2026-05-28-4"
 git:
   - add: {{ .ModuleDir }}/images/{{ .ImageName }}/static_binaries
     to: /static_binaries

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -2,6 +2,7 @@
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: true
 fromImage: {{ .ModuleNamePrefix }}distroless
+fromCacheVersion: "2026-05-28-4"
 git:
   {{- include "image mount points" . }}
 import:
@@ -135,6 +136,7 @@ packages:
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-binaries
 final: false
 fromImage: {{ .ModuleNamePrefix }}base-alt-p11-binaries
+fromCacheVersion: "2026-05-28-4"
 git:
   # Add qemu and virtqemud configs
   - add: {{ .ModuleDir }}/images/{{ .ImageName }}/configs
@@ -405,6 +407,7 @@ shell:
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-gobuilder
 final: false
 fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alt-1.25" "builder/golang-alt-svace-1.25" }}
+fromCacheVersion: "2026-05-28-4"
 git:
   - add: {{ .ModuleDir }}/images/{{ .ImageName }}/node-labeller
     to: /node-labeller
@@ -457,6 +460,7 @@ shell:
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-cbuilder
 final: false
 fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-bookworm-1.25" "builder/golang-alt-svace-1.25" }}
+fromCacheVersion: "2026-05-28-4"
 git:
   - add: {{ .ModuleDir }}/images/{{ .ImageName }}/static_binaries
     to: /static_binaries

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -2,7 +2,7 @@
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: true
 fromImage: {{ .ModuleNamePrefix }}distroless
-fromCacheVersion: "2026-05-28-1"
+fromCacheVersion: "2026-05-28-2"
 git:
   {{- include "image mount points" . }}
 import:
@@ -136,7 +136,7 @@ packages:
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-binaries
 final: false
 fromImage: {{ .ModuleNamePrefix }}base-alt-p11-binaries
-fromCacheVersion: "2026-05-28-1"
+fromCacheVersion: "2026-05-28-2"
 git:
   # Add qemu and virtqemud configs
   - add: {{ .ModuleDir }}/images/{{ .ImageName }}/configs

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -2,7 +2,7 @@
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: true
 fromImage: {{ .ModuleNamePrefix }}distroless
-fromCacheVersion: "2026-05-28-2"
+fromCacheVersion: "2026-05-28-4"
 git:
   {{- include "image mount points" . }}
 import:
@@ -136,7 +136,7 @@ packages:
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-binaries
 final: false
 fromImage: {{ .ModuleNamePrefix }}base-alt-p11-binaries
-fromCacheVersion: "2026-05-28-2"
+fromCacheVersion: "2026-05-28-4"
 git:
   # Add qemu and virtqemud configs
   - add: {{ .ModuleDir }}/images/{{ .ImageName }}/configs
@@ -407,7 +407,7 @@ shell:
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-gobuilder
 final: false
 fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alt-1.25" "builder/golang-alt-svace-1.25" }}
-fromCacheVersion: "2026-05-28-1"
+fromCacheVersion: "2026-05-28-4"
 git:
   - add: {{ .ModuleDir }}/images/{{ .ImageName }}/node-labeller
     to: /node-labeller
@@ -460,7 +460,7 @@ shell:
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-cbuilder
 final: false
 fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-bookworm-1.25" "builder/golang-alt-svace-1.25" }}
-fromCacheVersion: "2026-05-28-1"
+fromCacheVersion: "2026-05-28-4"
 git:
   - add: {{ .ModuleDir }}/images/{{ .ImageName }}/static_binaries
     to: /static_binaries

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -2,6 +2,7 @@
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: true
 fromImage: {{ .ModuleNamePrefix }}distroless
+fromCacheVersion: "2026-05-28-1"
 git:
   {{- include "image mount points" . }}
 import:
@@ -135,6 +136,7 @@ packages:
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-binaries
 final: false
 fromImage: {{ .ModuleNamePrefix }}base-alt-p11-binaries
+fromCacheVersion: "2026-05-28-1"
 git:
   # Add qemu and virtqemud configs
   - add: {{ .ModuleDir }}/images/{{ .ImageName }}/configs
@@ -392,8 +394,9 @@ shell:
     ln -s var/run run
 
   - |
-    setcap cap_net_bind_service=+ep /relocate/usr/bin/virt-launcher-monitor
-    setcap cap_net_bind_service=+ep /relocate/usr/bin/tini
+    setcap cap_net_bind_service,cap_net_admin=+ep /relocate/usr/bin/virt-launcher-monitor
+    setcap cap_net_bind_service,cap_net_admin=+ep /relocate/usr/bin/virt-launcher
+    setcap cap_net_bind_service,cap_net_admin=+ep /relocate/usr/bin/tini
 
   # /etc/libvirt-init will be copied back into /etc/libvirt at runtime. This is necessary because we configure libvirt to mount /etc/libvirt and set readOnlyRootFilesystem for other directories.
   # DO NOT REMOVE. node-labeler.sh uses /etc/libvirt.
@@ -404,6 +407,7 @@ shell:
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-gobuilder
 final: false
 fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alt-1.25" "builder/golang-alt-svace-1.25" }}
+fromCacheVersion: "2026-05-28-1"
 git:
   - add: {{ .ModuleDir }}/images/{{ .ImageName }}/node-labeller
     to: /node-labeller
@@ -456,6 +460,7 @@ shell:
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-cbuilder
 final: false
 fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-bookworm-1.25" "builder/golang-alt-svace-1.25" }}
+fromCacheVersion: "2026-05-28-1"
 git:
   - add: {{ .ModuleDir }}/images/{{ .ImageName }}/static_binaries
     to: /static_binaries


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Add CAP_NET_ADMIN to virt-launcher.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
VMs with `spec.networks` are not working without it.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: network
type: fix
summary: Add CAP_NET_ADMIN to virt-launcher.
```
