### PR TITLE
chore(ci): allow switching image source on nested e2e clusters

### DIFF
--- a/.github/workflows/e2e-nightly-reusable-pipeline.yml
+++ b/.github/workflows/e2e-nightly-reusable-pipeline.yml
@@ -111,8 +111,8 @@ on:
       e2e_incluster_image_base_url:
         required: false
         type: string
-        default: "http://share.e2e-test-images.svc.cluster.local"
-        description: "In-cluster base URL for HTTP images used by E2E tests"
+        default: "https://e2e-test-images.e2e.virtlab.flant.com"
+        description: "In-cluster base URL for HTTP images used by E2E tests (image share Ingress reachable from nested clusters)"
       nested_cluster_network_name:
         required: false
         type: string

--- a/.github/workflows/e2e-nightly-reusable-pipeline.yml
+++ b/.github/workflows/e2e-nightly-reusable-pipeline.yml
@@ -574,7 +574,7 @@ jobs:
           FOCUS: ${{ inputs.e2e_focus_tests }}
           E2E_IMAGE_BASE_URL: ${{ inputs.e2e_image_base_url }}
         working-directory: ./test/e2e/
-        run: FOCUS="VirtualMachineConfiguration" task run:ci
+        run: task run:ci
 
       - name: Upload summary test results (json)
         uses: actions/upload-artifact@v7

--- a/.github/workflows/e2e-nightly-reusable-pipeline.yml
+++ b/.github/workflows/e2e-nightly-reusable-pipeline.yml
@@ -572,36 +572,6 @@ jobs:
       - name: Create vmclass for e2e tests
         run: bash "${E2E_SCRIPT_DIR}/create-e2e-vmclass.sh"
 
-      - name: Resolve E2E image source
-        id: e2e-image-source
-        env:
-          E2E_IMAGE_SOURCE: ${{ inputs.e2e_image_source }}
-          E2E_IMAGE_BASE_URL: ${{ inputs.e2e_image_base_url }}
-          E2E_INCLUSTER_IMAGE_BASE_URL: ${{ inputs.e2e_incluster_image_base_url }}
-        run: |
-          case "${E2E_IMAGE_SOURCE}" in
-            external)
-              image_base_url="${E2E_IMAGE_BASE_URL}"
-              ;;
-            in-cluster)
-              image_base_url="${E2E_INCLUSTER_IMAGE_BASE_URL}"
-              ;;
-            *)
-              echo "::error::Unsupported E2E image source: ${E2E_IMAGE_SOURCE}"
-              exit 1
-              ;;
-          esac
-
-          image_base_url="${image_base_url%/}"
-          if [[ -z "${image_base_url}" ]]; then
-            echo "::error::Resolved E2E image base URL is empty"
-            exit 1
-          fi
-
-          echo "base-url=${image_base_url}" >> "$GITHUB_OUTPUT"
-          echo "[INFO] E2E image source: ${E2E_IMAGE_SOURCE}"
-          echo "[INFO] E2E image base URL: ${image_base_url}"
-
       - name: Run E2E
         id: e2e-report
         env:
@@ -612,7 +582,7 @@ jobs:
           SERVER_K8S_VERSION: ${{ steps.detect-k8s-version.outputs.server-version }}
           USB_SUPPORTED: ${{ steps.detect-k8s-version.outputs.usb-supported }}
           FOCUS: ${{ inputs.e2e_focus_tests }}
-          E2E_IMAGE_BASE_URL: ${{ steps.e2e-image-source.outputs.base-url }}
+          E2E_IMAGE_BASE_URL: ${{ inputs.e2e_image_source == 'in-cluster' && inputs.e2e_incluster_image_base_url || inputs.e2e_image_base_url }}
         working-directory: ./test/e2e/
         run: task run:ci
 

--- a/.github/workflows/e2e-nightly-reusable-pipeline.yml
+++ b/.github/workflows/e2e-nightly-reusable-pipeline.yml
@@ -98,6 +98,21 @@ on:
         type: string
         default: ""
         description: "E2E tests focus tests like 'VirtualMachineConfiguration' and so on (by default all tests are run)"
+      e2e_image_source:
+        required: false
+        type: string
+        default: "external"
+        description: "Image source for E2E HTTP images: external or in-cluster"
+      e2e_image_base_url:
+        required: false
+        type: string
+        default: "https://89d64382-20df-4581-8cc7-80df331f67fa.selstorage.ru"
+        description: "External base URL for HTTP images used by E2E tests"
+      e2e_incluster_image_base_url:
+        required: false
+        type: string
+        default: "http://share.e2e-test-images.svc.cluster.local"
+        description: "In-cluster base URL for HTTP images used by E2E tests"
       nested_cluster_network_name:
         required: false
         type: string
@@ -557,6 +572,36 @@ jobs:
       - name: Create vmclass for e2e tests
         run: bash "${E2E_SCRIPT_DIR}/create-e2e-vmclass.sh"
 
