### PR TITLE
test(vd): wait for SSH before checking disk size after resize

### DIFF
--- a/test/e2e/blockdevice/virtual_disk_resizing.go
+++ b/test/e2e/blockdevice/virtual_disk_resizing.go
@@ -118,6 +118,7 @@ var _ = Describe("VirtualDiskResizing", Label(precheck.NoPrecheck), func() {
 		util.UntilObjectPhase(ctx, string(v1alpha2.DiskReady), framework.MiddleTimeout, vdRoot, vdBlank, vdAttach)
 		util.UntilObjectPhase(ctx, string(v1alpha2.MachineRunning), framework.ShortTimeout, vm)
 		util.UntilObjectPhase(ctx, string(v1alpha2.BlockDeviceAttachmentPhaseAttached), framework.ShortTimeout, vmbda)
+		util.UntilSSHReady(f, vm, framework.MiddleTimeout)
 
 		err = f.GenericClient().Get(ctx, crclient.ObjectKeyFromObject(vdRoot), vdRoot)
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Description

Fixes the `VirtualDiskResizing` e2e test that fails with `signal: killed` error when executing SSH command `sudo lsblk --nodeps --json -o SERIAL,SIZE` after disk resize.

The test now includes `util.UntilSSHReady(f, vm, framework.MiddleTimeout)` before executing `lsblk` to verify the new disk sizes inside the VM.

## Why do we need it, and what problem does it solve?

The `VirtualDiskResizing` e2e test was failing with the following error:
```
failed to execute command sudo lsblk --nodeps --json -o SERIAL,SIZE: signal: killed
```

The root cause is that after disk resize, the SSH connection can become temporarily unavailable. The test was executing `lsblk` immediately after the resize without waiting for SSH to become available again.

This fix adds a proper wait for SSH readiness after the resize operation, similar to how it's done before the resize.

## What is the expected result?

The `VirtualDiskResizing` e2e test should pass consistently. The test now:
1. Waits for VM to be running and SSH to be ready (existing)
2. Gets initial disk sizes via lsblk (existing)
3. Resizes the disks (existing)
4. Waits for disks to become ready (existing)
5. **Waits for SSH to be ready** (new)
6. Gets new disk sizes via lsblk and verifies they increased (existing)

## Checklist

- [ ] The code is covered by unit tests (N/A - e2e test only)
- [x] e2e tests passed
- [ ] Documentation updated according to the changes (N/A)
- [x] Changes were tested in the Kubernetes cluster manually

## Changelog entries

```changes
section: test
type: fix
summary: "VirtualDiskResizing e2e test now waits for SSH before checking disk size after resize."
impact_level: low
```
