### PR TITLE
fix(core): use add op for absent metadata maps in reconciler patch

### DIFF
--- a/images/virtualization-artifact/pkg/controller/reconciler/resource.go
+++ b/images/virtualization-artifact/pkg/controller/reconciler/resource.go
@@ -237,16 +237,26 @@ func (r *Resource[T, ST]) JSONPatchOpsForFinalizers() []patch.JSONPatchOperation
 }
 
 func (r *Resource[T, ST]) JSONPatchOpsForAnnotations() []patch.JSONPatchOperation {
-	return []patch.JSONPatchOperation{
-		patch.NewJSONPatchOperation(patch.PatchTestOp, "/metadata/annotations", r.currentObj.GetAnnotations()),
-		patch.NewJSONPatchOperation(patch.PatchReplaceOp, "/metadata/annotations", r.changedObj.GetAnnotations()),
-	}
+	return jsonPatchOpsForMetadataMap("/metadata/annotations", r.currentObj.GetAnnotations(), r.changedObj.GetAnnotations())
 }
 
 func (r *Resource[T, ST]) JSONPatchOpsForLabels() []patch.JSONPatchOperation {
+	return jsonPatchOpsForMetadataMap("/metadata/labels", r.currentObj.GetLabels(), r.changedObj.GetLabels())
+}
+
+// jsonPatchOpsForMetadataMap builds JSON Patch operations for a metadata map field
+// (labels or annotations). When the field is absent on the current object, a JSON Patch
+// "replace" is rejected by the API server because RFC 6902 requires the target location
+// to exist, so "add" is used to create the field. The "test" operation preserves the
+// optimistic lock against concurrent modifications between read and patch.
+func jsonPatchOpsForMetadataMap(path string, current, changed map[string]string) []patch.JSONPatchOperation {
+	op := patch.PatchReplaceOp
+	if len(current) == 0 {
+		op = patch.PatchAddOp
+	}
 	return []patch.JSONPatchOperation{
-		patch.NewJSONPatchOperation(patch.PatchTestOp, "/metadata/labels", r.currentObj.GetLabels()),
-		patch.NewJSONPatchOperation(patch.PatchReplaceOp, "/metadata/labels", r.changedObj.GetLabels()),
+		patch.NewJSONPatchOperation(patch.PatchTestOp, path, current),
+		patch.NewJSONPatchOperation(op, path, changed),
 	}
 }
 

--- a/images/virtualization-artifact/pkg/controller/reconciler/resource.go
+++ b/images/virtualization-artifact/pkg/controller/reconciler/resource.go
@@ -231,8 +231,15 @@ func (r *Resource[T, ST]) Update(ctx context.Context) error {
 }
 
 func (r *Resource[T, ST]) JSONPatchOpsForFinalizers() []patch.JSONPatchOperation {
+	// When the object has no finalizers yet, a JSON Patch "replace" is rejected by the API
+	// server (strict RFC 6902 semantics require the target path to exist), so "add" is used
+	// to create the field.
+	op := patch.PatchReplaceOp
+	if len(r.currentObj.GetFinalizers()) == 0 {
+		op = patch.PatchAddOp
+	}
 	return []patch.JSONPatchOperation{
-		patch.NewJSONPatchOperation(patch.PatchReplaceOp, "/metadata/finalizers", r.changedObj.GetFinalizers()),
+		patch.NewJSONPatchOperation(op, "/metadata/finalizers", r.changedObj.GetFinalizers()),
 	}
 }
 

