### PR TITLE
fix(vm): ignore existing USB resource claim templates

### DIFF
--- a/images/virtualization-artifact/pkg/controller/nodeusbdevice/internal/handler/assigned.go
+++ b/images/virtualization-artifact/pkg/controller/nodeusbdevice/internal/handler/assigned.go
@@ -19,6 +19,7 @@ package handler
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -217,8 +218,20 @@ func (h *AssignedHandler) deleteUSBDevice(ctx context.Context, namespace, name s
 	}
 
 	if err := h.client.Delete(ctx, usbDevice); err != nil {
+		if isNotFoundUSBDeviceError(err, namespace, name) {
+			return nil
+		}
 		return fmt.Errorf("failed to delete USBDevice: %w", err)
 	}
 
 	return nil
+}
+
+func isNotFoundUSBDeviceError(err error, namespace, name string) bool {
+	if errors.IsNotFound(err) {
+		return true
+	}
+
+	errText := err.Error()
+	return namespace != "" && strings.Contains(errText, "usbdevices.virtualization.deckhouse.io") && strings.Contains(errText, name) && strings.Contains(errText, "not found")
 }

--- a/images/virtualization-artifact/pkg/controller/nodeusbdevice/internal/handler/assigned_test.go
+++ b/images/virtualization-artifact/pkg/controller/nodeusbdevice/internal/handler/assigned_test.go
@@ -18,6 +18,7 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -29,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/deckhouse/virtualization-controller/pkg/controller/indexer"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/nodeusbdevice/internal/state"
@@ -123,6 +125,54 @@ var _ = Describe("AssignedHandler", func() {
 		Entry("device absent on host removes USBDevice", "test-namespace", true, true, true, string(nodeusbdevicecondition.InProgress), false),
 		Entry("unassigned removes stale USBDevice", "", false, false, true, string(nodeusbdevicecondition.Available), false),
 	)
+
+	It("should ignore not found error when deleting orphaned USBDevice", func() {
+		scheme := apiruntime.NewScheme()
+		Expect(v1alpha2.AddToScheme(scheme)).To(Succeed())
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+		node := &v1alpha2.NodeUSBDevice{
+			ObjectMeta: metav1.ObjectMeta{Name: "usb-device-1", UID: types.UID("node-usb-uid")},
+			Status: v1alpha2.NodeUSBDeviceStatus{
+				Attributes: v1alpha2.NodeUSBDeviceAttributes{VendorID: "1234", ProductID: "5678"},
+				NodeName:   "node-1",
+			},
+		}
+		usbDevice := &v1alpha2.USBDevice{ObjectMeta: metav1.ObjectMeta{Name: "usb-device-1", Namespace: "stale-namespace"}}
+
+		cl := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(node, usbDevice).
+			WithIndex(&v1alpha2.USBDevice{}, indexer.IndexFieldUSBDeviceByName, func(object client.Object) []string {
+				usbDevice, ok := object.(*v1alpha2.USBDevice)
+				if !ok || usbDevice == nil {
+					return nil
+				}
+				return []string{usbDevice.Name}
+			}).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Delete: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.DeleteOption) error {
+					if _, ok := obj.(*v1alpha2.USBDevice); ok {
+						return errors.New(`usbdevices.virtualization.deckhouse.io "usb-device-1" not found`)
+					}
+					return nil
+				},
+			}).
+			Build()
+
+		res := reconciler.NewResource(
+			types.NamespacedName{Name: node.Name},
+			cl,
+			func() *v1alpha2.NodeUSBDevice { return &v1alpha2.NodeUSBDevice{} },
+			func(obj *v1alpha2.NodeUSBDevice) v1alpha2.NodeUSBDeviceStatus { return obj.Status },
+		)
+		Expect(res.Fetch(ctx)).To(Succeed())
+
+		h := NewAssignedHandler(cl)
+		st := state.New(cl, res)
+		_, err := h.Handle(ctx, st)
+		Expect(err).NotTo(HaveOccurred())
+	})
 
 	It("should update existing USBDevice when attributes change", func() {
 		scheme := apiruntime.NewScheme()

--- a/images/virtualization-artifact/pkg/controller/usbdevice/internal/handler/lifecycle.go
+++ b/images/virtualization-artifact/pkg/controller/usbdevice/internal/handler/lifecycle.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 
 	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -167,7 +168,7 @@ func (h *LifecycleHandler) ensureResourceClaimTemplate(ctx context.Context, s st
 			}
 
 			if err := h.client.Create(ctx, template); err != nil {
-				if apierrors.IsAlreadyExists(err) {
+				if isAlreadyExistsResourceClaimTemplateError(err, templateName) {
 					log.Debug("ResourceClaimTemplate already exists during recreate", "template", templateName)
 					return nil
 				}
@@ -189,7 +190,7 @@ func (h *LifecycleHandler) ensureResourceClaimTemplate(ctx context.Context, s st
 	}
 
 	if err := h.client.Create(ctx, template); err != nil {
-		if apierrors.IsAlreadyExists(err) {
+		if isAlreadyExistsResourceClaimTemplateError(err, templateName) {
 			log.Debug("ResourceClaimTemplate already exists during create", "template", templateName)
 			return nil
 		}
@@ -255,6 +256,15 @@ func (h *LifecycleHandler) syncAttached(ctx context.Context, s state.USBDeviceSt
 
 	setAttachedCondition(current, &changed.Status.Conditions, metav1.ConditionFalse, usbdevicecondition.Available, "Device is requested by a virtual machine but not attached yet.")
 	return nil
+}
+
+func isAlreadyExistsResourceClaimTemplateError(err error, templateName string) bool {
+	if apierrors.IsAlreadyExists(err) {
+		return true
+	}
+
+	errText := err.Error()
+	return strings.Contains(errText, "resourceclaimtemplates.resource.k8s.io") && strings.Contains(errText, templateName) && strings.Contains(errText, "already exists")
 }
 
 func buildResourceClaimTemplateSpec(usbDevice *v1alpha2.USBDevice) resourcev1.ResourceClaimTemplateSpec {

--- a/images/virtualization-artifact/pkg/controller/usbdevice/internal/handler/lifecycle.go
+++ b/images/virtualization-artifact/pkg/controller/usbdevice/internal/handler/lifecycle.go
@@ -167,6 +167,10 @@ func (h *LifecycleHandler) ensureResourceClaimTemplate(ctx context.Context, s st
 			}
 
 			if err := h.client.Create(ctx, template); err != nil {
+				if apierrors.IsAlreadyExists(err) {
+					log.Debug("ResourceClaimTemplate already exists during recreate", "template", templateName)
+					return nil
+				}
 				return fmt.Errorf("failed to recreate ResourceClaimTemplate: %w", err)
 			}
 
@@ -185,6 +189,10 @@ func (h *LifecycleHandler) ensureResourceClaimTemplate(ctx context.Context, s st
 	}
 
 	if err := h.client.Create(ctx, template); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			log.Debug("ResourceClaimTemplate already exists during create", "template", templateName)
+			return nil
+		}
 		return fmt.Errorf("failed to create ResourceClaimTemplate: %w", err)
 	}
 

--- a/images/virtualization-artifact/pkg/controller/usbdevice/internal/handler/lifecycle_test.go
+++ b/images/virtualization-artifact/pkg/controller/usbdevice/internal/handler/lifecycle_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/deckhouse/virtualization-controller/pkg/common/annotations"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/indexer"
@@ -395,6 +396,46 @@ var _ = Describe("LifecycleHandler", func() {
 		Entry("uses provided attribute name", "usb-raw-device", "usb-raw-device"),
 		Entry("falls back to resource name when attribute name is empty", "", "usb-device-cr"),
 	)
+
+	It("should ignore already existing ResourceClaimTemplate on stale create", func() {
+		usbDevice := &v1alpha2.USBDevice{
+			ObjectMeta: metav1.ObjectMeta{Name: "usb-device-cr", Namespace: "default", UID: "usb-uid-1"},
+			Status:     v1alpha2.USBDeviceStatus{Attributes: v1alpha2.NodeUSBDeviceAttributes{Name: "usb-new-name", VendorID: "1234", ProductID: "5678"}},
+		}
+
+		nodeUSBDevice := &v1alpha2.NodeUSBDevice{
+			ObjectMeta: metav1.ObjectMeta{Name: "usb-device-cr"},
+			Status: v1alpha2.NodeUSBDeviceStatus{
+				Attributes: v1alpha2.NodeUSBDeviceAttributes{Name: "usb-new-name", VendorID: "1234", ProductID: "5678"},
+				NodeName:   "node-1",
+				Conditions: []metav1.Condition{{Type: string(nodeusbdevicecondition.ReadyType), Status: metav1.ConditionTrue, Reason: string(nodeusbdevicecondition.Ready), Message: "Node status"}},
+			},
+		}
+
+		vmObj, vmField, vmExtractValue := indexer.IndexVMByUSBDevice()
+		vmNodeObj, vmNodeField, vmNodeExtractValue := indexer.IndexVMByNode()
+		cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(usbDevice, nodeUSBDevice).WithIndex(vmObj, vmField, vmExtractValue).WithIndex(vmNodeObj, vmNodeField, vmNodeExtractValue).WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.CreateOption) error {
+				if _, ok := obj.(*resourcev1.ResourceClaimTemplate); ok {
+					return apierrors.NewAlreadyExists(resourcev1.Resource("resourceclaimtemplates"), obj.GetName())
+				}
+				return nil
+			},
+		}).Build()
+
+		res := reconciler.NewResource(
+			types.NamespacedName{Name: usbDevice.Name, Namespace: usbDevice.Namespace},
+			cl,
+			func() *v1alpha2.USBDevice { return &v1alpha2.USBDevice{} },
+			func(obj *v1alpha2.USBDevice) v1alpha2.USBDeviceStatus { return obj.Status },
+		)
+		Expect(res.Fetch(ctx)).To(Succeed())
+
+		st := state.New(cl, res)
+		h := NewLifecycleHandler(cl)
+		_, err := h.Handle(ctx, st)
+		Expect(err).NotTo(HaveOccurred())
+	})
 
 	It("should update existing ResourceClaimTemplate when selector drifts", func() {
 		usbDevice := &v1alpha2.USBDevice{

--- a/images/virtualization-artifact/pkg/controller/usbdevice/internal/handler/lifecycle_test.go
+++ b/images/virtualization-artifact/pkg/controller/usbdevice/internal/handler/lifecycle_test.go
@@ -18,6 +18,7 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -397,7 +398,7 @@ var _ = Describe("LifecycleHandler", func() {
 		Entry("falls back to resource name when attribute name is empty", "", "usb-device-cr"),
 	)
 
-	It("should ignore already existing ResourceClaimTemplate on stale create", func() {
+	It("should ignore non-status already existing ResourceClaimTemplate on stale create", func() {
 		usbDevice := &v1alpha2.USBDevice{
 			ObjectMeta: metav1.ObjectMeta{Name: "usb-device-cr", Namespace: "default", UID: "usb-uid-1"},
 			Status:     v1alpha2.USBDeviceStatus{Attributes: v1alpha2.NodeUSBDeviceAttributes{Name: "usb-new-name", VendorID: "1234", ProductID: "5678"}},
@@ -417,7 +418,7 @@ var _ = Describe("LifecycleHandler", func() {
 		cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(usbDevice, nodeUSBDevice).WithIndex(vmObj, vmField, vmExtractValue).WithIndex(vmNodeObj, vmNodeField, vmNodeExtractValue).WithInterceptorFuncs(interceptor.Funcs{
 			Create: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.CreateOption) error {
 				if _, ok := obj.(*resourcev1.ResourceClaimTemplate); ok {
-					return apierrors.NewAlreadyExists(resourcev1.Resource("resourceclaimtemplates"), obj.GetName())
+					return errors.New(`resourceclaimtemplates.resource.k8s.io "usb-device-cr-template" already exists`)
 				}
 				return nil
 			},


### PR DESCRIPTION
## Description
Handle idempotent USB device reconciliation errors:

- ignore existing `ResourceClaimTemplate` objects during initial create and recreate flows;
- also handle non-status/plain-text `ResourceClaimTemplate already exists` errors;
- ignore missing orphaned `USBDevice` objects during cleanup when delete returns a plain-text `not found` error.

Unit tests cover stale create and stale delete cases.

## Why do we need it, and what problem does it solve?
A VM could stay pending after attaching a USB device if reconciliation failed on an already-created `ResourceClaimTemplate`. Also, the `nodeusbdevice-controller` could fail while cleaning up orphaned `USBDevice` objects if the object had already been removed by another reconciliation path.

Both cases are idempotent Kubernetes races and should not fail the handler. Ignoring these stale `AlreadyExists` and `NotFound` results makes USB attachment and cleanup reconciliation stable.

## What is the expected result?
1. Attach a USB device to a VM.
2. Ensure the corresponding `ResourceClaimTemplate` already exists or is created concurrently.
3. Verify reconciliation succeeds and the VM does not remain pending because of an `AlreadyExists` create error.
4. Remove or unassign a USB device while the corresponding `USBDevice` is already gone.
5. Verify `nodeusbdevice-controller` cleanup succeeds without a `not found` handler error.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: core
type: fix
summary: Ignore stale USB ResourceClaimTemplate and USBDevice cleanup errors during VM USB device reconciliation.
impact_level: low
```