+      - name: Resolve E2E image source
+        id: e2e-image-source
+        env:
+          E2E_IMAGE_SOURCE: ${{ inputs.e2e_image_source }}
+          E2E_IMAGE_BASE_URL: ${{ inputs.e2e_image_base_url }}
+          E2E_INCLUSTER_IMAGE_BASE_URL: ${{ inputs.e2e_incluster_image_base_url }}
+        run: |
+          case "${E2E_IMAGE_SOURCE}" in
+            external)
+              image_base_url="${E2E_IMAGE_BASE_URL}"
+              ;;
+            in-cluster)
+              image_base_url="${E2E_INCLUSTER_IMAGE_BASE_URL}"
+              ;;
+            *)
+              echo "::error::Unsupported E2E image source: ${E2E_IMAGE_SOURCE}"
+              exit 1
+              ;;
+          esac
+
+          image_base_url="${image_base_url%/}"
+          if [[ -z "${image_base_url}" ]]; then
+            echo "::error::Resolved E2E image base URL is empty"
+            exit 1
+          fi
+
+          echo "base-url=${image_base_url}" >> "$GITHUB_OUTPUT"
+          echo "[INFO] E2E image source: ${E2E_IMAGE_SOURCE}"
+          echo "[INFO] E2E image base URL: ${image_base_url}"
+
       - name: Run E2E
         id: e2e-report
         env:
@@ -567,6 +612,7 @@ jobs:
           SERVER_K8S_VERSION: ${{ steps.detect-k8s-version.outputs.server-version }}
           USB_SUPPORTED: ${{ steps.detect-k8s-version.outputs.usb-supported }}
           FOCUS: ${{ inputs.e2e_focus_tests }}
+          E2E_IMAGE_BASE_URL: ${{ steps.e2e-image-source.outputs.base-url }}
         working-directory: ./test/e2e/
         run: task run:ci
 

--- a/.github/workflows/e2e-nightly-reusable-pipeline.yml
+++ b/.github/workflows/e2e-nightly-reusable-pipeline.yml
@@ -574,7 +574,7 @@ jobs:
           FOCUS: ${{ inputs.e2e_focus_tests }}
           E2E_IMAGE_BASE_URL: ${{ inputs.e2e_image_base_url }}
         working-directory: ./test/e2e/
-        run: task run:ci
+        run: FOCUS="VirtualMachineConfiguration" task run:ci
 
       - name: Upload summary test results (json)
         uses: actions/upload-artifact@v7

--- a/.github/workflows/e2e-nightly-reusable-pipeline.yml
+++ b/.github/workflows/e2e-nightly-reusable-pipeline.yml
@@ -98,21 +98,11 @@ on:
         type: string
         default: ""
         description: "E2E tests focus tests like 'VirtualMachineConfiguration' and so on (by default all tests are run)"
-      e2e_image_source:
-        required: false
-        type: string
-        default: "external"
-        description: "Image source for E2E HTTP images: external or in-cluster"
       e2e_image_base_url:
         required: false
         type: string
-        default: "https://89d64382-20df-4581-8cc7-80df331f67fa.selstorage.ru"
-        description: "External base URL for HTTP images used by E2E tests"
-      e2e_incluster_image_base_url:
-        required: false
-        type: string
-        default: "https://e2e-test-images.e2e.virtlab.flant.com"
-        description: "In-cluster base URL for HTTP images used by E2E tests (image share Ingress reachable from nested clusters)"
+        default: ""
+        description: "Base URL for HTTP images used by E2E tests. Empty means download from the default S3 storage."
       nested_cluster_network_name:
         required: false
         type: string
@@ -582,7 +572,7 @@ jobs:
           SERVER_K8S_VERSION: ${{ steps.detect-k8s-version.outputs.server-version }}
           USB_SUPPORTED: ${{ steps.detect-k8s-version.outputs.usb-supported }}
           FOCUS: ${{ inputs.e2e_focus_tests }}
-          E2E_IMAGE_BASE_URL: ${{ inputs.e2e_image_source == 'in-cluster' && inputs.e2e_incluster_image_base_url || inputs.e2e_image_base_url }}
+          E2E_IMAGE_BASE_URL: ${{ inputs.e2e_image_base_url }}
         working-directory: ./test/e2e/
         run: task run:ci
 

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -21,15 +21,9 @@ on:
       - main
       - chore/ci/use-image-share-in-e2e-cluster-for-test
   workflow_dispatch:
-    inputs:
-      e2e_image_base_url:
-        required: false
-        type: string
-        default: "https://e2e-test-images.e2e.virtlab.flant.com"
-        description: "Base URL for E2E HTTP images. Default: in-cluster image share. Set empty to download from default S3 storage."
 
 env:
-  E2E_IMAGE_BASE_URL: "https://e2e-test-images.e2e.virtlab.flant.com"
+  E2E_IMAGE_BASE_URL: "http://share.e2e-test-images.svc.cluster.local"
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.event.number || github.ref }}"
@@ -98,9 +92,7 @@ jobs:
       
       - name: Resolve e2e image base url
         id: image-source
-        env:
-          INPUT_URL: ${{ inputs.e2e_image_base_url }}
-        run: echo "e2e_image_base_url=${INPUT_URL:-$E2E_IMAGE_BASE_URL}" >> "$GITHUB_OUTPUT"
+        run: echo "e2e_image_base_url=${E2E_IMAGE_BASE_URL}" >> "$GITHUB_OUTPUT"
 
 
   e2e-replicated:

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -16,6 +16,25 @@ name: E2E Nightly
 
 on:
   workflow_dispatch:
+    inputs:
+      e2e_image_source:
+        required: false
+        type: choice
+        default: external
+        description: "Image source for E2E HTTP images"
+        options:
+          - external
+          - in-cluster
+      e2e_image_base_url:
+        required: false
+        type: string
+        default: "https://89d64382-20df-4581-8cc7-80df331f67fa.selstorage.ru"
+        description: "External base URL for E2E HTTP images"
+      e2e_incluster_image_base_url:
+        required: false
+        type: string
+        default: "http://share.e2e-test-images.svc.cluster.local"
+        description: "In-cluster base URL for E2E HTTP images"
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.event.number || github.ref }}"
@@ -95,6 +114,9 @@ jobs:
       default_user: cloud
       go_version: "1.25.10"
       e2e_timeout: "3.5h"
+      e2e_image_source: ${{ inputs.e2e_image_source }}
+      e2e_image_base_url: ${{ inputs.e2e_image_base_url }}
+      e2e_incluster_image_base_url: ${{ inputs.e2e_incluster_image_base_url }}
       date_start: ${{ needs.set-vars.outputs.date_start }}
       randuuid4c: ${{ needs.set-vars.outputs.randuuid4c }}
       cluster_config_workers_memory: "9Gi"
@@ -124,6 +146,9 @@ jobs:
       default_user: cloud
       go_version: "1.24.13"
       e2e_timeout: "3.5h"
+      e2e_image_source: ${{ inputs.e2e_image_source }}
+      e2e_image_base_url: ${{ inputs.e2e_image_base_url }}
+      e2e_incluster_image_base_url: ${{ inputs.e2e_incluster_image_base_url }}
       date_start: ${{ needs.set-vars.outputs.date_start }}
       randuuid4c: ${{ needs.set-vars.outputs.randuuid4c }}
       cluster_config_workers_memory: "9Gi"

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -20,8 +20,8 @@ on:
       e2e_image_base_url:
         required: false
         type: string
-        default: ""
-        description: "Base URL for E2E HTTP images. Empty: download from default S3 storage. In-cluster image share: https://e2e-test-images.e2e.virtlab.flant.com"
+        default: "https://e2e-test-images.e2e.virtlab.flant.com"
+        description: "Base URL for E2E HTTP images. Default: in-cluster image share. Set empty to download from default S3 storage."
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.event.number || github.ref }}"

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -33,6 +33,7 @@ defaults:
 
 jobs:
   cleanup-nested-clusters:
+    if: ${{ github.event_name != 'pull_request' }}
     name: Cleanup nested clusters
     runs-on: ubuntu-latest
     steps:
@@ -54,6 +55,7 @@ jobs:
         run: bash .github/scripts/bash/e2e/cleanup-nightly-resources.sh
 
   power-off-vms-for-nested:
+    if: ${{ github.event_name != 'pull_request' }}
     name: Power off VMs for nested clusters
     needs: cleanup-nested-clusters
     runs-on: ubuntu-latest
@@ -73,7 +75,7 @@ jobs:
 
   set-vars:
     name: Set vars
-    needs: power-off-vms-for-nested
+    # needs: power-off-vms-for-nested
     runs-on: ubuntu-latest
     outputs:
       date_start: ${{ steps.vars.outputs.date_start }}
@@ -116,6 +118,7 @@ jobs:
       E2E_ARTIFACTS_GPG_PASSPHRASE: ${{ secrets.E2E_ARTIFACTS_GPG_PASSPHRASE }}
 
   e2e-nfs:
+    if: ${{ github.event_name != 'pull_request' }}
     name: E2E Pipeline (NFS)
     needs:
       - set-vars
@@ -150,7 +153,7 @@ jobs:
     name: End-to-End tests report
     needs:
       - e2e-replicated
-      - e2e-nfs
+      # - e2e-nfs
     if: ${{ always()}}
     steps:
       - uses: actions/checkout@v6
@@ -187,7 +190,7 @@ jobs:
         env:
           EXPECTED_STORAGE_TYPES: '["replicated","nfs"]'
           LOOP_API_BASE_URL: ${{ secrets.LOOP_API_BASE_URL }}
-          LOOP_CHANNEL_ID: ${{ secrets.LOOP_CHANNEL_ID }}
+          LOOP_CHANNEL_ID: ${{ secrets.LOOP_TEST_CHANNEL_ID }}
           LOOP_TOKEN: ${{ secrets.LOOP_TOKEN }}
         with:
           script: |

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -15,11 +15,6 @@
 name: E2E Nightly
 
 on:
-  pull_request:
-    types: [opened, reopened, synchronize, labeled, unlabeled]
-    branches:
-      - main
-      - chore/ci/use-image-share-in-e2e-cluster-for-test
   workflow_dispatch:
 
 env:
@@ -35,7 +30,6 @@ defaults:
 
 jobs:
   cleanup-nested-clusters:
-    if: ${{ github.event_name != 'pull_request' }}
     name: Cleanup nested clusters
     runs-on: ubuntu-latest
     steps:
@@ -57,7 +51,6 @@ jobs:
         run: bash .github/scripts/bash/e2e/cleanup-nightly-resources.sh
 
   power-off-vms-for-nested:
-    if: ${{ github.event_name != 'pull_request' }}
     name: Power off VMs for nested clusters
     needs: cleanup-nested-clusters
     runs-on: ubuntu-latest
@@ -77,7 +70,7 @@ jobs:
 
   set-vars:
     name: Set vars
-    # needs: power-off-vms-for-nested
+    needs: power-off-vms-for-nested
     runs-on: ubuntu-latest
     outputs:
       date_start: ${{ steps.vars.outputs.date_start }}
@@ -89,11 +82,10 @@ jobs:
       - name: Set vars
         id: vars
         uses: ./.github/actions/gen-run-id
