### PR TITLE
chore(module): add requirements for the sdn module

### DIFF
--- a/module.yaml
+++ b/module.yaml
@@ -11,6 +11,7 @@ requirements:
   deckhouse: ">= 1.74.2"
   modules:
     cni-cilium: ">= 0.0.0"
+    sdn: ">= 0.6.2 !optional"
 disable:
   confirmation: true
   message: |

--- a/module.yaml
+++ b/module.yaml
@@ -11,7 +11,7 @@ requirements:
   deckhouse: ">= 1.74.2"
   modules:
     cni-cilium: ">= 0.0.0"
-    sdn: ">= 0.6.2 !optional"
+    sdn: ">= 0.6.3 !optional"
 disable:
   confirmation: true
   message: |


### PR DESCRIPTION
## Description
Adds the `sdn` module to the Virtualization module requirements with the minimum supported version `>= 0.6.2`.

## Why do we need it, and what problem does it solve?
Virtualization depends on SDN functionality being available in the Deckhouse cluster. Declaring this dependency in `module.yaml` makes the requirement explicit and allows Deckhouse to validate that a compatible `sdn` module is present before running Virtualization.

## What is the expected result?
When the Virtualization module is enabled or rendered, Deckhouse sees the `sdn >= 0.6.2` module requirement.

The module should only be considered installable when the SDN module version satisfies this requirement.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: module
type: chore
summary: "Added an explicit dependency on the SDN module version 0.6.2 or newer."
```