### PR TITLE
chore(core): bump tag for kubevirt for disable DHCP

### DIFF
--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -3,7 +3,7 @@ firmware:
   libvirt: v10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: v1.6.2-v12n.25.2
+  3p-kubevirt: v1.6.2-v12n.25.3
   3p-containerized-data-importer: v1.60.3-v12n.19
   distribution: 2.8.3
 package:


### PR DESCRIPTION
## Description
Bump the `3p-kubevirt` component tag from `v1.6.2-v12n.25.2` to `v1.6.2-v12n.25.3` in `build/components/versions.yml`.

## Why do we need it, and what problem does it solve?
The new kubevirt tag includes the upstream fix that properly disables the DHCP relay in the cluster.
Without this bump, VMs configured to use the disabled DHCP relay path cannot rely on the corrected upstream behavior.

## What is the expected result?
1. Apply the change on a target cluster.
2. The `3p-kubevirt` image in DVCR is updated to `v1.6.2-v12n.25.3`.
3. DHCP relay is disabled as expected for affected VMs.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: vm
type: fix
summary: "Fixed an issue that blocked virtual machine migration for VMs with additional network interfaces."
```
