### PR TITLE
fix(vm): create network interfaces with deckhouse user

### DIFF
--- a/images/virtualization-artifact/pkg/common/network/spec.go
+++ b/images/virtualization-artifact/pkg/common/network/spec.go
@@ -45,6 +45,8 @@ func CreateNetworkSpec(vm *v1alpha2.VirtualMachine, vmmacs []*v1alpha2.VirtualMa
 	return specs
 }
 
+const deckhouseUID = 64535
+
 func createMainInterfaceSpec(net v1alpha2.NetworksSpec) InterfaceSpec {
 	return InterfaceSpec{
 		ID:            ptr.Deref(net.ID, 0),
@@ -52,6 +54,8 @@ func createMainInterfaceSpec(net v1alpha2.NetworksSpec) InterfaceSpec {
 		Name:          net.Name,
 		InterfaceName: NameDefaultInterface,
 		MAC:           "",
+		UID:           deckhouseUID,
+		GID:           deckhouseUID,
 	}
 }
 
@@ -62,6 +66,8 @@ func createAdditionalInterfaceSpec(net v1alpha2.NetworksSpec, mac string) Interf
 		Name:          net.Name,
 		InterfaceName: generateInterfaceName(mac, net.Type),
 		MAC:           mac,
+		UID:           deckhouseUID,
+		GID:           deckhouseUID,
 	}
 }
 

--- a/images/virtualization-artifact/pkg/common/network/types.go
+++ b/images/virtualization-artifact/pkg/common/network/types.go
@@ -52,6 +52,8 @@ type InterfaceSpec struct {
 	Name          string `json:"name"`
 	InterfaceName string `json:"ifName"`
 	MAC           string `json:"-"`
+	UID           int    `json:"uid"`
+	GID           int    `json:"gid"`
 }
 
 type InterfaceStatus struct {

--- a/images/virtualization-artifact/pkg/common/network/types_test.go
+++ b/images/virtualization-artifact/pkg/common/network/types_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Network types helpers", func() {
 			out, err := list.ToString()
 
 			Expect(err).ToNot(HaveOccurred())
-			Expect(out).To(Equal(`[{"id":2,"type":"Network","name":"n1","ifName":"veth_n12345678"}]`))
+			Expect(out).To(Equal(`[{"id":2,"type":"Network","name":"n1","ifName":"veth_n12345678","uid":0,"gid":0}]`))
 		})
 	})
 })


### PR DESCRIPTION
## Description
Add `UID` and `GID` fields to `InterfaceSpec`, set to deckhouse user (`64535`) for all VM network interfaces.

## Why do we need it, and what problem does it solve?
Tap devices were created with root ownership, causing permission issues for deckhouse user processes. Setting UID/GID explicitly fixes this.

## What is the expected result?
VM network interfaces are created with deckhouse user ownership (UID/GID 64535).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: core
type: fix
summary: Create network interfaces with deckhouse user ownership (UID/GID 64535).
impact_level: low
```
