### PR TITLE
test: temporary increase wait time for cvi ready

### DIFF
--- a/test/e2e/internal/precheck/precreatedcvi.go
+++ b/test/e2e/internal/precheck/precreatedcvi.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -121,8 +122,9 @@ func (p *precreatedCVIPrecheck) waitForCVIsReady(ctx context.Context, cvis []*v1
 		objs = append(objs, cvi)
 	}
 
-	// Use util's polling with 5 minute timeout
-	util.UntilObjectPhase(ctx, string(v1alpha2.ImageReady), framework.LongTimeout, objs...)
+	// Temporarily increasing the system readiness timeout to 20 minutes; currently, the Ubuntu ISO image is taking a long time to load.
+	// TODO: Revert back when the slow loading issue is fixed.
+	util.UntilObjectPhase(ctx, string(v1alpha2.ImageReady), 1200*time.Second, objs...)
 }
 
 // Register precreatedCVI precheck as common (runs for all tests).


### PR DESCRIPTION
## Description
Temporarily increase the CVI readiness wait timeout in e2e prechecks.

## Why do we need it, and what problem does it solve?
Some images cannot be downloaded within 5 minutes. The longest case is the Ubuntu ISO image, which makes e2e prechecks flaky.

## What is the expected result?
E2E prechecks wait long enough for CVIs backed by large downloadable images to become ready.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
