### PR TITLE
fix(vm): pin VM pod to local disk node for hotplug volumes on restart

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm/internal/state/state.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/state/state.go
@@ -455,7 +455,7 @@ func (s *state) collectBlockDeviceRefs(ctx context.Context) ([]blockDeviceRef, e
 	}
 
 	for _, vmbda := range vmbdaList.Items {
-		if vmbda.Status.Phase != v1alpha2.BlockDeviceAttachmentPhaseAttached {
+		if vmbda.Status.Phase == v1alpha2.BlockDeviceAttachmentPhaseTerminating || vmbda.DeletionTimestamp != nil {
 			continue
 		}
 		ref := blockDeviceRef{


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Propagate the PV node affinity for every VMBDA phase except `Terminating`.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
To fix hp pod being stuck in pending during VM restart (VMBDA transitions to `Pending` when restarting).

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


