### PR TITLE
chore(dvcr): remove unsupported s3 feature

### DIFF
--- a/openapi/config-values.yaml
+++ b/openapi/config-values.yaml
@@ -99,10 +99,8 @@ properties:
             description: |
               The storage usage type:
               - `persistentVolumeClaim` — Use PersistentVolumeClaim as store for dvcr.
-              - `objectStorage` — Use objectStorage as store for dvcr.
             enum:
               - "PersistentVolumeClaim"
-              - "ObjectStorage"
           persistentVolumeClaim:
             type: object
             description: |
@@ -119,68 +117,11 @@ properties:
                 x-examples: ["10Gi"]
                 description: |
                   Persistentvolumeclaim size
-          objectStorage:
-            type: object
-            description: |
-              Parameters for objectStorage.
-            properties:
-              type:
-                type: string
-                description: |
-                  What ObjectStorage to use as store for dvcr.
-                enum:
-                  - "S3"
-              s3:
-                type: object
-                description: |
-                  Parameters for S3.
-                required: [accessKey, secretKey, region, regionEndpoint, bucket]
-                properties:
-                  accessKey:
-                    type: string
-                    x-examples: ["YWNjZXNzS2V5Cg=="]
-                    description: |
-                      accessKey must be base64 encoded.
-                      accessKey is a unique identifier that identifies you as a user with access to S3.
-                    pattern: "^[A-Za-z0-9+/]*={0,2}$"
-                  secretKey:
-                    type: string
-                    x-examples: ["c2VjcmV0S2V5Cg=="]
-                    description: |
-                      secretKey must be base64 encoded.
-                      secretKey is a confidential secret key associated with your Access Key ID.
-                      Secret Access Key is used to sign HTTP requests to Amazon S3 to verify the authenticity of the request and ensure the security of your data.
-                    pattern: "^[A-Za-z0-9+/]*={0,2}$"
-                  region:
-                    type: string
-                    x-examples: ["us-east-2", "us-west-1"]
-                    description: |
-                      Geographical area.
-                  regionEndpoint:
-                    type: string
-                    x-examples: ["s3.example.com"]
-                    description: |
-                      Endpoint for connect to service S3.
-                    pattern: '^https?://[0-9a-zA-Z\.\-:@_]+$'
-                  bucket:
-                    type: string
-                    x-examples: ["dvcr"]
-                    description: |
-                      Bucket in which you can store your files and data objects.
-            oneOf:
-              - required: ["s3"]
-                properties:
-                  type:
-                    enum: ["S3"]
         oneOf:
           - required: ["persistentVolumeClaim"]
             properties:
               type:
                 enum: ["PersistentVolumeClaim"]
-          - required: ["objectStorage"]
-            properties:
-              type:
-                enum: ["ObjectStorage"]
       gc:
         description: |
           Parameters for garbage collection.

--- a/openapi/doc-ru-config-values.yaml
+++ b/openapi/doc-ru-config-values.yaml
@@ -57,7 +57,6 @@ properties:
             description: |
               Тип используемого хранилища.
               - `persistentVolumeClaim` — Использование pvc
-              - `objectStorage` — Использование objectStorage
           persistentVolumeClaim:
             description: |
               Параметры для настройки PersistentVolumeClaim.
@@ -68,31 +67,6 @@ properties:
               size:
                 description: |
                   Размер pvc.
-          objectStorage:
-            description: |
-              Параметры для настройки объектного хранилища.
-            properties:
-              s3:
-                description: |
-                  Параметры для использования s3.
-                properties:
-                  accessKey:
-                    description: |
-                      accessKey должен быть закодирован в base64.
-                      accessKey — это уникальный идентификатор, который идентифицирует вас как пользователя, имеющего доступ к S3.
-                  secretKey:
-                    description: |
-                      secretKey должен быть закодирован в base64.
-                      secretKey — это конфиденциальный секретный ключ, связанный с вашим идентификатором ключа доступа.
-                  region:
-                    description: |
-                      Географическая зона.
-                  regionEndpoint:
-                    description: |
-                      Конечная точка для подключения к сервису S3.
-                  bucket:
-                    description: |
-                      Контейнер, в котором вы можете хранить свои файлы и объекты данных.
       gc:
         description: Настройки очистки хранилища
         properties:

--- a/templates/dvcr/_helpers.tpl
+++ b/templates/dvcr/_helpers.tpl
@@ -30,25 +30,6 @@ true
 {{- if eq (.Values.virtualization.internal.moduleConfig | dig "dvcr" "storage" "type" "") "PersistentVolumeClaim" }}
 - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
   value: "/var/lib/registry"
-{{- else if eq (.Values.virtualization.internal.moduleConfig | dig "dvcr" "storage" "type" "") "ObjectStorage" }}
-  {{- if eq .Values.virtualization.internal.moduleConfig.dvcr.storage.objectStorage.type "S3" }}
-- name: REGISTRY_STORAGE_S3_REGION
-  value: "{{ .Values.virtualization.internal.moduleConfig.dvcr.storage.objectStorage.s3.region }}"
-- name: REGISTRY_STORAGE_S3_BUCKET
-  value: "{{ .Values.virtualization.internal.moduleConfig.dvcr.storage.objectStorage.s3.bucket }}"
-- name: REGISTRY_STORAGE_S3_ACCESSKEY
-  valueFrom:
-    secretKeyRef:
-      name: dvcr-object-storage-credentials
-      key: s3AccessKey
-- name: REGISTRY_STORAGE_S3_SECRETKEY
-  valueFrom:
-    secretKeyRef:
-      name: dvcr-object-storage-credentials
-      key: s3SecretKey
-- name: REGISTRY_STORAGE_S3_REGIONENDPOINT
-  value: "{{ .Values.virtualization.internal.moduleConfig.dvcr.storage.objectStorage.s3.regionEndpoint }}"
-  {{- end }}
 {{- end }}
 {{- end }}
 
