### PR TITLE
fix(vd): select vd migration target pvc strictly

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -275,16 +275,6 @@ tasks:
                   "readinessProbe": null,
                   "livenessProbe": null,
                   "command": null
-                },
-                {
-                  "name": "proxy",
-                  "readinessProbe": null,
-                  "livenessProbe": null
-                },
-                {
-                  "name": "kube-rbac-proxy",
-                  "readinessProbe": null,
-                  "livenessProbe": null
                 }
               ]
             }

--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -3,7 +3,7 @@ firmware:
   libvirt: v10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: v1.6.2-v12n.45
+  3p-kubevirt: v1.6.2-v12n.46
   3p-containerized-data-importer: v1.60.3-v12n.20
   distribution: 2.8.3
 package:

--- a/images/virtualization-artifact/pkg/controller/vd/internal/migration.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/migration.go
@@ -641,18 +641,41 @@ func (h MigrationHandler) createTargetPersistentVolumeClaim(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+
+	if targetPVCName == sourcePVCName && targetPVCName != "" {
+		return nil, fmt.Errorf("target PersistentVolumeClaim %q matches source PersistentVolumeClaim", targetPVCName)
+	}
+
 	switch len(pvcs) {
-	case 1: // only source pvc exists
+	case 1:
+		if pvcs[0].Name != sourcePVCName {
+			return nil, fmt.Errorf("source PersistentVolumeClaim %q was not found", sourcePVCName)
+		}
+		if targetPVCName != "" {
+			return nil, fmt.Errorf("target PersistentVolumeClaim %q was not found", targetPVCName)
+		}
 	case 2:
+		sourcePVCExists := false
+		var targetPVC *corev1.PersistentVolumeClaim
 		for _, pvc := range pvcs {
-			// If TargetPVC is empty, that means previous reconciliation failed and not updated TargetPVC in status.
-			// So, we should use pvc, that is not equal to SourcePVC.
-			if pvc.Name == targetPVCName || pvc.Name != sourcePVCName {
-				return &pvc, nil
+			if pvc.Name == sourcePVCName {
+				sourcePVCExists = true
+				continue
+			}
+			if targetPVCName == "" || pvc.Name == targetPVCName {
+				targetPVC = &pvc
+				break
 			}
 		}
+		if !sourcePVCExists {
+			return nil, fmt.Errorf("source PersistentVolumeClaim %q was not found", sourcePVCName)
+		}
+		if targetPVC != nil {
+			return targetPVC, nil
+		}
+		return nil, fmt.Errorf("target PersistentVolumeClaim %q was not found", targetPVCName)
 	default:
-		return nil, fmt.Errorf("unexpected number of pvcs: %d, please report a bug", len(pvcs))
+		return nil, fmt.Errorf("unexpected number of PersistentVolumeClaims: %d, expected 1 or 2", len(pvcs))
 	}
 
 	pvc := &corev1.PersistentVolumeClaim{

--- a/images/virtualization-artifact/pkg/controller/vd/internal/migration_test.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/migration_test.go
@@ -356,6 +356,84 @@ var _ = Describe("MigrationHandler", func() {
 		})
 	})
 
+	Describe("createTargetPersistentVolumeClaim", func() {
+		var size resource.Quantity
+
+		BeforeEach(func() {
+			size = resource.MustParse("10Gi")
+		})
+
+		It("should return error when target PVC name matches source PVC name", func() {
+			sourcePVC := newEmptyPVC("source-pvc", "default")
+			withOwner(sourcePVC, vd)
+			Expect(fakeClient.Create(ctx, sourcePVC)).To(Succeed())
+
+			pvc, err := migrationHandler.createTargetPersistentVolumeClaim(ctx, vd, storageClass, size, "source-pvc", "source-pvc", corev1.PersistentVolumeBlock, corev1.ReadWriteOnce)
+			Expect(err).To(MatchError(ContainSubstring("matches source PersistentVolumeClaim")))
+			Expect(pvc).To(BeNil())
+		})
+
+		It("should select the only non-source PVC when target PVC name is empty", func() {
+			sourcePVC := newEmptyPVC("source-pvc", "default")
+			withOwner(sourcePVC, vd)
+			Expect(fakeClient.Create(ctx, sourcePVC)).To(Succeed())
+
+			targetPVC := newEmptyPVC("target-pvc", "default")
+			withOwner(targetPVC, vd)
+			Expect(fakeClient.Create(ctx, targetPVC)).To(Succeed())
+
+			pvc, err := migrationHandler.createTargetPersistentVolumeClaim(ctx, vd, storageClass, size, "", "source-pvc", corev1.PersistentVolumeBlock, corev1.ReadWriteOnce)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pvc.Name).To(Equal("target-pvc"))
+		})
+
+		It("should return error when target PVC name is specified but not found", func() {
+			sourcePVC := newEmptyPVC("source-pvc", "default")
+			withOwner(sourcePVC, vd)
+			Expect(fakeClient.Create(ctx, sourcePVC)).To(Succeed())
+
+			otherPVC := newEmptyPVC("other-pvc", "default")
+			withOwner(otherPVC, vd)
+			Expect(fakeClient.Create(ctx, otherPVC)).To(Succeed())
+
+			pvc, err := migrationHandler.createTargetPersistentVolumeClaim(ctx, vd, storageClass, size, "missing-pvc", "source-pvc", corev1.PersistentVolumeBlock, corev1.ReadWriteOnce)
+			Expect(err).To(MatchError(ContainSubstring("target PersistentVolumeClaim \"missing-pvc\" was not found")))
+			Expect(pvc).To(BeNil())
+		})
+
+		It("should select target PVC by name when it is specified and found", func() {
+			sourcePVC := newEmptyPVC("source-pvc", "default")
+			withOwner(sourcePVC, vd)
+			Expect(fakeClient.Create(ctx, sourcePVC)).To(Succeed())
+
+			targetPVC := newEmptyPVC("target-pvc", "default")
+			withOwner(targetPVC, vd)
+			Expect(fakeClient.Create(ctx, targetPVC)).To(Succeed())
+
+			pvc, err := migrationHandler.createTargetPersistentVolumeClaim(ctx, vd, storageClass, size, "target-pvc", "source-pvc", corev1.PersistentVolumeBlock, corev1.ReadWriteOnce)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pvc.Name).To(Equal("target-pvc"))
+		})
+
+		It("should return error when target PVC cannot be selected unambiguously", func() {
+			sourcePVC := newEmptyPVC("source-pvc", "default")
+			withOwner(sourcePVC, vd)
+			Expect(fakeClient.Create(ctx, sourcePVC)).To(Succeed())
+
+			firstPVC := newEmptyPVC("first-pvc", "default")
+			withOwner(firstPVC, vd)
+			Expect(fakeClient.Create(ctx, firstPVC)).To(Succeed())
+
+			secondPVC := newEmptyPVC("second-pvc", "default")
+			withOwner(secondPVC, vd)
+			Expect(fakeClient.Create(ctx, secondPVC)).To(Succeed())
+
+			pvc, err := migrationHandler.createTargetPersistentVolumeClaim(ctx, vd, storageClass, size, "", "source-pvc", corev1.PersistentVolumeBlock, corev1.ReadWriteOnce)
+			Expect(err).To(MatchError(ContainSubstring("unexpected number of PersistentVolumeClaims: 3, expected 1 or 2")))
+			Expect(pvc).To(BeNil())
+		})
+	})
+
 	Describe("handleRevert", func() {
 		BeforeEach(func() {
 			vd.Status.MigrationState = v1alpha2.VirtualDiskMigrationState{


### PR DESCRIPTION
## Description
Make target PVC selection for VirtualDisk migration strict and deterministic.

The migration controller now:
- returns the PVC from `status.targetPVC` only when the exact PVC exists;
- rejects a target PVC name that matches the source PVC name;
- falls back to the only non-source PVC only when `status.targetPVC` is empty;
- reports an error when the source PVC is missing or when several target candidates exist.

This prevents the controller from silently choosing an unrelated PVC when the expected migration target is missing. The PR also updates the virt-controller debug patch helper to patch only the `virt-controller` container.

## Why do we need it, and what problem does it solve?
Previously, when `status.targetPVC` was set but the matching PVC was absent, the controller could return any PVC owned by the VirtualDisk whose name differed from the source PVC. In ambiguous or stale states this could make migration reconciliation use the wrong PVC and hide the real inconsistency.

Strict target selection makes migration failures explicit and keeps reconciliation safe: a specified target PVC must exist, and automatic fallback is allowed only for the recovery case where the target name has not yet been stored in status.

## What is the expected result?
1. Start or reconcile a VirtualDisk migration with a valid `status.targetPVC`.
2. Verify the controller selects exactly that PVC.
3. Remove or change the target PVC state to make the target missing or ambiguous.
4. Verify reconciliation fails with a clear error instead of selecting an unrelated PVC.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: core
type: fix
summary: Select VirtualDisk migration target PVC strictly to avoid using an unrelated PVC.
impact_level: low
```
