### PR TITLE
chore(ci): set replicated e2e cluster k8s version to 1.35

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -99,7 +99,7 @@ jobs:
       randuuid4c: ${{ needs.set-vars.outputs.randuuid4c }}
       cluster_config_workers_memory: "9Gi"
       cluster_config_additional_disk_size: "50Gi"
-      cluster_config_k8s_version: "1.34"
+      cluster_config_k8s_version: "1.35"
       apt_mirror_enabled: true
     secrets:
       DEV_REGISTRY_DOCKER_CFG: ${{ secrets.DEV_REGISTRY_DOCKER_CFG }}


### PR DESCRIPTION
## Description
Update the Kubernetes version used by replicated nightly e2e cluster configuration from 1.34 to 1.35.

## Why do we need it, and what problem does it solve?
This keeps the replicated nightly e2e environment aligned with the newer Kubernetes version expected for CI validation.

## What is the expected result?
Replicated nightly e2e workflow runs create clusters with Kubernetes 1.35.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ci
type: chore
summary: "Update the replicated nightly e2e cluster Kubernetes version to 1.35."
impact_level: low
```