### PR TITLE
chore(e2e): Add prechecks for Hotplug resources tests

### DIFF
--- a/test/e2e/internal/framework/mc.go
+++ b/test/e2e/internal/framework/mc.go
@@ -71,6 +71,7 @@ type VirtualizationModuleConfigSettings struct {
 	VirtualMachineCIDRs []string `json:"virtualMachineCIDRs"`
 	Dvcr                Dvcr     `json:"dvcr"`
 	HighAvailability    bool     `json:"highAvailability,omitempty"`
+	FeatureGates        []string `json:"featureGates,omitempty"`
 }
 
 type Dvcr struct {

--- a/test/e2e/internal/precheck/hotplug_featuregates.go
+++ b/test/e2e/internal/precheck/hotplug_featuregates.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package precheck
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/deckhouse/virtualization-controller/pkg/featuregates"
+	. "github.com/onsi/ginkgo/v2"
+	"k8s.io/component-base/featuregate"
+
+	"github.com/deckhouse/virtualization/test/e2e/internal/framework"
+)
+
+const (
+	hotplugCPUPrecheckEnvName    = "HOTPLUG_CPU_PRECHECK"
+	hotplugMemoryPrecheckEnvName = "HOTPLUG_MEMORY_PRECHECK"
+)
+
+type moduleConfigFeatureGatePrecheck struct {
+	label       string
+	envName     string
+	featureGate featuregate.Feature
+}
+
+func (p *moduleConfigFeatureGatePrecheck) Label() string {
+	return p.label
+}
+
+func (p *moduleConfigFeatureGatePrecheck) Run(ctx context.Context, f *framework.Framework) error {
+	if !isCheckEnabled(p.envName) {
+		_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("%s check is disabled.\n", p.featureGate)))
+		return nil
+	}
+
+	moduleConfig, err := f.GetVirtualizationModuleConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("%s=no to disable this precheck: failed to get ModuleConfig/%s: %w", p.envName, virtualizationModuleName, err)
+	}
+
+	featureGates := moduleConfig.Spec.Settings.FeatureGates
+	hasFeatureGate := false
+	for _, fg := range featureGates {
+		if fg == string(p.featureGate) {
+			hasFeatureGate = true
+			break
+		}
+	}
+
+	if !hasFeatureGate {
+		return fmt.Errorf("%s=no to disable this precheck: ModuleConfig/%s does not contain %q in .spec.settings.featureGates",
+			p.envName, p.featureGate, virtualizationModuleName)
+	}
+
+	return nil
+}
+
+func init() {
+	RegisterPrecheck(&moduleConfigFeatureGatePrecheck{
+		label:       PrecheckHotplugCPU,
+		envName:     hotplugCPUPrecheckEnvName,
+		featureGate: featuregates.HotplugCPUWithLiveMigration,
+	}, false)
+
+	RegisterPrecheck(&moduleConfigFeatureGatePrecheck{
+		label:       PrecheckHotplugMemory,
+		envName:     hotplugMemoryPrecheckEnvName,
+		featureGate: featuregates.HotplugMemoryWithLiveMigration,
+	}, false)
+}

--- a/test/e2e/internal/precheck/hotplug_featuregates.go
+++ b/test/e2e/internal/precheck/hotplug_featuregates.go
@@ -20,10 +20,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/deckhouse/virtualization-controller/pkg/featuregates"
 	. "github.com/onsi/ginkgo/v2"
 	"k8s.io/component-base/featuregate"
 
+	"github.com/deckhouse/virtualization-controller/pkg/featuregates"
 	"github.com/deckhouse/virtualization/test/e2e/internal/framework"
 )
 

