### PR TITLE
fix(vd): skip terminating PVC when selecting volume migration target

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vd/internal/migration.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/migration.go
@@ -642,9 +642,6 @@ func (h MigrationHandler) createTargetPersistentVolumeClaim(ctx context.Context,
 		return nil, err
 	}
 
-	// Skip terminating PVCs: the source PVC of a previous completed migration may still be
-	// finalizing when the next migration starts. Counting it would let the checks below adopt
-	// it as the target, leaving the migration stuck once it is deleted.
 	livePVCs := make([]corev1.PersistentVolumeClaim, 0, len(pvcs))
 	for _, pvc := range pvcs {
 		if pvc.DeletionTimestamp.IsZero() {

--- a/images/virtualization-artifact/pkg/controller/vd/internal/migration.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/migration.go
@@ -641,10 +641,18 @@ func (h MigrationHandler) createTargetPersistentVolumeClaim(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	switch len(pvcs) {
+
+	var livePVCs []corev1.PersistentVolumeClaim
+	for _, pvc := range pvcs {
+		if pvc.DeletionTimestamp.IsZero() {
+			livePVCs = append(livePVCs, pvc)
+		}
+	}
+
+	switch len(livePVCs) {
 	case 1: // only source pvc exists
 	case 2:
-		for _, pvc := range pvcs {
+		for _, pvc := range livePVCs {
 			// If TargetPVC is empty, that means previous reconciliation failed and not updated TargetPVC in status.
 			// So, we should use pvc, that is not equal to SourcePVC.
 			if pvc.Name == targetPVCName || pvc.Name != sourcePVCName {
@@ -652,7 +660,7 @@ func (h MigrationHandler) createTargetPersistentVolumeClaim(ctx context.Context,
 			}
 		}
 	default:
-		return nil, fmt.Errorf("unexpected number of pvcs: %d, please report a bug", len(pvcs))
+		return nil, fmt.Errorf("unexpected number of pvcs: %d, please report a bug", len(livePVCs))
 	}
 
 	pvc := &corev1.PersistentVolumeClaim{


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
In `createTargetPersistentVolumeClaim`, filter out terminating PVCs before selecting/counting the VD's PVCs, so a still-finalizing source PVC from a previous migration is no longer adopted as the new migration target.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
When a migration completes, the controller deletes the source PVC but doesn't wait for it to finalize. If the next migration starts within those few seconds, the handler saw 2 PVCs (current + still-terminating old source) and adopted the terminating one as the target. That PVC then disappeared, leaving the VD stuck on "Target persistent volume claim is not found". Surfaced by the e2e `StorageClassMigration` test.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
`StorageClassMigration` e2e test should not fail.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: vd
type: fix
summary: skip terminating PVC when selecting volume migration target
```
