### PR TITLE
feat(vmop): add migration transfer details to message

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle.go
@@ -627,23 +627,23 @@ func formatMigrationDetails(mig *virtv1.VirtualMachineInstanceMigration, now tim
 	status := state.TransferStatus
 	parts := make([]string, 0, 7)
 	if state.StartTimestamp != nil {
-		parts = append(parts, fmt.Sprintf("TimeElapsed: %dms", now.Sub(state.StartTimestamp.Time).Milliseconds()))
+		parts = append(parts, fmt.Sprintf("TimeElapsed:%dms", now.Sub(state.StartTimestamp.Time).Milliseconds()))
 	}
 	if status.DataProcessedBytes != nil {
-		parts = append(parts, fmt.Sprintf("DataProcessed: %dMiB", bytesToMiB(*status.DataProcessedBytes)))
+		parts = append(parts, fmt.Sprintf("DataProcessed:%dMiB", bytesToMiB(*status.DataProcessedBytes)))
 	}
 	if status.DataRemainingBytes != nil {
-		parts = append(parts, fmt.Sprintf("DataRemaining: %dMiB", bytesToMiB(*status.DataRemainingBytes)))
+		parts = append(parts, fmt.Sprintf("DataRemaining:%dMiB", bytesToMiB(*status.DataRemainingBytes)))
 	}
 	if status.DataTotalBytes != nil {
-		parts = append(parts, fmt.Sprintf("DataTotal: %dMiB", bytesToMiB(*status.DataTotalBytes)))
+		parts = append(parts, fmt.Sprintf("DataTotal:%dMiB", bytesToMiB(*status.DataTotalBytes)))
 	}
 	if status.Iteration != nil {
-		parts = append(parts, fmt.Sprintf("Iteration: %d", *status.Iteration))
+		parts = append(parts, fmt.Sprintf("Iteration:%d", *status.Iteration))
 	}
-	parts = append(parts, fmt.Sprintf("AutoConvergeThrottleSet: %t", status.AutoConvergeThrottle != nil))
+	parts = append(parts, fmt.Sprintf("AutoConvergeThrottleSet:%t", status.AutoConvergeThrottle != nil))
 	if status.AutoConvergeThrottle != nil {
-		parts = append(parts, fmt.Sprintf("AutoConvergeThrottle: %d", *status.AutoConvergeThrottle))
+		parts = append(parts, fmt.Sprintf("AutoConvergeThrottle:%d", *status.AutoConvergeThrottle))
 	}
 	if len(parts) == 0 {
 		return ""

--- a/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle.go
@@ -610,9 +610,50 @@ func (h LifecycleHandler) getInProgressReasonAndMessage(
 			reason = vmopcondition.ReasonSourceSuspended
 			message = messageSourceVMSuspended
 		}
+		if details := formatMigrationDetails(mig, time.Now()); details != "" {
+			message = fmt.Sprintf("%s. %s", message, details)
+		}
 	}
 
 	return reason, message, nil
+}
+
+func formatMigrationDetails(mig *virtv1.VirtualMachineInstanceMigration, now time.Time) string {
+	if mig == nil || mig.Status.MigrationState == nil || mig.Status.MigrationState.TransferStatus == nil {
+		return ""
+	}
+
+	state := mig.Status.MigrationState
+	status := state.TransferStatus
+	parts := make([]string, 0, 7)
+	if state.StartTimestamp != nil {
+		parts = append(parts, fmt.Sprintf("TimeElapsed:%dms", now.Sub(state.StartTimestamp.Time).Milliseconds()))
+	}
+	if status.DataProcessedBytes != nil {
+		parts = append(parts, fmt.Sprintf("DataProcessed:%dMiB", bytesToMiB(*status.DataProcessedBytes)))
+	}
+	if status.DataRemainingBytes != nil {
+		parts = append(parts, fmt.Sprintf("DataRemaining:%dMiB", bytesToMiB(*status.DataRemainingBytes)))
+	}
+	if status.DataTotalBytes != nil {
+		parts = append(parts, fmt.Sprintf("DataTotal:%dMiB", bytesToMiB(*status.DataTotalBytes)))
+	}
+	if status.Iteration != nil {
+		parts = append(parts, fmt.Sprintf("Iteration:%d", *status.Iteration))
+	}
+	parts = append(parts, fmt.Sprintf("AutoConvergeThrottleSet:%t", status.AutoConvergeThrottle != nil))
+	if status.AutoConvergeThrottle != nil {
+		parts = append(parts, fmt.Sprintf("AutoConvergeThrottle:%d", *status.AutoConvergeThrottle))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+
+	return fmt.Sprintf("Migration info for %s: %s", state.MigrationUID, strings.Join(parts, " "))
+}
+
+func bytesToMiB(value uint64) uint64 {
+	return value / 1024 / 1024
 }
 
 func (h LifecycleHandler) calculateMigrationProgress(

--- a/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle.go
@@ -627,29 +627,29 @@ func formatMigrationDetails(mig *virtv1.VirtualMachineInstanceMigration, now tim
 	status := state.TransferStatus
 	parts := make([]string, 0, 7)
 	if state.StartTimestamp != nil {
-		parts = append(parts, fmt.Sprintf("TimeElapsed:%dms", now.Sub(state.StartTimestamp.Time).Milliseconds()))
+		parts = append(parts, fmt.Sprintf("TimeElapsed: %dms", now.Sub(state.StartTimestamp.Time).Milliseconds()))
 	}
 	if status.DataProcessedBytes != nil {
-		parts = append(parts, fmt.Sprintf("DataProcessed:%dMiB", bytesToMiB(*status.DataProcessedBytes)))
+		parts = append(parts, fmt.Sprintf("DataProcessed: %dMiB", bytesToMiB(*status.DataProcessedBytes)))
 	}
 	if status.DataRemainingBytes != nil {
-		parts = append(parts, fmt.Sprintf("DataRemaining:%dMiB", bytesToMiB(*status.DataRemainingBytes)))
+		parts = append(parts, fmt.Sprintf("DataRemaining: %dMiB", bytesToMiB(*status.DataRemainingBytes)))
 	}
 	if status.DataTotalBytes != nil {
-		parts = append(parts, fmt.Sprintf("DataTotal:%dMiB", bytesToMiB(*status.DataTotalBytes)))
+		parts = append(parts, fmt.Sprintf("DataTotal: %dMiB", bytesToMiB(*status.DataTotalBytes)))
 	}
 	if status.Iteration != nil {
-		parts = append(parts, fmt.Sprintf("Iteration:%d", *status.Iteration))
+		parts = append(parts, fmt.Sprintf("Iteration: %d", *status.Iteration))
 	}
-	parts = append(parts, fmt.Sprintf("AutoConvergeThrottleSet:%t", status.AutoConvergeThrottle != nil))
+	parts = append(parts, fmt.Sprintf("AutoConvergeThrottleSet: %t", status.AutoConvergeThrottle != nil))
 	if status.AutoConvergeThrottle != nil {
-		parts = append(parts, fmt.Sprintf("AutoConvergeThrottle:%d", *status.AutoConvergeThrottle))
+		parts = append(parts, fmt.Sprintf("AutoConvergeThrottle: %d", *status.AutoConvergeThrottle))
 	}
 	if len(parts) == 0 {
 		return ""
 	}
 
-	return fmt.Sprintf("Migration info for %s: %s", state.MigrationUID, strings.Join(parts, " "))
+	return strings.Join(parts, " ")
 }
 
 func bytesToMiB(value uint64) uint64 {

--- a/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle_test.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle_test.go
@@ -674,8 +674,8 @@ var _ = Describe("LifecycleHandler", func() {
 			Expect(found).To(BeTrue())
 			Expect(completed.Message).NotTo(ContainSubstring("Migration info for 7d38a63b-ffa9-4d56-a924-6017f5832110:"))
 			Expect(completed.Message).To(ContainSubstring("Syncing source and target. TimeElapsed:"))
-			Expect(completed.Message).To(ContainSubstring("DataProcessed: 3529MiB DataRemaining: 12049MiB DataTotal: 16405MiB"))
-			Expect(completed.Message).To(ContainSubstring("Iteration: 1 AutoConvergeThrottleSet: true AutoConvergeThrottle: 0"))
+			Expect(completed.Message).To(ContainSubstring("DataProcessed:3529MiB DataRemaining:12049MiB DataTotal:16405MiB"))
+			Expect(completed.Message).To(ContainSubstring("Iteration:1 AutoConvergeThrottleSet:true AutoConvergeThrottle:0"))
 		})
 
 		It("should prefer Aborted over NotConverging for terminal reason", func() {

--- a/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle_test.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle_test.go
@@ -672,9 +672,10 @@ var _ = Describe("LifecycleHandler", func() {
 
 			completed, found := conditions.GetCondition(vmopcondition.TypeCompleted, srv.Changed().Status.Conditions)
 			Expect(found).To(BeTrue())
-			Expect(completed.Message).To(ContainSubstring("Syncing source and target. Migration info for 7d38a63b-ffa9-4d56-a924-6017f5832110:"))
-			Expect(completed.Message).To(ContainSubstring("DataProcessed:3529MiB DataRemaining:12049MiB DataTotal:16405MiB"))
-			Expect(completed.Message).To(ContainSubstring("Iteration:1 AutoConvergeThrottleSet:true AutoConvergeThrottle:0"))
+			Expect(completed.Message).NotTo(ContainSubstring("Migration info for 7d38a63b-ffa9-4d56-a924-6017f5832110:"))
+			Expect(completed.Message).To(ContainSubstring("Syncing source and target. TimeElapsed:"))
+			Expect(completed.Message).To(ContainSubstring("DataProcessed: 3529MiB DataRemaining: 12049MiB DataTotal: 16405MiB"))
+			Expect(completed.Message).To(ContainSubstring("Iteration: 1 AutoConvergeThrottleSet: true AutoConvergeThrottle: 0"))
 		})
 
 		It("should prefer Aborted over NotConverging for terminal reason", func() {

--- a/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle_test.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle_test.go
@@ -637,6 +637,46 @@ var _ = Describe("LifecycleHandler", func() {
 			Expect(completed.Reason).To(Equal(vmopcondition.ReasonSyncing.String()))
 		})
 
+		It("should include migration transfer details in syncing message", func() {
+			vm := newVM(v1alpha2.PreferSafeMigrationPolicy)
+			vmop := newVMOPMigrate()
+			vmop.Status.Phase = v1alpha2.VMOPPhaseInProgress
+			processed := uint64(3529 * 1024 * 1024)
+			remaining := uint64(12049 * 1024 * 1024)
+			total := uint64(16405 * 1024 * 1024)
+			iteration := uint32(1)
+			throttle := uint32(0)
+
+			mig := newSimpleMigration(fmt.Sprintf("vmop-%s", vmop.Name), name)
+			mig.Status.Phase = virtv1.MigrationRunning
+			mig.Status.MigrationState = &virtv1.VirtualMachineInstanceMigrationState{
+				StartTimestamp: &metav1.Time{Time: time.Now().Add(-30 * time.Second)},
+				MigrationUID:   types.UID("7d38a63b-ffa9-4d56-a924-6017f5832110"),
+				TransferStatus: &virtv1.VirtualMachineInstanceMigrationTransferStatus{
+					DataProcessedBytes:   &processed,
+					DataRemainingBytes:   &remaining,
+					DataTotalBytes:       &total,
+					Iteration:            &iteration,
+					AutoConvergeThrottle: &throttle,
+				},
+			}
+
+			fakeClient, srv = setupEnvironment(vmop, vm, mig)
+			migrationService := service.NewMigrationService(fakeClient, featuregates.Default())
+			base := genericservice.NewBaseVMOPService(fakeClient, recorderMock)
+			h := NewLifecycleHandler(fakeClient, migrationService, base, recorderMock)
+			h.progressStrategy = &progressStrategyStub{value: 30}
+
+			_, err := h.Handle(ctx, srv.Changed())
+			Expect(err).NotTo(HaveOccurred())
+
+			completed, found := conditions.GetCondition(vmopcondition.TypeCompleted, srv.Changed().Status.Conditions)
+			Expect(found).To(BeTrue())
+			Expect(completed.Message).To(ContainSubstring("Syncing source and target. Migration info for 7d38a63b-ffa9-4d56-a924-6017f5832110:"))
+			Expect(completed.Message).To(ContainSubstring("DataProcessed:3529MiB DataRemaining:12049MiB DataTotal:16405MiB"))
+			Expect(completed.Message).To(ContainSubstring("Iteration:1 AutoConvergeThrottleSet:true AutoConvergeThrottle:0"))
+		})
+
 		It("should prefer Aborted over NotConverging for terminal reason", func() {
 			h := LifecycleHandler{}
 			mig := &virtv1.VirtualMachineInstanceMigration{


### PR DESCRIPTION
## Description
Adds live migration transfer details to the `Completed` condition message for VMOP `Evict` and `Migrate` operations while migration is in progress.

The message now includes data from `MigrationState.TransferStatus`: elapsed time, processed/remaining/total data, iteration, and auto-converge throttle state.

## Why do we need it, and what problem does it solve?
Users currently see only a generic message like `Syncing source and target`, which does not explain migration progress details. This makes troubleshooting slow or stalled evict/migrate operations harder.

With transfer details in the VMOP condition message, users can inspect migration progress directly from the VMOP status.

## What is the expected result?
1. Start a VMOP `Evict` or `Migrate` operation.
2. Wait until the operation reaches the syncing phase.
3. Check the VMOP `Completed` condition message.
4. Verify that it contains migration details such as `DataProcessed`, `DataRemaining`, `DataTotal`, `Iteration`, and `AutoConvergeThrottle`.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: core
type: feature
summary: Add live migration transfer details to VMOP condition messages.
impact_level: low
```