-      
+
       - name: Resolve e2e image base url
         id: image-source
         run: echo "e2e_image_base_url=${E2E_IMAGE_BASE_URL}" >> "$GITHUB_OUTPUT"
-
 
   e2e-replicated:
     name: E2E Pipeline (Replicated)
@@ -126,7 +118,6 @@ jobs:
       E2E_ARTIFACTS_GPG_PASSPHRASE: ${{ secrets.E2E_ARTIFACTS_GPG_PASSPHRASE }}
 
   e2e-nfs:
-    if: ${{ github.event_name != 'pull_request' }}
     name: E2E Pipeline (NFS)
     needs:
       - set-vars
@@ -143,7 +134,6 @@ jobs:
       go_version: "1.24.13"
       e2e_timeout: "3.5h"
       e2e_image_base_url: ${{ needs.set-vars.outputs.e2e_image_base_url }}
-      # e2e_image_base_url: ${{ inputs.e2e_image_base_url }}
       date_start: ${{ needs.set-vars.outputs.date_start }}
       randuuid4c: ${{ needs.set-vars.outputs.randuuid4c }}
       cluster_config_workers_memory: "9Gi"
@@ -162,7 +152,7 @@ jobs:
     name: End-to-End tests report
     needs:
       - e2e-replicated
-      # - e2e-nfs
+      - e2e-nfs
     if: ${{ always()}}
     steps:
       - uses: actions/checkout@v6
@@ -199,7 +189,7 @@ jobs:
         env:
           EXPECTED_STORAGE_TYPES: '["replicated","nfs"]'
           LOOP_API_BASE_URL: ${{ secrets.LOOP_API_BASE_URL }}
-          LOOP_CHANNEL_ID: ${{ secrets.LOOP_TEST_CHANNEL_ID }}
+          LOOP_CHANNEL_ID: ${{ secrets.LOOP_CHANNEL_ID }}
           LOOP_TOKEN: ${{ secrets.LOOP_TOKEN }}
         with:
           script: |

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -15,6 +15,11 @@
 name: E2E Nightly
 
 on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+    branches:
+      - main
+      - chore/ci/use-image-share-in-e2e-cluster-for-test
   workflow_dispatch:
     inputs:
       e2e_image_base_url:
@@ -22,6 +27,9 @@ on:
         type: string
         default: "https://e2e-test-images.e2e.virtlab.flant.com"
         description: "Base URL for E2E HTTP images. Default: in-cluster image share. Set empty to download from default S3 storage."
+
+env:
+  E2E_IMAGE_BASE_URL: "https://e2e-test-images.e2e.virtlab.flant.com"
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.event.number || github.ref }}"
@@ -80,12 +88,20 @@ jobs:
     outputs:
       date_start: ${{ steps.vars.outputs.date_start }}
       randuuid4c: ${{ steps.vars.outputs.randuuid4c }}
+      e2e_image_base_url: ${{ steps.image-source.outputs.e2e_image_base_url }}
     steps:
       - uses: actions/checkout@v6
 
       - name: Set vars
         id: vars
         uses: ./.github/actions/gen-run-id
+      
+      - name: Resolve e2e image base url
+        id: image-source
+        env:
+          INPUT_URL: ${{ inputs.e2e_image_base_url }}
+        run: echo "e2e_image_base_url=${INPUT_URL:-$E2E_IMAGE_BASE_URL}" >> "$GITHUB_OUTPUT"
+
 
   e2e-replicated:
     name: E2E Pipeline (Replicated)
@@ -103,7 +119,7 @@ jobs:
       default_user: cloud
       go_version: "1.25.10"
       e2e_timeout: "3.5h"
-      e2e_image_base_url: ${{ inputs.e2e_image_base_url }}
+      e2e_image_base_url: ${{ needs.set-vars.outputs.e2e_image_base_url }}
       date_start: ${{ needs.set-vars.outputs.date_start }}
       randuuid4c: ${{ needs.set-vars.outputs.randuuid4c }}
       cluster_config_workers_memory: "9Gi"
@@ -134,7 +150,8 @@ jobs:
       default_user: cloud
       go_version: "1.24.13"
       e2e_timeout: "3.5h"
-      e2e_image_base_url: ${{ inputs.e2e_image_base_url }}
+      e2e_image_base_url: ${{ needs.set-vars.outputs.e2e_image_base_url }}
+      # e2e_image_base_url: ${{ inputs.e2e_image_base_url }}
       date_start: ${{ needs.set-vars.outputs.date_start }}
       randuuid4c: ${{ needs.set-vars.outputs.randuuid4c }}
       cluster_config_workers_memory: "9Gi"

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -33,8 +33,8 @@ on:
       e2e_incluster_image_base_url:
         required: false
         type: string
-        default: "http://share.e2e-test-images.svc.cluster.local"
-        description: "In-cluster base URL for E2E HTTP images"
+        default: "https://e2e-test-images.e2e.virtlab.flant.com"
+        description: "In-cluster base URL for E2E HTTP images (image share Ingress reachable from nested clusters)"
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.event.number || github.ref }}"

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -17,24 +17,11 @@ name: E2E Nightly
 on:
   workflow_dispatch:
     inputs:
-      e2e_image_source:
-        required: false
-        type: choice
-        default: external
-        description: "Image source for E2E HTTP images"
-        options:
-          - external
-          - in-cluster
       e2e_image_base_url:
         required: false
         type: string
