### PR TITLE
test: add target migration precheck

### DIFF
--- a/test/e2e/internal/framework/mc.go
+++ b/test/e2e/internal/framework/mc.go
@@ -69,6 +69,7 @@ type VirtualizationModuleConfigSpec struct {
 type VirtualizationModuleConfigSettings struct {
 	Loglevel            string   `json:"logLevel,omitempty"`
 	VirtualMachineCIDRs []string `json:"virtualMachineCIDRs"`
+	FeatureGates        []string `json:"featureGates,omitempty"`
 	Dvcr                Dvcr     `json:"dvcr"`
 	HighAvailability    bool     `json:"highAvailability,omitempty"`
 }

--- a/test/e2e/internal/precheck/labels.go
+++ b/test/e2e/internal/precheck/labels.go
@@ -48,6 +48,9 @@ const (
 	// PrecheckAffinityToleration - test requires enough ready KVM-enabled master/worker nodes.
 	PrecheckAffinityToleration = "affinity-toleration-precheck"
 
+	// PrecheckTargetMigration - test requires target migration feature to be available.
+	PrecheckTargetMigration = "target-migration-precheck"
+
 	// PrecheckPostCleanup - test requires postcleanup to be configured.
 	PrecheckPostCleanup = "postcleanup-precheck"
 
@@ -72,6 +75,7 @@ func KnownPrecheckLabels() []string {
 		PrecheckVirtualization,
 		PrecheckUSB,
 		PrecheckAffinityToleration,
+		PrecheckTargetMigration,
 		PrecheckPostCleanup,
 		PrecheckPrecreatedCVI,
 		NoPrecheck,

--- a/test/e2e/internal/precheck/target_migration.go
+++ b/test/e2e/internal/precheck/target_migration.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package precheck
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/test/e2e/internal/framework"
+)
+
+const (
+	targetMigrationPrecheckEnvName = "TARGET_MIGRATION_PRECHECK"
+
+	targetMigrationFeatureName         = "TargetMigration"
+	minReadyTargetMigrationWorkerNodes = 2
+)
+
+// targetMigrationPrecheck implements Precheck interface for VMOP target migration.
+type targetMigrationPrecheck struct{}
+
+func (t *targetMigrationPrecheck) Label() string {
+	return PrecheckTargetMigration
+}
+
+func (t *targetMigrationPrecheck) Run(ctx context.Context, f *framework.Framework) error {
+	if !isCheckEnabled(targetMigrationPrecheckEnvName) {
+		_, _ = GinkgoWriter.Write([]byte("Target migration precheck is disabled.\n"))
+		return nil
+	}
+
+	if err := checkTargetMigrationFeature(ctx, f); err != nil {
+		return err
+	}
+
+	workerNodes, err := listReadyNodesByLabels(ctx, f, map[string]string{
+		kvmLabelKey:       "true",
+		nodeGroupLabelKey: "worker",
+	})
+	if err != nil {
+		return fmt.Errorf("%s=no to disable this precheck: failed to list ready KVM-enabled worker nodes: %w", targetMigrationPrecheckEnvName, err)
+	}
+	if len(workerNodes) < minReadyTargetMigrationWorkerNodes {
+		return fmt.Errorf("%s=no to disable this precheck: at least %d ready KVM-enabled worker nodes are required, got %d", targetMigrationPrecheckEnvName, minReadyTargetMigrationWorkerNodes, len(workerNodes))
+	}
+
+	return nil
+}
+
+func checkTargetMigrationFeature(ctx context.Context, f *framework.Framework) error {
+	vmop := &v1alpha2.VirtualMachineOperation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "target-migration-precheck",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: v1alpha2.VirtualMachineOperationSpec{
+			Type:           v1alpha2.VMOPTypeMigrate,
+			VirtualMachine: "target-migration-precheck",
+			Migrate: &v1alpha2.VirtualMachineOperationMigrateSpec{
+				NodeSelector: map[string]string{
+					"kubernetes.io/hostname": "target-migration-precheck",
+				},
+			},
+		},
+	}
+
+	err := f.GenericClient().Create(ctx, vmop, &client.CreateOptions{
+		DryRun: []string{metav1.DryRunAll},
+	})
+	if err == nil {
+		return nil
+	}
+
+	if strings.Contains(err.Error(), "nodeSelector") {
+		return fmt.Errorf("%s=no to disable this precheck: %s feature should be enabled: %w", targetMigrationPrecheckEnvName, targetMigrationFeatureName, err)
+	}
+
+	return fmt.Errorf("%s=no to disable this precheck: failed to check %s feature availability: %w", targetMigrationPrecheckEnvName, targetMigrationFeatureName, err)
+}
+
+func init() {
+	RegisterPrecheck(&targetMigrationPrecheck{}, false)
+}

--- a/test/e2e/internal/precheck/target_migration.go
+++ b/test/e2e/internal/precheck/target_migration.go
@@ -19,7 +19,7 @@ package precheck
 import (
 	"context"
 	"fmt"
-	"strings"
+	"slices"
 
 	. "github.com/onsi/ginkgo/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -68,6 +68,16 @@ func (t *targetMigrationPrecheck) Run(ctx context.Context, f *framework.Framewor
 }
 
 func checkTargetMigrationFeature(ctx context.Context, f *framework.Framework) error {
+	mc, err := f.GetVirtualizationModuleConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("%s=no to disable this precheck: failed to get virtualization module config: %w", targetMigrationPrecheckEnvName, err)
+	}
+
+	enabled := slices.Contains(mc.Spec.Settings.FeatureGates, targetMigrationFeatureName)
+	if !enabled {
+		return fmt.Errorf("%s=no to disable this precheck: %s feature should be enabled", targetMigrationPrecheckEnvName, targetMigrationFeatureName)
+	}
+
 	vmop := &v1alpha2.VirtualMachineOperation{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "target-migration-precheck",
@@ -84,18 +94,14 @@ func checkTargetMigrationFeature(ctx context.Context, f *framework.Framework) er
 		},
 	}
 
