### PR TITLE
fix(vmop): update migration time elapsed every ten seconds

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle.go
@@ -46,6 +46,8 @@ import (
 
 const lifecycleHandlerName = "LifecycleHandler"
 
+const timeElapsedUpdateInterval = 10 * time.Second
+
 const (
 	progressMigrationPending   int32 = 0
 	progressDisksPreparing     int32 = 1
@@ -167,7 +169,7 @@ func (h LifecycleHandler) Handle(ctx context.Context, vmop *v1alpha2.VirtualMach
 	// Synchronize conditions to the VMOP.
 	if commonvmop.IsOperationInProgress(vmop) {
 		log.Debug("Operation in progress, check if VM is completed", "vm.phase", vm.Status.Phase, "vmop.phase", vmop.Status.Phase)
-		return reconcile.Result{}, h.syncOperationComplete(ctx, vmop)
+		return h.syncOperationCompleteResult(ctx, vmop)
 	}
 
 	// 4. Check migration, if exists, that means previous reconcile finished with error and SignalSent condition is not synced.
@@ -183,7 +185,7 @@ func (h LifecycleHandler) Handle(ctx context.Context, vmop *v1alpha2.VirtualMach
 				Reason(vmopcondition.ReasonSignalSentSuccess).
 				Status(metav1.ConditionTrue),
 			&vmop.Status.Conditions)
-		return reconcile.Result{}, h.syncOperationComplete(ctx, vmop)
+		return h.syncOperationCompleteResult(ctx, vmop)
 	}
 
 	// 5. VMOP is not in progress.
@@ -250,6 +252,17 @@ func (h LifecycleHandler) Handle(ctx context.Context, vmop *v1alpha2.VirtualMach
 
 func (h LifecycleHandler) Name() string {
 	return lifecycleHandlerName
+}
+
+func (h LifecycleHandler) syncOperationCompleteResult(ctx context.Context, vmop *v1alpha2.VirtualMachineOperation) (reconcile.Result, error) {
+	err := h.syncOperationComplete(ctx, vmop)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if vmop.Status.Phase == v1alpha2.VMOPPhaseInProgress || vmop.Status.Phase == v1alpha2.VMOPPhasePending {
+		return reconcile.Result{RequeueAfter: timeElapsedUpdateInterval}, nil
+	}
+	return reconcile.Result{}, nil
 }
 
 func (h LifecycleHandler) syncOperationComplete(ctx context.Context, vmop *v1alpha2.VirtualMachineOperation) error {
@@ -627,7 +640,11 @@ func formatMigrationDetails(mig *virtv1.VirtualMachineInstanceMigration, now tim
 	status := state.TransferStatus
 	parts := make([]string, 0, 7)
 	if state.StartTimestamp != nil {
-		parts = append(parts, fmt.Sprintf("TimeElapsed:%dms", now.Sub(state.StartTimestamp.Time).Milliseconds()))
+		elapsed := now.Sub(state.StartTimestamp.Time).Truncate(timeElapsedUpdateInterval)
+		if elapsed < 0 {
+			elapsed = 0
+		}
+		parts = append(parts, fmt.Sprintf("TimeElapsed:%ds", int64(elapsed.Seconds())))
 	}
 	if status.DataProcessedBytes != nil {
 		parts = append(parts, fmt.Sprintf("DataProcessed:%dMiB", bytesToMiB(*status.DataProcessedBytes)))

--- a/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle_test.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle_test.go
@@ -667,13 +667,14 @@ var _ = Describe("LifecycleHandler", func() {
 			h := NewLifecycleHandler(fakeClient, migrationService, base, recorderMock)
 			h.progressStrategy = &progressStrategyStub{value: 30}
 
-			_, err := h.Handle(ctx, srv.Changed())
+			result, err := h.Handle(ctx, srv.Changed())
 			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(10 * time.Second))
 
 			completed, found := conditions.GetCondition(vmopcondition.TypeCompleted, srv.Changed().Status.Conditions)
 			Expect(found).To(BeTrue())
 			Expect(completed.Message).NotTo(ContainSubstring("Migration info for 7d38a63b-ffa9-4d56-a924-6017f5832110:"))
-			Expect(completed.Message).To(ContainSubstring("Syncing source and target. TimeElapsed:"))
+			Expect(completed.Message).To(ContainSubstring("Syncing source and target. TimeElapsed:30s"))
 			Expect(completed.Message).To(ContainSubstring("DataProcessed:3529MiB DataRemaining:12049MiB DataTotal:16405MiB"))
 			Expect(completed.Message).To(ContainSubstring("Iteration:1 AutoConvergeThrottleSet:true AutoConvergeThrottle:0"))
 		})


### PR DESCRIPTION
## Description
Update VMOP migration progress reporting so the migration elapsed time is refreshed every 10 seconds while the operation is pending or in progress.

The elapsed time in the migration details message is now rounded down to the 10-second update interval, clamped to zero for clock skew cases, and displayed in seconds instead of milliseconds.

## Why do we need it, and what problem does it solve?
Previously, the migration details message could keep an outdated `TimeElapsed` value until another status change triggered reconciliation. This made in-progress migration status less informative for users.

Periodic requeueing keeps the elapsed time current without updating the status too frequently, and seconds-based output is easier to read in VMOP conditions.

## What is the expected result?
1. Start a VM migration operation.
2. Check the VMOP `Completed` condition message while migration is pending or in progress.
3. Verify that `TimeElapsed` is updated every 10 seconds and is shown in seconds.
4. Verify that reconciliation is requeued only while the VMOP remains pending or in progress.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: core
type: fix
summary: Update VMOP migration elapsed time every ten seconds while migration is in progress.
impact_level: low
```