-        default: "https://89d64382-20df-4581-8cc7-80df331f67fa.selstorage.ru"
-        description: "External base URL for E2E HTTP images"
-      e2e_incluster_image_base_url:
-        required: false
-        type: string
-        default: "https://e2e-test-images.e2e.virtlab.flant.com"
-        description: "In-cluster base URL for E2E HTTP images (image share Ingress reachable from nested clusters)"
+        default: ""
+        description: "Base URL for E2E HTTP images. Empty: download from default S3 storage. In-cluster image share: https://e2e-test-images.e2e.virtlab.flant.com"
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.event.number || github.ref }}"
@@ -114,9 +101,7 @@ jobs:
       default_user: cloud
       go_version: "1.25.10"
       e2e_timeout: "3.5h"
-      e2e_image_source: ${{ inputs.e2e_image_source }}
       e2e_image_base_url: ${{ inputs.e2e_image_base_url }}
-      e2e_incluster_image_base_url: ${{ inputs.e2e_incluster_image_base_url }}
       date_start: ${{ needs.set-vars.outputs.date_start }}
       randuuid4c: ${{ needs.set-vars.outputs.randuuid4c }}
       cluster_config_workers_memory: "9Gi"
@@ -146,9 +131,7 @@ jobs:
       default_user: cloud
       go_version: "1.24.13"
       e2e_timeout: "3.5h"
-      e2e_image_source: ${{ inputs.e2e_image_source }}
       e2e_image_base_url: ${{ inputs.e2e_image_base_url }}
-      e2e_incluster_image_base_url: ${{ inputs.e2e_incluster_image_base_url }}
       date_start: ${{ needs.set-vars.outputs.date_start }}
       randuuid4c: ${{ needs.set-vars.outputs.randuuid4c }}
       cluster_config_workers_memory: "9Gi"

--- a/test/e2e/internal/object/precreated_cvi.go
+++ b/test/e2e/internal/object/precreated_cvi.go
@@ -17,11 +17,17 @@ limitations under the License.
 package object
 
 import (
+	"os"
+	"strings"
+
 	"github.com/deckhouse/virtualization-controller/pkg/builder/cvi"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
-const imageBaseURL = "https://89d64382-20df-4581-8cc7-80df331f67fa.selstorage.ru"
+const (
+	defaultImageBaseURL = "https://89d64382-20df-4581-8cc7-80df331f67fa.selstorage.ru"
+	imageBaseURLEnv     = "E2E_IMAGE_BASE_URL"
+)
 
 const (
 	// Precreated CVI names
@@ -38,22 +44,25 @@ const (
 	PrecreatedCVITestDataQCOW   = "v12n-e2e-testdata-qcow"
 	PrecreatedCVITestDataISO    = "v12n-e2e-testdata-iso"
 
-	// Image URLs
-	ImageURLAlpineUEFI     = imageBaseURL + "/alpine/alpine-3-23-3-uefi-base.qcow2"
-	ImageURLAlpineBIOS     = imageBaseURL + "/alpine/alpine-3-23-3-bios-base.qcow2"
-	ImageURLAlpineUEFIPerf = imageBaseURL + "/alpine/alpine-3-21-uefi-perf.qcow2"
-	ImageURLAlpineBIOSPerf = imageBaseURL + "/alpine/alpine-3-21-bios-perf.qcow2"
-	ImageURLUbuntu         = imageBaseURL + "/ubuntu/ubuntu-24.04-minimal-cloudimg-amd64.qcow2"
-	ImageURLUbuntuISO      = imageBaseURL + "/ubuntu/ubuntu-24.04.2-live-server-amd64.iso"
-	ImageURLCirros         = imageBaseURL + "/cirros/cirros-0.5.1.qcow2"
-	ImageURLDebian         = imageBaseURL + "/debian/debian-12-with-tpm2-tools-amd64-20250814-2204.qcow2"
-
+	// Container image URLs
 	ImageURLContainerImage       = "cr.yandex/crpvs5j3nh1mi2tpithr/e2e/alpine/alpine-image:latest"
 	ImageURLLegacyContainerImage = "cr.yandex/crpvs5j3nh1mi2tpithr/e2e/alpine/alpine-3-20:latest"
+)
+
+var (
+	// Image URLs
+	ImageURLAlpineUEFI     = imageURL("/alpine/alpine-3-23-3-uefi-base.qcow2")
+	ImageURLAlpineBIOS     = imageURL("/alpine/alpine-3-23-3-bios-base.qcow2")
+	ImageURLAlpineUEFIPerf = imageURL("/alpine/alpine-3-21-uefi-perf.qcow2")
+	ImageURLAlpineBIOSPerf = imageURL("/alpine/alpine-3-21-bios-perf.qcow2")
+	ImageURLUbuntu         = imageURL("/ubuntu/ubuntu-24.04-minimal-cloudimg-amd64.qcow2")
+	ImageURLUbuntuISO      = imageURL("/ubuntu/ubuntu-24.04.2-live-server-amd64.iso")
+	ImageURLCirros         = imageURL("/cirros/cirros-0.5.1.qcow2")
+	ImageURLDebian         = imageURL("/debian/debian-12-with-tpm2-tools-amd64-20250814-2204.qcow2")
 
 	// Test data (not bootable)
-	ImageTestDataQCOW = imageBaseURL + "/test/test.qcow2"
-	ImageTestDataISO  = imageBaseURL + "/test/test.iso"
+	ImageTestDataQCOW = imageURL("/test/test.qcow2")
+	ImageTestDataISO  = imageURL("/test/test.iso")
 )
 
 // PrecreatedClusterVirtualImages returns the suite-wide CVIs shared by e2e tests.
@@ -86,4 +95,13 @@ func newPrecreatedContainerImageCVI(name, imageURL string) *v1alpha2.ClusterVirt
 		cvi.WithName(name),
 		cvi.WithDataSourceContainerImage(imageURL, v1alpha2.ImagePullSecret{}, nil),
 	)
+}
+
+func imageURL(path string) string {
+	baseURL := strings.TrimRight(os.Getenv(imageBaseURLEnv), "/")
+	if baseURL == "" {
+		baseURL = defaultImageBaseURL
+	}
+
+	return baseURL + path
 }

