### PR TITLE
fix(dvcr): fix garbage collection on empty registry

### DIFF
--- a/images/dvcr-artifact/cmd/dvcr-cleaner/cmd/gc.go
+++ b/images/dvcr-artifact/cmd/dvcr-cleaner/cmd/gc.go
@@ -134,6 +134,13 @@ func Confirm() (bool, error) {
 func autoCleanupHandler(cmd *cobra.Command, args []string) error {
 	started := time.Now().UTC()
 
+	// Make sure the registry data directory exists before reading its stats.
+	// The registry creates it lazily on the first image push; without this
+	// the cleaner would fail with "no such file or directory" on a fresh cluster.
+	if err := os.MkdirAll(RepoDir, 0o755); err != nil {
+		return fmt.Errorf("ensure repositories dir exists: %w", err)
+	}
+
 	fsInfoBeforeCleanup, err := registry.StorageStats()
 	if err != nil {
 		return fmt.Errorf("get repositories filesystem info before cleanup: %w", err)
@@ -241,9 +248,16 @@ func performAutoCleanup() error {
 }
 
 func checkCleanupHandler(_ *cobra.Command, _ []string) error {
+	// Make sure the registry data directory exists before reading its stats.
+	// The registry creates it lazily on the first image push; without this
+	// the cleaner would fail with "no such file or directory" on a fresh cluster.
+	if err := os.MkdirAll(RepoDir, 0o755); err != nil {
+		return fmt.Errorf("ensure repositories dir exists: %w", err)
+	}
+
 	fsInfo, err := registry.StorageStats()
 	if err != nil {
-		return fmt.Errorf("get repositories filesystem info before cleanup: %w", err)
+		return fmt.Errorf("get repositories filesystem info: %w", err)
 	}
 
 	absentImages, err := getAbsentImages()

--- a/images/dvcr-artifact/cmd/dvcr-cleaner/cmd/gc.go
+++ b/images/dvcr-artifact/cmd/dvcr-cleaner/cmd/gc.go
@@ -134,11 +134,8 @@ func Confirm() (bool, error) {
 func autoCleanupHandler(cmd *cobra.Command, args []string) error {
 	started := time.Now().UTC()
 
-	// Make sure the registry data directory exists before reading its stats.
-	// The registry creates it lazily on the first image push; without this
-	// the cleaner would fail with "no such file or directory" on a fresh cluster.
-	if err := os.MkdirAll(RepoDir, 0o755); err != nil {
-		return fmt.Errorf("ensure repositories dir exists: %w", err)
+	if err := ensureRepoDir(); err != nil {
+		return err
 	}
 
 	fsInfoBeforeCleanup, err := registry.StorageStats()
@@ -248,11 +245,8 @@ func performAutoCleanup() error {
 }
 
 func checkCleanupHandler(_ *cobra.Command, _ []string) error {
-	// Make sure the registry data directory exists before reading its stats.
-	// The registry creates it lazily on the first image push; without this
-	// the cleaner would fail with "no such file or directory" on a fresh cluster.
-	if err := os.MkdirAll(RepoDir, 0o755); err != nil {
-		return fmt.Errorf("ensure repositories dir exists: %w", err)
+	if err := ensureRepoDir(); err != nil {
+		return err
 	}
 
 	fsInfo, err := registry.StorageStats()
@@ -370,6 +364,13 @@ func compareRegistryAndClusterImages(images []registry.Image, kubeImages []kuber
 	}
 
 	return absentImages
+}
+
+func ensureRepoDir() error {
+	if err := os.MkdirAll(RepoDir, 0o755); err != nil {
+		return fmt.Errorf("ensure repositories dir exists: %w", err)
+	}
+	return nil
 }
 
 const (

--- a/images/dvcr-artifact/pkg/cleaner/storage/stats_test.go
+++ b/images/dvcr-artifact/pkg/cleaner/storage/stats_test.go
@@ -1,5 +1,7 @@
+//go:build unix
+
 /*
-Copyright 2025 Flant JSC
+Copyright 2026 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,21 +19,20 @@ limitations under the License.
 package storage
 
 import (
+	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 )
 
-func TestFSBytes_MissingDirReturnsEmpty(t *testing.T) {
+func TestFSBytes_MissingDirReturnsError(t *testing.T) {
 	// Path that almost certainly does not exist. Use t.TempDir() as a base
 	// and append a child that we never create.
 	missing := filepath.Join(t.TempDir(), "does-not-exist", "repositories")
 
-	info, err := FSBytes(missing)
-	if err != nil {
-		t.Fatalf("FSBytes on a missing path must not return an error, got: %v", err)
-	}
-	if info.Total != 0 || info.Available != 0 {
-		t.Fatalf("expected zero-valued FSInfo on missing path, got: %+v", info)
+	_, err := FSBytes(missing)
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected not exist error for %q, got: %v", missing, err)
 	}
 }
 

--- a/images/dvcr-artifact/pkg/cleaner/storage/stats_test.go
+++ b/images/dvcr-artifact/pkg/cleaner/storage/stats_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestFSBytes_MissingDirReturnsEmpty(t *testing.T) {
+	// Path that almost certainly does not exist. Use t.TempDir() as a base
+	// and append a child that we never create.
+	missing := filepath.Join(t.TempDir(), "does-not-exist", "repositories")
+
+	info, err := FSBytes(missing)
+	if err != nil {
+		t.Fatalf("FSBytes on a missing path must not return an error, got: %v", err)
+	}
+	if info.Total != 0 || info.Available != 0 {
+		t.Fatalf("expected zero-valued FSInfo on missing path, got: %+v", info)
+	}
+}
+
+func TestFSBytes_ExistingDir(t *testing.T) {
+	// t.TempDir() always exists and is a real directory.
+	dir := t.TempDir()
+
+	info, err := FSBytes(dir)
+	if err != nil {
+		t.Fatalf("FSBytes on an existing path returned an error: %v", err)
+	}
+	// On a real filesystem, total bytes is strictly positive.
+	if info.Total == 0 {
+		t.Fatalf("expected positive Total for %q, got 0", dir)
+	}
+}

--- a/images/dvcr-artifact/pkg/cleaner/storage/stats_unix.go
+++ b/images/dvcr-artifact/pkg/cleaner/storage/stats_unix.go
@@ -19,8 +19,6 @@ limitations under the License.
 package storage
 
 import (
-	"errors"
-
 	"golang.org/x/sys/unix"
 )
 
@@ -28,12 +26,6 @@ func FSBytes(dir string) (FSInfo, error) {
 	var stat unix.Statfs_t
 	err := unix.Statfs(dir, &stat)
 	if err != nil {
-		// Treat a missing path as "empty filesystem": the registry may not
-		// have created its data directory yet (e.g. before the first image
-		// push). Callers handle zero-valued FSInfo safely.
-		if errors.Is(err, unix.ENOENT) {
-			return FSInfo{}, nil
-		}
 		return FSInfo{}, err
 	}
 

--- a/images/dvcr-artifact/pkg/cleaner/storage/stats_unix.go
+++ b/images/dvcr-artifact/pkg/cleaner/storage/stats_unix.go
@@ -19,6 +19,8 @@ limitations under the License.
 package storage
 
 import (
+	"errors"
+
 	"golang.org/x/sys/unix"
 )
 
@@ -26,6 +28,12 @@ func FSBytes(dir string) (FSInfo, error) {
 	var stat unix.Statfs_t
 	err := unix.Statfs(dir, &stat)
 	if err != nil {
+		// Treat a missing path as "empty filesystem": the registry may not
+		// have created its data directory yet (e.g. before the first image
+		// push). Callers handle zero-valued FSInfo safely.
+		if errors.Is(err, unix.ENOENT) {
+			return FSInfo{}, nil
+		}
 		return FSInfo{}, err
 	}
 


### PR DESCRIPTION
## Description

Fix DVCR garbage collection startup on a fresh filesystem-backed registry.

The cleaner now ensures that the registry repositories directory exists before reading filesystem stats in `gc auto-cleanup` and `gc check`. This keeps the fix local to the DVCR cleaner path and preserves `FSBytes` behavior: missing paths are still reported as real filesystem errors.

## Why do we need it, and what problem does it solve?

On a fresh DVCR installation backed by a PersistentVolumeClaim, the Docker registry creates `/var/lib/registry/docker/registry/v2/repositories` lazily, only after the first image is pushed.

If garbage collection starts before any image has been uploaded, `dvcr-cleaner` tries to read filesystem stats for that directory and fails with:

```text
get repositories filesystem info before cleanup: no such file or directory
```

As a result, the `dvcr-garbage-collection` container exits and the cleanup cycle cannot complete without a manual workaround: delete the cleanup-triggering Secret and upload at least one image first.

## What is the expected result?

DVCR garbage collection can run on a fresh PVC-backed registry before the first image upload.

To verify the fix:

1. Deploy DVCR with `PersistentVolumeClaim` storage and no uploaded images.
2. Trigger DVCR garbage collection.
3. Confirm that the `dvcr-garbage-collection` container does not fail on missing `repositories` directory.
4. Confirm that cleanup finishes and reports the result through `secret/dvcr-garbage-collection`.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dvcr
type: fix
summary: "DVCR garbage collection no longer fails on a fresh PVC-backed registry before the first image upload."
```