### PR TITLE
chore(core, kubevirt): bump kubevirt to fix panic in CRD event handler

### DIFF
--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -3,7 +3,7 @@ firmware:
   libvirt: v10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: v1.6.2-v12n.39
+  3p-kubevirt: v1.6.2-v12n.40
   3p-containerized-data-importer: v1.60.3-v12n.19
   distribution: 2.8.3
 package:


### PR DESCRIPTION
## Description
Bump 3p-kubevirt to include a fix for a panic in the CRD event handler.

Upstream PR: https://github.com/deckhouse/3p-kubevirt/pull/123

## Why do we need it, and what problem does it solve?
`crdAddedDeleted` performed an unsafe type assertion `obj.(*extv1.CustomResourceDefinition)`. When the informer delivered a tombstone object (`*cache.DeletedFinalStateUnknown`) on a missed DELETE event, the assertion panicked and crashed virt-controller.

## What is the expected result?
virt-controller no longer panics when a CRD DELETE event delivers a tombstone object.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: core
type: fix
summary: Fix panic in kubevirt CRD event handler on tombstone object delivery.
impact_level: low
```
