### PR TITLE
fix: resolve xml dir for non root setup

### DIFF
--- a/images/virt-launcher/vlctl/cmd/vlctl/app/domain.go
+++ b/images/virt-launcher/vlctl/cmd/vlctl/app/domain.go
@@ -106,7 +106,7 @@ func runDomainCommand(opts BaseOptions, fromFile bool) error {
 func resolveXMLDir() (string, error) {
 	_, err := os.Stat(xmlDirNonRoot)
 	if err == nil {
-		return xmlDirNonRoot
+		return xmlDirNonRoot, nil
 	}
 	if os.IsNotExist(err) {
 		return xmlDir, nil

--- a/images/virt-launcher/vlctl/cmd/vlctl/app/domain.go
+++ b/images/virt-launcher/vlctl/cmd/vlctl/app/domain.go
@@ -104,13 +104,14 @@ func runDomainCommand(opts BaseOptions, fromFile bool) error {
 }
 
 func resolveXMLDir() (string, error) {
-	if _, err := os.Stat(xmlDirNonRoot); err != nil {
-		if os.IsNotExist(err) {
-			return xmlDir, nil
-		}
-		return "", err
+	_, err := os.Stat(xmlDirNonRoot)
+	if err == nil {
+		return xmlDirNonRoot
 	}
-	return xmlDirNonRoot, nil
+	if os.IsNotExist(err) {
+		return xmlDir, nil
+	}
+	return "", err
 }
 
 func NewDomainStatsCommand() *cobra.Command {

--- a/images/virt-launcher/vlctl/cmd/vlctl/app/domain.go
+++ b/images/virt-launcher/vlctl/cmd/vlctl/app/domain.go
@@ -25,7 +25,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const xmlDir = "/var/run/libvirt/qemu"
+const (
+	xmlDir        = "/var/run/libvirt/qemu"
+	xmlDirNonRoot = "/var/run/libvirt/qemu/run"
+)
 
 func NewDomainCommand() *cobra.Command {
 	var fromFile bool
@@ -55,13 +58,19 @@ func runDomainCommand(opts BaseOptions, fromFile bool) error {
 		if opts.Output != outputXml {
 			return fmt.Errorf("output format must be xml when reading from file")
 		}
-		entries, err := os.ReadDir(xmlDir)
+
+		dir, err := resolveXMLDir()
+		if err != nil {
+			return fmt.Errorf("failed to resolve xml dir: %w", err)
+		}
+
+		entries, err := os.ReadDir(dir)
 		if err != nil {
 			return fmt.Errorf("failed to read domain xml dir: %w", err)
 		}
 		for _, entry := range entries {
 			if strings.HasSuffix(entry.Name(), ".xml") {
-				b, err := os.ReadFile(filepath.Join(xmlDir, entry.Name()))
+				b, err := os.ReadFile(filepath.Join(dir, entry.Name()))
 				if err != nil {
 					return fmt.Errorf("failed to read domain xml file: %w", err)
 				}
@@ -92,6 +101,16 @@ func runDomainCommand(opts BaseOptions, fromFile bool) error {
 	}
 
 	return marshalAndPrintOutput(&opts, domain.Spec)
+}
+
+func resolveXMLDir() (string, error) {
+	if _, err := os.Stat(xmlDirNonRoot); err != nil {
+		if os.IsNotExist(err) {
+			return xmlDir, nil
+		}
+		return "", err
+	}
+	return xmlDirNonRoot, nil
 }
 
 func NewDomainStatsCommand() *cobra.Command {


### PR DESCRIPTION
## Description
resolve xml dir for non root setup

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: vm
type: fix 
summary: resolve xml dir for non root setup
impact_level: low
```
