### PR TITLE
fix(vd): correct restoring if original vd was deleted

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/step/create_pvc_from_vdsnapshot_step.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/step/create_pvc_from_vdsnapshot_step.go
@@ -281,6 +281,10 @@ func (s CreatePVCFromVDSnapshotStep) validateStorageClassCompatibility(ctx conte
 	var originalPVC corev1.PersistentVolumeClaim
 	err = s.client.Get(ctx, types.NamespacedName{Name: pvcName, Namespace: vdSnapshot.Namespace}, &originalPVC)
 	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			log.With("pvc.name", pvcName).Debug("Original PVC does not exist, skipping storage class compatibility validation")
+			return nil
+		}
 		return fmt.Errorf("cannot fetch original PVC %q: %w", pvcName, err)
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/step/create_pvc_step.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/step/create_pvc_step.go
@@ -230,6 +230,10 @@ func (s CreatePersistentVolumeClaimStep) validateStorageClassCompatibility(ctx c
 	var originalPVC corev1.PersistentVolumeClaim
 	err = s.client.Get(ctx, types.NamespacedName{Name: pvcName, Namespace: vdSnapshot.Namespace}, &originalPVC)
 	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			log.With("pvc.name", pvcName).Debug("Original PVC does not exist, skipping storage class compatibility validation")
+			return nil
+		}
 		return fmt.Errorf("cannot fetch original PVC %q: %w", pvcName, err)
 	}
 


### PR DESCRIPTION
## Description

Fixed PVC restore flow for VD/VI snapshot sources: when the original PVC no longer exists, storage class compatibility validation is skipped instead of failing the step.

## Why do we need it, and what problem does it solve?

During restore/import from `VDSnapshot`, the source/original PVC may already be deleted. Previously, controllers returned an error on `NotFound` while validating storage class compatibility, which blocked restore progress in a valid scenario.

## What is the expected result?

If the original PVC referenced by `VDSnapshot.Status.VirtualDiskPVCName` is missing, controllers log a debug message and continue reconciliation.  
Restore/import proceeds without failing on storage class compatibility checks for a non-existent source PVC.


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

