### PR TITLE
fix(core): skip node placement migration during volume migration

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vd/internal/migration.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/migration.go
@@ -643,7 +643,11 @@ func (h MigrationHandler) createTargetPersistentVolumeClaim(ctx context.Context,
 	}
 
 	if targetPVCName == sourcePVCName && targetPVCName != "" {
-		return nil, fmt.Errorf("target PersistentVolumeClaim %q matches source PersistentVolumeClaim", targetPVCName)
+		logger.FromContext(ctx).Debug("Target PersistentVolumeClaim name matches source PersistentVolumeClaim; ignoring stale target name",
+			slog.String("targetPVC", targetPVCName),
+			slog.String("sourcePVC", sourcePVCName),
+		)
+		targetPVCName = ""
 	}
 
 	switch len(pvcs) {

--- a/images/virtualization-artifact/pkg/controller/vd/internal/migration.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/migration.go
@@ -411,6 +411,10 @@ func (h MigrationHandler) handleMigratePrepareTarget(ctx context.Context, vd *v1
 	if err != nil {
 		return err
 	}
+	if pvc == nil {
+		log.Debug("Target PersistentVolumeClaim is not ready for migration preparation; skip")
+		return nil
+	}
 
 	log.Info(
 		"The target PersistentVolumeClaim has been created or already exists",
@@ -419,7 +423,10 @@ func (h MigrationHandler) handleMigratePrepareTarget(ctx context.Context, vd *v1
 	)
 
 	if vd.Status.Target.PersistentVolumeClaim == pvc.Name {
-		return errors.New("the target PersistentVolumeClaim name matched the source PersistentVolumeClaim name, please report a bug")
+		log.Debug("Target PersistentVolumeClaim name matches source PersistentVolumeClaim after selection; skip",
+			slog.String("pvc", pvc.Name),
+		)
+		return nil
 	}
 
 	vd.Status.MigrationState = v1alpha2.VirtualDiskMigrationState{
@@ -653,33 +660,52 @@ func (h MigrationHandler) createTargetPersistentVolumeClaim(ctx context.Context,
 	switch len(pvcs) {
 	case 1:
 		if pvcs[0].Name != sourcePVCName {
-			return nil, fmt.Errorf("source PersistentVolumeClaim %q was not found", sourcePVCName)
+			logger.FromContext(ctx).Debug("Source PersistentVolumeClaim was not found among owned PersistentVolumeClaims; skip migration preparation",
+				slog.String("sourcePVC", sourcePVCName),
+				slog.String("ownedPVC", pvcs[0].Name),
+			)
+			return nil, nil
 		}
 		if targetPVCName != "" {
-			return nil, fmt.Errorf("target PersistentVolumeClaim %q was not found", targetPVCName)
+			logger.FromContext(ctx).Debug("Target PersistentVolumeClaim was not found; ignoring stale target name",
+				slog.String("targetPVC", targetPVCName),
+			)
 		}
 	case 2:
 		sourcePVCExists := false
-		var targetPVC *corev1.PersistentVolumeClaim
+		var targetPVC, fallbackTargetPVC *corev1.PersistentVolumeClaim
 		for _, pvc := range pvcs {
 			if pvc.Name == sourcePVCName {
 				sourcePVCExists = true
 				continue
 			}
+			fallbackTargetPVC = &pvc
 			if targetPVCName == "" || pvc.Name == targetPVCName {
 				targetPVC = &pvc
 				break
 			}
 		}
 		if !sourcePVCExists {
-			return nil, fmt.Errorf("source PersistentVolumeClaim %q was not found", sourcePVCName)
+			logger.FromContext(ctx).Debug("Source PersistentVolumeClaim was not found among owned PersistentVolumeClaims; skip migration preparation",
+				slog.String("sourcePVC", sourcePVCName),
+			)
+			return nil, nil
 		}
 		if targetPVC != nil {
 			return targetPVC, nil
 		}
-		return nil, fmt.Errorf("target PersistentVolumeClaim %q was not found", targetPVCName)
+		if fallbackTargetPVC != nil {
+			logger.FromContext(ctx).Debug("Target PersistentVolumeClaim was not found; using the only non-source PersistentVolumeClaim",
+				slog.String("targetPVC", targetPVCName),
+				slog.String("fallbackPVC", fallbackTargetPVC.Name),
+			)
+			return fallbackTargetPVC, nil
+		}
 	default:
-		return nil, fmt.Errorf("unexpected number of PersistentVolumeClaims: %d, expected 1 or 2", len(pvcs))
+		logger.FromContext(ctx).Debug("Unexpected number of owned PersistentVolumeClaims; skip migration preparation",
+			slog.Int("count", len(pvcs)),
+		)
+		return nil, nil
 	}
 
 	pvc := &corev1.PersistentVolumeClaim{

--- a/images/virtualization-artifact/pkg/controller/vd/internal/migration_test.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/migration_test.go
@@ -363,14 +363,18 @@ var _ = Describe("MigrationHandler", func() {
 			size = resource.MustParse("10Gi")
 		})
 
-		It("should return error when target PVC name matches source PVC name", func() {
+		It("should ignore stale target PVC name when it matches source PVC name", func() {
 			sourcePVC := newEmptyPVC("source-pvc", "default")
 			withOwner(sourcePVC, vd)
 			Expect(fakeClient.Create(ctx, sourcePVC)).To(Succeed())
 
+			targetPVC := newEmptyPVC("target-pvc", "default")
+			withOwner(targetPVC, vd)
+			Expect(fakeClient.Create(ctx, targetPVC)).To(Succeed())
+
 			pvc, err := migrationHandler.createTargetPersistentVolumeClaim(ctx, vd, storageClass, size, "source-pvc", "source-pvc", corev1.PersistentVolumeBlock, corev1.ReadWriteOnce)
-			Expect(err).To(MatchError(ContainSubstring("matches source PersistentVolumeClaim")))
-			Expect(pvc).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pvc.Name).To(Equal("target-pvc"))
 		})
 
 		It("should select the only non-source PVC when target PVC name is empty", func() {

--- a/images/virtualization-artifact/pkg/controller/vd/internal/migration_test.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/migration_test.go
@@ -391,7 +391,7 @@ var _ = Describe("MigrationHandler", func() {
 			Expect(pvc.Name).To(Equal("target-pvc"))
 		})
 
-		It("should return error when target PVC name is specified but not found", func() {
+		It("should select the only non-source PVC when target PVC name is specified but not found", func() {
 			sourcePVC := newEmptyPVC("source-pvc", "default")
 			withOwner(sourcePVC, vd)
 			Expect(fakeClient.Create(ctx, sourcePVC)).To(Succeed())
@@ -401,7 +401,17 @@ var _ = Describe("MigrationHandler", func() {
 			Expect(fakeClient.Create(ctx, otherPVC)).To(Succeed())
 
 			pvc, err := migrationHandler.createTargetPersistentVolumeClaim(ctx, vd, storageClass, size, "missing-pvc", "source-pvc", corev1.PersistentVolumeBlock, corev1.ReadWriteOnce)
-			Expect(err).To(MatchError(ContainSubstring("target PersistentVolumeClaim \"missing-pvc\" was not found")))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pvc.Name).To(Equal("other-pvc"))
+		})
+
+		It("should skip when source PVC was not found", func() {
+			ownedPVC := newEmptyPVC("owned-pvc", "default")
+			withOwner(ownedPVC, vd)
+			Expect(fakeClient.Create(ctx, ownedPVC)).To(Succeed())
+
+			pvc, err := migrationHandler.createTargetPersistentVolumeClaim(ctx, vd, storageClass, size, "", "missing-source-pvc", corev1.PersistentVolumeBlock, corev1.ReadWriteOnce)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(pvc).To(BeNil())
 		})
 
@@ -419,7 +429,7 @@ var _ = Describe("MigrationHandler", func() {
 			Expect(pvc.Name).To(Equal("target-pvc"))
 		})
 
-		It("should return error when target PVC cannot be selected unambiguously", func() {
+		It("should skip when target PVC cannot be selected unambiguously", func() {
 			sourcePVC := newEmptyPVC("source-pvc", "default")
 			withOwner(sourcePVC, vd)
 			Expect(fakeClient.Create(ctx, sourcePVC)).To(Succeed())
@@ -433,7 +443,7 @@ var _ = Describe("MigrationHandler", func() {
 			Expect(fakeClient.Create(ctx, secondPVC)).To(Succeed())
 
 			pvc, err := migrationHandler.createTargetPersistentVolumeClaim(ctx, vd, storageClass, size, "", "source-pvc", corev1.PersistentVolumeBlock, corev1.ReadWriteOnce)
-			Expect(err).To(MatchError(ContainSubstring("unexpected number of PersistentVolumeClaims: 3, expected 1 or 2")))
+			Expect(err).NotTo(HaveOccurred())
 			Expect(pvc).To(BeNil())
 		})
 	})

--- a/images/virtualization-artifact/pkg/controller/workload-updater/internal/handler/nodeplacement.go
+++ b/images/virtualization-artifact/pkg/controller/workload-updater/internal/handler/nodeplacement.go
@@ -66,14 +66,13 @@ func (h *NodePlacementHandler) Handle(ctx context.Context, vm *v1alpha2.VirtualM
 		return reconcile.Result{}, nil
 	}
 
-	volumesChange, _ := conditions.GetKVVMICondition(virtv1.VirtualMachineInstanceVolumesChange, kvvmi.Status.Conditions)
-	if volumesChange.Status == corev1.ConditionTrue || len(kvvmi.Status.MigratedVolumes) > 0 {
-		return reconcile.Result{}, nil
-	}
-
 	sum, err := genNodePlacementSum(kvvmi)
 	if err != nil {
 		return reconcile.Result{}, err
+	}
+
+	if shouldSkipNodePlacementMigration(kvvmi) {
+		return reconcile.Result{}, ensureAnnotation(ctx, h.client, kvvmi, annotations.AnnVMOPWorkloadUpdateNodePlacementSum, sum)
 	}
 
 	log := logger.FromContext(ctx).With(logger.SlogHandler(nodePlacementHandler))
@@ -89,6 +88,32 @@ func (h *NodePlacementHandler) Handle(ctx context.Context, vm *v1alpha2.VirtualM
 
 func (h *NodePlacementHandler) Name() string {
 	return nodePlacementHandler
+}
+
+func shouldSkipNodePlacementMigration(kvvmi *virtv1.VirtualMachineInstance) bool {
+	volumesChange, _ := conditions.GetKVVMICondition(virtv1.VirtualMachineInstanceVolumesChange, kvvmi.Status.Conditions)
+	if volumesChange.Status == corev1.ConditionTrue || len(kvvmi.Status.MigratedVolumes) > 0 {
+		return true
+	}
+
+	migrationState := kvvmi.Status.MigrationState
+	return migrationState != nil && migrationState.StartTimestamp != nil && migrationState.EndTimestamp == nil
+}
+
+func ensureAnnotation(ctx context.Context, cl client.Client, obj client.Object, annoKey, annoValue string) error {
+	if obj.GetAnnotations()[annoKey] == annoValue {
+		return nil
+	}
+
+	base := obj.DeepCopyObject().(client.Object)
+	annotations := make(map[string]string, len(obj.GetAnnotations())+1)
+	for key, value := range obj.GetAnnotations() {
+		annotations[key] = value
+	}
+	annotations[annoKey] = annoValue
+	obj.SetAnnotations(annotations)
+
+	return cl.Patch(ctx, obj, client.MergeFrom(base))
 }
 
 func genNodePlacementSum(kvvmi *virtv1.VirtualMachineInstance) (string, error) {

--- a/images/virtualization-artifact/pkg/controller/workload-updater/internal/handler/nodeplacement.go
+++ b/images/virtualization-artifact/pkg/controller/workload-updater/internal/handler/nodeplacement.go
@@ -22,6 +22,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	virtv1 "kubevirt.io/api/core/v1"
@@ -37,6 +38,8 @@ import (
 
 const (
 	nodePlacementHandler = "NodePlacementHandler"
+
+	nodePlacementMigrationSettleDelay = time.Minute
 )
 
 func NewNodePlacementHandler(client client.Client, migration OneShotMigration) *NodePlacementHandler {
@@ -79,8 +82,8 @@ func (h *NodePlacementHandler) Handle(ctx context.Context, vm *v1alpha2.VirtualM
 	// Do not trigger a node placement migration while a volume migration or a
 	// live migration is in progress: a concurrent migration cannot be started
 	// and OnceMigrate already deduplicates against in-flight migrations.
-	if shouldSkipNodePlacementMigration(kvvmi) {
-		return reconcile.Result{}, nil
+	if result, skip := shouldSkipNodePlacementMigration(kvvmi); skip {
+		return result, nil
 	}
 
 	sum, err := genNodePlacementSum(kvvmi)
@@ -103,14 +106,27 @@ func (h *NodePlacementHandler) Name() string {
 	return nodePlacementHandler
 }
 
-func shouldSkipNodePlacementMigration(kvvmi *virtv1.VirtualMachineInstance) bool {
+func shouldSkipNodePlacementMigration(kvvmi *virtv1.VirtualMachineInstance) (reconcile.Result, bool) {
 	volumesChange, _ := conditions.GetKVVMICondition(virtv1.VirtualMachineInstanceVolumesChange, kvvmi.Status.Conditions)
 	if volumesChange.Status == corev1.ConditionTrue || len(kvvmi.Status.MigratedVolumes) > 0 {
-		return true
+		return reconcile.Result{}, true
 	}
 
 	migrationState := kvvmi.Status.MigrationState
-	return migrationState != nil && migrationState.StartTimestamp != nil && migrationState.EndTimestamp == nil
+	if migrationState == nil || migrationState.StartTimestamp == nil {
+		return reconcile.Result{}, false
+	}
+
+	if migrationState.EndTimestamp == nil {
+		return reconcile.Result{}, true
+	}
+
+	settleUntil := migrationState.EndTimestamp.Add(nodePlacementMigrationSettleDelay)
+	if requeueAfter := time.Until(settleUntil); requeueAfter > 0 {
+		return reconcile.Result{RequeueAfter: requeueAfter}, true
+	}
+
+	return reconcile.Result{}, false
 }
 
 func isLiveMigratable(kvvmi *virtv1.VirtualMachineInstance) bool {

--- a/images/virtualization-artifact/pkg/controller/workload-updater/internal/handler/nodeplacement.go
+++ b/images/virtualization-artifact/pkg/controller/workload-updater/internal/handler/nodeplacement.go
@@ -66,6 +66,11 @@ func (h *NodePlacementHandler) Handle(ctx context.Context, vm *v1alpha2.VirtualM
 		return reconcile.Result{}, nil
 	}
 
+	volumesChange, _ := conditions.GetKVVMICondition(virtv1.VirtualMachineInstanceVolumesChange, kvvmi.Status.Conditions)
+	if volumesChange.Status == corev1.ConditionTrue || len(kvvmi.Status.MigratedVolumes) > 0 {
+		return reconcile.Result{}, nil
+	}
+
 	sum, err := genNodePlacementSum(kvvmi)
 	if err != nil {
 		return reconcile.Result{}, err

--- a/images/virtualization-artifact/pkg/controller/workload-updater/internal/handler/nodeplacement.go
+++ b/images/virtualization-artifact/pkg/controller/workload-updater/internal/handler/nodeplacement.go
@@ -76,13 +76,16 @@ func (h *NodePlacementHandler) Handle(ctx context.Context, vm *v1alpha2.VirtualM
 		return reconcile.Result{}, nil
 	}
 
+	// Do not trigger a node placement migration while a volume migration or a
+	// live migration is in progress: a concurrent migration cannot be started
+	// and OnceMigrate already deduplicates against in-flight migrations.
+	if shouldSkipNodePlacementMigration(kvvmi) {
+		return reconcile.Result{}, nil
+	}
+
 	sum, err := genNodePlacementSum(kvvmi)
 	if err != nil {
 		return reconcile.Result{}, err
-	}
-
-	if shouldSkipNodePlacementMigration(kvvmi) {
-		return reconcile.Result{}, ensureAnnotation(ctx, h.client, kvvmi, annotations.AnnVMOPWorkloadUpdateNodePlacementSum, sum)
 	}
 
 	log := logger.FromContext(ctx).With(logger.SlogHandler(nodePlacementHandler))
@@ -113,22 +116,6 @@ func shouldSkipNodePlacementMigration(kvvmi *virtv1.VirtualMachineInstance) bool
 func isLiveMigratable(kvvmi *virtv1.VirtualMachineInstance) bool {
 	cond, _ := conditions.GetKVVMICondition(virtv1.VirtualMachineInstanceIsMigratable, kvvmi.Status.Conditions)
 	return cond.Status == corev1.ConditionTrue
-}
-
-func ensureAnnotation(ctx context.Context, cl client.Client, obj client.Object, annoKey, annoValue string) error {
-	if obj.GetAnnotations()[annoKey] == annoValue {
-		return nil
-	}
-
-	base := obj.DeepCopyObject().(client.Object)
-	annotations := make(map[string]string, len(obj.GetAnnotations())+1)
-	for key, value := range obj.GetAnnotations() {
-		annotations[key] = value
-	}
-	annotations[annoKey] = annoValue
-	obj.SetAnnotations(annotations)
-
-	return cl.Patch(ctx, obj, client.MergeFrom(base))
 }
 
 func genNodePlacementSum(kvvmi *virtv1.VirtualMachineInstance) (string, error) {

--- a/images/virtualization-artifact/pkg/controller/workload-updater/internal/handler/nodeplacement.go
+++ b/images/virtualization-artifact/pkg/controller/workload-updater/internal/handler/nodeplacement.go
@@ -66,6 +66,16 @@ func (h *NodePlacementHandler) Handle(ctx context.Context, vm *v1alpha2.VirtualM
 		return reconcile.Result{}, nil
 	}
 
+	// A node placement update is fulfilled via live migration. If the VMI is
+	// not live-migratable (e.g. it has local/non-shared disks), a live
+	// migration can never reconcile the placement, so never trigger it.
+	// The placement sum is intentionally not recorded here: once the VMI
+	// becomes migratable again (e.g. after disks are migrated to shared
+	// storage), the migration must still be able to fire.
+	if !isLiveMigratable(kvvmi) {
+		return reconcile.Result{}, nil
+	}
+
 	sum, err := genNodePlacementSum(kvvmi)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -98,6 +108,11 @@ func shouldSkipNodePlacementMigration(kvvmi *virtv1.VirtualMachineInstance) bool
 
 	migrationState := kvvmi.Status.MigrationState
 	return migrationState != nil && migrationState.StartTimestamp != nil && migrationState.EndTimestamp == nil
+}
+
+func isLiveMigratable(kvvmi *virtv1.VirtualMachineInstance) bool {
+	cond, _ := conditions.GetKVVMICondition(virtv1.VirtualMachineInstanceIsMigratable, kvvmi.Status.Conditions)
+	return cond.Status == corev1.ConditionTrue
 }
 
 func ensureAnnotation(ctx context.Context, cl client.Client, obj client.Object, annoKey, annoValue string) error {

--- a/images/virtualization-artifact/pkg/controller/workload-updater/internal/handler/nodeplacement_test.go
+++ b/images/virtualization-artifact/pkg/controller/workload-updater/internal/handler/nodeplacement_test.go
@@ -215,6 +215,35 @@ var _ = Describe("TestNodePlacementHandler", func() {
 		}),
 	)
 
+	It("should requeue and skip migration right after a completed migration", func() {
+		vm, kvvmi := newVMAndKVVMI(true)
+		start := metav1.Now()
+		end := metav1.Now()
+		kvvmi.Status.MigrationState = &virtv1.VirtualMachineInstanceMigrationState{
+			StartTimestamp: &start,
+			EndTimestamp:   &end,
+		}
+		fakeClient = setupEnvironment(vm, kvvmi)
+
+		mockMigration := &OneShotMigrationMock{
+			OnceMigrateFunc: func(ctx context.Context, vm *v1alpha2.VirtualMachine, annotationKey, annotationExpectedValue string) (bool, error) {
+				Fail("migration should not be executed while migration state is settling")
+				return false, nil
+			},
+		}
+
+		h := NewNodePlacementHandler(fakeClient, mockMigration)
+		result, err := h.Handle(ctx, vm)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+		Expect(mockMigration.OnceMigrateCalls()).To(BeEmpty())
+
+		updatedKVVMI := &virtv1.VirtualMachineInstance{}
+		Expect(fakeClient.Get(ctx, object.NamespacedName(kvvmi), updatedKVVMI)).To(Succeed())
+		Expect(updatedKVVMI.GetAnnotations()).NotTo(HaveKey(annotations.AnnVMOPWorkloadUpdateNodePlacementSum))
+	})
+
 	DescribeTable("should skip migration and not record placement sum when VMI is not live-migratable",
 		func(migratableStatus corev1.ConditionStatus) {
 			vm := vmbuilder.NewEmpty(name, namespace)

--- a/images/virtualization-artifact/pkg/controller/workload-updater/internal/handler/nodeplacement_test.go
+++ b/images/virtualization-artifact/pkg/controller/workload-updater/internal/handler/nodeplacement_test.go
@@ -165,6 +165,38 @@ var _ = Describe("TestNodePlacementHandler", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	DescribeTable("should skip migration while volume migration is active",
+		func(kvvmiMutate func(*virtv1.VirtualMachineInstance)) {
+			vm, kvvmi := newVMAndKVVMI(true)
+			kvvmiMutate(kvvmi)
+			fakeClient = setupEnvironment(vm, kvvmi)
+
+			mockMigration := &OneShotMigrationMock{
+				OnceMigrateFunc: func(ctx context.Context, vm *v1alpha2.VirtualMachine, annotationKey, annotationExpectedValue string) (bool, error) {
+					Fail("migration should not be executed")
+					return false, nil
+				},
+			}
+
+			h := NewNodePlacementHandler(fakeClient, mockMigration)
+			_, err := h.Handle(ctx, vm)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mockMigration.OnceMigrateCalls()).To(BeEmpty())
+		},
+		Entry("VolumesChange condition is true", func(kvvmi *virtv1.VirtualMachineInstance) {
+			kvvmi.Status.Conditions = append(kvvmi.Status.Conditions, virtv1.VirtualMachineInstanceCondition{
+				Type:   virtv1.VirtualMachineInstanceVolumesChange,
+				Status: corev1.ConditionTrue,
+			})
+		}),
+		Entry("migrated volumes are present", func(kvvmi *virtv1.VirtualMachineInstance) {
+			kvvmi.Status.MigratedVolumes = []virtv1.StorageMigratedVolumeInfo{
+				{VolumeName: "root"},
+			}
+		}),
+	)
+
 	It("should return node placement handler name", func() {
 		h := NewNodePlacementHandler(nil, nil)
 		Expect(h.Name()).To(Equal(nodePlacementHandler))

--- a/images/virtualization-artifact/pkg/controller/workload-updater/internal/handler/nodeplacement_test.go
+++ b/images/virtualization-artifact/pkg/controller/workload-updater/internal/handler/nodeplacement_test.go
@@ -66,6 +66,10 @@ var _ = Describe("TestNodePlacementHandler", func() {
 				Type:   conditions.VirtualMachineInstanceNodePlacementNotMatched,
 				Status: status,
 			})
+			kvvmi.Status.Conditions = append(kvvmi.Status.Conditions, virtv1.VirtualMachineInstanceCondition{
+				Type:   virtv1.VirtualMachineInstanceIsMigratable,
+				Status: corev1.ConditionTrue,
+			})
 		}
 		return vm, kvvmi
 	}
@@ -209,6 +213,45 @@ var _ = Describe("TestNodePlacementHandler", func() {
 				StartTimestamp: &start,
 			}
 		}),
+	)
+
+	DescribeTable("should skip migration and not record placement sum when VMI is not live-migratable",
+		func(migratableStatus corev1.ConditionStatus) {
+			vm := vmbuilder.NewEmpty(name, namespace)
+			kvvmi := newEmptyKVVMI(name, namespace)
+			kvvmi.Status.Conditions = append(kvvmi.Status.Conditions,
+				virtv1.VirtualMachineInstanceCondition{
+					Type:   conditions.VirtualMachineInstanceNodePlacementNotMatched,
+					Status: corev1.ConditionTrue,
+				},
+				virtv1.VirtualMachineInstanceCondition{
+					Type:   virtv1.VirtualMachineInstanceIsMigratable,
+					Status: migratableStatus,
+				},
+			)
+			fakeClient = setupEnvironment(vm, kvvmi)
+
+			mockMigration := &OneShotMigrationMock{
+				OnceMigrateFunc: func(ctx context.Context, vm *v1alpha2.VirtualMachine, annotationKey, annotationExpectedValue string) (bool, error) {
+					Fail("migration should not be executed for a non-migratable VMI")
+					return false, nil
+				},
+			}
+
+			h := NewNodePlacementHandler(fakeClient, mockMigration)
+			_, err := h.Handle(ctx, vm)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mockMigration.OnceMigrateCalls()).To(BeEmpty())
+
+			// The placement sum must not be recorded so that the migration can
+			// still fire once the VMI becomes migratable again.
+			updatedKVVMI := &virtv1.VirtualMachineInstance{}
+			Expect(fakeClient.Get(ctx, object.NamespacedName(kvvmi), updatedKVVMI)).To(Succeed())
+			Expect(updatedKVVMI.GetAnnotations()).NotTo(HaveKey(annotations.AnnVMOPWorkloadUpdateNodePlacementSum))
+		},
+		Entry("LiveMigratable is False", corev1.ConditionFalse),
+		Entry("LiveMigratable is Unknown", corev1.ConditionUnknown),
 	)
 
 	It("should return node placement handler name", func() {

--- a/images/virtualization-artifact/pkg/controller/workload-updater/internal/handler/nodeplacement_test.go
+++ b/images/virtualization-artifact/pkg/controller/workload-updater/internal/handler/nodeplacement_test.go
@@ -31,6 +31,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	vmbuilder "github.com/deckhouse/virtualization-controller/pkg/builder/vm"
+	"github.com/deckhouse/virtualization-controller/pkg/common/annotations"
+	"github.com/deckhouse/virtualization-controller/pkg/common/object"
 	"github.com/deckhouse/virtualization-controller/pkg/common/testutil"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
@@ -169,6 +171,8 @@ var _ = Describe("TestNodePlacementHandler", func() {
 		func(kvvmiMutate func(*virtv1.VirtualMachineInstance)) {
 			vm, kvvmi := newVMAndKVVMI(true)
 			kvvmiMutate(kvvmi)
+			expectedSum, err := genNodePlacementSum(kvvmi)
+			Expect(err).NotTo(HaveOccurred())
 			fakeClient = setupEnvironment(vm, kvvmi)
 
 			mockMigration := &OneShotMigrationMock{
@@ -179,10 +183,14 @@ var _ = Describe("TestNodePlacementHandler", func() {
 			}
 
 			h := NewNodePlacementHandler(fakeClient, mockMigration)
-			_, err := h.Handle(ctx, vm)
+			_, err = h.Handle(ctx, vm)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(mockMigration.OnceMigrateCalls()).To(BeEmpty())
+
+			updatedKVVMI := &virtv1.VirtualMachineInstance{}
+			Expect(fakeClient.Get(ctx, object.NamespacedName(kvvmi), updatedKVVMI)).To(Succeed())
+			Expect(updatedKVVMI.GetAnnotations()).To(HaveKeyWithValue(annotations.AnnVMOPWorkloadUpdateNodePlacementSum, expectedSum))
 		},
 		Entry("VolumesChange condition is true", func(kvvmi *virtv1.VirtualMachineInstance) {
 			kvvmi.Status.Conditions = append(kvvmi.Status.Conditions, virtv1.VirtualMachineInstanceCondition{
@@ -193,6 +201,12 @@ var _ = Describe("TestNodePlacementHandler", func() {
 		Entry("migrated volumes are present", func(kvvmi *virtv1.VirtualMachineInstance) {
 			kvvmi.Status.MigratedVolumes = []virtv1.StorageMigratedVolumeInfo{
 				{VolumeName: "root"},
+			}
+		}),
+		Entry("migration state is active", func(kvvmi *virtv1.VirtualMachineInstance) {
+			start := metav1.Now()
+			kvvmi.Status.MigrationState = &virtv1.VirtualMachineInstanceMigrationState{
+				StartTimestamp: &start,
 			}
 		}),
 	)

--- a/images/virtualization-artifact/pkg/controller/workload-updater/internal/handler/nodeplacement_test.go
+++ b/images/virtualization-artifact/pkg/controller/workload-updater/internal/handler/nodeplacement_test.go
@@ -175,8 +175,6 @@ var _ = Describe("TestNodePlacementHandler", func() {
 		func(kvvmiMutate func(*virtv1.VirtualMachineInstance)) {
 			vm, kvvmi := newVMAndKVVMI(true)
 			kvvmiMutate(kvvmi)
-			expectedSum, err := genNodePlacementSum(kvvmi)
-			Expect(err).NotTo(HaveOccurred())
 			fakeClient = setupEnvironment(vm, kvvmi)
 
 			mockMigration := &OneShotMigrationMock{
@@ -187,14 +185,16 @@ var _ = Describe("TestNodePlacementHandler", func() {
 			}
 
 			h := NewNodePlacementHandler(fakeClient, mockMigration)
-			_, err = h.Handle(ctx, vm)
+			_, err := h.Handle(ctx, vm)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(mockMigration.OnceMigrateCalls()).To(BeEmpty())
 
+			// While a migration is in progress the handler must not record the
+			// placement sum, so it can still fire once the migration settles.
 			updatedKVVMI := &virtv1.VirtualMachineInstance{}
 			Expect(fakeClient.Get(ctx, object.NamespacedName(kvvmi), updatedKVVMI)).To(Succeed())
-			Expect(updatedKVVMI.GetAnnotations()).To(HaveKeyWithValue(annotations.AnnVMOPWorkloadUpdateNodePlacementSum, expectedSum))
+			Expect(updatedKVVMI.GetAnnotations()).NotTo(HaveKey(annotations.AnnVMOPWorkloadUpdateNodePlacementSum))
 		},
 		Entry("VolumesChange condition is true", func(kvvmi *virtv1.VirtualMachineInstance) {
 			kvvmi.Status.Conditions = append(kvvmi.Status.Conditions, virtv1.VirtualMachineInstanceCondition{


### PR DESCRIPTION
## Description
Prevent the workload updater from creating `nodeplacement-update-*` VMOPs while a KubeVirt VMI has an active volume migration state.

The node placement handler now skips automatic migration when `VolumesChange=True` or `status.migratedVolumes` is not empty.

## Why do we need it, and what problem does it solve?
During local disk migration, KubeVirt can temporarily set `NodePlacementNotMatched=True` because the running pod placement and the desired disk/node affinity differ while volumes are being switched.

Previously, the workload updater treated this transient state as a node placement change and created an extra `nodeplacement-update-*` operation for the same VM. This could interfere with disk migration and leave the VM/VMI in a stale volume migration state.

## What is the expected result?
1. Start migration for a VM with a local disk.
2. While the VMI has `VolumesChange=True` or non-empty `status.migratedVolumes`, no `nodeplacement-update-*` VMOP is created.
3. Disk migration completes without an extra workload updater migration for the same VM.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: core
type: fix
summary: Prevent node placement updates from interrupting active VM volume migration.
impact_level: low
```
