### PR TITLE
test(vm): add virtualization-dra precheck

### DIFF
--- a/test/e2e/internal/precheck/usb.go
+++ b/test/e2e/internal/precheck/usb.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/deckhouse/virtualization/test/e2e/internal/framework"
@@ -49,7 +50,7 @@ func checkDummyHCDConfigured(ctx context.Context, f *framework.Framework) bool {
 
 	nodeUSBList, err := virtClient.NodeUSBDevices().List(ctx, metav1.ListOptions{})
 	if err != nil {
-		_, _ = fmt.Fprintf(GinkgoWriter, "failed to list NodeUSBDevices: %v\n", err)
+		GinkgoWriter.Printf("failed to list NodeUSBDevices: %v\n", err)
 		return false
 	}
 
@@ -62,10 +63,27 @@ func checkDummyHCDConfigured(ctx context.Context, f *framework.Framework) bool {
 	return false
 }
 
+func (u *usbPrecheck) checkVirtualizationDra(ctx context.Context, f *framework.Framework) bool {
+	_, err := f.KubeClient().AppsV1().DaemonSets(metav1.NamespaceSystem).Get(ctx, "virtualization-dra", metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return false
+		}
+		GinkgoWriter.Printf("failed to get virtualization-dra DaemonSet: %v\n", err)
+		return false
+	}
+	return true
+}
+
 func (u *usbPrecheck) Run(ctx context.Context, f *framework.Framework) error {
 	if !isCheckEnabled(usbPrecheckEnvName) {
 		_, _ = GinkgoWriter.Write([]byte("USB precheck is disabled.\n"))
 		return nil
+	}
+
+	if !u.checkVirtualizationDra(ctx, f) {
+		return fmt.Errorf("%s=no to disable this precheck: virtualization-dra DaemonSet is not running. "+
+			"Configure virtualization with DRA support", usbPrecheckEnvName)
 	}
 
 	if !checkDummyHCDConfigured(ctx, f) {


### PR DESCRIPTION
## Description
Added a precheck that verifies the `virtualization-dra` DaemonSet is running before executing USB-related e2e tests.

## Why do we need it, and what problem does it solve?
USB precheck tests require DRA support to be enabled in the cluster. Without this check, tests could fail with misleading errors when `virtualization-dra` is not deployed.

## What is the expected result?
1. Run e2e tests with USB precheck enabled.
2. If `virtualization-dra` DaemonSet is absent, the precheck fails with a clear error message prompting to configure DRA support.
3. If DaemonSet is present, the precheck passes and tests proceed normally.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: test
type: chore
summary: Add virtualization-dra precheck to verify DaemonSet is running before USB e2e tests.
impact_level: low
```