@@ -118,33 +99,11 @@ true
 replicas: 1
 strategy:
   type: Recreate
-{{- else if and (include "helm_lib_ha_enabled" .) (eq (.Values.virtualization.internal.moduleConfig | dig "dvcr" "storage" "type" "") "ObjectStorage") }}
-replicas: 2
-strategy:
-  type: RollingUpdate
-  rollingUpdate:
-    maxSurge: 0
-    maxUnavailable: 1
-{{- else if eq (.Values.virtualization.internal.moduleConfig | dig "dvcr" "storage" "type" "") "ObjectStorage" }}
-replicas: 1
-strategy:
-  type: RollingUpdate
 {{- else if eq (.Values.virtualization.internal.moduleConfig | dig "dvcr" "storage" "type" "") "PersistentVolumeClaim" }}
 replicas: 1
 strategy:
   type: Recreate
 {{- end }}
-{{- end -}}
-
-{{- define "dvcr.helm_lib_is_ha_to_value" -}}
-  {{- $context := index . 0 -}}
-  {{- $yes := index . 1 -}}
-  {{- $no  := index . 2 -}}
-  {{- if and (include "helm_lib_ha_enabled" $context) (eq ($context.Values.virtualization.internal.moduleConfig | dig "dvcr" "storage" "type" "") "ObjectStorage") }}
-    {{- $yes -}}
-  {{- else }}
-    {{- $no -}}
-  {{- end }}
 {{- end -}}
 
 {{- define "dvcr.generate_dockercfg" -}}

--- a/templates/dvcr/deployment.yaml
+++ b/templates/dvcr/deployment.yaml
@@ -49,7 +49,7 @@ metadata:
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "dvcr" )) | nindent 2 }}
 spec:
-  minAvailable: {{ include "dvcr.helm_lib_is_ha_to_value" (list . 1 0) }}
+  minAvailable: 0
   selector:
     matchLabels:
       app: dvcr

--- a/templates/dvcr/secret.yaml
+++ b/templates/dvcr/secret.yaml
@@ -39,21 +39,4 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
   {{- include "dvcr.generate_dockercfg" (list . $registry "admin" .Values.virtualization.internal.dvcr.passwordRW) | nindent 2 }}
-
-{{- if eq (.Values.virtualization.internal.moduleConfig | dig "dvcr" "storage" "type" "") "ObjectStorage"}}
-
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: dvcr-object-storage-credentials
-  namespace: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" "dvcr" )) | nindent 2 }}
-type: Opaque
-data:
-  {{- if eq .Values.virtualization.internal.moduleConfig.dvcr.storage.objectStorage.type "S3"}}
-  s3AccessKey: {{ .Values.virtualization.internal.moduleConfig.dvcr.storage.objectStorage.s3.accessKey | quote }}
-  s3SecretKey: {{ .Values.virtualization.internal.moduleConfig.dvcr.storage.objectStorage.s3.secretKey | quote }}
-  {{- end }}
-{{- end }}
 {{- end }}


### PR DESCRIPTION
## Description

Remove the unsupported legacy S3 object storage configuration for DVCR.

The following options are dropped from the module config:

- `dvcr.storage.objectStorage.s3.accessKey`
- `dvcr.storage.objectStorage.s3.secretKey`
- `dvcr.storage.objectStorage.s3.region`
- `dvcr.storage.objectStorage.s3.regionEndpoint`
- `dvcr.storage.objectStorage.s3.bucket`

Details:

- Removes the `objectStorage.s3` section from `openapi/config-values.yaml` and its Russian localization in `openapi/doc-ru-config-values.yaml`. `dvcr.storage.type` now allows only `PersistentVolumeClaim`.
- Drops the `REGISTRY_STORAGE_S3_*` environment variables and the s3 related template helpers from `templates/dvcr/_helpers.tpl`, and removes the now-unused local `dvcr.helm_lib_is_ha_to_value` helper (DVCR PDB uses an explicit `minAvailable: 0`).
- Removes the `dvcr-object-storage-credentials` Secret (`s3AccessKey`/`s3SecretKey`) from `templates/dvcr/secret.yaml`.

## Why do we need it, and what problem does it solve?

The S3 object storage path was unsupported legacy configuration that is no longer maintained. Keeping it in the public schema and Helm templates was misleading and added dead code paths. Removing it keeps DVCR storage configuration limited to the supported `PersistentVolumeClaim` mode.

## What is the expected result?

- The module config schema accepts only `dvcr.storage.type: PersistentVolumeClaim`.
- The DVCR chart renders without any S3-related env, Secret, or HA branch.
- Local kubeconform render validation passes (115 valid resources, 0 errors, 0 invalid; remaining "no schema" items are pre-existing CRDs without downloaded schemas).

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dvcr
type: chore
summary: Remove unsupported legacy S3 object storage configuration for DVCR.
```