-	err := f.GenericClient().Create(ctx, vmop, &client.CreateOptions{
+	err = f.GenericClient().Create(ctx, vmop, &client.CreateOptions{
 		DryRun: []string{metav1.DryRunAll},
 	})
-	if err == nil {
-		return nil
+	if err != nil {
+		return fmt.Errorf("%s=no to disable this precheck: failed to check %s feature availability: %w", targetMigrationPrecheckEnvName, targetMigrationFeatureName, err)
 	}
 
-	if strings.Contains(err.Error(), "nodeSelector") {
-		return fmt.Errorf("%s=no to disable this precheck: %s feature should be enabled: %w", targetMigrationPrecheckEnvName, targetMigrationFeatureName, err)
-	}
-
-	return fmt.Errorf("%s=no to disable this precheck: failed to check %s feature availability: %w", targetMigrationPrecheckEnvName, targetMigrationFeatureName, err)
+	return nil
 }
 
 func init() {

--- a/test/e2e/vm/target_migration.go
+++ b/test/e2e/vm/target_migration.go
@@ -42,7 +42,7 @@ import (
 
 const hostnameLabelKey = "kubernetes.io/hostname"
 
-var _ = Describe("TargetMigration", Label(precheck.NoPrecheck), func() {
+var _ = Describe("TargetMigration", Label(precheck.PrecheckTargetMigration), func() {
 	var (
 		virtualMachine      *v1alpha2.VirtualMachine
 		targetMigrationVMOP *v1alpha2.VirtualMachineOperation


### PR DESCRIPTION
## Description

Adds a dedicated e2e precheck label for TargetMigration tests.

The new precheck verifies that the TargetMigration feature accepts `VirtualMachineOperation.spec.migrate.nodeSelector` via dry-run creation and checks that at least two ready KVM-enabled worker nodes are available before running the target migration e2e scenario.

## Why do we need it, and what problem does it solve?

Target migration e2e tests require both the TargetMigration feature and enough suitable worker nodes. Without a dedicated precheck, the test can fail later with less actionable errors when the environment does not satisfy these requirements.

## What is the expected result?

TargetMigration e2e tests are skipped or fail early with a clear precheck message when the required feature or worker nodes are unavailable. The precheck can be disabled with `TARGET_MIGRATION_PRECHECK=no`.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.