### PR TITLE
chore(api): replace non-canonical annotation with the correct one

### DIFF
--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -4,7 +4,7 @@ firmware:
   edk2: stable202411
 core:
   3p-kubevirt: v1.6.2-v12n.45
-  3p-containerized-data-importer: v1.60.3-v12n.19
+  3p-containerized-data-importer: v1.60.3-v12n.20
   distribution: 2.8.3
 package:
   acl: v2.3.1

--- a/images/virtualization-artifact/pkg/common/annotations/annotations.go
+++ b/images/virtualization-artifact/pkg/common/annotations/annotations.go
@@ -39,7 +39,7 @@ const (
 	AnnIntegrityCoreChecksumApplied = AnnIntegrityGroup + "core-spec-checksum-applied"
 
 	// AnnAPIGroup is the APIGroup for virtualization-controller.
-	AnnAPIGroup = "virt.deckhouse.io"
+	AnnAPIGroup = "internal.virtualization.deckhouse.io"
 
 	// AnnCreatedBy is a pod annotation indicating if the pod was created by the PVC.
 	AnnCreatedBy = AnnAPIGroup + "/storage.createdByController"

--- a/images/virtualization-artifact/pkg/common/annotations/annotations.go
+++ b/images/virtualization-artifact/pkg/common/annotations/annotations.go
@@ -40,6 +40,8 @@ const (
 
 	// AnnAPIGroup is the APIGroup for virtualization-controller.
 	AnnAPIGroup = "internal.virtualization.deckhouse.io"
+	// AnnAPIGroupLegacy is the legacy APIGroup for virtualization-controller annotations.
+	AnnAPIGroupLegacy = "virt.deckhouse.io"
 
 	// AnnCreatedBy is a pod annotation indicating if the pod was created by the PVC.
 	AnnCreatedBy = AnnAPIGroup + "/storage.createdByController"
@@ -47,16 +49,24 @@ const (
 	// AnnPodRetainAfterCompletion is PVC annotation for retaining transfer pods after completion
 	AnnPodRetainAfterCompletion = AnnAPIGroup + "/storage.pod.retainAfterCompletion"
 
+	// AnnPodRetainAfterCompletionLegacy is the legacy PVC annotation for retaining transfer pods after completion.
+	AnnPodRetainAfterCompletionLegacy = AnnAPIGroupLegacy + "/storage.pod.retainAfterCompletion"
+
 	// AnnUploadURLDeprecated provides a const for CVMI/VMI/VMD uploadURL annotation.
 	// TODO remove annotation and its usages after version 1.0 becomes Stable.
-	AnnUploadURLDeprecated = AnnAPIGroup + "/upload.url"
+	AnnUploadURLDeprecated = AnnAPIGroupLegacy + "/upload.url"
 
 	// AnnTolerationsHash provides a const for annotation with hash of applied tolerations.
 	AnnTolerationsHash = AnnAPIGroup + "/tolerations-hash"
+	// AnnTolerationsHashLegacy provides a const for legacy annotation with hash of applied tolerations.
+	AnnTolerationsHashLegacy = AnnAPIGroupLegacy + "/tolerations-hash"
+
 	// AnnProvisionerTolerations provides a const for tolerations to use for provisioners.
 	AnnProvisionerTolerations = AnnAPIGroup + "/provisioner-tolerations"
 	// AnnProvisionerName provides a name of data volume provisioner.
 	AnnProvisionerName = AnnAPIGroup + "/provisioner-name"
+	// AnnProvisionerNameLegacy provides a legacy name of data volume provisioner.
+	AnnProvisionerNameLegacy = AnnAPIGroupLegacy + "/provisioner-name"
 
 	// AnnDefaultStorageClass is the annotation indicating that a storage class is the default one.
 	AnnDefaultStorageClass = "storageclass.kubernetes.io/is-default-class"
@@ -72,14 +82,22 @@ const (
 
 	// AnnVMLastAppliedSpec is an annotation on KVVM. It contains a JSON with VM spec.
 	AnnVMLastAppliedSpec = AnnAPIGroup + "/vm.last-applied-spec"
+	// AnnVMLastAppliedSpecLegacy is a legacy annotation on KVVM. It contains a JSON with VM spec.
+	AnnVMLastAppliedSpecLegacy = AnnAPIGroupLegacy + "/vm.last-applied-spec"
 
 	// AnnVMClassLastAppliedSpec is an annotation on KVVM. It contains a JSON with VM spec.
 	AnnVMClassLastAppliedSpec = AnnAPIGroup + "/vmclass.last-applied-spec"
+	// AnnVMClassLastAppliedSpecLegacy is a legacy annotation on KVVM. It contains a JSON with VMClass spec.
+	AnnVMClassLastAppliedSpecLegacy = AnnAPIGroupLegacy + "/vmclass.last-applied-spec"
 
 	// LastPropagatedVMAnnotationsAnnotation is a marshalled map of previously applied virtual machine annotations.
 	LastPropagatedVMAnnotationsAnnotation = AnnAPIGroup + "/last-propagated-vm-annotations"
+	// LastPropagatedVMAnnotationsAnnotationLegacy is a legacy marshalled map of previously applied virtual machine annotations.
+	LastPropagatedVMAnnotationsAnnotationLegacy = AnnAPIGroupLegacy + "/last-propagated-vm-annotations"
 	// LastPropagatedVMLabelsAnnotation is a marshalled map of previously applied virtual machine labels.
 	LastPropagatedVMLabelsAnnotation = AnnAPIGroup + "/last-propagated-vm-labels"
+	// LastPropagatedVMLabelsAnnotationLegacy is a legacy marshalled map of previously applied virtual machine labels.
+	LastPropagatedVMLabelsAnnotationLegacy = AnnAPIGroupLegacy + "/last-propagated-vm-labels"
 
 	AnnOsType = AnnAPIGroupV + "/os-type"
 

--- a/images/virtualization-artifact/pkg/common/object/object.go
+++ b/images/virtualization-artifact/pkg/common/object/object.go
@@ -133,7 +133,9 @@ func GetAge(obj client.Object) time.Duration {
 // - CVMI, VMI has no annotation to retain pod after import
 // - CVMI, VMI is deleted
 func ShouldCleanupSubResources(obj metav1.Object) bool {
-	return obj.GetAnnotations()[annotations.AnnPodRetainAfterCompletion] != "true" || obj.GetDeletionTimestamp() != nil
+	return (obj.GetAnnotations()[annotations.AnnPodRetainAfterCompletion] != "true" &&
+		obj.GetAnnotations()[annotations.AnnPodRetainAfterCompletionLegacy] != "true") ||
+		obj.GetDeletionTimestamp() != nil
 }
 
 func IsTerminating(obj client.Object) bool {

--- a/images/virtualization-artifact/pkg/common/provisioner/node_placement.go
+++ b/images/virtualization-artifact/pkg/common/provisioner/node_placement.go
@@ -36,6 +36,10 @@ type NodePlacement struct {
 func IsNodePlacementChanged(nodePlacement *NodePlacement, obj client.Object) (bool, error) {
 	oldHash, exists := obj.GetAnnotations()[annotations.AnnTolerationsHash]
 
+	if !exists {
+		oldHash, exists = obj.GetAnnotations()[annotations.AnnTolerationsHashLegacy]
+	}
+
 	if nodePlacement == nil && exists {
 		return true, nil
 	}
@@ -59,11 +63,17 @@ func KeepNodePlacementTolerations(nodePlacement *NodePlacement, obj client.Objec
 
 	if nodePlacement == nil || len(nodePlacement.Tolerations) == 0 {
 		_, ok := anno[annotations.AnnTolerationsHash]
+
+		if !ok {
+			_, ok = anno[annotations.AnnTolerationsHashLegacy]
+		}
+
 		if !ok {
 			return nil
 		}
 
 		delete(anno, annotations.AnnTolerationsHash)
+		delete(anno, annotations.AnnTolerationsHashLegacy)
 
 		obj.SetAnnotations(anno)
 

--- a/images/virtualization-artifact/pkg/common/vm/vm.go
+++ b/images/virtualization-artifact/pkg/common/vm/vm.go
@@ -131,7 +131,10 @@ func RemoveNonPropagatableAnnotations(anno map[string]string) map[string]string 
 	res := make(map[string]string)
 
 	for k, v := range anno {
-		if k == annotations.LastPropagatedVMAnnotationsAnnotation || k == annotations.LastPropagatedVMLabelsAnnotation {
+		if k == annotations.LastPropagatedVMAnnotationsAnnotation ||
+			k == annotations.LastPropagatedVMAnnotationsAnnotationLegacy ||
+			k == annotations.LastPropagatedVMLabelsAnnotation ||
+			k == annotations.LastPropagatedVMLabelsAnnotationLegacy {
 			continue
 		}
 

--- a/images/virtualization-artifact/pkg/controller/importer/importer_pod.go
+++ b/images/virtualization-artifact/pkg/controller/importer/importer_pod.go
@@ -39,9 +39,6 @@ const (
 	// CABundleVolName is the name of the volume containing certs from dataSource.http.caBundle field.
 	caBundleVolName = "ca-bundle-vol"
 
-	// AnnOwnerRef is used when owner is in a different namespace
-	AnnOwnerRef = annotations.AnnAPIGroup + "/storage.ownerRef"
-
 	// PodRunningReason is const that defines the pod was started as a reason
 	// PodRunningReason = "Pod is running"
 

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/last_applied_spec.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/last_applied_spec.go
@@ -29,7 +29,12 @@ import (
 
 // LoadLastAppliedSpec loads VM spec from JSON in the last-applied-spec annotation.
 func LoadLastAppliedSpec(kvvm *virtv1.VirtualMachine) (*v1alpha2.VirtualMachineSpec, error) {
-	lastSpecJSON := kvvm.GetAnnotations()[annotations.AnnVMLastAppliedSpec]
+	lastSpecJSON, ok := kvvm.GetAnnotations()[annotations.AnnVMLastAppliedSpec]
+
+	if !ok {
+		lastSpecJSON = kvvm.GetAnnotations()[annotations.AnnVMLastAppliedSpecLegacy]
+	}
+
 	if strings.TrimSpace(lastSpecJSON) == "" {
 		return nil, nil
 	}
@@ -55,7 +60,12 @@ func SetLastAppliedSpec(kvvm *virtv1.VirtualMachine, vm *v1alpha2.VirtualMachine
 
 // LoadLastAppliedClassSpec loads VMClass spec from JSON in the last-applied-spec annotation.
 func LoadLastAppliedClassSpec(kvvm *virtv1.VirtualMachine) (*v1alpha2.VirtualMachineClassSpec, error) {
-	lastSpecJSON := kvvm.GetAnnotations()[annotations.AnnVMClassLastAppliedSpec]
+	lastSpecJSON, ok := kvvm.GetAnnotations()[annotations.AnnVMClassLastAppliedSpec]
+
+	if !ok {
+		lastSpecJSON = kvvm.GetAnnotations()[annotations.AnnVMClassLastAppliedSpecLegacy]
+	}
+
 	if strings.TrimSpace(lastSpecJSON) == "" {
 		return nil, nil
 	}

--- a/images/virtualization-artifact/pkg/controller/service/disk_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/disk_service.go
@@ -172,6 +172,11 @@ func (s DiskService) CheckProvisioning(ctx context.Context, pvc *corev1.Persiste
 	}
 
 	podName, ok := pvc.Annotations[annotations.AnnProvisionerName]
+
+	if !ok || podName == "" {
+		podName, ok = pvc.Annotations[annotations.AnnProvisionerNameLegacy]
+	}
+
 	if !ok || podName == "" {
 		return nil
 	}

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
@@ -585,11 +585,29 @@ func MakeKVVMFromVMSpec(ctx context.Context, s state.VirtualMachineState) (*virt
 
 // IsKVVMChanged returns whether kvvm spec or special annotations are changed.
 func IsKVVMChanged(prevKVVM, newKVVM *virtv1.VirtualMachine) bool {
-	if prevKVVM.Annotations[annotations.AnnVMLastAppliedSpec] != newKVVM.Annotations[annotations.AnnVMLastAppliedSpec] {
+	prevKVVMLastAppliedSpecAnnotations, ok := prevKVVM.Annotations[annotations.AnnVMLastAppliedSpec]
+	if !ok {
+		prevKVVMLastAppliedSpecAnnotations = prevKVVM.Annotations[annotations.AnnVMLastAppliedSpecLegacy]
+	}
+	newKVVMLastAppliedSpecAnnotations, ok := newKVVM.Annotations[annotations.AnnVMLastAppliedSpec]
+	if !ok {
+		newKVVMLastAppliedSpecAnnotations = newKVVM.Annotations[annotations.AnnVMLastAppliedSpecLegacy]
+	}
+
+	if prevKVVMLastAppliedSpecAnnotations != newKVVMLastAppliedSpecAnnotations {
 		return true
 	}
 
-	if prevKVVM.Annotations[annotations.AnnVMClassLastAppliedSpec] != newKVVM.Annotations[annotations.AnnVMClassLastAppliedSpec] {
+	prevKVVMClassLastAppliedSpecAnnotations, ok := prevKVVM.Annotations[annotations.AnnVMClassLastAppliedSpec]
+	if !ok {
+		prevKVVMClassLastAppliedSpecAnnotations = prevKVVM.Annotations[annotations.AnnVMClassLastAppliedSpecLegacy]
+	}
+	newKVVMClassLastAppliedSpecAnnotations, ok := newKVVM.Annotations[annotations.AnnVMClassLastAppliedSpec]
+	if !ok {
+		newKVVMClassLastAppliedSpecAnnotations = newKVVM.Annotations[annotations.AnnVMClassLastAppliedSpecLegacy]
+	}
+
+	if prevKVVMClassLastAppliedSpecAnnotations != newKVVMClassLastAppliedSpecAnnotations {
 		return true
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_metadata.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_metadata.go
@@ -204,7 +204,10 @@ func (h *SyncMetadataHandler) updateKVVMSpecTemplateMetadataAnnotations(currAnno
 	res := make(map[string]string, len(newAnno))
 
 	for k, v := range newAnno {
-		if k == annotations.AnnVMLastAppliedSpec || k == annotations.AnnVMClassLastAppliedSpec {
+		if k == annotations.AnnVMLastAppliedSpec ||
+			k == annotations.AnnVMLastAppliedSpecLegacy ||
+			k == annotations.AnnVMClassLastAppliedSpec ||
+			k == annotations.AnnVMClassLastAppliedSpecLegacy {
 			continue
 		}
 
@@ -294,8 +297,15 @@ func PropagateVMMetadata(vm *v1alpha2.VirtualMachine, kvvm *virtv1.VirtualMachin
 func GetLastPropagatedLabels(kvvm *virtv1.VirtualMachine) (map[string]string, error) {
 	var lastPropagatedLabels map[string]string
 
-	if kvvm.Annotations[annotations.LastPropagatedVMLabelsAnnotation] != "" {
-		err := json.Unmarshal([]byte(kvvm.Annotations[annotations.LastPropagatedVMLabelsAnnotation]), &lastPropagatedLabels)
+	key := annotations.LastPropagatedVMLabelsAnnotation
+	lastPropagatedVMLabelsAnnotation, ok := kvvm.Annotations[key]
+	if !ok {
+		key = annotations.LastPropagatedVMLabelsAnnotationLegacy
+		lastPropagatedVMLabelsAnnotation = kvvm.Annotations[key]
+	}
+
+	if lastPropagatedVMLabelsAnnotation != "" {
+		err := json.Unmarshal([]byte(lastPropagatedVMLabelsAnnotation), &lastPropagatedLabels)
 		if err != nil {
 			return nil, err
 		}
@@ -323,8 +333,15 @@ func SetLastPropagatedLabels(metadata *metav1.ObjectMeta, vm *v1alpha2.VirtualMa
 func GetLastPropagatedAnnotations(kvvm *virtv1.VirtualMachine) (map[string]string, error) {
 	var lastPropagatedAnno map[string]string
 
-	if kvvm.Annotations[annotations.LastPropagatedVMAnnotationsAnnotation] != "" {
-		err := json.Unmarshal([]byte(kvvm.Annotations[annotations.LastPropagatedVMAnnotationsAnnotation]), &lastPropagatedAnno)
+	key := annotations.LastPropagatedVMAnnotationsAnnotation
+	lastPropagatedAnnotations, ok := kvvm.Annotations[key]
+	if !ok {
+		key = annotations.LastPropagatedVMAnnotationsAnnotationLegacy
+		lastPropagatedAnnotations = kvvm.Annotations[key]
+	}
+
+	if lastPropagatedAnnotations != "" {
+		err := json.Unmarshal([]byte(lastPropagatedAnnotations), &lastPropagatedAnno)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Description

Renamed the internal annotation API group prefix in `annotations.go` from `virt.deckhouse.io` to `internal.virtualization.deckhouse.io`.  
Also updated `3p-containerized-data-importer` in `build/components/versions.yml` to `chore/rename-deckhouse-anno-prefix` to keep dependency behavior aligned with the prefix change. ( https://github.com/deckhouse/3p-containerized-data-importer/pull/36 )

## Why do we need it, and what problem does it solve?

The previous annotation prefix looked like a public-facing API domain. This change makes the namespace explicitly internal and aligns the CDI dependency branch to avoid annotation-prefix mismatches across components.

## What is the expected result?

Annotations produced by the controller now use the `internal.virtualization.deckhouse.io/*` prefix.  
Builds consume the CDI branch that includes the same annotation-prefix rename.


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
