### PR TITLE
chore(ci): clean up custom release tags in dev registry

### DIFF
--- a/.github/scripts/bash/registry-module-cleanup.sh
+++ b/.github/scripts/bash/registry-module-cleanup.sh
@@ -44,7 +44,7 @@ tag_created_epoch() {
   local tag="$1"
 
   crane config "${RELEASE_REPO}:${tag}" \
-    | jq -r '.created | split(".")[0] + "Z" | fromdateiso8601'
+    | jq -r '.created | sub("\\.[0-9]+";"") | sub("Z?$";"Z") | fromdateiso8601'
 }
 
 # Returns 0 if the tag is expired and should be deleted.
@@ -88,7 +88,7 @@ cleanup_repo() {
   while read -r tag; do
     [ -z "${tag}" ] && continue
 
-    created_epoch="$(tag_created_epoch "${tag}")"
+    created_epoch="$(tag_created_epoch "${tag}" 2>/dev/null)" || created_epoch=""
     if [ -z "${created_epoch}" ]; then
       log "skip ${tag}: cannot resolve creation time"
       kept=$((kept + 1))

--- a/.github/scripts/bash/registry-module-cleanup.sh
+++ b/.github/scripts/bash/registry-module-cleanup.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/scripts/bash/e2e/common.sh
+source "${SCRIPT_DIR}/e2e/common.sh"
+
+require_env MODULES_MODULE_SOURCE
+require_env MODULES_MODULE_NAME
+
+readonly PR_TAG_TTL_DAYS="${REGISTRY_CLEANUP_PR_TAG_TTL_DAYS:-14}"
+readonly RC_TAG_TTL_DAYS="${REGISTRY_CLEANUP_RC_TAG_TTL_DAYS:-60}"
+readonly DRY_RUN="${REGISTRY_CLEANUP_DRY_RUN:-false}"
+# MODULES_MODULE_SOURCE and MODULES_MODULE_NAME come from the workflow env block
+# and are validated by require_env above.
+# shellcheck disable=SC2154
+readonly RELEASE_REPO="${MODULES_MODULE_SOURCE}/${MODULES_MODULE_NAME}/release"
+readonly SECONDS_PER_DAY=$((24 * 60 * 60))
+
+now_epoch="$(date +%s)"
+readonly pr_threshold_epoch=$((now_epoch - PR_TAG_TTL_DAYS * SECONDS_PER_DAY))
+readonly rc_threshold_epoch=$((now_epoch - RC_TAG_TTL_DAYS * SECONDS_PER_DAY))
+
+log() {
+  echo "[INFO] $*"
+}
+
+tag_created_epoch() {
+  local tag="$1"
+
+  crane config "${RELEASE_REPO}:${tag}" \
+    | jq -r '.created | split(".")[0] + "Z" | fromdateiso8601'
+}
+
+# Returns 0 if the tag is expired and should be deleted.
+# Protected tags (release channels, stable vX.Y.Z, main) never match.
+is_expired_tag() {
+  local tag="$1"
+  local created_epoch="$2"
+
+  case "${tag}" in
+    pr[0-9]* | release-*)
+      [ "${created_epoch}" -lt "${pr_threshold_epoch}" ]
+      ;;
+    v[0-9]*.[0-9]*.[0-9]*-rc.[0-9]*)
+      [ "${created_epoch}" -lt "${rc_threshold_epoch}" ]
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+# crane delete removes the manifest by the digest the tag points to. Tags that
+# share a digest with the deleted one are untagged too, so only expired and
+# unprotected tags reach this function.
+delete_tag() {
+  local tag="$1"
+
+  if [ "${DRY_RUN}" = "true" ]; then
+    log "[dry-run] would delete ${RELEASE_REPO}:${tag}"
+    return
+  fi
+
+  log "deleting ${RELEASE_REPO}:${tag}"
+  crane delete "${RELEASE_REPO}:${tag}"
+}
+
+cleanup_repo() {
+  local tag created_epoch
+  local deleted=0 kept=0
+
+  while read -r tag; do
+    [ -z "${tag}" ] && continue
+
+    created_epoch="$(tag_created_epoch "${tag}")"
+    if [ -z "${created_epoch}" ]; then
+      log "skip ${tag}: cannot resolve creation time"
+      kept=$((kept + 1))
+      continue
+    fi
+
+    if is_expired_tag "${tag}" "${created_epoch}"; then
+      delete_tag "${tag}"
+      deleted=$((deleted + 1))
+    else
+      kept=$((kept + 1))
+    fi
+  done < <(crane ls "${RELEASE_REPO}")
+
+  log "done: ${deleted} deleted, ${kept} kept"
+}
+
+log "cleaning custom release tags in ${RELEASE_REPO}"
+log "dry run: ${DRY_RUN}"
+log "pr/release branch tag TTL: ${PR_TAG_TTL_DAYS} days"
+log "release candidate tag TTL: ${RC_TAG_TTL_DAYS} days"
+
+cleanup_repo

