### PR TITLE
chore(module): temporarily disable restricted security policies

### DIFF
--- a/templates/namespace.yaml
+++ b/templates/namespace.yaml
@@ -4,6 +4,10 @@ d8-{{ .Chart.Name }}
 
 {{- define "namespace.labels" }}
 prometheus.deckhouse.io/rules-watcher-enabled: "true"
+{{- end }}
+
+{{/* add these labels back to namespace.labels template after fixing securityContext in virt-handler and job install-strategy */}}
+{{- define "namespace.labels.disabled.temporarily" }}
 security.deckhouse.io/pod-policy: "restricted"
 security.deckhouse.io/enable-security-policy-check: "true"
 {{- end }}


### PR DESCRIPTION

## Description
<!---
  Describe your changes with technical details.
-->
- Remove security.deckhouse.io labels from d8-virtualization namespace.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->

SPE can't handle drop: "ALL" and drop is empty.
virt-handler needs securityContexts with drop ALL in all containers.

Also, install-strategy Job requires SPE and security.deckhouse.io labels: kubevirt patch required.

Disable Restricted policy until further investigation.

Same as #2062 .

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->

Module enable is working when ModuleConfig admission-policy-engine is not present in cluster.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->
