### PR TITLE
fix(vm): fix rootless upgrade migration for VMs with container disks (release 1.9)

### DIFF
--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -3,7 +3,7 @@ firmware:
   libvirt: v10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: v1.6.2-v12n.43
+  3p-kubevirt: v1.6.2-v12n.43.1
   3p-containerized-data-importer: v1.60.3-v12n.19
   distribution: 2.8.3
 package:


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Fixes live migration of container-disk VMs in kubevirt:
1. `unknown user deckhouse`: a 1.9 virt-handler probing a 1.8 launcher's container disk via `virt-chroot --user deckhouse` fails (the old launcher image has no `deckhouse` user), so the source VMI never syncs. `GetImageInfo` now falls back to the legacy `qemu` user when the launcher predates `deckhouse` (`pkg/virt-handler/container-disk/hotplug.go`).
2. `Hotplug container disk not mounted on the migration target`: `findVirtlauncherUID` matched the target launcher by its hotplug-disks dir, but a terminated pod left in `ActivePods` keeps that dir, so a lingering pod yields multiple matches and skips the bind-mount. It now keys off the launcher command socket (live pod only).
3. **Blank qemu-img errors**: some funcs used `cmd.StderrPipe()` + `cmd.Output()`. `Wait()` closed the pipe before stderr was read, so every failure logged with no reason. Switched to a captured `bytes.Buffer`.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

