### PR TITLE
chore(test): fix prechecks in e2e

### DIFF
--- a/test/e2e/internal/precheck/common.go
+++ b/test/e2e/internal/precheck/common.go
@@ -175,7 +175,7 @@ func filterSpecs(specs []specInfo, focusRegex, labelFilter string) []specInfo {
 		}
 	}
 
-	// Parse label filter (comma-separated, supports ~ for negated)
+	// Parse label filter (comma-separated, supports ! for negated)
 	requiredLabels := make(map[string]bool)
 	negatedLabels := make(map[string]bool)
 	if labelFilter != "" {

--- a/test/e2e/internal/precheck/common.go
+++ b/test/e2e/internal/precheck/common.go
@@ -181,7 +181,7 @@ func filterSpecs(specs []specInfo, focusRegex, labelFilter string) []specInfo {
 	if labelFilter != "" {
 		for _, l := range strings.Split(labelFilter, ",") {
 			l = strings.TrimSpace(l)
-			if strings.HasPrefix(l, "~") {
+			if strings.HasPrefix(l, "!") {
 				negatedLabels[l[1:]] = true
 			} else {
 				requiredLabels[l] = true


### PR DESCRIPTION
## Description
Align the custom e2e precheck label filter parser with Ginkgo label filter syntax by treating `!` as a negation prefix.

## Why do we need it, and what problem does it solve?
The e2e precheck loader parsed negated labels differently from Ginkgo. Ginkgo uses `!Slow`, while the custom precheck filter expected `~Slow`. As a result, when running tests with `--label-filter='!Slow'`, Ginkgo excluded slow specs correctly, but the precheck loader treated `!Slow` as a required label name, collected no matching specs, and skipped all non-common prechecks.

This change removes that mismatch and makes precheck selection consistent with the actual Ginkgo run.

## What is the expected result?
1. Run e2e tests with `go tool ginkgo --label-filter='!Slow'`.
2. Verify slow specs are excluded by Ginkgo.
3. Verify prechecks required by the remaining specs are still detected and executed.
4. Verify only unrelated specs are skipped, while non-common prechecks are no longer dropped incorrectly.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: test
type: fix
summary: "Make e2e precheck label parsing compatible with Ginkgo negated label filters."
impact_level: low
```
