### PR TITLE
fix(vd): vdsnapshot without size annotation

### DIFF
--- a/api/core/v1alpha2/events.go
+++ b/api/core/v1alpha2/events.go
@@ -113,6 +113,8 @@ const (
 	ReasonDataSourceSyncCompleted = "DataSourceImportCompleted"
 	// ReasonDataSourceSyncFailed is event reason that DataSource sync is failed.
 	ReasonDataSourceSyncFailed = "DataSourceImportFailed"
+	// ReasonDataSourceSyncFallback is event reason that DataSource sync uses fallback settings.
+	ReasonDataSourceSyncFallback = "DataSourceImportFallback"
 	// ReasonDataSourceQuotaExceeded is event reason that DataSource sync is failed because quota exceed.
 	ReasonDataSourceQuotaExceeded = "DataSourceQuotaExceed"
 

--- a/api/core/v1alpha2/vdcondition/condition.go
+++ b/api/core/v1alpha2/vdcondition/condition.go
@@ -38,6 +38,8 @@ const (
 	InUseType Type = "InUse"
 	// MigratingType indicates that the virtual disk is in the process of migrating data from one volume to another (during the migration of a local disk or migration to another storage class).
 	MigratingType Type = "Migrating"
+	// SnapshotSizeFallbackType indicates that the disk is restored from a snapshot using fallback size detection.
+	SnapshotSizeFallbackType Type = "SnapshotSizeFallback"
 )
 
 type (
@@ -55,6 +57,8 @@ type (
 	InUseReason string
 	// MigratingReason represents the various reasons for the Migration condition type.
 	MigratingReason string
+	// SnapshotSizeFallbackReason represents the various reasons for the SnapshotSizeFallback condition type.
+	SnapshotSizeFallbackReason string
 )
 
 func (s DatasourceReadyReason) String() string {
@@ -82,6 +86,10 @@ func (s InUseReason) String() string {
 }
 
 func (s MigratingReason) String() string {
+	return string(s)
+}
+
+func (s SnapshotSizeFallbackReason) String() string {
 	return string(s)
 }
 
@@ -129,6 +137,9 @@ const (
 	StorageClassIsNotReady ReadyReason = "StorageClassIsNotReady"
 	// StorageClassProvisionerMismatch indicates that the VirtualDisk and source VirtualImage storage classes have different provisioners.
 	StorageClassProvisionerMismatch ReadyReason = "StorageClassProvisionerMismatch"
+
+	// LegacyNFSVolumeSnapshot indicates that a legacy NFS VolumeSnapshot does not contain the original VirtualDisk size annotation.
+	LegacyNFSVolumeSnapshot SnapshotSizeFallbackReason = "LegacyNFSVolumeSnapshot"
 
 	// InProgress indicates that the resize request has been detected and the operation is currently in progress.
 	InProgress ResizedReason = "InProgress"

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_vdsnapshot_test.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_vdsnapshot_test.go
@@ -218,8 +218,8 @@ var _ = Describe("ObjectRef VirtualDiskSnapshot", func() {
 			Entry("from restore size when annotation and VD size are omitted", "", "", "10Gi", "10Gi"),
 		)
 
-		DescribeTable("reports legacy snapshot size fallback only for NFS provisioner",
-			func(provisioner string, expectFallback bool) {
+		DescribeTable("waits for explicit size only for legacy NFS snapshots",
+			func(provisioner string, expectWait bool) {
 				sc.Provisioner = provisioner
 				vs.Annotations = map[string]string{
 					annotations.AnnStorageClassName: sc.Name,
@@ -229,11 +229,13 @@ var _ = Describe("ObjectRef VirtualDiskSnapshot", func() {
 					EventFunc: func(_ client.Object, _, _, _ string) {},
 				}
 
+				var pvcCreated bool
 				client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(vdSnapshot, vs, sc).
 					WithInterceptorFuncs(interceptor.Funcs{
 						Create: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.CreateOption) error {
 							_, ok := obj.(*corev1.PersistentVolumeClaim)
 							Expect(ok).To(BeTrue())
+							pvcCreated = true
 							return nil
 						},
 					}).Build()
@@ -245,11 +247,13 @@ var _ = Describe("ObjectRef VirtualDiskSnapshot", func() {
 				Expect(res.IsZero()).To(BeTrue())
 
 				ready, _ := conditions.GetCondition(vdcondition.Ready, vd.Status.Conditions)
-				Expect(ready.Reason).To(Equal(vdcondition.Provisioning.String()))
-
 				events := mockRecorder.EventCalls()
 				fallbackCondition, fallbackConditionExists := conditions.GetCondition(vdcondition.SnapshotSizeFallbackType, vd.Status.Conditions)
-				if expectFallback {
+				if expectWait {
+					Expect(pvcCreated).To(BeFalse())
+					Expect(vd.Status.Phase).To(Equal(v1alpha2.DiskPending))
+					Expect(ready.Reason).To(Equal(vdcondition.ProvisioningNotStarted.String()))
+					Expect(ready.Message).To(ContainSubstring("spec.persistentVolumeClaim.size"))
 					Expect(fallbackConditionExists).To(BeTrue())
 					Expect(fallbackCondition.Status).To(Equal(metav1.ConditionTrue))
 					Expect(fallbackCondition.Reason).To(Equal(vdcondition.LegacyNFSVolumeSnapshot.String()))
@@ -259,6 +263,8 @@ var _ = Describe("ObjectRef VirtualDiskSnapshot", func() {
 					Expect(events[1].Reason).To(Equal(v1alpha2.ReasonDataSourceSyncFallback))
 					Expect(events[1].Message).To(ContainSubstring(annotations.AnnVirtualDiskOriginalSize))
 				} else {
+					Expect(pvcCreated).To(BeTrue())
+					Expect(ready.Reason).To(Equal(vdcondition.Provisioning.String()))
 					Expect(fallbackConditionExists).To(BeFalse())
 					Expect(events).To(HaveLen(1))
 				}

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_vdsnapshot_test.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/object_ref_vdsnapshot_test.go
@@ -217,6 +217,55 @@ var _ = Describe("ObjectRef VirtualDiskSnapshot", func() {
 			Entry("from VD spec size when it is set", "30Gi", "20Gi", "10Gi", "30Gi"),
 			Entry("from restore size when annotation and VD size are omitted", "", "", "10Gi", "10Gi"),
 		)
+
+		DescribeTable("reports legacy snapshot size fallback only for NFS provisioner",
+			func(provisioner string, expectFallback bool) {
+				sc.Provisioner = provisioner
+				vs.Annotations = map[string]string{
+					annotations.AnnStorageClassName: sc.Name,
+				}
+				vs.Status.RestoreSize = ptr.To(resource.MustParse("10Gi"))
+				mockRecorder := &eventrecord.EventRecorderLoggerMock{
+					EventFunc: func(_ client.Object, _, _, _ string) {},
+				}
+
+				client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(vdSnapshot, vs, sc).
+					WithInterceptorFuncs(interceptor.Funcs{
+						Create: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.CreateOption) error {
+							_, ok := obj.(*corev1.PersistentVolumeClaim)
+							Expect(ok).To(BeTrue())
+							return nil
+						},
+					}).Build()
+
+				syncer := NewObjectRefVirtualDiskSnapshot(mockRecorder, svc, client)
+
+				res, err := syncer.Sync(ctx, vd)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.IsZero()).To(BeTrue())
+
+				ready, _ := conditions.GetCondition(vdcondition.Ready, vd.Status.Conditions)
+				Expect(ready.Reason).To(Equal(vdcondition.Provisioning.String()))
+
+				events := mockRecorder.EventCalls()
+				fallbackCondition, fallbackConditionExists := conditions.GetCondition(vdcondition.SnapshotSizeFallbackType, vd.Status.Conditions)
+				if expectFallback {
+					Expect(fallbackConditionExists).To(BeTrue())
+					Expect(fallbackCondition.Status).To(Equal(metav1.ConditionTrue))
+					Expect(fallbackCondition.Reason).To(Equal(vdcondition.LegacyNFSVolumeSnapshot.String()))
+					Expect(fallbackCondition.Message).To(ContainSubstring(annotations.AnnVirtualDiskOriginalSize))
+					Expect(events).To(HaveLen(2))
+					Expect(events[1].Eventtype).To(Equal(corev1.EventTypeWarning))
+					Expect(events[1].Reason).To(Equal(v1alpha2.ReasonDataSourceSyncFallback))
+					Expect(events[1].Message).To(ContainSubstring(annotations.AnnVirtualDiskOriginalSize))
+				} else {
+					Expect(fallbackConditionExists).To(BeFalse())
+					Expect(events).To(HaveLen(1))
+				}
+			},
+			Entry("for NFS", "nfs.csi.k8s.io", true),
+			Entry("not for other provisioner", "example.com/csi", false),
+		)
 	})
 
 	Context("VirtualDisk waits for the PVC to be Bound", func() {

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/step/create_pvc_from_vdsnapshot_step.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/step/create_pvc_from_vdsnapshot_step.go
@@ -44,6 +44,8 @@ import (
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
 )
 
+const nfsCSIProvisioner = "nfs.csi.k8s.io"
+
 type CreatePVCFromVDSnapshotStep struct {
 	pvc      *corev1.PersistentVolumeClaim
 	recorder eventrecord.EventRecorderLogger
@@ -120,7 +122,7 @@ func (s CreatePVCFromVDSnapshotStep) Take(ctx context.Context, vd *v1alpha2.Virt
 		return &reconcile.Result{}, nil
 	}
 
-	pvc, err := s.buildPVC(vd, vs)
+	pvc, legacySnapshotSizeFallback, err := s.buildPVC(ctx, vd, vs)
 	if err != nil {
 		if errors.Is(err, service.ErrInsufficientPVCSize) {
 			vd.Status.Phase = v1alpha2.DiskFailed
@@ -146,10 +148,39 @@ func (s CreatePVCFromVDSnapshotStep) Take(ctx context.Context, vd *v1alpha2.Virt
 	}
 
 	vd.Status.Phase = v1alpha2.DiskProvisioning
+	message := "PVC has created: waiting to be Bound."
+	if legacySnapshotSizeFallback {
+		message = fmt.Sprintf(
+			"PVC has created from a legacy snapshot without the %q annotation: using VolumeSnapshot restore size; waiting to be Bound.",
+			annotations.AnnVirtualDiskOriginalSize,
+		)
+		conditions.SetCondition(
+			conditions.NewConditionBuilder(vdcondition.SnapshotSizeFallbackType).
+				Generation(vd.Generation).
+				Status(metav1.ConditionTrue).
+				Reason(vdcondition.LegacyNFSVolumeSnapshot).
+				Message(fmt.Sprintf(
+					"VolumeSnapshot %q does not contain the %q annotation; using VolumeSnapshot restore size for NFS provisioner.",
+					vs.Name,
+					annotations.AnnVirtualDiskOriginalSize,
+				)),
+			&vd.Status.Conditions,
+		)
+		s.recorder.Event(
+			vd,
+			corev1.EventTypeWarning,
+			v1alpha2.ReasonDataSourceSyncFallback,
+			fmt.Sprintf(
+				"VolumeSnapshot %q does not contain the %q annotation; using VolumeSnapshot restore size.",
+				vs.Name,
+				annotations.AnnVirtualDiskOriginalSize,
+			),
+		)
+	}
 	s.cb.
 		Status(metav1.ConditionFalse).
 		Reason(vdcondition.Provisioning).
-		Message("PVC has created: waiting to be Bound.")
+		Message(message)
 
 	vd.Status.Progress = "0%"
 	vd.Status.SourceUID = ptr.To(vdSnapshot.UID)
@@ -158,15 +189,13 @@ func (s CreatePVCFromVDSnapshotStep) Take(ctx context.Context, vd *v1alpha2.Virt
 	return nil, nil
 }
 
-func (s CreatePVCFromVDSnapshotStep) buildPVC(vd *v1alpha2.VirtualDisk, vs *vsv1.VolumeSnapshot) (*corev1.PersistentVolumeClaim, error) {
+func (s CreatePVCFromVDSnapshotStep) buildPVC(ctx context.Context, vd *v1alpha2.VirtualDisk, vs *vsv1.VolumeSnapshot) (*corev1.PersistentVolumeClaim, bool, error) {
 	var storageClassName string
+	snapshotStorageClassName := getSnapshotStorageClassName(vs)
 	if vd.Spec.PersistentVolumeClaim.StorageClass != nil && *vd.Spec.PersistentVolumeClaim.StorageClass != "" {
 		storageClassName = *vd.Spec.PersistentVolumeClaim.StorageClass
 	} else {
-		storageClassName = vs.Annotations[annotations.AnnStorageClassName]
-		if storageClassName == "" {
-			storageClassName = vs.Annotations[annotations.AnnStorageClassNameDeprecated]
-		}
+		storageClassName = snapshotStorageClassName
 	}
 
 	volumeMode := vs.Annotations[annotations.AnnVolumeMode]
@@ -202,9 +231,9 @@ func (s CreatePVCFromVDSnapshotStep) buildPVC(vd *v1alpha2.VirtualDisk, vs *vsv1
 		spec.VolumeMode = ptr.To(corev1.PersistentVolumeMode(volumeMode))
 	}
 
-	size, err := s.getPVCSize(vd, vs)
+	size, legacySnapshotSizeFallback, err := s.getPVCSize(ctx, vd, vs, snapshotStorageClassName)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	if size != nil {
@@ -229,32 +258,66 @@ func (s CreatePVCFromVDSnapshotStep) buildPVC(vd *v1alpha2.VirtualDisk, vs *vsv1
 			},
 		},
 		Spec: spec,
-	}, nil
+	}, legacySnapshotSizeFallback, nil
 }
 
-func (s CreatePVCFromVDSnapshotStep) getPVCSize(vd *v1alpha2.VirtualDisk, vs *vsv1.VolumeSnapshot) (*resource.Quantity, error) {
+func getSnapshotStorageClassName(vs *vsv1.VolumeSnapshot) string {
+	storageClassName := vs.Annotations[annotations.AnnStorageClassName]
+	if storageClassName == "" {
+		storageClassName = vs.Annotations[annotations.AnnStorageClassNameDeprecated]
+	}
+	return storageClassName
+}
+
+func (s CreatePVCFromVDSnapshotStep) getPVCSize(ctx context.Context, vd *v1alpha2.VirtualDisk, vs *vsv1.VolumeSnapshot, snapshotStorageClassName string) (*resource.Quantity, bool, error) {
 	requestedSize := vd.Spec.PersistentVolumeClaim.Size
 	if requestedSize == nil {
 		originalSize := vs.Annotations[annotations.AnnVirtualDiskOriginalSize]
 		if originalSize != "" {
 			size, err := resource.ParseQuantity(originalSize)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse the original size %q: %w", originalSize, err)
+				return nil, false, fmt.Errorf("failed to parse the original size %q: %w", originalSize, err)
 			}
 			requestedSize = &size
 		}
 	}
 
 	if vs.Status == nil || vs.Status.RestoreSize == nil {
-		return requestedSize, nil
+		return requestedSize, false, nil
+	}
+
+	legacySnapshotSizeFallback := false
+	if requestedSize == nil && vs.Annotations[annotations.AnnVirtualDiskOriginalSize] == "" {
+		var err error
+		legacySnapshotSizeFallback, err = s.isNFSStorageClass(ctx, snapshotStorageClassName)
+		if err != nil {
+			return nil, false, err
+		}
 	}
 
 	size, err := service.GetValidatedPVCSize(requestedSize, *vs.Status.RestoreSize)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
-	return &size, nil
+	return &size, legacySnapshotSizeFallback, nil
+}
+
+func (s CreatePVCFromVDSnapshotStep) isNFSStorageClass(ctx context.Context, storageClassName string) (bool, error) {
+	if storageClassName == "" {
+		return false, nil
+	}
+
+	var storageClass storagev1.StorageClass
+	err := s.client.Get(ctx, types.NamespacedName{Name: storageClassName}, &storageClass)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("cannot fetch storage class %q: %w", storageClassName, err)
+	}
+
+	return storageClass.Provisioner == nfsCSIProvisioner, nil
 }
 
 func (s CreatePVCFromVDSnapshotStep) validateStorageClassCompatibility(ctx context.Context, vd *v1alpha2.VirtualDisk, vdSnapshot *v1alpha2.VirtualDiskSnapshot, vs *vsv1.VolumeSnapshot) error {

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/step/create_pvc_from_vdsnapshot_step.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/step/create_pvc_from_vdsnapshot_step.go
@@ -194,12 +194,9 @@ func (s CreatePVCFromVDSnapshotStep) Take(ctx context.Context, vd *v1alpha2.Virt
 }
 
 func (s CreatePVCFromVDSnapshotStep) buildPVC(vd *v1alpha2.VirtualDisk, vs *vsv1.VolumeSnapshot) (*corev1.PersistentVolumeClaim, error) {
-	var storageClassName string
-	snapshotStorageClassName := getSnapshotStorageClassName(vs)
+	storageClassName := getSnapshotStorageClassName(vs)
 	if vd.Spec.PersistentVolumeClaim.StorageClass != nil && *vd.Spec.PersistentVolumeClaim.StorageClass != "" {
 		storageClassName = *vd.Spec.PersistentVolumeClaim.StorageClass
-	} else {
-		storageClassName = snapshotStorageClassName
 	}
 
 	volumeMode := vs.Annotations[annotations.AnnVolumeMode]

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/step/create_pvc_from_vdsnapshot_step.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/step/create_pvc_from_vdsnapshot_step.go
@@ -122,7 +122,40 @@ func (s CreatePVCFromVDSnapshotStep) Take(ctx context.Context, vd *v1alpha2.Virt
 		return &reconcile.Result{}, nil
 	}
 
-	pvc, legacySnapshotSizeFallback, err := s.buildPVC(ctx, vd, vs)
+	waitForExplicitSize, err := s.shouldWaitForExplicitSize(ctx, vd, vs)
+	if err != nil {
+		return nil, err
+	}
+	if waitForExplicitSize {
+		vd.Status.Phase = v1alpha2.DiskPending
+		message := fmt.Sprintf(
+			"VolumeSnapshot %q does not contain the %q annotation for NFS provisioner; specify spec.persistentVolumeClaim.size to continue.",
+			vs.Name,
+			annotations.AnnVirtualDiskOriginalSize,
+		)
+		conditions.SetCondition(
+			conditions.NewConditionBuilder(vdcondition.SnapshotSizeFallbackType).
+				Generation(vd.Generation).
+				Status(metav1.ConditionTrue).
+				Reason(vdcondition.LegacyNFSVolumeSnapshot).
+				Message(message),
+			&vd.Status.Conditions,
+		)
+		s.cb.
+			Status(metav1.ConditionFalse).
+			Reason(vdcondition.ProvisioningNotStarted).
+			Message(message)
+		s.recorder.Event(
+			vd,
+			corev1.EventTypeWarning,
+			v1alpha2.ReasonDataSourceSyncFallback,
+			message,
+		)
+		return &reconcile.Result{}, nil
+	}
+	conditions.RemoveCondition(vdcondition.SnapshotSizeFallbackType, &vd.Status.Conditions)
+
+	pvc, err := s.buildPVC(vd, vs)
 	if err != nil {
 		if errors.Is(err, service.ErrInsufficientPVCSize) {
 			vd.Status.Phase = v1alpha2.DiskFailed
@@ -148,39 +181,10 @@ func (s CreatePVCFromVDSnapshotStep) Take(ctx context.Context, vd *v1alpha2.Virt
 	}
 
 	vd.Status.Phase = v1alpha2.DiskProvisioning
-	message := "PVC has created: waiting to be Bound."
-	if legacySnapshotSizeFallback {
-		message = fmt.Sprintf(
-			"PVC has created from a legacy snapshot without the %q annotation: using VolumeSnapshot restore size; waiting to be Bound.",
-			annotations.AnnVirtualDiskOriginalSize,
-		)
-		conditions.SetCondition(
-			conditions.NewConditionBuilder(vdcondition.SnapshotSizeFallbackType).
-				Generation(vd.Generation).
-				Status(metav1.ConditionTrue).
-				Reason(vdcondition.LegacyNFSVolumeSnapshot).
-				Message(fmt.Sprintf(
-					"VolumeSnapshot %q does not contain the %q annotation; using VolumeSnapshot restore size for NFS provisioner.",
-					vs.Name,
-					annotations.AnnVirtualDiskOriginalSize,
-				)),
-			&vd.Status.Conditions,
-		)
-		s.recorder.Event(
-			vd,
-			corev1.EventTypeWarning,
-			v1alpha2.ReasonDataSourceSyncFallback,
-			fmt.Sprintf(
-				"VolumeSnapshot %q does not contain the %q annotation; using VolumeSnapshot restore size.",
-				vs.Name,
-				annotations.AnnVirtualDiskOriginalSize,
-			),
-		)
-	}
 	s.cb.
 		Status(metav1.ConditionFalse).
 		Reason(vdcondition.Provisioning).
-		Message(message)
+		Message("PVC has created: waiting to be Bound.")
 
 	vd.Status.Progress = "0%"
 	vd.Status.SourceUID = ptr.To(vdSnapshot.UID)
@@ -189,7 +193,7 @@ func (s CreatePVCFromVDSnapshotStep) Take(ctx context.Context, vd *v1alpha2.Virt
 	return nil, nil
 }
 
-func (s CreatePVCFromVDSnapshotStep) buildPVC(ctx context.Context, vd *v1alpha2.VirtualDisk, vs *vsv1.VolumeSnapshot) (*corev1.PersistentVolumeClaim, bool, error) {
+func (s CreatePVCFromVDSnapshotStep) buildPVC(vd *v1alpha2.VirtualDisk, vs *vsv1.VolumeSnapshot) (*corev1.PersistentVolumeClaim, error) {
 	var storageClassName string
 	snapshotStorageClassName := getSnapshotStorageClassName(vs)
 	if vd.Spec.PersistentVolumeClaim.StorageClass != nil && *vd.Spec.PersistentVolumeClaim.StorageClass != "" {
@@ -231,9 +235,9 @@ func (s CreatePVCFromVDSnapshotStep) buildPVC(ctx context.Context, vd *v1alpha2.
 		spec.VolumeMode = ptr.To(corev1.PersistentVolumeMode(volumeMode))
 	}
 
-	size, legacySnapshotSizeFallback, err := s.getPVCSize(ctx, vd, vs, snapshotStorageClassName)
+	size, err := s.getPVCSize(vd, vs)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 
 	if size != nil {
@@ -258,7 +262,7 @@ func (s CreatePVCFromVDSnapshotStep) buildPVC(ctx context.Context, vd *v1alpha2.
 			},
 		},
 		Spec: spec,
-	}, legacySnapshotSizeFallback, nil
+	}, nil
 }
 
 func getSnapshotStorageClassName(vs *vsv1.VolumeSnapshot) string {
@@ -269,38 +273,43 @@ func getSnapshotStorageClassName(vs *vsv1.VolumeSnapshot) string {
 	return storageClassName
 }
 
-func (s CreatePVCFromVDSnapshotStep) getPVCSize(ctx context.Context, vd *v1alpha2.VirtualDisk, vs *vsv1.VolumeSnapshot, snapshotStorageClassName string) (*resource.Quantity, bool, error) {
+func (s CreatePVCFromVDSnapshotStep) getPVCSize(vd *v1alpha2.VirtualDisk, vs *vsv1.VolumeSnapshot) (*resource.Quantity, error) {
 	requestedSize := vd.Spec.PersistentVolumeClaim.Size
 	if requestedSize == nil {
 		originalSize := vs.Annotations[annotations.AnnVirtualDiskOriginalSize]
 		if originalSize != "" {
 			size, err := resource.ParseQuantity(originalSize)
 			if err != nil {
-				return nil, false, fmt.Errorf("failed to parse the original size %q: %w", originalSize, err)
+				return nil, fmt.Errorf("failed to parse the original size %q: %w", originalSize, err)
 			}
 			requestedSize = &size
 		}
 	}
 
 	if vs.Status == nil || vs.Status.RestoreSize == nil {
-		return requestedSize, false, nil
-	}
-
-	legacySnapshotSizeFallback := false
-	if requestedSize == nil && vs.Annotations[annotations.AnnVirtualDiskOriginalSize] == "" {
-		var err error
-		legacySnapshotSizeFallback, err = s.isNFSStorageClass(ctx, snapshotStorageClassName)
-		if err != nil {
-			return nil, false, err
-		}
+		return requestedSize, nil
 	}
 
 	size, err := service.GetValidatedPVCSize(requestedSize, *vs.Status.RestoreSize)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 
-	return &size, legacySnapshotSizeFallback, nil
+	return &size, nil
+}
+
+func (s CreatePVCFromVDSnapshotStep) shouldWaitForExplicitSize(ctx context.Context, vd *v1alpha2.VirtualDisk, vs *vsv1.VolumeSnapshot) (bool, error) {
+	if vd.Spec.PersistentVolumeClaim.Size != nil {
+		return false, nil
+	}
+	if vs.Annotations[annotations.AnnVirtualDiskOriginalSize] != "" {
+		return false, nil
+	}
+	if vs.Status == nil || vs.Status.RestoreSize == nil {
+		return false, nil
+	}
+
+	return s.isNFSStorageClass(ctx, getSnapshotStorageClassName(vs))
 }
 
 func (s CreatePVCFromVDSnapshotStep) isNFSStorageClass(ctx context.Context, storageClassName string) (bool, error) {


### PR DESCRIPTION
## Description
Handle legacy VirtualDiskSnapshot restores for NFS snapshots that do not have the `virtualization.deckhouse.io/vd-original-size` annotation.

When a VirtualDisk is restored from such a snapshot and the source StorageClass provisioner is `nfs.csi.k8s.io`, the controller no longer falls back to `VolumeSnapshot.status.restoreSize` silently. Instead, it stops provisioning and waits for the user to specify `spec.persistentVolumeClaim.size` explicitly.

The change adds:
- `SnapshotSizeFallback` condition on VirtualDisk;
- `DataSourceImportFallback` warning event;
- tests for NFS and non-NFS provisioners.

## Why do we need it, and what problem does it solve?
Legacy NFS snapshots may not contain the original requested VirtualDisk size annotation. Falling back to `VolumeSnapshot.status.restoreSize` can create a PVC with an unexpected size.

For NFS snapshots without the annotation, the controller now makes the situation explicit and requires the user to provide the desired disk size before provisioning continues.

## What is the expected result?
1. Create a VirtualDisk from a legacy VirtualDiskSnapshot whose VolumeSnapshot has no `vd-original-size` annotation.
2. If the snapshot StorageClass provisioner is `nfs.csi.k8s.io` and `spec.persistentVolumeClaim.size` is not set, verify that:
   - PVC is not created;
   - VirtualDisk remains in `Pending`;
   - `Ready=False` with `ProvisioningNotStarted` reason;
   - `SnapshotSizeFallback=True` with `LegacyNFSVolumeSnapshot` reason;
   - `DataSourceImportFallback` warning event is emitted.
3. Specify `spec.persistentVolumeClaim.size` and verify that provisioning continues.
4. Verify that non-NFS snapshots keep the previous fallback behavior.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: vd
type: fix
summary: Require explicit VirtualDisk size when restoring legacy NFS snapshots without original size metadata.
```
