### PR TITLE
chore(ci): add trivy env to release branches

### DIFF
--- a/.github/workflows/cve_scan_daily.yml
+++ b/.github/workflows/cve_scan_daily.yml
@@ -88,5 +88,6 @@ jobs:
           cve_test_repo_git: ${{ steps.secrets.outputs.CVE_TEST_REPO_GIT }}
           cve_ssh_private_key: ${{ steps.secrets.outputs.CVE_TEST_SSH_PRIVATE_KEY }}
           trivy_reports_log_output: "1"
+          release_in_dev: ${{ startsWith(github.event.inputs.tag_name || 'main', 'release-') && 'true' || 'false' }}
           latest_releases_amount: 5
           scan_several_latest_releases: ${{ github.event_name == 'schedule' && 'True' || (inputs.scan_several_latest_releases && 'True' || 'False') }}

--- a/.github/workflows/dev_module_build.yml
+++ b/.github/workflows/dev_module_build.yml
@@ -64,6 +64,7 @@ jobs:
       modules_module_tag: ${{ steps.modules_module_tag.outputs.MODULES_MODULE_TAG }}
       module_edition: ${{ steps.modules_module_tag.outputs.MODULE_EDITION }}
       runner_type: ${{ steps.modules_module_tag.outputs.RUNNER_TYPE }}
+      release_in_dev: ${{ steps.modules_module_tag.outputs.RELEASE_IN_DEV }}
       debug_component: ${{ steps.get-labels.outputs.debug_component }}
     steps:
       - name: Get Pull Request Labels
@@ -131,6 +132,12 @@ jobs:
           fi
 
           echo "MODULES_MODULE_TAG=$MODULES_MODULE_TAG" >> "$GITHUB_OUTPUT"
+
+          if [[ "${{ github.ref_name }}" =~ ^release-[0-9]+\.[0-9]+ ]]; then
+            echo "RELEASE_IN_DEV=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "RELEASE_IN_DEV=false" >> "$GITHUB_OUTPUT"
+          fi
 
           # Select edition for build, default EE
           if echo "${{ steps.get-labels.outputs.prLabels }}" | grep -q "edition/ce"; then
@@ -560,6 +567,7 @@ jobs:
           cve_test_repo_git: ${{ steps.secrets.outputs.CVE_TEST_REPO_GIT }}
           cve_ssh_private_key: ${{ steps.secrets.outputs.CVE_TEST_SSH_PRIVATE_KEY }}
           trivy_reports_log_output: "1"
+          release_in_dev: ${{ needs.set_vars.outputs.release_in_dev }}
 
   analyze_build:
     if: ${{ github.event.inputs.svace_enabled == 'true' || contains(github.event.pull_request.labels.*.name, 'analyze/svace') }}


### PR DESCRIPTION
## Description
Pass `release_in_dev` to `deckhouse/modules-actions/cve_scan` based on the branch or tag being scanned.

The workflow now sets `release_in_dev: true` for `release-*` branches/tags and `false` for all other cases. This logic was added to both the dev build workflow and the daily CVE scan workflow.

## Why do we need it, and what problem does it solve?
Trivy scans for release branches should run with release-specific behavior in `cve_scan`. Previously, the workflows did not provide an explicit `release_in_dev` input, so release branch scans were not distinguished from regular dev scans.

This change makes the scan mode explicit and consistent across workflows:
- `dev_module_build.yml` passes `release_in_dev: true` when the workflow runs on `release-*` branches.
- `cve_scan_daily.yml` passes `release_in_dev: true` when the selected `tag_name` starts with `release-`.

As a result, release scans use the correct configuration while non-release scans keep the default behavior.

## What is the expected result?
1. Run `dev_module_build.yml` from a `release-*` branch and verify that `cve_scan` receives `release_in_dev: true`.
2. Run `dev_module_build.yml` from `main` or a PR branch and verify that `cve_scan` receives `release_in_dev: false`.
3. Run `cve_scan_daily.yml` with `tag_name=release-*` and verify that `cve_scan` receives `release_in_dev: true`.
4. Run `cve_scan_daily.yml` without a release tag and verify that `cve_scan` receives `release_in_dev: false`.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: chore
summary: "Pass release_in_dev to Trivy cve_scan for release branches and tags."
impact_level: low
```