--- a/.github/scripts/bash/registry-module-cleanup.sh
+++ b/.github/scripts/bash/registry-module-cleanup.sh
@@ -53,17 +53,13 @@ is_expired_tag() {
   local tag="$1"
   local created_epoch="$2"
 
-  case "${tag}" in
-    pr[0-9]* | release-*)
-      [ "${created_epoch}" -lt "${pr_threshold_epoch}" ]
-      ;;
-    v[0-9]*.[0-9]*.[0-9]*-rc.[0-9]*)
-      [ "${created_epoch}" -lt "${rc_threshold_epoch}" ]
-      ;;
-    *)
-      return 1
-      ;;
-  esac
+  if [[ "${tag}" =~ ^pr[0-9]+$ || "${tag}" =~ ^release-[0-9]+\.[0-9]+ ]]; then
+    [ "${created_epoch}" -lt "${pr_threshold_epoch}" ]
+  elif [[ "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
+    [ "${created_epoch}" -lt "${rc_threshold_epoch}" ]
+  else
+    return 1
+  fi
 }
 
 # crane delete removes the manifest by the digest the tag points to. Tags that
@@ -83,7 +79,7 @@ delete_tag() {
 
 cleanup_repo() {
   local tag created_epoch
-  local deleted=0 kept=0
+  local deleted=0 kept=0 failed=0
 
   while read -r tag; do
     [ -z "${tag}" ] && continue
@@ -96,14 +92,22 @@ cleanup_repo() {
     fi
 
     if is_expired_tag "${tag}" "${created_epoch}"; then
-      delete_tag "${tag}"
-      deleted=$((deleted + 1))
+      if delete_tag "${tag}"; then
+        deleted=$((deleted + 1))
+      else
+        log "WARN: failed to delete ${RELEASE_REPO}:${tag}"
+        failed=$((failed + 1))
+      fi
     else
       kept=$((kept + 1))
     fi
   done < <(crane ls "${RELEASE_REPO}")
 
-  log "done: ${deleted} deleted, ${kept} kept"
+  log "done: ${deleted} deleted, ${kept} kept, ${failed} failed"
+
+  if [ "${failed}" -gt 0 ]; then
+    return 1
+  fi
 }
 
 log "cleaning custom release tags in ${RELEASE_REPO}"

--- a/.github/scripts/bash/registry-module-cleanup.sh
+++ b/.github/scripts/bash/registry-module-cleanup.sh
@@ -47,16 +47,16 @@ tag_created_epoch() {
     | jq -r '.created | sub("\\.[0-9]+";"") | sub("Z?$";"Z") | fromdateiso8601'
 }
 
-# Returns 0 if the tag is expired and should be deleted.
-# Protected tags (release channels, stable vX.Y.Z, main) never match.
-is_expired_tag() {
+# Echoes the expiry threshold epoch for a cleanup-candidate tag, or returns 1
+# for protected tags (release channels, stable vX.Y.Z, main). Name-only, no
+# network — lets the caller skip the crane config call for protected tags.
+tag_threshold_epoch() {
   local tag="$1"
-  local created_epoch="$2"
 
   if [[ "${tag}" =~ ^pr[0-9]+$ || "${tag}" =~ ^release-[0-9]+\.[0-9]+ ]]; then
-    [ "${created_epoch}" -lt "${pr_threshold_epoch}" ]
+    echo "${pr_threshold_epoch}"
   elif [[ "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
-    [ "${created_epoch}" -lt "${rc_threshold_epoch}" ]
+    echo "${rc_threshold_epoch}"
   else
     return 1
   fi
@@ -78,11 +78,14 @@ delete_tag() {
 }
 
 cleanup_repo() {
-  local tag created_epoch
+  local tag threshold_epoch created_epoch
   local deleted=0 kept=0 failed=0
 
   while read -r tag; do
     [ -z "${tag}" ] && continue
+
+    # Filter by name first: protected tags never reach the crane config call.
+    threshold_epoch="$(tag_threshold_epoch "${tag}")" || { kept=$((kept + 1)); continue; }
 
     created_epoch="$(tag_created_epoch "${tag}" 2>/dev/null)" || created_epoch=""
     if [ -z "${created_epoch}" ]; then
@@ -91,7 +94,7 @@ cleanup_repo() {
       continue
     fi
 
-    if is_expired_tag "${tag}" "${created_epoch}"; then
+    if [ "${created_epoch}" -lt "${threshold_epoch}" ]; then
       if delete_tag "${tag}"; then
         deleted=$((deleted + 1))
       else

--- a/.github/workflows/dev_registry-cleanup.yml
+++ b/.github/workflows/dev_registry-cleanup.yml
@@ -21,7 +21,6 @@ env:
   MODULES_MODULE_SOURCE: ${{ vars.DEV_MODULE_SOURCE }}
   MODULES_REGISTRY_LOGIN: ${{ vars.DEV_MODULES_REGISTRY_LOGIN }}
   MODULES_REGISTRY_PASSWORD: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
-  WERF_DRY_RUN: "false"
 
 on:
   workflow_dispatch:
@@ -58,6 +57,8 @@ jobs:
           registry_password: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
 
       - name: Cleanup
+        env:
+          WERF_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
         run: |
           werf cleanup \
           --repo "${MODULES_MODULE_SOURCE}/${MODULES_MODULE_NAME}" \

--- a/.github/workflows/dev_registry-cleanup.yml
+++ b/.github/workflows/dev_registry-cleanup.yml
@@ -41,7 +41,7 @@ defaults:
     shell: bash
 
 jobs:
-  lint:
+  cleanup:
     runs-on: [self-hosted, regular]
     name: Run cleanup
     steps:

--- a/.github/workflows/dev_registry-cleanup.yml
+++ b/.github/workflows/dev_registry-cleanup.yml
@@ -21,18 +21,10 @@ env:
   MODULES_MODULE_SOURCE: ${{ vars.DEV_MODULE_SOURCE }}
   MODULES_REGISTRY_LOGIN: ${{ vars.DEV_MODULES_REGISTRY_LOGIN }}
   MODULES_REGISTRY_PASSWORD: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
+  WERF_DRY_RUN: "false"
 
 on:
   workflow_dispatch:
-    inputs:
-      dry_run:
-        description: "Show custom release tag cleanup actions without deleting tags"
-        required: true
-        default: "true"
-        type: choice
-        options:
-          - "true"
-          - "false"
   schedule:
     - cron: "12 0 * * 6"
 
@@ -57,15 +49,11 @@ jobs:
           registry_password: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
 
       - name: Cleanup
-        env:
-          WERF_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
         run: |
           werf cleanup \
           --repo "${MODULES_MODULE_SOURCE}/${MODULES_MODULE_NAME}" \
           --without-kube=true --config werf_cleanup.yaml
 
       - name: Cleanup custom release tags
-        env:
-          REGISTRY_CLEANUP_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
         run: |
           bash .github/scripts/bash/registry-module-cleanup.sh

--- a/.github/workflows/dev_registry-cleanup.yml
+++ b/.github/workflows/dev_registry-cleanup.yml
@@ -25,6 +25,15 @@ env:
 
 on:
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Show custom release tag cleanup actions without deleting tags"
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
   schedule:
     - cron: "12 0 * * 6"
 
@@ -38,7 +47,11 @@ jobs:
     name: Run cleanup
     steps:
       - uses: actions/checkout@v4
-      - uses: deckhouse/modules-actions/setup@v2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - uses: deckhouse/modules-actions/setup@v4
         with:
           registry: ${{ vars.DEV_REGISTRY }}
           registry_login: ${{ vars.DEV_MODULES_REGISTRY_LOGIN }}
@@ -47,5 +60,11 @@ jobs:
       - name: Cleanup
         run: |
           werf cleanup \
-          --repo ${MODULES_MODULE_SOURCE}/${MODULES_MODULE_NAME} \
+          --repo "${MODULES_MODULE_SOURCE}/${MODULES_MODULE_NAME}" \
           --without-kube=true --config werf_cleanup.yaml
+
+      - name: Cleanup custom release tags
+        env:
+          REGISTRY_CLEANUP_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
+        run: |
+          bash .github/scripts/bash/registry-module-cleanup.sh


### PR DESCRIPTION
## Description
Add a dedicated cleanup script for custom module release tags in the development registry.

The dev registry cleanup workflow now:
- checks out full Git history and tags before running `werf cleanup`;
- keeps the existing `werf cleanup` for werf-managed images;
- runs `.github/scripts/bash/registry-module-cleanup.sh` to clean custom tags in `${MODULES_MODULE_SOURCE}/${MODULES_MODULE_NAME}/release`.

The script removes expired `pr*`, `release-*`, and `v*-rc.*` tags based on configurable TTL values (`REGISTRY_CLEANUP_PR_TAG_TTL_DAYS`, `REGISTRY_CLEANUP_RC_TAG_TTL_DAYS`) while leaving stable release tags, release channel tags, and `main` untouched. Protected tags are filtered by name first, so only cleanup candidates trigger a `crane config` call to resolve their creation time.

## Why do we need it, and what problem does it solve?
`werf cleanup` policies are based on Git history and apply to werf-managed image versions. The module release tags published to the `/release` repository are created separately via `crane copy`, so tags such as `pr1234` and old release candidates were not removed by the existing cleanup job.

This change adds cleanup for those custom registry tags and prevents the development registry from accumulating obsolete module release images.

## What is the expected result?
1. Run the `Cleanup dev registries` workflow (manually or on schedule).
2. Verify that expired `pr*`, `release-*`, and old `v*-rc.*` tags are removed from the dev registry while stable releases and channel tags remain available.
3. Verify the step logs a `done: N deleted, M kept, K failed` summary and fails the job if any deletion failed.

> Note: the workflow always runs in delete mode. The script still honors a `REGISTRY_CLEANUP_DRY_RUN=true` env var for local/manual runs, but it is not exposed as a workflow input.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: chore
summary: Clean up obsolete custom release tags in the development registry.
impact_level: low
```
