### PR TITLE
fix(vm): preserve enableParavirtualization=false on update

### DIFF
--- a/api/core/v1alpha2/virtual_machine.go
+++ b/api/core/v1alpha2/virtual_machine.go
@@ -95,7 +95,7 @@ type VirtualMachineSpec struct {
 	// Use the `virtio` bus to connect virtual devices of the VM. Set false to disable `virtio` for this VM.
 	// Note: To use paravirtualization mode, some operating systems require the appropriate drivers to be installed.
 	// +kubebuilder:default:=true
-	EnableParavirtualization bool `json:"enableParavirtualization,omitempty"`
+	EnableParavirtualization *bool `json:"enableParavirtualization,omitempty"`
 
 	// +kubebuilder:default:="Generic"
 	OsType OsType `json:"osType,omitempty"`
@@ -119,6 +119,10 @@ type VirtualMachineSpec struct {
 	// Devices are referenced by name of USBDevice resource in the same namespace.
 	// +kubebuilder:validation:MaxItems:=8
 	USBDevices []USBDeviceSpecRef `json:"usbDevices,omitempty"`
+}
+
+func (s *VirtualMachineSpec) IsParavirtualizationEnabled() bool {
+	return s == nil || s.EnableParavirtualization == nil || *s.EnableParavirtualization
 }
 
 // RunPolicy parameter defines the VM startup policy

--- a/api/core/v1alpha2/zz_generated.deepcopy.go
+++ b/api/core/v1alpha2/zz_generated.deepcopy.go
@@ -3333,6 +3333,11 @@ func (in *VirtualMachineSpec) DeepCopyInto(out *VirtualMachineSpec) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.EnableParavirtualization != nil {
+		in, out := &in.EnableParavirtualization, &out.EnableParavirtualization
+		*out = new(bool)
+		**out = **in
+	}
 	out.CPU = in.CPU
 	in.Memory.DeepCopyInto(&out.Memory)
 	if in.BlockDeviceRefs != nil {

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
@@ -88,7 +88,7 @@ func NewKVVM(currentKVVM *virtv1.VirtualMachine, opts KVVMOptions) *KVVM {
 
 func DefaultOptions(current *v1alpha2.VirtualMachine) KVVMOptions {
 	return KVVMOptions{
-		EnableParavirtualization: current.Spec.EnableParavirtualization,
+		EnableParavirtualization: current.Spec.IsParavirtualizationEnabled(),
 		OsType:                   current.Spec.OsType,
 		DisableHypervSyNIC:       os.Getenv("DISABLE_HYPERV_SYNIC") == "1",
 	}

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
@@ -168,6 +168,8 @@ func applyBlockDeviceRefs(
 	cviByName map[string]*v1alpha2.ClusterVirtualImage,
 	vmbdaByBlockDeviceRef map[v1alpha2.VMBDAObjectRef][]*v1alpha2.VirtualMachineBlockDeviceAttachment,
 ) error {
+	isParavirtualizationEnabled := vm.Spec.IsParavirtualizationEnabled()
+
 	hasExplicitBootOrder := false
 	for _, bd := range vm.Spec.BlockDeviceRefs {
 		if bd.BootOrder != nil {
@@ -201,7 +203,7 @@ func applyBlockDeviceRefs(
 	for i, bd := range vm.Spec.BlockDeviceRefs {
 		diskName := GenerateDiskName(bd.Kind, bd.Name)
 		// When VM is stopped, update disks unconditionally.
-		if isVmRunning && vm.Spec.EnableParavirtualization && len(kvvmVolumes) > 0 && !slices.ContainsFunc(kvvmVolumes, func(v virtv1.Volume) bool { return v.Name == diskName }) {
+		if isVmRunning && isParavirtualizationEnabled && len(kvvmVolumes) > 0 && !slices.ContainsFunc(kvvmVolumes, func(v virtv1.Volume) bool { return v.Name == diskName }) {
 			continue
 		}
 
@@ -215,7 +217,7 @@ func applyBlockDeviceRefs(
 		}
 
 		_, hotpluggable := hotpluggableVolumes[diskName]
-		if err := setBlockDeviceDisk(kvvm, bd, kvBootOrder, hotpluggable || (vm.Spec.EnableParavirtualization && !isVmRunning), vdByName, viByName, cviByName); err != nil {
+		if err := setBlockDeviceDisk(kvvm, bd, kvBootOrder, hotpluggable || (isParavirtualizationEnabled && !isVmRunning), vdByName, viByName, cviByName); err != nil {
 			return err
 		}
 	}

--- a/images/virtualization-artifact/pkg/controller/vm/internal/hotplug_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/hotplug_handler.go
@@ -57,7 +57,7 @@ func (h *HotplugHandler) Handle(ctx context.Context, s state.VirtualMachineState
 		return reconcile.Result{}, err
 	}
 
-	if !current.Spec.EnableParavirtualization {
+	if !current.Spec.IsParavirtualizationEnabled() {
 		return reconcile.Result{}, nil
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vm/internal/hotplug_handler_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/hotplug_handler_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	virtv1 "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -65,7 +66,7 @@ var _ = Describe("HotplugHandler", func() {
 		return &v1alpha2.VirtualMachine{
 			ObjectMeta: metav1.ObjectMeta{Name: vmName, Namespace: vmNamespace},
 			Spec: v1alpha2.VirtualMachineSpec{
-				EnableParavirtualization: true,
+				EnableParavirtualization: ptr.To(true),
 				BlockDeviceRefs:          bdRefs,
 			},
 			Status: v1alpha2.VirtualMachineStatus{
@@ -291,7 +292,7 @@ var _ = Describe("HotplugHandler", func() {
 			vm := newVM(v1alpha2.MachineRunning, v1alpha2.BlockDeviceSpecRef{
 				Kind: v1alpha2.DiskDevice, Name: vdName,
 			})
-			vm.Spec.EnableParavirtualization = false
+			vm.Spec.EnableParavirtualization = ptr.To(false)
 			kvvm := newKVVM(nil)
 			kvvmi := newEmptyKVVMI(vmName, vmNamespace)
 			vd := newVD(vdName, vdPVCName)
@@ -305,7 +306,7 @@ var _ = Describe("HotplugHandler", func() {
 
 		It("should not unplug a hotpluggable disk removed from spec", func() {
 			vm := newVM(v1alpha2.MachineRunning)
-			vm.Spec.EnableParavirtualization = false
+			vm.Spec.EnableParavirtualization = ptr.To(false)
 			kvvm := newKVVM([]virtv1.Volume{
 				{
 					Name: "vd-" + vdName,

--- a/images/virtualization-artifact/pkg/controller/vm/internal/validators/block_device_refs_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/validators/block_device_refs_validator.go
@@ -74,7 +74,7 @@ func (v *BlockDeviceSpecRefsValidator) ValidateCreate(_ context.Context, vm *v1a
 func (v *BlockDeviceSpecRefsValidator) ValidateUpdate(_ context.Context, oldVM, newVM *v1alpha2.VirtualMachine) (admission.Warnings, error) {
 	var warnings admission.Warnings
 
-	if !newVM.Spec.EnableParavirtualization && hasBlockDeviceChanges(oldVM, newVM) {
+	if !newVM.Spec.IsParavirtualizationEnabled() && hasBlockDeviceChanges(oldVM, newVM) {
 		warnings = append(warnings, "Hot-plugging block devices with enableParavirtualization=false is not supported. Restart the VM to apply changes.")
 	}
 

--- a/images/virtualization-artifact/pkg/controller/vmchange/comparator_block_devices.go
+++ b/images/virtualization-artifact/pkg/controller/vmchange/comparator_block_devices.go
@@ -79,7 +79,7 @@ func compareBlockDevices(current, desired *v1alpha2.VirtualMachineSpec) []FieldC
 		itemPath := blockDevicesItemPath(idx)
 
 		action := ActionApplyImmediate
-		if !current.EnableParavirtualization {
+		if !current.IsParavirtualizationEnabled() {
 			action = ActionRestart
 		}
 

--- a/images/virtualization-artifact/pkg/controller/vmchange/comparator_operations.go
+++ b/images/virtualization-artifact/pkg/controller/vmchange/comparator_operations.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package vmchange
 
-import "k8s.io/apimachinery/pkg/api/resource"
+import (
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/ptr"
+)
 
 func compareStrings(path, current, desired, defaultValue string, onChange ActionType) []FieldChange {
 	currentValue := NewStringValue(current, defaultValue)
@@ -53,10 +56,15 @@ func comparePtrInt64(path string, current, desired *int64, defaultValue int64, o
 	return compareValues(path, currentValue, desiredValue, isEqual, onChange)
 }
 
-func compareBools(path string, current, desired, defaultValue bool, onChange ActionType) []FieldChange {
-	currentValue := NewBoolValue(current, defaultValue)
-	desiredValue := NewBoolValue(desired, defaultValue)
-	isEqual := current == desired
+func comparePtrBools(path string, current, desired *bool, defaultValue bool, onChange ActionType) []FieldChange {
+	if current == nil && desired == nil {
+		return nil
+	}
+
+	isEqual := ptr.Equal(current, desired)
+	currentValue := NewPtrBoolValue(current, defaultValue)
+	desiredValue := NewPtrBoolValue(desired, defaultValue)
+
 	return compareValues(path, currentValue, desiredValue, isEqual, onChange)
 }
 

--- a/images/virtualization-artifact/pkg/controller/vmchange/comparators.go
+++ b/images/virtualization-artifact/pkg/controller/vmchange/comparators.go
@@ -93,7 +93,7 @@ func compareTerminationGracePeriodSeconds(current, desired *v1alpha2.VirtualMach
 }
 
 func compareEnableParavirtualization(current, desired *v1alpha2.VirtualMachineSpec) []FieldChange {
-	return compareBools(
+	return comparePtrBools(
 		"enableParavirtualization",
 		current.EnableParavirtualization,
 		desired.EnableParavirtualization,

--- a/test/performance/tools/shatal/internal/shatal/creator.go
+++ b/test/performance/tools/shatal/internal/shatal/creator.go
@@ -110,11 +110,10 @@ func (s *Creator) createVMs(ctx context.Context) {
 				},
 			},
 			Spec: v1alpha2.VirtualMachineSpec{
-				VirtualMachineClassName:  "generic-v1",
-				RunPolicy:                v1alpha2.AlwaysOnPolicy,
-				EnableParavirtualization: true,
-				OsType:                   v1alpha2.GenericOs,
-				Bootloader:               "BIOS",
+				VirtualMachineClassName: "generic-v1",
+				RunPolicy:               v1alpha2.AlwaysOnPolicy,
+				OsType:                  v1alpha2.GenericOs,
+				Bootloader:              "BIOS",
 				CPU: v1alpha2.CPUSpec{
 					Cores:        1,
 					CoreFraction: "10%",


### PR DESCRIPTION
## Description
Preserve explicit `spec.enableParavirtualization: false` on VirtualMachine updates.

The VM API now stores `enableParavirtualization` as a pointer, so the controller can distinguish an omitted value from an explicitly disabled one while keeping the default enabled behavior for existing manifests. The VM builder, hotplug handler, block device validator, VM change comparator, and performance VM creator were updated to use nil-aware paravirtualization checks.

## Why do we need it, and what problem does it solve?
Previously, `enableParavirtualization` was a non-pointer boolean with `omitempty` and a default value of `true`. This made an explicit `false` value indistinguishable from an omitted field in update flows, so a VM could unexpectedly return to the default paravirtualized behavior after an update.

This fix preserves the user's explicit choice to disable paravirtualization and keeps block device hotplug/change handling consistent with that setting.

## What is the expected result?
1. Create or update a VirtualMachine with `spec.enableParavirtualization: false`.
2. Update other VirtualMachine fields.
3. Verify that `spec.enableParavirtualization` remains `false`.
4. Verify that block device changes for this VM still require a restart instead of being handled as paravirtualized hotplug operations.
5. Verify that VirtualMachines without this field set keep the default paravirtualization-enabled behavior.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: core
type: fix
summary: Preserve explicit enableParavirtualization=false value during VirtualMachine updates.
impact_level: low
```
