### PR TITLE
chore(ci): use ru registry for release checks

### DIFF
--- a/.github/workflows/release_module_release-channels.yml
+++ b/.github/workflows/release_module_release-channels.yml
@@ -441,13 +441,6 @@ jobs:
         with:
           go-version: "${{ env.GO_VERSION }}"
 
-      - name: Login to PROD_REGISTRY
-        uses: deckhouse/modules-actions/setup@v2
-        with:
-          registry: ${{ vars.PROD_READ_REGISTRY }}
-          registry_login: ${{ secrets.PROD_READ_REGISTRY_USER }}
-          registry_password: ${{ secrets.PROD_READ_REGISTRY_PASSWORD }}
-
       - name: Log in to private registry
         id: registry-login
         uses: ./.github/actions/registry-login

--- a/.github/workflows/release_module_release-channels.yml
+++ b/.github/workflows/release_module_release-channels.yml
@@ -448,6 +448,12 @@ jobs:
           registry_login: ${{ secrets.PROD_READ_REGISTRY_USER }}
           registry_password: ${{ secrets.PROD_READ_REGISTRY_PASSWORD }}
 
+      - name: Log in to private registry
+        id: registry-login
+        uses: ./.github/actions/registry-login
+        with:
+          docker_cfg: ${{ secrets.PROD_RU_REGISTRY_DOCKER_CFG }}
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/tools/moduleversions/Taskfile.dist.yaml
+++ b/tools/moduleversions/Taskfile.dist.yaml
@@ -2,6 +2,7 @@ version: "3"
 
 vars:
   PROD_REGISTRY: registry.deckhouse.io/deckhouse
+  PROD_REGISTRY_RU: registry.deckhouse.ru/deckhouse
   CHANNEL: '{{ .CHANNEL | default "alpha" }}'
   VERSION: "{{ .VERSION }}"
 
@@ -45,7 +46,7 @@ tasks:
     cmds:
       - |
         if [[ -z "{{ .VERSION }}" ]] || [[ -z "{{ .CHANNEL }}" ]]; then
-          echo "TAG and CHANNEL are required"
+          echo "VERSION (tag) and CHANNEL are required"
           exit 1
         fi
 
@@ -56,7 +57,7 @@ tasks:
 
         check_editions_version() {
           local editions=("ee" "fe" "ce" "se-plus")
-          local prod_registry="registry.deckhouse.io/deckhouse"
+          local prod_registry={{ .PROD_REGISTRY_RU }}
           local channel=$1
           local version=$2
 

--- a/tools/moduleversions/Taskfile.dist.yaml
+++ b/tools/moduleversions/Taskfile.dist.yaml
@@ -1,8 +1,7 @@
 version: "3"
 
 vars:
-  PROD_REGISTRY: registry.deckhouse.io/deckhouse
-  PROD_REGISTRY_RU: registry.deckhouse.ru/deckhouse
+  PROD_REGISTRY: registry.deckhouse.ru/deckhouse
   CHANNEL: '{{ .CHANNEL | default "alpha" }}'
   VERSION: "{{ .VERSION }}"
 
@@ -57,7 +56,7 @@ tasks:
 
         check_editions_version() {
           local editions=("ee" "fe" "ce" "se-plus")
-          local prod_registry={{ .PROD_REGISTRY_RU }}
+          local prod_registry={{ .PROD_REGISTRY }}
           local channel=$1
           local version=$2
 


### PR DESCRIPTION
## Description
Log in to the private RU registry in the release channels workflow and check module versions against `registry.deckhouse.ru/deckhouse`.

## Why do we need it, and what problem does it solve?
Release channel checks need access to artifacts in the RU registry. This keeps the workflow and version check pointed at the registry that contains the expected release artifacts.

## What is the expected result?
The release channels workflow logs in to the RU registry and the module version check completes without registry access errors.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: chore
summary: "Use the RU registry for release channel module version checks."
impact_level: low
```