### PR TITLE
fix(core): validate target pvc during disk migration

### DIFF
--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -3,7 +3,7 @@ firmware:
   libvirt: v10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: v1.6.2-v12n.43.1
+  3p-kubevirt: v1.6.2-v12n.43.2
   3p-containerized-data-importer: v1.60.3-v12n.19
   distribution: 2.8.3
 package:

--- a/images/virtualization-artifact/pkg/controller/vd/internal/migration.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/migration.go
@@ -641,18 +641,41 @@ func (h MigrationHandler) createTargetPersistentVolumeClaim(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+
+	if targetPVCName == sourcePVCName && targetPVCName != "" {
+		return nil, fmt.Errorf("target PersistentVolumeClaim %q matches source PersistentVolumeClaim", targetPVCName)
+	}
+
 	switch len(pvcs) {
-	case 1: // only source pvc exists
+	case 1:
+		if pvcs[0].Name != sourcePVCName {
+			return nil, fmt.Errorf("source PersistentVolumeClaim %q was not found", sourcePVCName)
+		}
+		if targetPVCName != "" {
+			return nil, fmt.Errorf("target PersistentVolumeClaim %q was not found", targetPVCName)
+		}
 	case 2:
+		sourcePVCExists := false
+		var targetPVC *corev1.PersistentVolumeClaim
 		for _, pvc := range pvcs {
-			// If TargetPVC is empty, that means previous reconciliation failed and not updated TargetPVC in status.
-			// So, we should use pvc, that is not equal to SourcePVC.
-			if pvc.Name == targetPVCName || pvc.Name != sourcePVCName {
-				return &pvc, nil
+			if pvc.Name == sourcePVCName {
+				sourcePVCExists = true
+				continue
+			}
+			if targetPVCName == "" || pvc.Name == targetPVCName {
+				targetPVC = &pvc
+				break
 			}
 		}
+		if !sourcePVCExists {
+			return nil, fmt.Errorf("source PersistentVolumeClaim %q was not found", sourcePVCName)
+		}
+		if targetPVC != nil {
+			return targetPVC, nil
+		}
+		return nil, fmt.Errorf("target PersistentVolumeClaim %q was not found", targetPVCName)
 	default:
-		return nil, fmt.Errorf("unexpected number of pvcs: %d, please report a bug", len(pvcs))
+		return nil, fmt.Errorf("unexpected number of PersistentVolumeClaims: %d, expected 1 or 2", len(pvcs))
 	}
 
 	pvc := &corev1.PersistentVolumeClaim{

--- a/images/virtualization-artifact/pkg/controller/vd/internal/migration_test.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/migration_test.go
@@ -356,6 +356,84 @@ var _ = Describe("MigrationHandler", func() {
 		})
 	})
 
+	Describe("createTargetPersistentVolumeClaim", func() {
+		var size resource.Quantity
+
+		BeforeEach(func() {
+			size = resource.MustParse("10Gi")
+		})
+
+		It("should return error when target PVC name matches source PVC name", func() {
+			sourcePVC := newEmptyPVC("source-pvc", "default")
+			withOwner(sourcePVC, vd)
+			Expect(fakeClient.Create(ctx, sourcePVC)).To(Succeed())
+
+			pvc, err := migrationHandler.createTargetPersistentVolumeClaim(ctx, vd, storageClass, size, "source-pvc", "source-pvc", corev1.PersistentVolumeBlock, corev1.ReadWriteOnce)
+			Expect(err).To(MatchError(ContainSubstring("matches source PersistentVolumeClaim")))
+			Expect(pvc).To(BeNil())
+		})
+
+		It("should select the only non-source PVC when target PVC name is empty", func() {
+			sourcePVC := newEmptyPVC("source-pvc", "default")
+			withOwner(sourcePVC, vd)
+			Expect(fakeClient.Create(ctx, sourcePVC)).To(Succeed())
+
+			targetPVC := newEmptyPVC("target-pvc", "default")
+			withOwner(targetPVC, vd)
+			Expect(fakeClient.Create(ctx, targetPVC)).To(Succeed())
+
+			pvc, err := migrationHandler.createTargetPersistentVolumeClaim(ctx, vd, storageClass, size, "", "source-pvc", corev1.PersistentVolumeBlock, corev1.ReadWriteOnce)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pvc.Name).To(Equal("target-pvc"))
+		})
+
+		It("should return error when target PVC name is specified but not found", func() {
+			sourcePVC := newEmptyPVC("source-pvc", "default")
+			withOwner(sourcePVC, vd)
+			Expect(fakeClient.Create(ctx, sourcePVC)).To(Succeed())
+
+			otherPVC := newEmptyPVC("other-pvc", "default")
+			withOwner(otherPVC, vd)
+			Expect(fakeClient.Create(ctx, otherPVC)).To(Succeed())
+
+			pvc, err := migrationHandler.createTargetPersistentVolumeClaim(ctx, vd, storageClass, size, "missing-pvc", "source-pvc", corev1.PersistentVolumeBlock, corev1.ReadWriteOnce)
+			Expect(err).To(MatchError(ContainSubstring("target PersistentVolumeClaim \"missing-pvc\" was not found")))
+			Expect(pvc).To(BeNil())
+		})
+
+		It("should select target PVC by name when it is specified and found", func() {
+			sourcePVC := newEmptyPVC("source-pvc", "default")
+			withOwner(sourcePVC, vd)
+			Expect(fakeClient.Create(ctx, sourcePVC)).To(Succeed())
+
+			targetPVC := newEmptyPVC("target-pvc", "default")
+			withOwner(targetPVC, vd)
+			Expect(fakeClient.Create(ctx, targetPVC)).To(Succeed())
+
+			pvc, err := migrationHandler.createTargetPersistentVolumeClaim(ctx, vd, storageClass, size, "target-pvc", "source-pvc", corev1.PersistentVolumeBlock, corev1.ReadWriteOnce)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pvc.Name).To(Equal("target-pvc"))
+		})
+
+		It("should return error when target PVC cannot be selected unambiguously", func() {
+			sourcePVC := newEmptyPVC("source-pvc", "default")
+			withOwner(sourcePVC, vd)
+			Expect(fakeClient.Create(ctx, sourcePVC)).To(Succeed())
+
+			firstPVC := newEmptyPVC("first-pvc", "default")
+			withOwner(firstPVC, vd)
+			Expect(fakeClient.Create(ctx, firstPVC)).To(Succeed())
+
+			secondPVC := newEmptyPVC("second-pvc", "default")
+			withOwner(secondPVC, vd)
+			Expect(fakeClient.Create(ctx, secondPVC)).To(Succeed())
+
+			pvc, err := migrationHandler.createTargetPersistentVolumeClaim(ctx, vd, storageClass, size, "", "source-pvc", corev1.PersistentVolumeBlock, corev1.ReadWriteOnce)
+			Expect(err).To(MatchError(ContainSubstring("unexpected number of PersistentVolumeClaims: 3, expected 1 or 2")))
+			Expect(pvc).To(BeNil())
+		})
+	})
+
 	Describe("handleRevert", func() {
 		BeforeEach(func() {
 			vd.Status.MigrationState = v1alpha2.VirtualDiskMigrationState{


### PR DESCRIPTION
## Description
Improve target PersistentVolumeClaim selection during VirtualDisk migration revert and bump the KubeVirt component version.

The migration controller now validates that source and target PVC names do not match, checks that the source PVC exists, selects the target PVC only when it can be identified safely, and returns explicit errors for inconsistent PVC states.

## Why do we need it, and what problem does it solve?
During local migration revert, the controller could select an unexpected PVC when the target PVC name was missing or inconsistent. This made recovery behavior ambiguous and could hide corrupted migration state.

This fix makes target PVC selection deterministic and fails fast when the PVC set does not match the expected migration state.

## What is the expected result?
1. Start a VirtualDisk local migration revert.
2. Verify that the controller selects the existing target PVC only when it is the single non-source PVC or matches the recorded target PVC name.
3. Verify that reconciliation returns a clear error when source or target PVC state is inconsistent.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: vd
type: fix
summary: Fixed cancellation of virtual disk storage class changes and cancellation of local disk migration.
```
