### PR TITLE
fix(vmop): migration disk preparing

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle.go
@@ -58,6 +58,7 @@ const (
 
 const (
 	messageMigrationPending       = "The VirtualMachineOperation for migrating the virtual machine has been queued. Waiting for the queue to be processed and for this operation to be executed."
+	messageDisksPreparing         = "Preparing virtual disks for migration. VM migration will start after disk migration completes."
 	messageSyncingSourceAndTarget = "Syncing source and target"
 	messageTargetPodScheduling    = "Target pod is being scheduled"
 	messageTargetPodPreparing     = "Target pod is being prepared"
@@ -407,12 +408,18 @@ func (h LifecycleHandler) canExecute(vmop *v1alpha2.VirtualMachineOperation, vm 
 	migratable, _ := conditions.GetCondition(vmcondition.TypeMigratable, vm.Status.Conditions)
 
 	if migratable.Status == metav1.ConditionTrue {
+		message := ""
+		if migratable.Reason == vmcondition.ReasonDisksShouldBeMigrating.String() {
+			message = messageDisksPreparing
+		}
+
 		vmop.Status.Phase = v1alpha2.VMOPPhasePending
 		vmop.Status.Progress = migrationprogress.FormatPercent(1)
 		conditions.SetCondition(
 			conditions.NewConditionBuilder(vmopcondition.TypeCompleted).
 				Generation(vmop.GetGeneration()).
 				Reason(vmopcondition.ReasonWaitingForVirtualMachineToBeReadyToMigrate).
+				Message(message).
 				Status(metav1.ConditionFalse),
 			&vmop.Status.Conditions)
 		return false

--- a/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle_test.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle_test.go
@@ -307,6 +307,29 @@ var _ = Describe("LifecycleHandler", func() {
 		),
 	)
 
+	It("should show disk preparation message while waiting for local disk migration", func() {
+		vm := newVM(v1alpha2.PreferSafeMigrationPolicy)
+		vm.Status.Conditions = []metav1.Condition{
+			{
+				Type:   vmcondition.TypeMigratable.String(),
+				Status: metav1.ConditionTrue,
+				Reason: vmcondition.ReasonDisksShouldBeMigrating.String(),
+			},
+		}
+		vmop := newVMOPMigrate()
+		h := LifecycleHandler{}
+
+		canExecute := h.canExecute(vmop, vm)
+
+		Expect(canExecute).To(BeFalse())
+		Expect(vmop.Status.Phase).To(Equal(v1alpha2.VMOPPhasePending))
+		Expect(vmop.Status.Progress).To(Equal("1%"))
+		completed, found := conditions.GetCondition(vmopcondition.TypeCompleted, vmop.Status.Conditions)
+		Expect(found).To(BeTrue())
+		Expect(completed.Reason).To(Equal(vmopcondition.ReasonWaitingForVirtualMachineToBeReadyToMigrate.String()))
+		Expect(completed.Message).To(Equal(messageDisksPreparing))
+	})
+
 	Describe("migration progress integration", func() {
 		It("should return generic failed reason for nil migration", func() {
 			h := LifecycleHandler{}


### PR DESCRIPTION
## Description
Update VMOP migration lifecycle status while a virtual machine is waiting for migration prerequisites:

- show `DisksPreparing` reason and an explicit message when local disks must be migrated before VM migration starts;
- keep a separate progress value for VM readiness preparation before target scheduling;
- adjust migration progress ordering and cover the behavior with unit tests.

## Why do we need it, and what problem does it solve?
During VM migration with local disks, the operation could remain in a generic readiness waiting state with progress that did not clearly explain that disk preparation was in progress. This made VMOP status less informative for users and automation watching migration progress.

The change makes the pending migration state explicit: when disks must be migrated first, VMOP reports disk preparation before continuing with the regular migration lifecycle.

## What is the expected result?
1. Start VM migration for a VM that requires local disk migration.
2. Check the VMOP status before the actual VM migration starts.
3. VMOP is in `Pending` phase with `DisksPreparing` reason, `1%` progress, and a message explaining that virtual disks are being prepared.
4. Once disk preparation is not required, VMOP keeps the VM readiness waiting reason with `2%` progress and then proceeds to target scheduling at `3%`.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: core
type: fix
summary: Show disk preparation state in VMOP migration status before VM migration starts.
impact_level: low
```
