### PR TITLE
test(vd): increase VM memory to 512Mi for disk resizing test

### DIFF
--- a/test/e2e/blockdevice/virtual_disk_resizing.go
+++ b/test/e2e/blockdevice/virtual_disk_resizing.go
@@ -118,7 +118,6 @@ var _ = Describe("VirtualDiskResizing", Label(precheck.NoPrecheck), func() {
 		util.UntilObjectPhase(ctx, string(v1alpha2.DiskReady), framework.MiddleTimeout, vdRoot, vdBlank, vdAttach)
 		util.UntilObjectPhase(ctx, string(v1alpha2.MachineRunning), framework.ShortTimeout, vm)
 		util.UntilObjectPhase(ctx, string(v1alpha2.BlockDeviceAttachmentPhaseAttached), framework.ShortTimeout, vmbda)
-		util.UntilSSHReady(f, vm, framework.MiddleTimeout)
 
 		err = f.GenericClient().Get(ctx, crclient.ObjectKeyFromObject(vdRoot), vdRoot)
 		Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/internal/object/const.go
+++ b/test/e2e/internal/object/const.go
@@ -18,6 +18,7 @@ package object
 
 const (
 	Mi256          = 256 * 1024 * 1024
+	Mi512          = 512 * 1024 * 1024
 	DefaultVMClass = "generic-for-e2e"
 
 	iperf3Script = `#!/bin/bash

--- a/test/e2e/internal/object/vm.go
+++ b/test/e2e/internal/object/vm.go
@@ -29,7 +29,7 @@ func NewMinimalVM(prefix, namespace string, opts ...vm.Option) *v1alpha2.Virtual
 		vm.WithGenerateName(prefix),
 		vm.WithNamespace(namespace),
 		vm.WithCPU(1, ptr.To("20%")),
-		vm.WithMemory(*resource.NewQuantity(Mi256, resource.BinarySI)),
+		vm.WithMemory(*resource.NewQuantity(Mi512, resource.BinarySI)),
 		vm.WithLiveMigrationPolicy(v1alpha2.AlwaysSafeMigrationPolicy),
 		vm.WithProvisioningUserData(AlpineCloudInit),
 	}


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->

Increased VM memory from 256Mi to 512Mi in the `virtual-disk-resizing` e2e test. Also removed redundant SSH check after resize operation.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->

The `virtual-disk-resizing` e2e test was failing due to OOM (Out of Memory) in the VM. The VM was configured with only 256Mi of memory, which is insufficient for:
- Ubuntu OS
- qemu-guest-agent
- cloud-init packages (qemu-guest-agent, curl, jq, etc.)
- disk hotplug operations

This caused the VM to run out of memory during boot, resulting in:
1. `apt-get` or `unattended-upgr` processes being killed by OOM killer
2. SSH commands (like `lsblk`) failing with "Killed" status
3. Intermittent "Guest agent is not responding" errors

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->

After increasing memory to 512Mi:
- VM has sufficient memory to boot and run all services
- No OOM events in dmesg
- SSH commands work reliably
- Test completes successfully without additional delays

## Checklist
- [ ] The code is covered by unit tests. (N/A - test changes only)
- [x] e2e tests passed. (Verified in namespace v12n-e2e-virtual-disk-resizing-tpfnd)
- [ ] Documentation updated according to the changes. (N/A)
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: test
type: chore
summary: "Increase VM memory to 512Mi in virtual-disk-resizing e2e test to fix OOM issues"
impact_level: low
```