--- a/test/e2e/internal/precheck/hotplug_featuregates.go
+++ b/test/e2e/internal/precheck/hotplug_featuregates.go
@@ -21,21 +21,22 @@ import (
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
-	"k8s.io/component-base/featuregate"
 
-	"github.com/deckhouse/virtualization-controller/pkg/featuregates"
 	"github.com/deckhouse/virtualization/test/e2e/internal/framework"
 )
 
 const (
 	hotplugCPUPrecheckEnvName    = "HOTPLUG_CPU_PRECHECK"
 	hotplugMemoryPrecheckEnvName = "HOTPLUG_MEMORY_PRECHECK"
+
+	hotplugCPUWithLiveMigration    = "HotplugCPUWithLiveMigration"
+	hotplugMemoryWithLiveMigration = "HotplugMemoryWithLiveMigration"
 )
 
 type moduleConfigFeatureGatePrecheck struct {
 	label       string
 	envName     string
-	featureGate featuregate.Feature
+	featureGate string
 }
 
 func (p *moduleConfigFeatureGatePrecheck) Label() string {
@@ -56,7 +57,7 @@ func (p *moduleConfigFeatureGatePrecheck) Run(ctx context.Context, f *framework.
 	featureGates := moduleConfig.Spec.Settings.FeatureGates
 	hasFeatureGate := false
 	for _, fg := range featureGates {
-		if fg == string(p.featureGate) {
+		if fg == p.featureGate {
 			hasFeatureGate = true
 			break
 		}
@@ -74,12 +75,12 @@ func init() {
 	RegisterPrecheck(&moduleConfigFeatureGatePrecheck{
 		label:       PrecheckHotplugCPU,
 		envName:     hotplugCPUPrecheckEnvName,
-		featureGate: featuregates.HotplugCPUWithLiveMigration,
+		featureGate: hotplugCPUWithLiveMigration,
 	}, false)
 
 	RegisterPrecheck(&moduleConfigFeatureGatePrecheck{
 		label:       PrecheckHotplugMemory,
 		envName:     hotplugMemoryPrecheckEnvName,
-		featureGate: featuregates.HotplugMemoryWithLiveMigration,
+		featureGate: hotplugMemoryWithLiveMigration,
 	}, false)
 }

--- a/test/e2e/internal/precheck/hotplug_featuregates.go
+++ b/test/e2e/internal/precheck/hotplug_featuregates.go
@@ -45,7 +45,7 @@ func (p *moduleConfigFeatureGatePrecheck) Label() string {
 
 func (p *moduleConfigFeatureGatePrecheck) Run(ctx context.Context, f *framework.Framework) error {
 	if !isCheckEnabled(p.envName) {
-		_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("%s check is disabled.\n", p.featureGate)))
+		GinkgoWriter.Printf("%s check is disabled.\n", p.featureGate)
 		return nil
 	}
 

--- a/test/e2e/internal/precheck/labels.go
+++ b/test/e2e/internal/precheck/labels.go
@@ -45,6 +45,12 @@ const (
 	// PrecheckUSB - test requires USB device with dummy_hcd to be configured.
 	PrecheckUSB = "usb-precheck"
 
+	// PrecheckHotplugCPU - test requires HotplugCPUWithLiveMigration feature gate to be enabled in ModuleConfig/virtualization.
+	PrecheckHotplugCPU = "hotplug-cpu-precheck"
+
+	// PrecheckHotplugMemory - test requires HotplugMemoryWithLiveMigration feature gate to be enabled in ModuleConfig/virtualization.
+	PrecheckHotplugMemory = "hotplug-memory-precheck"
+
 	// PrecheckAffinityToleration - test requires enough ready KVM-enabled master/worker nodes.
 	PrecheckAffinityToleration = "affinity-toleration-precheck"
 
@@ -71,6 +77,8 @@ func KnownPrecheckLabels() []string {
 		PrecheckSnapshot,
 		PrecheckVirtualization,
 		PrecheckUSB,
+		PrecheckHotplugCPU,
+		PrecheckHotplugMemory,
 		PrecheckAffinityToleration,
 		PrecheckPostCleanup,
 		PrecheckPrecreatedCVI,

--- a/test/e2e/vm/hotplug_cpu.go
+++ b/test/e2e/vm/hotplug_cpu.go
@@ -38,14 +38,13 @@ import (
 	"github.com/deckhouse/virtualization/test/e2e/internal/util"
 )
 
-var _ = Describe("HotplugCPU", Label(precheck.NoPrecheck), func() {
+var _ = Describe("HotplugCPU", Label(precheck.PrecheckHotplugCPU), func() {
 	var (
 		f *framework.Framework
 		t *cpuHotplugTest
 	)
 
 	BeforeEach(func() {
-		Skip("Hotplug CPU requires enabled feature gates in ModuleConfig. Skip until prechecks are implemented.")
 		f = framework.NewFramework("cpu-hotplug")
 		DeferCleanup(f.After)
 		f.Before()

--- a/test/e2e/vm/hotplug_memory.go
+++ b/test/e2e/vm/hotplug_memory.go
@@ -40,14 +40,13 @@ import (
 	"github.com/deckhouse/virtualization/test/e2e/internal/util"
 )
 
-var _ = Describe("HotplugMemory", Label(precheck.NoPrecheck), func() {
+var _ = Describe("HotplugMemory", Label(precheck.PrecheckHotplugMemory), func() {
 	var (
 		f *framework.Framework
 		t *memoryHotplugTest
 	)
 
 	BeforeEach(func() {
-		Skip("Hotplug memory requires enabling feature gate 'HotplugMemoryWithLiveMigration' in ModuleConfig. Skip until prechecks are implemented.")
 		f = framework.NewFramework("memory-hotplug")
 		DeferCleanup(f.After)
 		f.Before()


### PR DESCRIPTION

## Description
<!---
  Describe your changes with technical details.
-->
- Replace explicit Skips with prechecks to enable Hotplug resources tests in compatible clusters.


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->

We want to run hotplug resources tests in compatible clusters.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->

Hotplug resources tests run in clusters with enabled feature gates.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->
