### PR TITLE
chore(module): add upmeter VM image

### DIFF
--- a/images/upmeter-vm/werf.inc.yaml
+++ b/images/upmeter-vm/werf.inc.yaml
@@ -1,0 +1,17 @@
+---
+image: {{ .ModuleNamePrefix }}{{ .ImageName }}-artifact
+final: false
+fromImage: builder/alpine
+shell:
+  install:
+    - apk add --no-cache ca-certificates curl
+    - mkdir -p /out/disk
+    - curl -fL --retry 5 --retry-delay 2 -o /out/disk/alpine-3-23-uefi-minimal.qcow2 https://89d64382-20df-4581-8cc7-80df331f67fa.selstorage.ru/upmeter/alpine-3-23-uefi-minimal.qcow2
+---
+image: {{ .ModuleNamePrefix }}{{ .ImageName }}
+fromImage: builder/scratch
+import:
+  - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-artifact
+    add: /out/disk/alpine-3-23-uefi-minimal.qcow2
+    to: /disk/alpine-3-23-uefi-minimal.qcow2
+    after: install

--- a/images/upmeter-vm/werf.inc.yaml
+++ b/images/upmeter-vm/werf.inc.yaml
@@ -6,12 +6,12 @@ shell:
   install:
     - apk add --no-cache ca-certificates curl
     - mkdir -p /out/disk
-    - curl -fL --retry 5 --retry-delay 2 -o /out/disk/alpine-3-23-uefi-minimal.qcow2 https://89d64382-20df-4581-8cc7-80df331f67fa.selstorage.ru/upmeter/alpine-3-23-uefi-minimal.qcow2
+    - curl -fL --retry 5 --retry-delay 2 -o /out/disk/alpine-3-23-bios-minimal.qcow2 https://89d64382-20df-4581-8cc7-80df331f67fa.selstorage.ru/upmeter/alpine-3-23-bios-minimal.qcow2
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 fromImage: builder/scratch
 import:
   - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-artifact
-    add: /out/disk/alpine-3-23-uefi-minimal.qcow2
-    to: /disk/alpine-3-23-uefi-minimal.qcow2
+    add: /out/disk/alpine-3-23-bios-minimal.qcow2
+    to: /disk/alpine-3-23-bios-minimal.qcow2
     after: install


### PR DESCRIPTION
## Description
add upmeter VM image


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: module
type: chore
summary: "Added a VM image container for upmeter checks."
impact_level: low
```
