### PR TITLE
chore(module): reword module disabling warning

### DIFF
--- a/module.yaml
+++ b/module.yaml
@@ -14,12 +14,13 @@ requirements:
 disable:
   confirmation: true
   message: |
-    Attention!
+    Very important!
 
     Disabling this module will stop all services responsible for creating and running virtual machines.
-    Before disabling the module, be sure to do the following:
 
-    - Make sure that all resources created using the module (virtual machines, disks, images, etc.) are deleted.
-    - Check for active resources using the command: `kubectl get virtualization`. If there are objects left in the command output, remove them before deactivating the module.
+    Ensure proper cleanup before disabling this module:
 
-    Failure to do so may result in data loss or incorrect system operation.
+    - Check for active resources using the command: `d8 k get virtualization,cvi -A`.
+    - Make sure to remove all resources created using the module (virtual machines, disks, images, etc.).
+
+    Stale resources may result in a data loss or further system operation fails.


### PR DESCRIPTION

## Description
<!---
  Describe your changes with technical details.
-->

- Change command to get all virtualization resources in cluster and ClusterVirtualImages.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->

- Command in warning lists resources only on the deafult namespace. It is not sufficient to proper cleanup before module disabling.
- Also, list CVIs is important, as stuck CVIs left Pods in the d8-virtualization namespace, these CVIs should be deleted before module disabling.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->

Users can see all resources that should be cleaned up.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->