### PR TITLE
test(e2e): rely on precheck for DataExport availability

### DIFF
--- a/test/e2e/blockdevice/data_exports.go
+++ b/test/e2e/blockdevice/data_exports.go
@@ -66,11 +66,6 @@ var _ = Describe("DataExports", label.Slow(), Label(precheck.PrecheckSVDM, prech
 	BeforeEach(func() {
 		ctx = context.Background()
 		f = framework.NewFramework("data-exports")
-		moduleEnabled, err := checkStorageVolumeDataManagerEnabled(ctx)
-		Expect(err).NotTo(HaveOccurred(), "Failed to get modules")
-		if !moduleEnabled {
-			Skip("Module 'storage-volume-data-manager' is disabled. Skipping all tests with using this module.")
-		}
 
 		f.Before()
 		DeferCleanup(f.After)
@@ -367,14 +362,4 @@ func handleUploadResponse(resp *http.Response) error {
 	}
 
 	return fmt.Errorf("upload failed with status %d: %s", resp.StatusCode, body)
-}
-
-func checkStorageVolumeDataManagerEnabled(ctx context.Context) (bool, error) {
-	sdnModule, err := framework.NewFramework("").GetModuleConfig(ctx, "storage-volume-data-manager")
-	if err != nil {
-		return false, err
-	}
-	enabled := sdnModule.Spec.Enabled
-
-	return enabled != nil && *enabled, nil
 }


### PR DESCRIPTION
## Description
Remove the runtime skip from the `DataExports` e2e suite that checked whether the `storage-volume-data-manager` module is enabled.

The suite already has `PrecheckSVDM` and `PrecheckDataExport` labels, so the environment suitability should be handled by prechecks before the test starts.

## Why do we need it, and what problem does it solve?
The test duplicated module availability validation in `BeforeEach` and silently skipped execution when `storage-volume-data-manager` was disabled.

Prechecks are enough for this condition, and keeping the skip in the test hides configuration issues from the precheck layer.

## What is the expected result?
`DataExports` e2e tests are selected or rejected by the existing prechecks. The test code no longer performs an additional skip based on the `storage-volume-data-manager` module state.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.