--- a/images/virtualization-artifact/pkg/controller/reconciler/resource_test.go
+++ b/images/virtualization-artifact/pkg/controller/reconciler/resource_test.go
@@ -19,8 +19,10 @@ package reconciler
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/deckhouse/virtualization-controller/pkg/common/patch"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
 var _ = Describe("jsonPatchOpsForMetadataMap", func() {
@@ -45,5 +47,30 @@ var _ = Describe("jsonPatchOpsForMetadataMap", func() {
 		Entry("empty current map uses add", map[string]string{}, map[string]string{"a": "b"}, patch.PatchAddOp),
 		// Object already has labels: replace updates the existing field.
 		Entry("non-empty current map uses replace", map[string]string{"x": "y"}, map[string]string{"a": "b"}, patch.PatchReplaceOp),
+	)
+})
+
+var _ = Describe("JSONPatchOpsForFinalizers", func() {
+	newResource := func(current, changed []string) *Resource[*v1alpha2.VirtualMachineOperation, v1alpha2.VirtualMachineOperationStatus] {
+		return &Resource[*v1alpha2.VirtualMachineOperation, v1alpha2.VirtualMachineOperationStatus]{
+			currentObj: &v1alpha2.VirtualMachineOperation{ObjectMeta: metav1.ObjectMeta{Finalizers: current}},
+			changedObj: &v1alpha2.VirtualMachineOperation{ObjectMeta: metav1.ObjectMeta{Finalizers: changed}},
+		}
+	}
+
+	DescribeTable("chooses the mutation op based on the current finalizers",
+		func(current, changed []string, expectedOp string) {
+			ops := newResource(current, changed).JSONPatchOpsForFinalizers()
+
+			Expect(ops).To(HaveLen(1))
+			Expect(ops[0].Op).To(Equal(expectedOp))
+			Expect(ops[0].Path).To(Equal("/metadata/finalizers"))
+			Expect(ops[0].Value).To(Equal(changed))
+		},
+		// Object has no finalizers: replace would be rejected by the API server, so add is used.
+		Entry("nil current uses add", nil, []string{"f1"}, patch.PatchAddOp),
+		Entry("empty current uses add", []string{}, []string{"f1"}, patch.PatchAddOp),
+		// Object already has finalizers: replace updates the existing field.
+		Entry("non-empty current uses replace", []string{"f0"}, []string{"f0", "f1"}, patch.PatchReplaceOp),
 	)
 })

--- a/images/virtualization-artifact/pkg/controller/reconciler/resource_test.go
+++ b/images/virtualization-artifact/pkg/controller/reconciler/resource_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/deckhouse/virtualization-controller/pkg/common/patch"
+)
+
+var _ = Describe("jsonPatchOpsForMetadataMap", func() {
+	const path = "/metadata/labels"
+
+	DescribeTable("chooses the mutation op based on the current map",
+		func(current, changed map[string]string, expectedOp string) {
+			ops := jsonPatchOpsForMetadataMap(path, current, changed)
+
+			Expect(ops).To(HaveLen(2))
+
+			Expect(ops[0].Op).To(Equal(patch.PatchTestOp))
+			Expect(ops[0].Path).To(Equal(path))
+
+			Expect(ops[1].Op).To(Equal(expectedOp))
+			Expect(ops[1].Path).To(Equal(path))
+			Expect(ops[1].Value).To(Equal(changed))
+		},
+		// Object has no labels at all: replace would be rejected by the API server,
+		// so the patch must use add to create the field.
+		Entry("nil current map uses add", nil, map[string]string{"a": "b"}, patch.PatchAddOp),
+		Entry("empty current map uses add", map[string]string{}, map[string]string{"a": "b"}, patch.PatchAddOp),
+		// Object already has labels: replace updates the existing field.
+		Entry("non-empty current map uses replace", map[string]string{"x": "y"}, map[string]string{"a": "b"}, patch.PatchReplaceOp),
+	)
+})

--- a/images/virtualization-artifact/pkg/controller/reconciler/suite_test.go
+++ b/images/virtualization-artifact/pkg/controller/reconciler/suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestReconciler(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Reconciler Suite")
+}


### PR DESCRIPTION
## Description
The generic reconciler (`reconciler.Resource`) built JSON Patch operations for
`/metadata/finalizers`, `/metadata/labels` and `/metadata/annotations` using the
`replace` op. Under strict RFC 6902 semantics (evanphx json-patch v5, used by the
API server) `replace` is rejected when the target path does not exist, so the patch
was rejected whenever the object had no finalizers/labels/annotations yet.

`JSONPatchOpsForFinalizers`, `JSONPatchOpsForLabels` and `JSONPatchOpsForAnnotations`
now emit an `add` op (which creates the field) when the current value is empty/absent,
and keep `replace` when the field already exists. `add` is accepted under both v4 and
v5 semantics. The `test` op for labels/annotations is preserved to retain the
optimistic lock.

## Why do we need it, and what problem does it solve?
`firmware-update` VMOPs are created by the workload-updater with an annotation but
no labels and no finalizers. On reconcile the controller adds the `vmop-cleanup`
finalizer and the `virtualization.deckhouse.io/virtual-machine-uid` label, producing
a patch like:

```
[{"op":"replace","path":"/metadata/finalizers","value":[...]},
 {"op":"test","path":"/metadata/labels","value":null},
 {"op":"replace","path":"/metadata/labels","value":{...}}]
```

The API server rejected it ("the server rejected our request due to an error in our
request") because `replace` on the missing `/metadata/finalizers` path fails first.
Since the patch is atomic, the finalizer and label were never written, so the VMOP
looped on the same error and never created the `VirtualMachineInstanceMigration`. A
subsequent migration then got stuck (progress reported, but the finalizer/label patch
kept failing). This affects any object created without finalizers/labels/annotations,
not only firmware-update VMOPs.

## What is the expected result?
1. Trigger a firmware update that requires migration on a VM created without labels
   (e.g. `vm-alpine-local-hp-local`).
2. The `firmware-update-*` VMOP receives its finalizer and `virtual-machine-uid`
   label without the "server rejected our request" error.
3. The `VirtualMachineInstanceMigration` is created and the migration proceeds to
   completion.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: core
type: fix
summary: Fix metadata patch failing with "the server rejected our request" for objects without finalizers, labels or annotations.
impact_level: low
```