### PR TITLE
fix(vm): preserve no bootable device error after migration (#2463)

### DIFF
--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -3,7 +3,7 @@ firmware:
   libvirt: v10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: v1.6.2-v12n.42
+  3p-kubevirt: v1.6.2-v12n.43
   3p-containerized-data-importer: v1.60.3-v12n.19
   distribution: 2.8.3
 package:


### PR DESCRIPTION
## Description
Bump the `3p-kubevirt` component from `v1.6.2-v12n.42` to `v1.6.2-v12n.43`.

The updated KubeVirt artifact includes a fix that keeps the VM boot failure state when a VM with `No bootable device.` is migrated.

## Why do we need it, and what problem does it solve?
A VM that failed to boot with `No bootable device.` could lose that error state during migration. As a result, the VM status no longer reflected the real boot failure after the migration flow touched the VMI state.

This change preserves the boot failure information across migration, so users and controllers continue to see the actual VM problem instead of a cleared status.

## What is the expected result?
A VM that reaches the `No bootable device.` boot failure state keeps this error during and after migration.

To verify the fix, reproduce a VM boot failure with no bootable device, migrate the VM, and check that the VM status still reports the boot failure after migration completes.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: vm
type: fix
summary: "The No bootable device error is no longer cleared when a failed VM is migrated."
```