### PR TITLE
refactor(vm): deprecate kvvm protection finalizaer

### DIFF
--- a/api/core/v1alpha2/finalizers.go
+++ b/api/core/v1alpha2/finalizers.go
@@ -17,9 +17,12 @@ limitations under the License.
 package v1alpha2
 
 const (
-	FinalizerCVIProtection                        = "virtualization.deckhouse.io/cvi-protection"
-	FinalizerVIProtection                         = "virtualization.deckhouse.io/vi-protection"
-	FinalizerVDProtection                         = "virtualization.deckhouse.io/vd-protection"
+	FinalizerCVIProtection = "virtualization.deckhouse.io/cvi-protection"
+	FinalizerVIProtection  = "virtualization.deckhouse.io/vi-protection"
+	FinalizerVDProtection  = "virtualization.deckhouse.io/vd-protection"
+	// FinalizerKVVMProtection protects KVVMs from deletion.
+	//
+	// Deprecated: FinalizerKVVMProtection is deprecated and should be deleted in the next versions.
 	FinalizerKVVMProtection                       = "virtualization.deckhouse.io/kvvm-protection"
 	FinalizerIPAddressProtection                  = "virtualization.deckhouse.io/vmip-protection"
 	FinalizerPodProtection                        = "virtualization.deckhouse.io/pod-protection"
@@ -41,6 +44,6 @@ const (
 	FinalizerVMBDACleanup           = "virtualization.deckhouse.io/vmbda-cleanup"
 	FinalizerMACAddressCleanup      = "virtualization.deckhouse.io/vmmac-cleanup"
 	FinalizerMACAddressLeaseCleanup = "virtualization.deckhouse.io/vmmacl-cleanup"
-	FinalizerNodeUSBDeviceCleanup  = "virtualization.deckhouse.io/nodeusbdevice-cleanup"
-	FinalizerUSBDeviceCleanup      = "virtualization.deckhouse.io/usbdevice-cleanup"
+	FinalizerNodeUSBDeviceCleanup   = "virtualization.deckhouse.io/nodeusbdevice-cleanup"
+	FinalizerUSBDeviceCleanup       = "virtualization.deckhouse.io/usbdevice-cleanup"
 )

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
@@ -144,7 +144,6 @@ func ApplyVirtualMachineSpec(
 		Version: v1alpha2.SchemeGroupVersion.Version,
 		Kind:    "VirtualMachine",
 	})
-	kvvm.AddFinalizer(v1alpha2.FinalizerKVVMProtection)
 
 	if ipAddress != "" {
 		// Set ip address cni request annotation.

--- a/images/virtualization-artifact/pkg/controller/vm/internal/deletion_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/deletion_handler.go
@@ -37,7 +37,7 @@ const deletionHandlerName = "DeletionHandler"
 func NewDeletionHandler(client client.Client) *DeletionHandler {
 	return &DeletionHandler{
 		client:     client,
-		protection: service.NewProtectionService(client, v1alpha2.FinalizerKVVMProtection),
+		protection: service.NewProtectionService(client, v1alpha2.FinalizerKVVMProtection), //nolint:staticcheck // FinalizerKVVMProtection is deprecated but still required until migration is complete.
 	}
 }
 


### PR DESCRIPTION
## Description
refactor(vm): deprecate kvvm protection finalizaer


## Why do we need it, and what problem does it solve?
This finalizer doesn’t make sense. It doesn’t protect against unauthorized deletion, and on the contrary, it prevents recreating the resource after such deletion.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

