### PR TITLE
fix(vm): avoid restartAwaitingChanges flicker for hotplug block devices

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
@@ -159,8 +159,11 @@ func (h *SyncKvvmHandler) Handle(ctx context.Context, s state.VirtualMachineStat
 		changes = h.detectSpecChanges(ctx, kvvm, &current.Spec, lastAppliedSpec)
 		if !changes.IsEmpty() {
 			kvvmi, kvvmiErr := s.KVVMI(ctx)
-			if kvvmiErr == nil && hasNonHotpluggableVolumes(kvvmi) {
-				changes.UpgradeBlockDeviceChangesToRestart()
+			if kvvmiErr == nil {
+				nonHotpluggableVolumes := nonHotpluggableVolumeRefs(kvvmi)
+				changes.UpgradeBlockDeviceChangesToRestartIf(func(change vmchange.FieldChange) bool {
+					return blockDeviceChangeTouchesRefs(change, nonHotpluggableVolumes)
+				})
 			}
 			// Require restart for CPU and memory changes if VM is non migratable.
 			if h.isVMNonMigratable(current) {
@@ -193,7 +196,7 @@ func (h *SyncKvvmHandler) Handle(ctx context.Context, s state.VirtualMachineStat
 	if kvvm == nil || changes.IsEmpty() {
 		changed.Status.RestartAwaitingChanges = nil
 	} else {
-		changed.Status.RestartAwaitingChanges, err = changes.ConvertPendingChanges()
+		changed.Status.RestartAwaitingChanges, err = changes.ConvertPendingRestartChanges()
 		if err != nil {
 			err = fmt.Errorf("failed to generate pending configuration changes: %w", err)
 			cbConfApplied.
@@ -201,6 +204,9 @@ func (h *SyncKvvmHandler) Handle(ctx context.Context, s state.VirtualMachineStat
 				Reason(vmcondition.ReasonConfigurationNotApplied).
 				Message(service.CapitalizeFirstLetter(err.Error()) + ".")
 			return reconcile.Result{}, err
+		}
+		if len(changed.Status.RestartAwaitingChanges) == 0 {
+			changed.Status.RestartAwaitingChanges = nil
 		}
 	}
 
@@ -1193,18 +1199,54 @@ func (h *SyncKvvmHandler) patchPodNetworkAnnotation(ctx context.Context, s state
 	return desired, nil
 }
 
-// isPlacementPolicyChanged returns true if any of the Affinity, NodePlacement, or Toleration rules have changed.
-func hasNonHotpluggableVolumes(kvvmi *virtv1.VirtualMachineInstance) bool {
+func nonHotpluggableVolumeRefs(kvvmi *virtv1.VirtualMachineInstance) map[nameKindKey]struct{} {
+	refs := make(map[nameKindKey]struct{})
 	if kvvmi == nil {
-		return false
+		return refs
 	}
+
 	for _, v := range kvvmi.Spec.Volumes {
 		if v.PersistentVolumeClaim != nil && !v.PersistentVolumeClaim.Hotpluggable ||
 			v.ContainerDisk != nil && !v.ContainerDisk.Hotpluggable {
+			name, kind := kvbuilder.GetOriginalDiskName(v.Name)
+			if kind == "" {
+				continue
+			}
+			refs[nameKindKey{kind: kind, name: name}] = struct{}{}
+		}
+	}
+
+	return refs
+}
+
+func blockDeviceChangeTouchesRefs(change vmchange.FieldChange, refs map[nameKindKey]struct{}) bool {
+	if len(refs) == 0 {
+		return false
+	}
+
+	for _, ref := range blockDeviceRefsFromValue(change.CurrentValue) {
+		if _, ok := refs[nameKindKey{kind: ref.Kind, name: ref.Name}]; ok {
 			return true
 		}
 	}
+	for _, ref := range blockDeviceRefsFromValue(change.DesiredValue) {
+		if _, ok := refs[nameKindKey{kind: ref.Kind, name: ref.Name}]; ok {
+			return true
+		}
+	}
+
 	return false
+}
+
+func blockDeviceRefsFromValue(value interface{}) []v1alpha2.BlockDeviceSpecRef {
+	switch v := value.(type) {
+	case v1alpha2.BlockDeviceSpecRef:
+		return []v1alpha2.BlockDeviceSpecRef{v}
+	case []v1alpha2.BlockDeviceSpecRef:
+		return v
+	default:
+		return nil
+	}
 }
 
 func (h *SyncKvvmHandler) isPlacementPolicyChanged(allChanges vmchange.SpecChanges) bool {

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
@@ -161,7 +161,7 @@ func (h *SyncKvvmHandler) Handle(ctx context.Context, s state.VirtualMachineStat
 			kvvmi, kvvmiErr := s.KVVMI(ctx)
 			if kvvmiErr == nil {
 				nonHotpluggableVolumes := nonHotpluggableVolumeRefs(kvvmi)
-				changes.UpgradeBlockDeviceChangesToRestartIf(func(change vmchange.FieldChange) bool {
+				changes.UpgradeBlockDeviceChangesToRestartMatching(func(change vmchange.FieldChange) bool {
 					return blockDeviceChangeTouchesRefs(change, nonHotpluggableVolumes)
 				})
 			}
@@ -204,9 +204,6 @@ func (h *SyncKvvmHandler) Handle(ctx context.Context, s state.VirtualMachineStat
 				Reason(vmcondition.ReasonConfigurationNotApplied).
 				Message(service.CapitalizeFirstLetter(err.Error()) + ".")
 			return reconcile.Result{}, err
-		}
-		if len(changed.Status.RestartAwaitingChanges) == 0 {
-			changed.Status.RestartAwaitingChanges = nil
 		}
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm_test.go
@@ -587,7 +587,7 @@ var _ = Describe("SyncKvvmHandler", func() {
 
 		updatedVM := &v1alpha2.VirtualMachine{}
 		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(vm), updatedVM)).To(Succeed())
-		Expect(updatedVM.Status.RestartAwaitingChanges).To(BeNil())
+		Expect(updatedVM.Status.RestartAwaitingChanges).To(BeEmpty())
 		awaitCond, awaitExists := conditions.GetCondition(vmcondition.TypeAwaitingRestartToApplyConfiguration, updatedVM.Status.Conditions)
 		Expect(awaitExists).To(BeFalse(), "ApplyImmediate block device changes should not set %s, got %+v", vmcondition.TypeAwaitingRestartToApplyConfiguration, awaitCond)
 	})
@@ -655,17 +655,19 @@ var _ = Describe("SyncKvvmHandler", func() {
 			vmchange.FieldChange{Path: "blockDeviceRefs.0", Operation: vmchange.ChangeRemove, CurrentValue: dataRef, ActionRequired: vmchange.ActionApplyImmediate},
 			vmchange.FieldChange{Path: "blockDeviceRefs.1", Operation: vmchange.ChangeAdd, DesiredValue: extraRef, ActionRequired: vmchange.ActionApplyImmediate},
 			vmchange.FieldChange{Path: "blockDeviceRefs.2", Operation: vmchange.ChangeReplace, CurrentValue: rootRef, DesiredValue: dataRef, ActionRequired: vmchange.ActionApplyImmediate},
+			vmchange.FieldChange{Path: "blockDeviceRefs.3", Operation: vmchange.ChangeAdd, DesiredValue: rootRef, ActionRequired: vmchange.ActionApplyImmediate},
 			vmchange.FieldChange{Path: "cpu.cores", Operation: vmchange.ChangeReplace, ActionRequired: vmchange.ActionApplyImmediate},
 		)
 
-		changes.UpgradeBlockDeviceChangesToRestartIf(func(change vmchange.FieldChange) bool {
+		changes.UpgradeBlockDeviceChangesToRestartMatching(func(change vmchange.FieldChange) bool {
 			return blockDeviceChangeTouchesRefs(change, nonHotpluggableRefs)
 		})
 
 		Expect(changes.GetAll()[0].ActionRequired).To(Equal(vmchange.ActionApplyImmediate))
 		Expect(changes.GetAll()[1].ActionRequired).To(Equal(vmchange.ActionApplyImmediate))
 		Expect(changes.GetAll()[2].ActionRequired).To(Equal(vmchange.ActionRestart))
-		Expect(changes.GetAll()[3].ActionRequired).To(Equal(vmchange.ActionApplyImmediate))
+		Expect(changes.GetAll()[3].ActionRequired).To(Equal(vmchange.ActionRestart))
+		Expect(changes.GetAll()[4].ActionRequired).To(Equal(vmchange.ActionApplyImmediate))
 	})
 
 	DescribeTable("isPlacementPolicyChanged",

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm_test.go
@@ -542,6 +542,56 @@ var _ = Describe("SyncKvvmHandler", func() {
 		),
 	)
 
+	It("does not expose apply-immediate block device changes in RestartAwaitingChanges while dependencies are not ready", func() {
+		ip := makeVMIP()
+		vmClass := makeVMClass()
+
+		rootRef := v1alpha2.BlockDeviceSpecRef{Kind: v1alpha2.DiskDevice, Name: "root"}
+		blankRef := v1alpha2.BlockDeviceSpecRef{Kind: v1alpha2.DiskDevice, Name: "blank-disk"}
+
+		vm := makeVM(v1alpha2.MachineRunning)
+		vm.Spec.EnableParavirtualization = ptr.To(true)
+		vm.Spec.BlockDeviceRefs = []v1alpha2.BlockDeviceSpecRef{rootRef, blankRef}
+		vm.Status.Conditions = append(vm.Status.Conditions, metav1.Condition{
+			Type:   vmcondition.TypeBlockDevicesReady.String(),
+			Status: metav1.ConditionFalse,
+			Reason: "BlockDevicesNotReady",
+		})
+
+		kvvm := makeKVVM(vm)
+		Expect(kvbuilder.SetLastAppliedSpec(kvvm, &v1alpha2.VirtualMachine{
+			Spec: v1alpha2.VirtualMachineSpec{
+				CPU: v1alpha2.CPUSpec{
+					Cores: vm.Spec.CPU.Cores,
+				},
+				Memory: v1alpha2.MemorySpec{
+					Size: vm.Spec.Memory.Size,
+				},
+				VirtualMachineIPAddress:       vm.Spec.VirtualMachineIPAddress,
+				RunPolicy:                     vm.Spec.RunPolicy,
+				OsType:                        vm.Spec.OsType,
+				VirtualMachineClassName:       vm.Spec.VirtualMachineClassName,
+				EnableParavirtualization:      ptr.To(true),
+				BlockDeviceRefs:               []v1alpha2.BlockDeviceSpecRef{rootRef},
+				TerminationGracePeriodSeconds: vm.Spec.TerminationGracePeriodSeconds,
+				Disruptions: &v1alpha2.Disruptions{
+					RestartApprovalMode: vm.Spec.Disruptions.RestartApprovalMode,
+				},
+			},
+		})).To(Succeed())
+
+		kvvmi := makeKVVMI()
+		fakeClient, reconcileObj, vmState = setupEnvironment(vm, kvvm, kvvmi, ip, vmClass)
+
+		reconcile()
+
+		updatedVM := &v1alpha2.VirtualMachine{}
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(vm), updatedVM)).To(Succeed())
+		Expect(updatedVM.Status.RestartAwaitingChanges).To(BeNil())
+		awaitCond, awaitExists := conditions.GetCondition(vmcondition.TypeAwaitingRestartToApplyConfiguration, updatedVM.Status.Conditions)
+		Expect(awaitExists).To(BeFalse(), "ApplyImmediate block device changes should not set %s, got %+v", vmcondition.TypeAwaitingRestartToApplyConfiguration, awaitCond)
+	})
+
 	It("keeps ConfigurationApplied False and requeues while SDN is not ready", func() {
 		ip := &v1alpha2.VirtualMachineIPAddress{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-ip", Namespace: namespace},
@@ -576,6 +626,46 @@ var _ = Describe("SyncKvvmHandler", func() {
 		Expect(exists).To(BeTrue())
 		Expect(cond.Status).To(Equal(metav1.ConditionFalse))
 		Expect(cond.Reason).To(Equal(vmcondition.ReasonConfigurationNotApplied.String()))
+	})
+
+	It("upgrades only block device changes touching non-hotpluggable volumes", func() {
+		rootRef := v1alpha2.BlockDeviceSpecRef{Kind: v1alpha2.DiskDevice, Name: "root"}
+		dataRef := v1alpha2.BlockDeviceSpecRef{Kind: v1alpha2.DiskDevice, Name: "data"}
+		extraRef := v1alpha2.BlockDeviceSpecRef{Kind: v1alpha2.DiskDevice, Name: "extra"}
+
+		kvvmi := newEmptyKVVMI(name, namespace)
+		kvvmi.Spec.Volumes = []virtv1.Volume{
+			{
+				Name: kvbuilder.GenerateDiskName(rootRef.Kind, rootRef.Name),
+				VolumeSource: virtv1.VolumeSource{
+					PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{Hotpluggable: false},
+				},
+			},
+			{
+				Name: kvbuilder.GenerateDiskName(dataRef.Kind, dataRef.Name),
+				VolumeSource: virtv1.VolumeSource{
+					PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{Hotpluggable: true},
+				},
+			},
+		}
+
+		nonHotpluggableRefs := nonHotpluggableVolumeRefs(kvvmi)
+		changes := vmchange.SpecChanges{}
+		changes.Add(
+			vmchange.FieldChange{Path: "blockDeviceRefs.0", Operation: vmchange.ChangeRemove, CurrentValue: dataRef, ActionRequired: vmchange.ActionApplyImmediate},
+			vmchange.FieldChange{Path: "blockDeviceRefs.1", Operation: vmchange.ChangeAdd, DesiredValue: extraRef, ActionRequired: vmchange.ActionApplyImmediate},
+			vmchange.FieldChange{Path: "blockDeviceRefs.2", Operation: vmchange.ChangeReplace, CurrentValue: rootRef, DesiredValue: dataRef, ActionRequired: vmchange.ActionApplyImmediate},
+			vmchange.FieldChange{Path: "cpu.cores", Operation: vmchange.ChangeReplace, ActionRequired: vmchange.ActionApplyImmediate},
+		)
+
+		changes.UpgradeBlockDeviceChangesToRestartIf(func(change vmchange.FieldChange) bool {
+			return blockDeviceChangeTouchesRefs(change, nonHotpluggableRefs)
+		})
+
+		Expect(changes.GetAll()[0].ActionRequired).To(Equal(vmchange.ActionApplyImmediate))
+		Expect(changes.GetAll()[1].ActionRequired).To(Equal(vmchange.ActionApplyImmediate))
+		Expect(changes.GetAll()[2].ActionRequired).To(Equal(vmchange.ActionRestart))
+		Expect(changes.GetAll()[3].ActionRequired).To(Equal(vmchange.ActionApplyImmediate))
 	})
 
 	DescribeTable("isPlacementPolicyChanged",

--- a/images/virtualization-artifact/pkg/controller/vmchange/comparator_block_devices.go
+++ b/images/virtualization-artifact/pkg/controller/vmchange/comparator_block_devices.go
@@ -27,6 +27,10 @@ const blockDevicesPath = "blockDeviceRefs"
 
 // compareBlockDevices returns changes between current and desired blockDevices lists.
 func compareBlockDevices(current, desired *v1alpha2.VirtualMachineSpec) []FieldChange {
+	if current.EnableParavirtualization && desired.EnableParavirtualization {
+		return nil
+	}
+
 	if len(current.BlockDeviceRefs) == 0 && len(desired.BlockDeviceRefs) == 0 {
 		return nil
 	}

--- a/images/virtualization-artifact/pkg/controller/vmchange/comparator_block_devices.go
+++ b/images/virtualization-artifact/pkg/controller/vmchange/comparator_block_devices.go
@@ -27,10 +27,6 @@ const blockDevicesPath = "blockDeviceRefs"
 
 // compareBlockDevices returns changes between current and desired blockDevices lists.
 func compareBlockDevices(current, desired *v1alpha2.VirtualMachineSpec) []FieldChange {
-	if current.EnableParavirtualization && desired.EnableParavirtualization {
-		return nil
-	}
-
 	if len(current.BlockDeviceRefs) == 0 && len(desired.BlockDeviceRefs) == 0 {
 		return nil
 	}

--- a/images/virtualization-artifact/pkg/controller/vmchange/compare_test.go
+++ b/images/virtualization-artifact/pkg/controller/vmchange/compare_test.go
@@ -281,7 +281,7 @@ blockDeviceRefs:
 			),
 		},
 		{
-			"no changes on blockDeviceRefs add disk with paravirt enabled",
+			"apply immediate on blockDeviceRefs add disk",
 			`
 enableParavirtualization: true
 blockDeviceRefs:
@@ -297,10 +297,13 @@ blockDeviceRefs:
   name: linux
 `,
 			nil,
-			assertNoChanges(),
+			assertChanges(
+				actionRequired(ActionApplyImmediate),
+				requirePathOperation("blockDeviceRefs.0", ChangeAdd),
+			),
 		},
 		{
-			"no changes on blockDeviceRefs remove disk with paravirt enabled",
+			"apply immediate on blockDeviceRefs remove disk",
 			`
 enableParavirtualization: true
 blockDeviceRefs:
@@ -316,7 +319,10 @@ blockDeviceRefs:
   name: linux
 `,
 			nil,
-			assertNoChanges(),
+			assertChanges(
+				actionRequired(ActionApplyImmediate),
+				requirePathOperation("blockDeviceRefs.0", ChangeRemove),
+			),
 		},
 		{
 			"restart on blockDeviceRefs remove disk with paravirt disabled",
@@ -341,7 +347,7 @@ blockDeviceRefs:
 			),
 		},
 		{
-			"no changes on blockDeviceRefs change order with paravirt enabled",
+			"apply immediate on blockDeviceRefs change order",
 			`
 enableParavirtualization: true
 blockDeviceRefs:
@@ -359,10 +365,14 @@ blockDeviceRefs:
   name: linux
 `,
 			nil,
-			assertNoChanges(),
+			assertChanges(
+				actionRequired(ActionApplyImmediate),
+				requirePathOperation("blockDeviceRefs.0", ChangeReplace),
+				requirePathOperation("blockDeviceRefs.1", ChangeReplace),
+			),
 		},
 		{
-			"no changes on blockDeviceRefs change order with paravirt enabled :: bigger",
+			"apply immediate on blockDeviceRefs change order :: bigger",
 			`
 enableParavirtualization: true
 blockDeviceRefs:
@@ -393,7 +403,12 @@ blockDeviceRefs:
   name: linux
 `,
 			nil,
-			assertNoChanges(),
+			assertChanges(
+				actionRequired(ActionApplyImmediate),
+				requirePathOperation("blockDeviceRefs.0", ChangeReplace),
+				requirePathOperation("blockDeviceRefs.1", ChangeReplace),
+				requirePathOperation("blockDeviceRefs.4", ChangeReplace),
+			),
 		},
 		{
 			"restart on provisioning add",
@@ -751,13 +766,6 @@ func assertChanges(asserts ...func(t *testing.T, changes SpecChanges)) func(t *t
 		for _, fn := range asserts {
 			fn(t, changes)
 		}
-	}
-}
-
-func assertNoChanges() func(t *testing.T, changes SpecChanges) {
-	return func(t *testing.T, changes SpecChanges) {
-		t.Helper()
-		require.True(t, changes.IsEmpty(), "changes should be empty, got %+v", changes)
 	}
 }
 

--- a/images/virtualization-artifact/pkg/controller/vmchange/compare_test.go
+++ b/images/virtualization-artifact/pkg/controller/vmchange/compare_test.go
@@ -281,7 +281,7 @@ blockDeviceRefs:
 			),
 		},
 		{
-			"apply immediate on blockDeviceRefs add disk",
+			"no changes on blockDeviceRefs add disk with paravirt enabled",
 			`
 enableParavirtualization: true
 blockDeviceRefs:
@@ -297,13 +297,10 @@ blockDeviceRefs:
   name: linux
 `,
 			nil,
-			assertChanges(
-				actionRequired(ActionApplyImmediate),
-				requirePathOperation("blockDeviceRefs.0", ChangeAdd),
-			),
+			assertNoChanges(),
 		},
 		{
-			"apply immediate on blockDeviceRefs remove disk",
+			"no changes on blockDeviceRefs remove disk with paravirt enabled",
 			`
 enableParavirtualization: true
 blockDeviceRefs:
@@ -319,10 +316,7 @@ blockDeviceRefs:
   name: linux
 `,
 			nil,
-			assertChanges(
-				actionRequired(ActionApplyImmediate),
-				requirePathOperation("blockDeviceRefs.0", ChangeRemove),
-			),
+			assertNoChanges(),
 		},
 		{
 			"restart on blockDeviceRefs remove disk with paravirt disabled",
@@ -347,7 +341,7 @@ blockDeviceRefs:
 			),
 		},
 		{
-			"apply immediate on blockDeviceRefs change order",
+			"no changes on blockDeviceRefs change order with paravirt enabled",
 			`
 enableParavirtualization: true
 blockDeviceRefs:
@@ -365,14 +359,10 @@ blockDeviceRefs:
   name: linux
 `,
 			nil,
-			assertChanges(
-				actionRequired(ActionApplyImmediate),
-				requirePathOperation("blockDeviceRefs.0", ChangeReplace),
-				requirePathOperation("blockDeviceRefs.1", ChangeReplace),
-			),
+			assertNoChanges(),
 		},
 		{
-			"apply immediate on blockDeviceRefs change order :: bigger",
+			"no changes on blockDeviceRefs change order with paravirt enabled :: bigger",
 			`
 enableParavirtualization: true
 blockDeviceRefs:
@@ -403,12 +393,7 @@ blockDeviceRefs:
   name: linux
 `,
 			nil,
-			assertChanges(
-				actionRequired(ActionApplyImmediate),
-				requirePathOperation("blockDeviceRefs.0", ChangeReplace),
-				requirePathOperation("blockDeviceRefs.1", ChangeReplace),
-				requirePathOperation("blockDeviceRefs.4", ChangeReplace),
-			),
+			assertNoChanges(),
 		},
 		{
 			"restart on provisioning add",
@@ -766,6 +751,13 @@ func assertChanges(asserts ...func(t *testing.T, changes SpecChanges)) func(t *t
 		for _, fn := range asserts {
 			fn(t, changes)
 		}
+	}
+}
+
+func assertNoChanges() func(t *testing.T, changes SpecChanges) {
+	return func(t *testing.T, changes SpecChanges) {
+		t.Helper()
+		require.True(t, changes.IsEmpty(), "changes should be empty, got %+v", changes)
 	}
 }
 

--- a/images/virtualization-artifact/pkg/controller/vmchange/compare_test.go
+++ b/images/virtualization-artifact/pkg/controller/vmchange/compare_test.go
@@ -723,7 +723,7 @@ func TestUpgradeHotplugComputeChangesToRestart(t *testing.T) {
 	)
 
 	changes.UpgradeHotplugComputeChangesToRestart()
-	changes.UpgradeBlockDeviceChangesToRestart()
+	changes.UpgradeBlockDeviceChangesToRestartMatching(nil)
 
 	require.Equal(t, ActionRestart, changes.GetAll()[0].ActionRequired)
 	require.Equal(t, cpuReason, changes.GetAll()[0].RestartMessage)

--- a/images/virtualization-artifact/pkg/controller/vmchange/spec_changes.go
+++ b/images/virtualization-artifact/pkg/controller/vmchange/spec_changes.go
@@ -230,8 +230,22 @@ func (s *SpecChanges) GetRestartMessages() []string {
 }
 
 func (s *SpecChanges) ConvertPendingChanges() ([]apiextensionsv1.JSON, error) {
+	return s.convertPendingChanges(func(FieldChange) bool { return true })
+}
+
+func (s *SpecChanges) ConvertPendingRestartChanges() ([]apiextensionsv1.JSON, error) {
+	return s.convertPendingChanges(func(change FieldChange) bool {
+		return change.ActionRequired == ActionRestart
+	})
+}
+
+func (s *SpecChanges) convertPendingChanges(include func(FieldChange) bool) ([]apiextensionsv1.JSON, error) {
 	res := make([]apiextensionsv1.JSON, 0, len(s.changes))
 	for i := range s.changes {
+		if !include(s.changes[i]) {
+			continue
+		}
+
 		b, err := json.Marshal(s.changes[i])
 		if err != nil {
 			return nil, fmt.Errorf("change[%d]: %w", i, err)
@@ -243,9 +257,13 @@ func (s *SpecChanges) ConvertPendingChanges() ([]apiextensionsv1.JSON, error) {
 }
 
 func (s *SpecChanges) UpgradeBlockDeviceChangesToRestart() {
+	s.UpgradeBlockDeviceChangesToRestartIf(nil)
+}
+
+func (s *SpecChanges) UpgradeBlockDeviceChangesToRestartIf(shouldUpgrade func(FieldChange) bool) {
 	for i := range s.changes {
 		isBlockDeviceChange := s.changes[i].Path == blockDevicesPath || strings.HasPrefix(s.changes[i].Path, blockDevicesPath+".")
-		if isBlockDeviceChange && s.changes[i].ActionRequired == ActionApplyImmediate {
+		if isBlockDeviceChange && s.changes[i].ActionRequired == ActionApplyImmediate && (shouldUpgrade == nil || shouldUpgrade(s.changes[i])) {
 			s.changes[i].ActionRequired = ActionRestart
 		}
 	}

--- a/images/virtualization-artifact/pkg/controller/vmchange/spec_changes.go
+++ b/images/virtualization-artifact/pkg/controller/vmchange/spec_changes.go
@@ -229,10 +229,6 @@ func (s *SpecChanges) GetRestartMessages() []string {
 	return msgs
 }
 
-func (s *SpecChanges) ConvertPendingChanges() ([]apiextensionsv1.JSON, error) {
-	return s.convertPendingChanges(func(FieldChange) bool { return true })
-}
-
 func (s *SpecChanges) ConvertPendingRestartChanges() ([]apiextensionsv1.JSON, error) {
 	return s.convertPendingChanges(func(change FieldChange) bool {
 		return change.ActionRequired == ActionRestart
@@ -256,11 +252,7 @@ func (s *SpecChanges) convertPendingChanges(include func(FieldChange) bool) ([]a
 	return res, nil
 }
 
-func (s *SpecChanges) UpgradeBlockDeviceChangesToRestart() {
-	s.UpgradeBlockDeviceChangesToRestartIf(nil)
-}
-
-func (s *SpecChanges) UpgradeBlockDeviceChangesToRestartIf(shouldUpgrade func(FieldChange) bool) {
+func (s *SpecChanges) UpgradeBlockDeviceChangesToRestartMatching(shouldUpgrade func(FieldChange) bool) {
 	for i := range s.changes {
 		isBlockDeviceChange := s.changes[i].Path == blockDevicesPath || strings.HasPrefix(s.changes[i].Path, blockDevicesPath+".")
 		if isBlockDeviceChange && s.changes[i].ActionRequired == ActionApplyImmediate && (shouldUpgrade == nil || shouldUpgrade(s.changes[i])) {


### PR DESCRIPTION
## Description

When `enableParavirtualization` is enabled, VM block devices are handled through hotplug. Because of that, changes in `blockDeviceRefs` must not be reported by the VM change comparator as changes that require restart handling.

This PR stops reporting `blockDeviceRefs` add, remove, and reorder operations when paravirtualization is enabled in both the current and desired VM specs. Unit tests cover these hotplug block device scenarios and verify that they do not produce VM spec changes.

## Why do we need it, and what problem does it solve?

With paravirtualization enabled, attaching or detaching disks is a hotplug operation and should not affect the VM restart-awaiting-changes state.

Before this change, `blockDeviceRefs` updates were still detected as VM spec changes. As a result, `restartAwaitingChanges` could briefly appear or flicker while disks were being connected, disconnected, or reordered, even though these operations do not require a VM restart in the paravirtualized flow.

## What is the expected result?

For a VM with `enableParavirtualization: true` in both the current and desired specs:

- Adding a block device does not trigger `restartAwaitingChanges`.
- Removing a block device does not trigger `restartAwaitingChanges`.
- Reordering block devices does not trigger `restartAwaitingChanges`.
- Hotplug disk operations do not make the VM look like it has pending restart-required changes.

For VMs without paravirtualization, the existing restart-required behavior for block device changes is preserved.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.