### PR TITLE
chore(ci): move registry write operations to self-hosted runners

### DIFF
--- a/.github/workflows/dev_registry-cleanup.yml
+++ b/.github/workflows/dev_registry-cleanup.yml
@@ -34,7 +34,7 @@ defaults:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, regular]
     name: Run cleanup
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description
Change the cleanup workflow to run on a self-hosted runner instead of `ubuntu-latest`.

## Why do we need it, and what problem does it solve?
The `dev_registry-cleanup.yml` workflow logs in to the dev registry and performs `werf cleanup`, which is a write/delete operation against the registry. Running this job on a GitHub-hosted runner means registry-modifying actions happen outside self-hosted infrastructure. This change moves the workflow to a self-hosted runner to keep registry write operations on internal runners.

## What is the expected result?
1. Trigger `.github/workflows/dev_registry-cleanup.yml` manually or wait for the scheduled run.
2. Verify the workflow job is started on a runner labeled `self-hosted, regular`.
3. Verify cleanup completes successfully and no registry write/delete operations are performed from GitHub-hosted runners.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: chore
summary: Move dev registry cleanup workflow to self-hosted runners.
impact_level: low
```