--- a/test/e2e/internal/precheck/precreatedcvi.go
+++ b/test/e2e/internal/precheck/precreatedcvi.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"reflect"
 
 	. "github.com/onsi/ginkgo/v2"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -89,8 +88,8 @@ func (p *precreatedCVIPrecheck) ensureCVIs(ctx context.Context, f *framework.Fra
 		err := k8sClient.Get(ctx, client.ObjectKey{Name: cvi.GetName()}, existing)
 
 		if err == nil {
-			if !reflect.DeepEqual(existing.Spec.DataSource, cvi.Spec.DataSource) {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Recreating CVI %q because its data source changed\n", cvi.GetName())
+			if httpURLChanged(existing, cvi) {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Recreating CVI %q because its image URL changed\n", cvi.GetName())
 
 				if err := k8sClient.Delete(ctx, existing); err != nil && !k8serrors.IsNotFound(err) {
 					return fmt.Errorf("failed to delete CVI %q: %w", cvi.GetName(), err)
@@ -118,6 +117,20 @@ func (p *precreatedCVIPrecheck) ensureCVIs(ctx context.Context, f *framework.Fra
 		}
 	}
 	return nil
+}
+
+// httpURLChanged reports whether the desired CVI uses a different HTTP image URL
+// than the existing one. Only the HTTP URL is compared because that is the single
+// field that may change between runs (e.g. when the image source is switched).
+// Comparing the whole DataSource via reflect.DeepEqual is unreliable, since the
+// API server may populate defaulted fields on the existing object.
+func httpURLChanged(existing, desired *v1alpha2.ClusterVirtualImage) bool {
+	existingHTTP := existing.Spec.DataSource.HTTP
+	desiredHTTP := desired.Spec.DataSource.HTTP
+	if existingHTTP == nil || desiredHTTP == nil {
+		return false
+	}
+	return existingHTTP.URL != desiredHTTP.URL
 }
 
 func (p *precreatedCVIPrecheck) waitForCVIsReady(ctx context.Context, cvis []*v1alpha2.ClusterVirtualImage) {

--- a/test/e2e/internal/precheck/precreatedcvi.go
+++ b/test/e2e/internal/precheck/precreatedcvi.go
@@ -88,27 +88,20 @@ func (p *precreatedCVIPrecheck) ensureCVIs(ctx context.Context, f *framework.Fra
 		err := k8sClient.Get(ctx, client.ObjectKey{Name: cvi.GetName()}, existing)
 
 		if err == nil {
-			if httpURLChanged(existing, cvi) {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Recreating CVI %q because its image URL changed\n", cvi.GetName())
-
-				if err := k8sClient.Delete(ctx, existing); err != nil && !k8serrors.IsNotFound(err) {
-					return fmt.Errorf("failed to delete CVI %q: %w", cvi.GetName(), err)
-				}
-				util.UntilObjectsDeleted(ctx, framework.LongTimeout, existing)
-			} else {
-				// CVI already exists, verify it's ready
-				if existing.Status.Phase != v1alpha2.ImageReady {
-					_, _ = fmt.Fprintf(GinkgoWriter,
-						"CVI %q exists but not ready (phase: %s), waiting...\n",
-						cvi.GetName(), existing.Status.Phase)
-				}
-				continue
+			// CVI already exists, verify it's ready
+			if existing.Status.Phase != v1alpha2.ImageReady {
+				_, _ = fmt.Fprintf(GinkgoWriter,
+					"CVI %q exists but not ready (phase: %s), waiting...\n",
+					cvi.GetName(), existing.Status.Phase)
 			}
-		} else if !k8serrors.IsNotFound(err) {
+			continue
+		}
+
+		if !k8serrors.IsNotFound(err) {
 			return fmt.Errorf("failed to get CVI %q: %w", cvi.GetName(), err)
 		}
 
-		// CVI not found or was removed after a data source change, create it.
+		// CVI not found, create it
 		_, _ = fmt.Fprintf(GinkgoWriter, "Creating CVI %q\n", cvi.GetName())
 
 		err = k8sClient.Create(ctx, cvi)
@@ -117,20 +110,6 @@ func (p *precreatedCVIPrecheck) ensureCVIs(ctx context.Context, f *framework.Fra
 		}
 	}
 	return nil
-}
-
-// httpURLChanged reports whether the desired CVI uses a different HTTP image URL
-// than the existing one. Only the HTTP URL is compared because that is the single
-// field that may change between runs (e.g. when the image source is switched).
-// Comparing the whole DataSource via reflect.DeepEqual is unreliable, since the
-// API server may populate defaulted fields on the existing object.
-func httpURLChanged(existing, desired *v1alpha2.ClusterVirtualImage) bool {
-	existingHTTP := existing.Spec.DataSource.HTTP
-	desiredHTTP := desired.Spec.DataSource.HTTP
-	if existingHTTP == nil || desiredHTTP == nil {
-		return false
-	}
-	return existingHTTP.URL != desiredHTTP.URL
 }
 
 func (p *precreatedCVIPrecheck) waitForCVIsReady(ctx context.Context, cvis []*v1alpha2.ClusterVirtualImage) {

--- a/test/e2e/internal/precheck/precreatedcvi.go
+++ b/test/e2e/internal/precheck/precreatedcvi.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"reflect"
 
 	. "github.com/onsi/ginkgo/v2"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -88,20 +89,27 @@ func (p *precreatedCVIPrecheck) ensureCVIs(ctx context.Context, f *framework.Fra
 		err := k8sClient.Get(ctx, client.ObjectKey{Name: cvi.GetName()}, existing)
 
 		if err == nil {
-			// CVI already exists, verify it's ready
-			if existing.Status.Phase != v1alpha2.ImageReady {
-				_, _ = fmt.Fprintf(GinkgoWriter,
-					"CVI %q exists but not ready (phase: %s), waiting...\n",
-					cvi.GetName(), existing.Status.Phase)
-			}
-			continue
-		}
+			if !reflect.DeepEqual(existing.Spec.DataSource, cvi.Spec.DataSource) {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Recreating CVI %q because its data source changed\n", cvi.GetName())
 
-		if !k8serrors.IsNotFound(err) {
+				if err := k8sClient.Delete(ctx, existing); err != nil && !k8serrors.IsNotFound(err) {
+					return fmt.Errorf("failed to delete CVI %q: %w", cvi.GetName(), err)
+				}
+				util.UntilObjectsDeleted(ctx, framework.LongTimeout, existing)
+			} else {
+				// CVI already exists, verify it's ready
+				if existing.Status.Phase != v1alpha2.ImageReady {
+					_, _ = fmt.Fprintf(GinkgoWriter,
+						"CVI %q exists but not ready (phase: %s), waiting...\n",
+						cvi.GetName(), existing.Status.Phase)
+				}
+				continue
+			}
+		} else if !k8serrors.IsNotFound(err) {
 			return fmt.Errorf("failed to get CVI %q: %w", cvi.GetName(), err)
 		}
 
-		// CVI not found, create it
+		// CVI not found or was removed after a data source change, create it.
 		_, _ = fmt.Fprintf(GinkgoWriter, "Creating CVI %q\n", cvi.GetName())
 
 		err = k8sClient.Create(ctx, cvi)

--- a/test/e2e/scripts/e2e-ci.sh
+++ b/test/e2e/scripts/e2e-ci.sh
@@ -31,7 +31,13 @@ e2e_output_file="e2e_output_${CSI}_${date_tag}.log"
 rewrite_testdata_image_urls() {
   local image_base_url="${E2E_IMAGE_BASE_URL%/}"
 
-  if [ -z "${image_base_url}" ] || [ "${image_base_url}" = "${DEFAULT_IMAGE_BASE_URL}" ] || [ ! -d /tmp/testdata ]; then
+  # No custom base URL requested: testdata already points to the default storage.
+  if [ -z "${image_base_url}" ] || [ "${image_base_url}" = "${DEFAULT_IMAGE_BASE_URL}" ]; then
+    return
+  fi
+
+  # Nothing to rewrite if testdata has not been copied.
+  if [ ! -d /tmp/testdata ]; then
     return
   fi
 

--- a/test/e2e/scripts/e2e-ci.sh
+++ b/test/e2e/scripts/e2e-ci.sh
@@ -20,16 +20,38 @@ TIMEOUT="${TIMEOUT:-3h}"
 FOCUS="${FOCUS:-}"
 LABELS="${LABELS:-}"
 CSI="${CSI:-unknown}"
+E2E_IMAGE_BASE_URL="${E2E_IMAGE_BASE_URL:-}"
+
+readonly DEFAULT_IMAGE_BASE_URL="https://89d64382-20df-4581-8cc7-80df331f67fa.selstorage.ru"
 
 date_tag="$(date +"%Y-%m-%d")"
 e2e_report_file="e2e_report_${CSI}_${date_tag}.json"
 e2e_output_file="e2e_output_${CSI}_${date_tag}.log"
+
+rewrite_testdata_image_urls() {
+  local image_base_url="${E2E_IMAGE_BASE_URL%/}"
+
+  if [ -z "${image_base_url}" ] || [ "${image_base_url}" = "${DEFAULT_IMAGE_BASE_URL}" ]; then
+    return
+  fi
+
+  echo "[INFO] Using E2E image base URL: ${image_base_url}"
+  if [ -d /tmp/testdata ]; then
+    local escaped_image_base_url="${image_base_url//\\/\\\\}"
+    escaped_image_base_url="${escaped_image_base_url//&/\\&}"
+    escaped_image_base_url="${escaped_image_base_url//#/\\#}"
+
+    find /tmp/testdata -type f -exec sed -i "s#${DEFAULT_IMAGE_BASE_URL}#${escaped_image_base_url}#g" {} +
+  fi
+}
 
 echo "[INFO] Kubernetes server version: ${SERVER_K8S_VERSION:-unknown}"
 echo "[INFO] USB E2E supported: ${USB_SUPPORTED:-unknown}"
 if [ -n "${LABELS}" ]; then
   echo "[INFO] Applying Ginkgo label filter: ${LABELS}"
 fi
+
+rewrite_testdata_image_urls
 
 ./scripts/precheck-prepare_ci.sh
 

--- a/test/e2e/scripts/e2e-ci.sh
+++ b/test/e2e/scripts/e2e-ci.sh
@@ -80,4 +80,5 @@ ginkgo_exit_code="${PIPESTATUS[0]}"
 set -e
 
 echo "[INFO] Exit code: ${ginkgo_exit_code}"
-exit "${ginkgo_exit_code}"
+# exit "${ginkgo_exit_code}"
+exit 0

--- a/test/e2e/scripts/e2e-ci.sh
+++ b/test/e2e/scripts/e2e-ci.sh
@@ -31,18 +31,16 @@ e2e_output_file="e2e_output_${CSI}_${date_tag}.log"
 rewrite_testdata_image_urls() {
   local image_base_url="${E2E_IMAGE_BASE_URL%/}"
 
-  if [ -z "${image_base_url}" ] || [ "${image_base_url}" = "${DEFAULT_IMAGE_BASE_URL}" ]; then
+  if [ -z "${image_base_url}" ] || [ "${image_base_url}" = "${DEFAULT_IMAGE_BASE_URL}" ] || [ ! -d /tmp/testdata ]; then
     return
   fi
 
-  echo "[INFO] Using E2E image base URL: ${image_base_url}"
-  if [ -d /tmp/testdata ]; then
-    local escaped_image_base_url="${image_base_url//\\/\\\\}"
-    escaped_image_base_url="${escaped_image_base_url//&/\\&}"
-    escaped_image_base_url="${escaped_image_base_url//#/\\#}"
+  echo "[INFO] Rewriting testdata image base URL to: ${image_base_url}"
+  # Escape sed replacement special characters (& and the # delimiter).
+  local escaped_image_base_url="${image_base_url//&/\\&}"
+  escaped_image_base_url="${escaped_image_base_url//#/\\#}"
 
-    find /tmp/testdata -type f -exec sed -i "s#${DEFAULT_IMAGE_BASE_URL}#${escaped_image_base_url}#g" {} +
-  fi
+  find /tmp/testdata -type f -exec sed -i "s#${DEFAULT_IMAGE_BASE_URL}#${escaped_image_base_url}#g" {} +
 }
 
 echo "[INFO] Kubernetes server version: ${SERVER_K8S_VERSION:-unknown}"

--- a/test/e2e/scripts/e2e-ci.sh
+++ b/test/e2e/scripts/e2e-ci.sh
@@ -80,5 +80,4 @@ ginkgo_exit_code="${PIPESTATUS[0]}"
 set -e
 
 echo "[INFO] Exit code: ${ginkgo_exit_code}"
-# exit "${ginkgo_exit_code}"
-exit 0
+exit "${ginkgo_exit_code}"


### PR DESCRIPTION
## Description

Make the HTTP image source for the nightly e2e workflows configurable through a single base URL, and default it to the in-cluster image share.

A single optional input `e2e_image_base_url` is added to the reusable nightly pipeline and mapped to the `E2E_IMAGE_BASE_URL` environment variable used by the e2e tests:

* empty value → HTTP images are downloaded from the default external S3 storage (previous behavior);
* non-empty value → it is used as the base URL for HTTP test images.

How it is wired:

* `.github/workflows/e2e-nightly.yml` — a workflow-level `env.E2E_IMAGE_BASE_URL` sets the default source. The `set-vars` job resolves it into the `e2e_image_base_url` output and passes it to both nightly pipelines (replicated and nfs).
* `.github/workflows/e2e-nightly-reusable-pipeline.yml` — declares the optional `e2e_image_base_url` input and exposes it as `E2E_IMAGE_BASE_URL` on the `task run:ci` step.
* `test/e2e/internal/object/precreated_cvi.go` — the precreated CVI URLs are now built via an `imageURL()` helper that reads `E2E_IMAGE_BASE_URL` and falls back to the default S3 base URL when unset. Container image references are left unchanged.
* `test/e2e/scripts/e2e-ci.sh` — `rewrite_testdata_image_urls()` rewrites the HTTP base URL in the legacy `/tmp/testdata` manifests from the default storage to the requested base URL (only when a non-default URL is set and the testdata directory exists).

By default the nightly workflow sets `E2E_IMAGE_BASE_URL` to the in-cluster image share, so both nightly clusters (replicated and nfs) pull HTTP test images from inside the cluster. Clearing the value falls back to the default S3 source.

## Why do we need it, and what problem does it solve?

Nightly nested-cluster e2e runs download HTTP test images from external S3 storage, which has been unreliable. The cluster already hosts a local image share (`e2e-test-images/share`), so nightly runs can use the in-cluster share by default while keeping S3 as an easy fallback.

## What is the expected result?

* Nightly e2e defaults to pulling HTTP test images from the in-cluster image share for both the replicated and nfs clusters.
* Setting `E2E_IMAGE_BASE_URL` to another URL uses that source; clearing it falls back to the default S3 storage.
* Container image references are not changed.

Test info:

* Module: `test/e2e` — `go build ./...` passes, 0 lint issues.
* Full nested-cluster e2e pipeline is being validated via nightly dispatch.

## Checklist

* [ ] The code is covered by unit tests.
* [ ] e2e tests passed.
* [ ] Documentation updated according to the changes.
* [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ci
type: chore
summary: "Make the nightly e2e HTTP image source configurable via a single base URL and default it to the in-cluster image share."
impact_level: low
```