### PR TITLE
test: add postcleanup mode

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -90,13 +90,13 @@ task runp
 ### Debugging options
 
 - Use the FOCUS environment variable to run a specific test.
-- Set POST_CLEANUP=no to disable cleanup after tests (takes precedence over isCleanupNeeded in config).
+- Set `POST_CLEANUP=never` to disable cleanup after tests (takes precedence over `postCleanupMode` in config).
 - Set LABELS to run tests with specific label(https://onsi.github.io/ginkgo/#spec-labels).
 - Manage timeouts for new e2e tests (not for legacy tests) using env variables `E2E_SHORT_TIMEOUT`, `E2E_MIDDLE_TIMEOUT`, `E2E_LONG_TIMEOUT` and `E2E_MAX_TIMEOUT`.
 
 For example, to run only one test and leave all created resources in the cluster, use the following command:
 ```bash
-FOCUS="VirtualMachineConnectivity" POST_CLEANUP=no task run
+FOCUS="VirtualMachineConnectivity" POST_CLEANUP=never task run
 ```
 
 ### PostCleanUp option
@@ -104,19 +104,20 @@ FOCUS="VirtualMachineConnectivity" POST_CLEANUP=no task run
 `POST_CLEANUP` defines an environment variable used to explicitly request the deletion of created/used resources.
 
 Valid values:
-- `yes` or "" (empty) - perform cleanup after tests (default)
-- `no` - skip cleanup after tests
+- `always` or "" (empty) - perform cleanup after tests (default)
+- `never` - skip cleanup after tests
+- `no-on-failure` - perform cleanup only when the spec passes (skip cleanup on failure, preserving resources for investigation)
 
-You can also control cleanup behavior via the `isCleanupNeeded` field in `default_config.yaml`:
+You can also control cleanup behavior via the `postCleanupMode` field in `default_config.yaml`:
 ```yaml
-isCleanupNeeded: true  # default: cleanup enabled
+postCleanupMode: always  # default: cleanup enabled
 ```
 
 The `POST_CLEANUP` environment variable takes precedence over the YAML config.
 
 For example, run a test in no-cleanup mode:
 ```bash
-POST_CLEANUP=no task run
+POST_CLEANUP=never task run
 ```
 
 ### Working with `Virtualization-controller` errors

--- a/test/e2e/default_config.yaml
+++ b/test/e2e/default_config.yaml
@@ -1,8 +1,8 @@
 namespaceSuffix: "e2e"
 
-# isCleanupNeeded controls cleanup of resources created during test execution (VMs, VDs, namespaces, etc.)
-# Enabled by default. Set to false to skip cleanup for debugging.
-isCleanupNeeded: true
+# postCleanupMode controls cleanup of resources created during test execution (VMs, VDs, namespaces, etc.)
+# Enabled by default. Set to never or no-on-failure to skip cleanup for debugging.
+postCleanupMode: always
 # isPrecreatedCVICleanupNeeded controls cleanup of precreated ClusterVirtualImages shared across test runs
 # Disabled by default: CVIs persist between runs for faster execution.
 # Set to true to delete them after the suite.

--- a/test/e2e/internal/config/cleanup.go
+++ b/test/e2e/internal/config/cleanup.go
@@ -16,6 +16,11 @@ limitations under the License.
 
 package config
 
+import (
+	"fmt"
+	"os"
+)
+
 // PrecreatedCVICleanupEnv defines an environment variable to explicitly enable deletion of precreated CVIs after the suite.
 //
 // By default, precreated CVIs are not deleted: they are shared across runs and may be reused.
@@ -23,5 +28,21 @@ package config
 const PrecreatedCVICleanupEnv = "PRECREATED_CVI_CLEANUP"
 
 // PostCleanupEnv defines an environment variable used to explicitly request the deletion of created/used resources.
-// Valid values: "yes", "no", or "" (default = yes).
+// Valid values: "always", "never", "no-on-failure", or "" (default = always).
 const PostCleanupEnv = "POST_CLEANUP"
+
+func LoadPostCleanupMode() (PostCleanupMode, error) {
+	if e, ok := os.LookupEnv(PostCleanupEnv); ok {
+		switch e {
+		case string(PostCleanupAlways), "yes", "true", "0", "":
+			return PostCleanupAlways, nil
+		case string(PostCleanupNever), "no", "false", "1":
+			return PostCleanupNever, nil
+		case string(PostCleanupNoOnFailure), "2":
+			return PostCleanupNoOnFailure, nil
+		default:
+			return "", fmt.Errorf("invalid value for %s: %s", PostCleanupEnv, e)
+		}
+	}
+	return PostCleanupAlways, nil
+}

--- a/test/e2e/internal/config/config.go
+++ b/test/e2e/internal/config/config.go
@@ -26,6 +26,7 @@ import (
 	"slices"
 	"strconv"
 
+	"github.com/onsi/ginkgo/v2"
 	yamlv3 "gopkg.in/yaml.v3"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -76,9 +77,9 @@ type Config struct {
 	LogFilter        []string         `yaml:"logFilter"`
 	CleanupResources []string         `yaml:"cleanupResources"`
 	RegexpLogFilter  []regexp.Regexp  `yaml:"regexpLogFilter"`
-	// IsCleanupNeeded controls cleanup of resources created during test execution (VMs, VDs, namespaces, etc.).
-	// Enabled by default (POST_CLEANUP=yes or unset). Set to false to skip cleanup for debugging.
-	IsCleanupNeeded bool `yaml:"isCleanupNeeded"`
+	// PostCleanupMode controls cleanup of resources created during test execution (VMs, VDs, namespaces, etc.).
+	// Enabled by default (POST_CLEANUP=always or unset). Set to never or no-on-failure to skip cleanup for debugging.
+	PostCleanupMode PostCleanupMode `yaml:"postCleanupMode"`
 	// IsPrecreatedCVICleanupNeeded controls cleanup of precreated ClusterVirtualImages that are shared across test runs.
 	// Disabled by default (PRECREATED_CVI_CLEANUP=no): CVIs persist between runs for faster execution.
 	// Set to true to delete them after the suite.
@@ -86,6 +87,28 @@ type Config struct {
 
 	StorageClass StorageClass
 }
+
+func (c *Config) IsCleanupNeeded() bool {
+	switch c.PostCleanupMode {
+	case PostCleanupAlways:
+		return true
+	case PostCleanupNever:
+		return false
+	case PostCleanupNoOnFailure:
+		return !ginkgo.CurrentSpecReport().Failed()
+	default:
+		ginkgo.GinkgoWriter.Printf("Unknown PostCleanupMode: %s, defaulting to always\n", c.PostCleanupMode)
+		return true
+	}
+}
+
+type PostCleanupMode string
+
+const (
+	PostCleanupAlways      PostCleanupMode = "always"
+	PostCleanupNever       PostCleanupMode = "never"
+	PostCleanupNoOnFailure PostCleanupMode = "no-on-failure"
+)
 
 type TestData struct {
 	ImageHotplug string `yaml:"imageHotplug"`
@@ -133,10 +156,12 @@ type HelperImages struct {
 }
 
 func (c *Config) setEnvs() error {
-	// isCleanupNeeded: env var has priority over yaml config
-	if e, ok := os.LookupEnv(PostCleanupEnv); ok {
-		c.IsCleanupNeeded = e != "no"
+	postCleanupMode, err := LoadPostCleanupMode()
+	if err != nil {
+		return err
 	}
+	c.PostCleanupMode = postCleanupMode
+
 	// isPrecreatedCVICleanupNeeded: env var has priority over yaml config
 	if e, ok := os.LookupEnv("PRECREATED_CVI_CLEANUP"); ok {
 		c.IsPrecreatedCVICleanupNeeded = e == "yes"

--- a/test/e2e/internal/framework/framework.go
+++ b/test/e2e/internal/framework/framework.go
@@ -72,7 +72,7 @@ func (f *Framework) Before() {
 func (f *Framework) After() {
 	GinkgoHelper()
 
-	if GetConfig().IsCleanupNeeded {
+	if GetConfig().IsCleanupNeeded() {
 		defer func() {
 			if f.namespace != nil {
 				By("Cleanup: delete namespace")

--- a/test/e2e/internal/precheck/postcleanup.go
+++ b/test/e2e/internal/precheck/postcleanup.go
@@ -51,10 +51,17 @@ func (c *postcleanupPrecheck) Run(ctx context.Context, f *framework.Framework) e
 	// Validate POST_CLEANUP env var (controls cleanup behavior)
 	env := os.Getenv(config.PostCleanupEnv)
 	switch env {
-	case "yes", "no", "":
+	case string(config.PostCleanupAlways), string(config.PostCleanupNever), string(config.PostCleanupNoOnFailure), "", "yes", "true", "0", "no", "false", "1", "2":
 		// valid values
 	default:
-		return fmt.Errorf("invalid value for the %s env: %q (allowed: \"\", \"yes\", \"no\")", config.PostCleanupEnv, env)
+		return fmt.Errorf(
+			"invalid value for the %s env: %q (allowed: \"\", %q, %q, %q)",
+			config.PostCleanupEnv,
+			env,
+			config.PostCleanupAlways,
+			config.PostCleanupNever,
+			config.PostCleanupNoOnFailure,
+		)
 	}
 
 	return nil

--- a/test/e2e/legacy/image_hotplug.go
+++ b/test/e2e/legacy/image_hotplug.go
@@ -82,7 +82,7 @@ var _ = Describe("ImageHotplug", Ordered, label.Legacy(), Label(precheck.NoPrech
 	})
 
 	AfterAll(func() {
-		if conf.IsCleanupNeeded {
+		if conf.IsCleanupNeeded() {
 			DeleteTestCaseResources(ns, ResourcesToDelete{
 				KustomizationDir: conf.TestData.ImageHotplug,
 			})

--- a/test/e2e/legacy/legacy.go
+++ b/test/e2e/legacy/legacy.go
@@ -150,7 +150,7 @@ func NewBeforeProcess1Body() {
 }
 
 func NewAfterAllProcessBody() {
-	if conf.IsCleanupNeeded {
+	if conf.IsCleanupNeeded() {
 		Expect(Cleanup()).To(Succeed())
 	}
 }


### PR DESCRIPTION
## Description
Replace boolean `IsCleanupNeeded` flag with `PostCleanupMode` enum in e2e test config.

New values for `POST_CLEANUP` env:
- `always` (default) — always clean up resources after tests
- `never` — never clean up (useful for debugging)
- `no-on-failure` — skip cleanup only when the test suite fails, preserving resources on failure for investigation (cleanup runs on success)

## Why do we need it, and what problem does it solve?
The old boolean flag (`yes`/`no`) didn't allow keeping resources when tests fail while still cleaning up on success. The new `no-on-failure` mode fills this gap, making it easier to debug failing e2e tests without manually toggling cleanup.

## What is the expected result?
1. Set `POST_CLEANUP=no-failure` before running e2e tests
2. If tests pass — resources are cleaned up as usual
3. If tests fail — resources remain in the cluster for investigation

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: test
type: chore
summary: Replace boolean POST_CLEANUP flag with PostCleanupMode enum (always/never/no-on-failure) in e2e config.
impact_level: low
```
