### PR TITLE
fix(vm): avoid false no bootable device events from EFI shell

### DIFF
--- a/images/edk2/patches/002-shell-no-bootable-message-only-without-startup-options.patch
+++ b/images/edk2/patches/002-shell-no-bootable-message-only-without-startup-options.patch
@@ -1,0 +1,37 @@
+diff --git a/ShellPkg/Application/Shell/Shell.c b/ShellPkg/Application/Shell/Shell.c
+index 174eccecdd..fc1791d2cf 100644
+--- a/ShellPkg/Application/Shell/Shell.c
++++ b/ShellPkg/Application/Shell/Shell.c
+@@ -359,14 +359,6 @@ UefiMain (
+   EFI_SIMPLE_TEXT_INPUT_PROTOCOL  *OldConIn;
+   SPLIT_LIST                      *Split;
+ 
+-  {
+-    STATIC CONST CHAR8  Msg[] = "No bootable device.\r\n";
+-    UINTN               i;
+-    for (i = 0; i < sizeof (Msg) - 1; i++) {
+-      IoWrite8 (0x403, (UINT8)Msg[i]);
+-    }
+-  }
+-
+   if (PcdGet8 (PcdShellSupportLevel) > 3) {
+     return (EFI_UNSUPPORTED);
+   }
+@@ -481,6 +473,17 @@ UefiMain (
+       goto FreeResources;
+     }
+ 
++    if (  (ShellInfoObject.ShellInitSettings.FileName == NULL)
++       && !ShellInfoObject.ShellInitSettings.BitUnion.Bits.NoConsoleIn
++       && !ShellInfoObject.ShellInitSettings.BitUnion.Bits.Exit)
++    {
++      STATIC CONST CHAR8  Msg[] = "No bootable device.\r\n";
++      UINTN               i;
++      for (i = 0; i < sizeof (Msg) - 1; i++) {
++        IoWrite8 (0x403, (UINT8)Msg[i]);
++      }
++    }
++
+     //
+     // If shell support level is >= 1 create the mappings and paths
+     //

--- a/images/edk2/patches/002-shell-no-bootable-message-only-without-startup-options.patch
+++ b/images/edk2/patches/002-shell-no-bootable-message-only-without-startup-options.patch
@@ -1,5 +1,5 @@
 diff --git a/ShellPkg/Application/Shell/Shell.c b/ShellPkg/Application/Shell/Shell.c
-index 174eccecdd..fc1791d2cf 100644
+index 174eccecdd..579c2a62f0 100644
 --- a/ShellPkg/Application/Shell/Shell.c
 +++ b/ShellPkg/Application/Shell/Shell.c
 @@ -359,14 +359,6 @@ UefiMain (
@@ -17,21 +17,33 @@ index 174eccecdd..fc1791d2cf 100644
    if (PcdGet8 (PcdShellSupportLevel) > 3) {
      return (EFI_UNSUPPORTED);
    }
-@@ -481,6 +473,17 @@ UefiMain (
-       goto FreeResources;
-     }
+@@ -639,6 +631,29 @@ UefiMain (
+       }
  
-+    if (  (ShellInfoObject.ShellInitSettings.FileName == NULL)
-+       && !ShellInfoObject.ShellInitSettings.BitUnion.Bits.NoConsoleIn
-+       && !ShellInfoObject.ShellInitSettings.BitUnion.Bits.Exit)
-+    {
-+      STATIC CONST CHAR8  Msg[] = "No bootable device.\r\n";
-+      UINTN               i;
-+      for (i = 0; i < sizeof (Msg) - 1; i++) {
-+        IoWrite8 (0x403, (UINT8)Msg[i]);
-+      }
-+    }
+       if (!ShellInfoObject.ShellInitSettings.BitUnion.Bits.Exit && !ShellCommandGetExit () && ((PcdGet8 (PcdShellSupportLevel) >= 3) || PcdGetBool (PcdShellForceConsole)) && !EFI_ERROR (Status) && !ShellInfoObject.ShellInitSettings.BitUnion.Bits.NoConsoleIn) {
++        if (ShellInfoObject.ShellInitSettings.FileName == NULL)
++        {
++          CHAR16  *StartupScriptPath;
 +
-     //
-     // If shell support level is >= 1 create the mappings and paths
-     //
++          StartupScriptPath = NULL;
++          if ((PcdGet8 (PcdShellSupportLevel) >= 1) &&
++              !(ShellInfoObject.ShellInitSettings.BitUnion.Bits.NoStartup &&
++                !ShellInfoObject.ShellInitSettings.BitUnion.Bits.Startup))
++          {
++            StartupScriptPath = LocateStartupScript (ShellInfoObject.ImageDevPath, ShellInfoObject.FileDevPath);
++          }
++
++          if (StartupScriptPath == NULL) {
++            STATIC CONST CHAR8  Msg[] = "No bootable device.\r\n";
++            UINTN               i;
++            for (i = 0; i < sizeof (Msg) - 1; i++) {
++              IoWrite8 (0x403, (UINT8)Msg[i]);
++            }
++          } else {
++            FreePool (StartupScriptPath);
++          }
++        }
++
+         //
+         // begin the UI waiting loop
+         //

--- a/images/edk2/patches/002-shell-no-bootable-message-only-without-startup-options.patch
+++ b/images/edk2/patches/002-shell-no-bootable-message-only-without-startup-options.patch
@@ -1,8 +1,22 @@
 diff --git a/ShellPkg/Application/Shell/Shell.c b/ShellPkg/Application/Shell/Shell.c
-index 174eccecdd..579c2a62f0 100644
+index 174eccecdd..453adff412 100644
 --- a/ShellPkg/Application/Shell/Shell.c
 +++ b/ShellPkg/Application/Shell/Shell.c
-@@ -359,14 +359,6 @@ UefiMain (
+@@ -80,6 +80,13 @@ CONST CHAR16         mNoNestingEnvVarName[]  = L"nonesting";
+ CONST CHAR16         mNoNestingTrue[]        = L"True";
+ CONST CHAR16         mNoNestingFalse[]       = L"False";
+ 
++STATIC
++CHAR16 *
++LocateStartupScript (
++  IN EFI_DEVICE_PATH_PROTOCOL  *ImageDevicePath,
++  IN EFI_DEVICE_PATH_PROTOCOL  *FileDevicePath
++  );
++
+ /**
+   Cleans off leading and trailing spaces and tabs.
+ 
+@@ -359,14 +366,6 @@ UefiMain (
    EFI_SIMPLE_TEXT_INPUT_PROTOCOL  *OldConIn;
    SPLIT_LIST                      *Split;
  
@@ -17,7 +31,7 @@ index 174eccecdd..579c2a62f0 100644
    if (PcdGet8 (PcdShellSupportLevel) > 3) {
      return (EFI_UNSUPPORTED);
    }
-@@ -639,6 +631,29 @@ UefiMain (
+@@ -639,6 +638,29 @@ UefiMain (
        }
  
        if (!ShellInfoObject.ShellInitSettings.BitUnion.Bits.Exit && !ShellCommandGetExit () && ((PcdGet8 (PcdShellSupportLevel) >= 3) || PcdGetBool (PcdShellForceConsole)) && !EFI_ERROR (Status) && !ShellInfoObject.ShellInitSettings.BitUnion.Bits.NoConsoleIn) {
@@ -47,3 +61,11 @@ index 174eccecdd..579c2a62f0 100644
          //
          // begin the UI waiting loop
          //
+@@ -1240,6 +1262,7 @@ ProcessCommandLine (
+   @retval   NULL                  No Startup.nsh file was found.
+   @return   !=NULL                Pointer to NULL-terminated path.
+ **/
++STATIC
+ CHAR16 *
+ LocateStartupScript (
+   IN EFI_DEVICE_PATH_PROTOCOL  *ImageDevicePath,

--- a/images/edk2/patches/README.md
+++ b/images/edk2/patches/README.md
@@ -1,6 +1,29 @@
-# 001-debug-device-no-bootable-device-message.patch
+# Patches
+
+This directory contains downstream patches applied to the EDK2 source during the image build.
+Patch files are applied in lexicographical order.
+
+## 001-debug-device-no-bootable-device-message.patch
+
 If OVMF cannot find a bootable device, or the firmware drops into the EFI shell,
 output `No bootable device.` to the debug port at address `0x403`.
 
 This patch is intended to be used together with the QEMU patch that watches the
 debug console and emits a `NO_BOOTABLE_DEVICE` QMP event.
+
+## 002-shell-no-bootable-message-only-without-startup-options.patch
+
+Limits the EFI shell debug marker emission to fallback shell startups only.
+
+Why this patch is kept:
+
+- Some operating systems legitimately launch EFI shell with startup parameters.
+- Emitting `No bootable device.` unconditionally from shell entry causes false
+  `NO_BOOTABLE_DEVICE` detections in QEMU.
+
+Effect:
+
+- The marker is emitted only when shell is started without a target file and
+  without `NoConsoleIn` or `Exit` options.
+- Real "no bootable device" firmware fallback remains detectable, while normal
+  parameterized shell boot flows are not treated as failures.

--- a/images/edk2/werf.inc.yaml
+++ b/images/edk2/werf.inc.yaml
@@ -75,6 +75,8 @@ shell:
   - |
     cd /src
 
+    echo 123
+
     echo "Git clone Edk2 repository..."
     git clone \
       --depth=1 $(cat /run/secrets/SOURCE_REPO)/{{ $gitRepoUrl }} \

--- a/images/edk2/werf.inc.yaml
+++ b/images/edk2/werf.inc.yaml
@@ -75,7 +75,7 @@ shell:
   - |
     cd /src
 
-    echo 123
+    echo 1234
 
     echo "Git clone Edk2 repository..."
     git clone \

--- a/images/edk2/werf.inc.yaml
+++ b/images/edk2/werf.inc.yaml
@@ -75,8 +75,6 @@ shell:
   - |
     cd /src
 
-    echo 1234
-
     echo "Git clone Edk2 repository..."
     git clone \
       --depth=1 $(cat /run/secrets/SOURCE_REPO)/{{ $gitRepoUrl }} \


### PR DESCRIPTION
## Description
Add a downstream EDK2 shell patch that moves the `No bootable device.` debug-port marker from unconditional shell startup to the interactive fallback shell path only.

The patch now checks that the EFI shell was started without a target file and without a `Startup.nsh` script before writing the marker to debug port `0x403`. The patches README was updated to document the new downstream patch and patch ordering.

## Why do we need it, and what problem does it solve?
Some operating systems legitimately launch the EFI shell with startup parameters or scripts. Emitting `No bootable device.` at every shell entry makes QEMU report a `NO_BOOTABLE_DEVICE` event even when the VM boot flow is valid.

This change keeps real firmware fallback detection intact while avoiding false no-bootable-device reports for normal parameterized EFI shell launches.

## What is the expected result?
A VM that really falls back to the EFI shell without a bootable device still emits `No bootable device.` and produces the expected `NO_BOOTABLE_DEVICE` event.

A VM or OS flow that starts the EFI shell with a file, options, or `Startup.nsh` no longer emits the marker and is not treated as a no-bootable-device failure.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
