### PR TITLE
fix(vm): skip template network sync for main-only VMs

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
@@ -829,10 +829,6 @@ func (h *SyncKvvmHandler) networksOutOfSync(ctx context.Context, s state.Virtual
 		return false, nil
 	}
 	vm := s.VirtualMachine().Current()
-	kvvmi, err := s.KVVMI(ctx)
-	if err != nil {
-		return false, err
-	}
 	// For Main-only VMs, the default pod network may be implicit in the KVVM
 	// template but explicit in the running VMI: KubeVirt defaulting adds it to
 	// the VMI spec when the instance starts. If we later "fix" the KVVM template
@@ -840,8 +836,14 @@ func (h *SyncKvvmHandler) networksOutOfSync(ctx context.Context, s state.Virtual
 	// template diff as a non-live-updatable network change and sets RestartRequired.
 	// When there are no active additional interfaces, this is only an implicit-vs-
 	// explicit default-network drift, so do not reconcile it.
-	if hasOnlyDefaultNetwork(vm) && !hasActiveAdditionalInterfaces(kvvm) && isKVVMIRunning(kvvmi) {
-		return false, nil
+	if hasOnlyDefaultNetwork(vm) {
+		kvvmi, err := s.KVVMI(ctx)
+		if err != nil {
+			return false, err
+		}
+		if !hasActiveAdditionalInterfaces(kvvm) && isKVVMIRunning(kvvmi) {
+			return false, nil
+		}
 	}
 	filteredVM, err := filterReadyNetworks(ctx, s.Client(), vm)
 	if err != nil {

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
@@ -215,7 +215,7 @@ func (h *SyncKvvmHandler) Handle(ctx context.Context, s state.VirtualMachineStat
 		cbConfApplied.
 			Status(metav1.ConditionFalse).
 			Reason(vmcondition.ReasonConfigurationNotApplied).
-			Message("Waiting for SDN to configure network interfaces on the pod.")
+			Message("Waiting for SDN to configure network interfaces.")
 	case kvvmSyncErr != nil:
 		h.recorder.Event(current, corev1.EventTypeWarning, v1alpha2.ReasonErrVmNotSynced, kvvmSyncErr.Error())
 		cbConfApplied.
@@ -758,7 +758,7 @@ func (h *SyncKvvmHandler) applyVMChangesToKVVM(ctx context.Context, s state.Virt
 				return fmt.Errorf("unable to check pod network status: %w", err)
 			}
 			if !ready {
-				msg := "Waiting for SDN to configure network interfaces on the pod"
+				msg := "Waiting for SDN to configure network interfaces"
 				log.Info(msg)
 				h.recorder.Event(current, corev1.EventTypeNormal, v1alpha2.ReasonVMChangesApplied, msg)
 				return errWaitForNetworkReady
@@ -828,7 +828,22 @@ func (h *SyncKvvmHandler) networksOutOfSync(ctx context.Context, s state.Virtual
 	if kvvm == nil {
 		return false, nil
 	}
-	filteredVM, err := filterReadyNetworks(ctx, s.Client(), s.VirtualMachine().Current())
+	vm := s.VirtualMachine().Current()
+	kvvmi, err := s.KVVMI(ctx)
+	if err != nil {
+		return false, err
+	}
+	// For Main-only VMs, the default pod network may be implicit in the KVVM
+	// template but explicit in the running VMI: KubeVirt defaulting adds it to
+	// the VMI spec when the instance starts. If we later "fix" the KVVM template
+	// from [] to [default] while the VM is already Running, KubeVirt treats that
+	// template diff as a non-live-updatable network change and sets RestartRequired.
+	// When there are no active additional interfaces, this is only an implicit-vs-
+	// explicit default-network drift, so do not reconcile it.
+	if hasOnlyDefaultNetwork(vm) && !hasActiveAdditionalInterfaces(kvvm) && isKVVMIRunning(kvvmi) {
+		return false, nil
+	}
+	filteredVM, err := filterReadyNetworks(ctx, s.Client(), vm)
 	if err != nil {
 		return false, err
 	}
@@ -855,7 +870,45 @@ func (h *SyncKvvmHandler) networksOutOfSync(ctx context.Context, s state.Virtual
 	return false, nil
 }
 
+func isKVVMIRunning(kvvmi *virtv1.VirtualMachineInstance) bool {
+	return kvvmi != nil && kvvmi.Status.Phase == virtv1.Running
+}
+
+func hasActiveAdditionalInterfaces(kvvm *virtv1.VirtualMachine) bool {
+	if kvvm == nil || kvvm.Spec.Template == nil {
+		return false
+	}
+	for _, iface := range kvvm.Spec.Template.Spec.Domain.Devices.Interfaces {
+		if iface.Name == network.NameDefaultInterface || iface.State == virtv1.InterfaceStateAbsent {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
 func (h *SyncKvvmHandler) applyNetworkReadinessSync(ctx context.Context, s state.VirtualMachineState) error {
+	vm := s.VirtualMachine().Current()
+	if hasOnlyDefaultNetwork(vm) {
+		kvvm, err := s.KVVM(ctx)
+		if err != nil {
+			return fmt.Errorf("find the internal virtual machine: %w", err)
+		}
+		kvvmi, err := s.KVVMI(ctx)
+		if err != nil {
+			return fmt.Errorf("find the internal virtual machine instance: %w", err)
+		}
+		// For Main-only VMs, KubeVirt may have already defaulted the pod network into
+		// the running VMI while the KVVM template still has no explicit interfaces.
+		// Waiting for SDN and updating the template would materialize [] -> [default]
+		// after the VM is Running, which KubeVirt can report as RestartRequired.
+		// If there are no active additional interfaces, there is nothing SDN-managed
+		// to wait for or sync, so skip the network readiness/update path.
+		if !hasActiveAdditionalInterfaces(kvvm) && isKVVMIRunning(kvvmi) {
+			return nil
+		}
+	}
+
 	desired, err := h.patchPodNetworkAnnotation(ctx, s)
 	if err != nil {
 		return fmt.Errorf("patch pod network annotation: %w", err)


### PR DESCRIPTION
## Description

Skip the network template synchronization path for VirtualMachines that only use the implicit Main network.

The network hotplug reconciliation can detect a mismatch between the desired implicit default network and an existing KubeVirt VM template that does not explicitly contain `spec.template.spec.domain.devices.interfaces` / `spec.template.spec.networks`. For Main-only VMs this mismatch must not be reconciled into a running KubeVirt VM template, because materializing the implicit default network as an explicit template field creates a non-live-updatable diff for KubeVirt.

## Why do we need it, and what problem does it solve?

After the network hotplug changes, `SyncKvvmHandler` can enter the `networksOutOfSync -> applyNetworkReadinessSync -> updateKVVM` path for a Main-only VM.

For such VMs, the running VMI already has the default pod network via KubeVirt defaulting, but the KubeVirt VM template may not explicitly contain it. Updating the template while the VM is running changes:

```yaml
spec.template.spec.domain.devices.interfaces:
- name: default
  bridge: {}
  model: virtio
  acpiIndex: 1

spec.template.spec.networks:
- name: default
  pod: {}
```

Older `virt-controller` versions can see this `[] -> [default]` template diff during module rollout and set KubeVirt `RestartRequired=True` with `a non-live-updatable field was changed in the template spec`. DVP then exposes it as `AwaitingRestartToApplyConfiguration=True` with `UnexpectedState`.

The same path can also produce a misleading `ConfigurationApplied=False` message about waiting for SDN, even though Main-only VMs do not have additional SDN-managed interfaces to wait for.

This fix skips the out-of-sync network reconciliation and readiness/update path for Main-only VMs. VMs with additional networks still use the existing SDN readiness and hotplug flow.

## What is the expected result?

1. Create a VM without explicit `spec.networks` or with only the Main network.
2. Roll out the virtualization module version that contains network hotplug changes.
3. Verify that the VM does not get:
   - `ConfigurationApplied=False` with `Waiting for SDN to configure network interfaces on the pod.`
   - `AwaitingRestartToApplyConfiguration=True` caused by materializing the implicit default network in the KubeVirt VM template.
4. Verify that VMs with additional networks still reconcile through the SDN readiness path.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: vm
type: fix
summary: Fixed a false reboot requirement for VMs with only the Main network after upgrading to v1.9.1. Such VMs now do not receive the RestartRequired status if their configuration has not actually changed.
```
