### PR TITLE
fix(vm): revert migrated volumes when kvvmi is missing

### DIFF
--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
@@ -355,16 +355,19 @@ func setVMBDABlockDeviceDisk(
 ) error {
 	switch ref.Kind {
 	case v1alpha2.VMBDAObjectRefKindVirtualDisk:
+		name := GenerateVDDiskName(ref.Name)
 		vd, ok := vdByName[ref.Name]
 		if !ok || vd == nil {
-			return fmt.Errorf("unexpected error: virtual disk %q should exist in the cluster; please recreate it", ref.Name)
-		}
-
-		if vd.Status.Phase == v1alpha2.DiskTerminating || vd.Status.Target.PersistentVolumeClaim == "" {
+			removeDisk(kvvm, name)
 			return nil
 		}
 
-		return kvvm.SetDisk(GenerateVDDiskName(ref.Name), SetDiskOptions{
+		if vd.Status.Phase == v1alpha2.DiskTerminating || vd.Status.Target.PersistentVolumeClaim == "" {
+			removeDisk(kvvm, name)
+			return nil
+		}
+
+		return kvvm.SetDisk(name, SetDiskOptions{
 			PersistentVolumeClaim: ptr.To(vd.Status.Target.PersistentVolumeClaim),
 			Serial:                GenerateSerialFromObject(vd),
 			IsHotplugged:          true,
@@ -376,6 +379,17 @@ func setVMBDABlockDeviceDisk(
 	default:
 		return fmt.Errorf("unknown VMBDA block device kind %q. %w", ref.Kind, common.ErrUnknownType)
 	}
+}
+
+func removeDisk(kvvm *KVVM, name string) {
+	kvvm.Resource.Spec.Template.Spec.Domain.Devices.Disks = slices.DeleteFunc(
+		kvvm.Resource.Spec.Template.Spec.Domain.Devices.Disks,
+		func(d virtv1.Disk) bool { return d.Name == name },
+	)
+	kvvm.Resource.Spec.Template.Spec.Volumes = slices.DeleteFunc(
+		kvvm.Resource.Spec.Template.Spec.Volumes,
+		func(v virtv1.Volume) bool { return v.Name == name },
+	)
 }
 
 func ApplyMigrationVolumes(kvvm *KVVM, vm *v1alpha2.VirtualMachine, vdsByName map[string]*v1alpha2.VirtualDisk) error {

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
@@ -360,7 +360,7 @@ func setVMBDABlockDeviceDisk(
 			return fmt.Errorf("unexpected error: virtual disk %q should exist in the cluster; please recreate it", ref.Name)
 		}
 
-		if vd.Status.Target.PersistentVolumeClaim == "" {
+		if vd.Status.Phase == v1alpha2.DiskTerminating || vd.Status.Target.PersistentVolumeClaim == "" {
 			return nil
 		}
 

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
@@ -220,6 +220,10 @@ func applyBlockDeviceRefs(
 		}
 	}
 
+	if err := syncAttachedVMBDAHotplugVolumes(kvvm, vdByName, viByName, cviByName, vmbdaByBlockDeviceRef); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -252,6 +256,33 @@ func cleanupRemovedStaticDisks(kvvm *KVVM, specDiskNames, hotpluggableVolumes, v
 		kvvm.Resource.Spec.Template.Spec.Volumes,
 		func(v virtv1.Volume) bool { return isRemovedStatic(v.Name) },
 	)
+}
+
+func syncAttachedVMBDAHotplugVolumes(
+	kvvm *KVVM,
+	vdByName map[string]*v1alpha2.VirtualDisk,
+	viByName map[string]*v1alpha2.VirtualImage,
+	cviByName map[string]*v1alpha2.ClusterVirtualImage,
+	vmbdaByBlockDeviceRef map[v1alpha2.VMBDAObjectRef][]*v1alpha2.VirtualMachineBlockDeviceAttachment,
+) error {
+	kvvmVolumes := kvvm.Resource.Spec.Template.Spec.Volumes
+
+	for ref := range vmbdaByBlockDeviceRef {
+		diskName := GenerateDiskName(v1alpha2.BlockDeviceKind(ref.Kind), ref.Name)
+		if diskName == "" {
+			continue
+		}
+
+		if !slices.ContainsFunc(kvvmVolumes, func(v virtv1.Volume) bool { return v.Name == diskName }) {
+			continue
+		}
+
+		if err := setVMBDABlockDeviceDisk(kvvm, ref, vdByName, viByName, cviByName); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func setBlockDeviceDisk(
@@ -312,6 +343,38 @@ func setBlockDeviceDisk(
 
 	default:
 		return fmt.Errorf("unknown block device kind %q. %w", bd.Kind, common.ErrUnknownType)
+	}
+}
+
+func setVMBDABlockDeviceDisk(
+	kvvm *KVVM,
+	ref v1alpha2.VMBDAObjectRef,
+	vdByName map[string]*v1alpha2.VirtualDisk,
+	viByName map[string]*v1alpha2.VirtualImage,
+	cviByName map[string]*v1alpha2.ClusterVirtualImage,
+) error {
+	switch ref.Kind {
+	case v1alpha2.VMBDAObjectRefKindVirtualDisk:
+		vd, ok := vdByName[ref.Name]
+		if !ok || vd == nil {
+			return fmt.Errorf("unexpected error: virtual disk %q should exist in the cluster; please recreate it", ref.Name)
+		}
+
+		if vd.Status.Target.PersistentVolumeClaim == "" {
+			return nil
+		}
+
+		return kvvm.SetDisk(GenerateVDDiskName(ref.Name), SetDiskOptions{
+			PersistentVolumeClaim: ptr.To(vd.Status.Target.PersistentVolumeClaim),
+			Serial:                GenerateSerialFromObject(vd),
+			IsHotplugged:          true,
+		})
+	case v1alpha2.VMBDAObjectRefKindVirtualImage:
+		return setBlockDeviceDisk(kvvm, v1alpha2.BlockDeviceSpecRef{Kind: v1alpha2.ImageDevice, Name: ref.Name}, 0, true, vdByName, viByName, cviByName)
+	case v1alpha2.VMBDAObjectRefKindClusterVirtualImage:
+		return setBlockDeviceDisk(kvvm, v1alpha2.BlockDeviceSpecRef{Kind: v1alpha2.ClusterImageDevice, Name: ref.Name}, 0, true, vdByName, viByName, cviByName)
+	default:
+		return fmt.Errorf("unknown VMBDA block device kind %q. %w", ref.Kind, common.ErrUnknownType)
 	}
 }
 

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils_test.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils_test.go
@@ -99,6 +99,30 @@ var _ = Describe("syncAttachedVMBDAHotplugVolumes", func() {
 		Expect(kvvm.Resource.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim).NotTo(BeNil())
 		Expect(kvvm.Resource.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName).To(Equal(sourcePVC))
 	})
+
+	It("should skip terminating VirtualDisk attached via VMBDA", func() {
+		kvvm := NewEmptyKVVM(namespacedName(vmName, vmNamespace), KVVMOptions{})
+		vd := &v1alpha2.VirtualDisk{
+			ObjectMeta: metav1.ObjectMeta{Name: diskName, Namespace: vmNamespace},
+			Status: v1alpha2.VirtualDiskStatus{
+				Phase:  v1alpha2.DiskTerminating,
+				Target: v1alpha2.DiskTarget{PersistentVolumeClaim: sourcePVC},
+			},
+		}
+
+		err := syncAttachedVMBDAHotplugVolumes(
+			kvvm,
+			map[string]*v1alpha2.VirtualDisk{diskName: vd},
+			nil,
+			nil,
+			map[v1alpha2.VMBDAObjectRef][]*v1alpha2.VirtualMachineBlockDeviceAttachment{
+				{Kind: v1alpha2.VMBDAObjectRefKindVirtualDisk, Name: diskName}: nil,
+			},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvvm.Resource.Spec.Template.Spec.Volumes).To(BeEmpty())
+		Expect(kvvm.Resource.Spec.Template.Spec.Domain.Devices.Disks).To(BeEmpty())
+	})
 })
 
 var _ = Describe("ApplyMigrationVolumes", func() {

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils_test.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils_test.go
@@ -20,9 +20,139 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	virtv1 "kubevirt.io/api/core/v1"
+
+	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
 )
+
+func newKVVMWithVMBDAVolume(vmName, vmNamespace, diskName, pvcName string) *KVVM {
+	kvvm := NewEmptyKVVM(
+		namespacedName(vmName, vmNamespace),
+		KVVMOptions{},
+	)
+	kvvm.Resource.Spec.Template.Spec.Volumes = []virtv1.Volume{
+		{
+			Name: GenerateVDDiskName(diskName),
+			VolumeSource: virtv1.VolumeSource{
+				PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{
+					PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: pvcName,
+					},
+					Hotpluggable: true,
+				},
+			},
+		},
+	}
+	kvvm.Resource.Spec.Template.Spec.Domain.Devices.Disks = []virtv1.Disk{
+		{Name: GenerateVDDiskName(diskName)},
+	}
+	return kvvm
+}
+
+var _ = Describe("syncAttachedVMBDAHotplugVolumes", func() {
+	const (
+		vmName      = "test-vm"
+		vmNamespace = "test-ns"
+		diskName    = "data-disk"
+		sourcePVC   = "pvc-source"
+		targetPVC   = "pvc-target"
+	)
+
+	It("should switch existing VMBDA volume back to source PVC after migration rollback", func() {
+		kvvm := newKVVMWithVMBDAVolume(vmName, vmNamespace, diskName, targetPVC)
+		vd := &v1alpha2.VirtualDisk{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       diskName,
+				Namespace:  vmNamespace,
+				UID:        "vd-uid",
+				Generation: 2,
+			},
+			Status: v1alpha2.VirtualDiskStatus{
+				Target: v1alpha2.DiskTarget{PersistentVolumeClaim: sourcePVC},
+				Conditions: []metav1.Condition{{
+					Type:               vdcondition.MigratingType.String(),
+					Status:             metav1.ConditionFalse,
+					ObservedGeneration: 2,
+					Reason:             "MigrationReverted",
+				}},
+				MigrationState: v1alpha2.VirtualDiskMigrationState{
+					SourcePVC: sourcePVC,
+					TargetPVC: targetPVC,
+				},
+			},
+		}
+
+		err := syncAttachedVMBDAHotplugVolumes(
+			kvvm,
+			map[string]*v1alpha2.VirtualDisk{diskName: vd},
+			nil,
+			nil,
+			map[v1alpha2.VMBDAObjectRef][]*v1alpha2.VirtualMachineBlockDeviceAttachment{
+				{Kind: v1alpha2.VMBDAObjectRefKindVirtualDisk, Name: diskName}: nil,
+			},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvvm.Resource.Spec.Template.Spec.Volumes).To(HaveLen(1))
+		Expect(kvvm.Resource.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim).NotTo(BeNil())
+		Expect(kvvm.Resource.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName).To(Equal(sourcePVC))
+	})
+})
+
+var _ = Describe("ApplyMigrationVolumes", func() {
+	const (
+		vmName      = "test-vm"
+		vmNamespace = "test-ns"
+		diskName    = "data-disk"
+		sourcePVC   = "pvc-source"
+		targetPVC   = "pvc-target"
+	)
+
+	It("should switch hotplugged VMBDA disk to migration target PVC", func() {
+		kvvm := newKVVMWithVMBDAVolume(vmName, vmNamespace, diskName, sourcePVC)
+		vm := &v1alpha2.VirtualMachine{
+			Status: v1alpha2.VirtualMachineStatus{
+				BlockDeviceRefs: []v1alpha2.BlockDeviceStatusRef{
+					{
+						Kind:       v1alpha2.DiskDevice,
+						Name:       diskName,
+						Hotplugged: true,
+					},
+				},
+			},
+		}
+		vd := &v1alpha2.VirtualDisk{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       diskName,
+				Namespace:  vmNamespace,
+				UID:        "vd-uid",
+				Generation: 1,
+			},
+			Status: v1alpha2.VirtualDiskStatus{
+				Target: v1alpha2.DiskTarget{PersistentVolumeClaim: sourcePVC},
+				Conditions: []metav1.Condition{{
+					Type:               vdcondition.MigratingType.String(),
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 1,
+					Reason:             "Migrating",
+				}},
+				MigrationState: v1alpha2.VirtualDiskMigrationState{
+					SourcePVC: sourcePVC,
+					TargetPVC: targetPVC,
+				},
+			},
+		}
+
+		err := ApplyMigrationVolumes(kvvm, vm, map[string]*v1alpha2.VirtualDisk{diskName: vd})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvvm.Resource.Spec.Template.Spec.Volumes).To(HaveLen(1))
+		Expect(kvvm.Resource.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim).NotTo(BeNil())
+		Expect(kvvm.Resource.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName).To(Equal(targetPVC))
+		Expect(kvvm.Resource.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.Hotpluggable).To(BeTrue())
+	})
+})
 
 var _ = Describe("cleanupRemovedStaticDisks", func() {
 	const (

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils_test.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils_test.go
@@ -28,9 +28,9 @@ import (
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
 )
 
-func newKVVMWithVMBDAVolume(vmName, vmNamespace, diskName, pvcName string) *KVVM {
+func newKVVMWithVMBDAVolume(vmNamespace, diskName, pvcName string) *KVVM {
 	kvvm := NewEmptyKVVM(
-		namespacedName(vmName, vmNamespace),
+		namespacedName("test-vm", vmNamespace),
 		KVVMOptions{},
 	)
 	kvvm.Resource.Spec.Template.Spec.Volumes = []virtv1.Volume{
@@ -62,7 +62,7 @@ var _ = Describe("syncAttachedVMBDAHotplugVolumes", func() {
 	)
 
 	It("should switch existing VMBDA volume back to source PVC after migration rollback", func() {
-		kvvm := newKVVMWithVMBDAVolume(vmName, vmNamespace, diskName, targetPVC)
+		kvvm := newKVVMWithVMBDAVolume(vmNamespace, diskName, targetPVC)
 		vd := &v1alpha2.VirtualDisk{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       diskName,
@@ -101,7 +101,7 @@ var _ = Describe("syncAttachedVMBDAHotplugVolumes", func() {
 	})
 
 	It("should remove terminating VirtualDisk attached via VMBDA", func() {
-		kvvm := newKVVMWithVMBDAVolume(vmName, vmNamespace, diskName, sourcePVC)
+		kvvm := newKVVMWithVMBDAVolume(vmNamespace, diskName, sourcePVC)
 		vd := &v1alpha2.VirtualDisk{
 			ObjectMeta: metav1.ObjectMeta{Name: diskName, Namespace: vmNamespace},
 			Status: v1alpha2.VirtualDiskStatus{
@@ -125,7 +125,7 @@ var _ = Describe("syncAttachedVMBDAHotplugVolumes", func() {
 	})
 
 	It("should remove missing VirtualDisk attached via VMBDA", func() {
-		kvvm := newKVVMWithVMBDAVolume(vmName, vmNamespace, diskName, sourcePVC)
+		kvvm := newKVVMWithVMBDAVolume(vmNamespace, diskName, sourcePVC)
 
 		err := syncAttachedVMBDAHotplugVolumes(
 			kvvm,
@@ -152,7 +152,7 @@ var _ = Describe("ApplyMigrationVolumes", func() {
 	)
 
 	It("should switch hotplugged VMBDA disk to migration target PVC", func() {
-		kvvm := newKVVMWithVMBDAVolume(vmName, vmNamespace, diskName, sourcePVC)
+		kvvm := newKVVMWithVMBDAVolume(vmNamespace, diskName, sourcePVC)
 		vm := &v1alpha2.VirtualMachine{
 			Status: v1alpha2.VirtualMachineStatus{
 				BlockDeviceRefs: []v1alpha2.BlockDeviceStatusRef{

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils_test.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils_test.go
@@ -28,7 +28,12 @@ import (
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
 )
 
-func newKVVMWithVMBDAVolume(vmNamespace, diskName, pvcName string) *KVVM {
+func newKVVMWithVMBDAVolume(pvcName string) *KVVM {
+	const (
+		vmNamespace = "test-ns"
+		diskName    = "data-disk"
+	)
+
 	kvvm := NewEmptyKVVM(
 		namespacedName("test-vm", vmNamespace),
 		KVVMOptions{},
@@ -62,7 +67,7 @@ var _ = Describe("syncAttachedVMBDAHotplugVolumes", func() {
 	)
 
 	It("should switch existing VMBDA volume back to source PVC after migration rollback", func() {
-		kvvm := newKVVMWithVMBDAVolume(vmNamespace, diskName, targetPVC)
+		kvvm := newKVVMWithVMBDAVolume(targetPVC)
 		vd := &v1alpha2.VirtualDisk{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       diskName,
@@ -101,7 +106,7 @@ var _ = Describe("syncAttachedVMBDAHotplugVolumes", func() {
 	})
 
 	It("should remove terminating VirtualDisk attached via VMBDA", func() {
-		kvvm := newKVVMWithVMBDAVolume(vmNamespace, diskName, sourcePVC)
+		kvvm := newKVVMWithVMBDAVolume(sourcePVC)
 		vd := &v1alpha2.VirtualDisk{
 			ObjectMeta: metav1.ObjectMeta{Name: diskName, Namespace: vmNamespace},
 			Status: v1alpha2.VirtualDiskStatus{
@@ -125,7 +130,7 @@ var _ = Describe("syncAttachedVMBDAHotplugVolumes", func() {
 	})
 
 	It("should remove missing VirtualDisk attached via VMBDA", func() {
-		kvvm := newKVVMWithVMBDAVolume(vmNamespace, diskName, sourcePVC)
+		kvvm := newKVVMWithVMBDAVolume(sourcePVC)
 
 		err := syncAttachedVMBDAHotplugVolumes(
 			kvvm,
@@ -152,7 +157,7 @@ var _ = Describe("ApplyMigrationVolumes", func() {
 	)
 
 	It("should switch hotplugged VMBDA disk to migration target PVC", func() {
-		kvvm := newKVVMWithVMBDAVolume(vmNamespace, diskName, sourcePVC)
+		kvvm := newKVVMWithVMBDAVolume(sourcePVC)
 		vm := &v1alpha2.VirtualMachine{
 			Status: v1alpha2.VirtualMachineStatus{
 				BlockDeviceRefs: []v1alpha2.BlockDeviceStatusRef{

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils_test.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils_test.go
@@ -100,8 +100,8 @@ var _ = Describe("syncAttachedVMBDAHotplugVolumes", func() {
 		Expect(kvvm.Resource.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName).To(Equal(sourcePVC))
 	})
 
-	It("should skip terminating VirtualDisk attached via VMBDA", func() {
-		kvvm := NewEmptyKVVM(namespacedName(vmName, vmNamespace), KVVMOptions{})
+	It("should remove terminating VirtualDisk attached via VMBDA", func() {
+		kvvm := newKVVMWithVMBDAVolume(vmName, vmNamespace, diskName, sourcePVC)
 		vd := &v1alpha2.VirtualDisk{
 			ObjectMeta: metav1.ObjectMeta{Name: diskName, Namespace: vmNamespace},
 			Status: v1alpha2.VirtualDiskStatus{
@@ -113,6 +113,23 @@ var _ = Describe("syncAttachedVMBDAHotplugVolumes", func() {
 		err := syncAttachedVMBDAHotplugVolumes(
 			kvvm,
 			map[string]*v1alpha2.VirtualDisk{diskName: vd},
+			nil,
+			nil,
+			map[v1alpha2.VMBDAObjectRef][]*v1alpha2.VirtualMachineBlockDeviceAttachment{
+				{Kind: v1alpha2.VMBDAObjectRefKindVirtualDisk, Name: diskName}: nil,
+			},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvvm.Resource.Spec.Template.Spec.Volumes).To(BeEmpty())
+		Expect(kvvm.Resource.Spec.Template.Spec.Domain.Devices.Disks).To(BeEmpty())
+	})
+
+	It("should remove missing VirtualDisk attached via VMBDA", func() {
+		kvvm := newKVVMWithVMBDAVolume(vmName, vmNamespace, diskName, sourcePVC)
+
+		err := syncAttachedVMBDAHotplugVolumes(
+			kvvm,
+			map[string]*v1alpha2.VirtualDisk{},
 			nil,
 			nil,
 			map[v1alpha2.VMBDAObjectRef][]*v1alpha2.VirtualMachineBlockDeviceAttachment{

--- a/images/virtualization-artifact/pkg/controller/vm/internal/service/migration_volumes.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/service/migration_volumes.go
@@ -104,8 +104,18 @@ func (s MigrationVolumesService) SyncVolumes(ctx context.Context, vmState state.
 		return reconcile.Result{}, err
 	}
 
-	if kvvmInCluster == nil || kvvmiInCluster == nil {
-		log.Info("Virtualmachine or kvvmi is nil, skip volume migration.")
+	if kvvmInCluster == nil {
+		log.Info("Virtualmachine is nil, skip volume migration.")
+		return reconcile.Result{}, nil
+	}
+
+	if kvvmiInCluster == nil {
+		if s.shouldPatchVolumes(kvvmInCluster, builtKVVM) {
+			log.Info("kvvmi is nil, force revert kvvm volumes to source volumes.")
+			return reconcile.Result{}, s.patchVolumes(ctx, builtKVVM)
+		}
+
+		log.Info("kvvmi is nil and kvvm volumes are already reverted, skip volume migration.")
 		return reconcile.Result{}, nil
 	}
 
@@ -250,6 +260,12 @@ func (s MigrationVolumesService) patchVolumes(ctx context.Context, kvvm *virtv1.
 
 	err = s.client.Patch(ctx, kvvm, client.RawPatch(types.JSONPatchType, patchBytes))
 	return err
+}
+
+func (s MigrationVolumesService) shouldPatchVolumes(currentKVVM, desiredKVVM *virtv1.VirtualMachine) bool {
+	return !equality.Semantic.DeepEqual(currentKVVM.Spec.UpdateVolumesStrategy, desiredKVVM.Spec.UpdateVolumesStrategy) ||
+		!equality.Semantic.DeepEqual(currentKVVM.Spec.Template.Spec.Volumes, desiredKVVM.Spec.Template.Spec.Volumes) ||
+		!equality.Semantic.DeepEqual(currentKVVM.Spec.Template.Spec.Affinity, desiredKVVM.Spec.Template.Spec.Affinity)
 }
 
 func (s MigrationVolumesService) VolumesSynced(ctx context.Context, vmState state.VirtualMachineState) (bool, error) {

--- a/images/virtualization-artifact/pkg/controller/vm/internal/service/migration_volumes_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/service/migration_volumes_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	virtv1 "kubevirt.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/deckhouse/virtualization-controller/pkg/common/testutil"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/reconciler"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/vm/internal/state"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+)
+
+var _ = Describe("MigrationVolumesService", func() {
+	const (
+		vmName    = "vm-test"
+		namespace = "default"
+		sourcePVC = "disk-source"
+		targetPVC = "disk-target"
+	)
+
+	newVM := func() *v1alpha2.VirtualMachine {
+		return &v1alpha2.VirtualMachine{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: v1alpha2.SchemeGroupVersion.String(),
+				Kind:       v1alpha2.VirtualMachineKind,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       vmName,
+				Namespace:  namespace,
+				Generation: 1,
+			},
+			Spec: v1alpha2.VirtualMachineSpec{},
+		}
+	}
+
+	newKVVMWithVolume := func(pvcName string, strategy *virtv1.UpdateVolumesStrategy, nodeLabel string) *virtv1.VirtualMachine {
+		return &virtv1.VirtualMachine{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: virtv1.GroupVersion.String(),
+				Kind:       "VirtualMachine",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      vmName,
+				Namespace: namespace,
+			},
+			Spec: virtv1.VirtualMachineSpec{
+				UpdateVolumesStrategy: strategy,
+				Template: &virtv1.VirtualMachineInstanceTemplateSpec{
+					Spec: virtv1.VirtualMachineInstanceSpec{
+						Affinity: &corev1.Affinity{
+							NodeAffinity: &corev1.NodeAffinity{
+								RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+									NodeSelectorTerms: []corev1.NodeSelectorTerm{
+										{
+											MatchExpressions: []corev1.NodeSelectorRequirement{
+												{
+													Key:      "kubernetes.io/hostname",
+													Operator: corev1.NodeSelectorOpIn,
+													Values:   []string{nodeLabel},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						Volumes: []virtv1.Volume{
+							{
+								Name: "rootdisk",
+								VolumeSource: virtv1.VolumeSource{
+									PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{
+										PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+											ClaimName: pvcName,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	setupState := func(vm *v1alpha2.VirtualMachine, objs ...client.Object) state.VirtualMachineState {
+		allObjects := append([]client.Object{vm}, objs...)
+		fakeClient, err := testutil.NewFakeClientWithObjects(allObjects...)
+		Expect(err).NotTo(HaveOccurred())
+
+		resource := reconciler.NewResource(client.ObjectKeyFromObject(vm), fakeClient,
+			func() *v1alpha2.VirtualMachine {
+				return &v1alpha2.VirtualMachine{}
+			},
+			func(obj *v1alpha2.VirtualMachine) v1alpha2.VirtualMachineStatus {
+				return obj.Status
+			},
+		)
+		Expect(resource.Fetch(context.Background())).To(Succeed())
+
+		return state.New(fakeClient, resource)
+	}
+
+	It("forces volume rollback when kvvmi is missing", func() {
+		ctx := testutil.ContextBackgroundWithNoOpLogger()
+		migrationStrategy := virtv1.UpdateVolumesStrategyMigration
+
+		vm := newVM()
+		kvvmInCluster := newKVVMWithVolume(targetPVC, &migrationStrategy, "target-node")
+		desiredKVVM := newKVVMWithVolume(sourcePVC, nil, "source-node")
+		vmState := setupState(vm, kvvmInCluster)
+
+		service := NewMigrationVolumesService(
+			vmState.Client(),
+			func(context.Context, state.VirtualMachineState) (*virtv1.VirtualMachine, error) {
+				return desiredKVVM.DeepCopy(), nil
+			},
+			10*time.Second,
+		)
+
+		_, err := service.SyncVolumes(ctx, vmState, false)
+		Expect(err).NotTo(HaveOccurred())
+
+		updatedKVVM := &virtv1.VirtualMachine{}
+		Expect(vmState.Client().Get(ctx, types.NamespacedName{Name: vmName, Namespace: namespace}, updatedKVVM)).To(Succeed())
+		Expect(updatedKVVM.Spec.UpdateVolumesStrategy).To(BeNil())
+		Expect(updatedKVVM.Spec.Template.Spec.Volumes).To(HaveLen(1))
+		Expect(updatedKVVM.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim).NotTo(BeNil())
+		Expect(updatedKVVM.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName).To(Equal(sourcePVC))
+		Expect(updatedKVVM.Spec.Template.Spec.Affinity).To(Equal(desiredKVVM.Spec.Template.Spec.Affinity))
+	})
+})

--- a/images/virtualization-artifact/pkg/controller/vm/internal/service/suite_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/service/suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMigrationVolumesService(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "MigrationVolumesService Suite")
+}


### PR DESCRIPTION
## Description
The fix restores migrated volumes in `kvvm.spec` when `kvvmi` is already missing.

It also fixes the VMBDA case: existing hotplug volumes are now rebuilt from the current `VirtualDisk.Status.Target.PersistentVolumeClaim`, so after migration rollback they no longer keep a stale target PVC in `kvvm.spec`.

## Why do we need it, and what problem does it solve?
A user could hit this during the following flow:
- a VM uses at least one local-storage disk, including a disk attached through VMBDA;
- VM eviction starts volume migration;
- migration fails;
- the user uncordons nodes and requests VM restart;
- `kvvmi` is already deleted, while `kvvm.spec` still points to migrated target PVCs.

In that state KubeVirt sets `ManualRecoveryRequired` and refuses to start the VM. The controller could not revert volumes without `kvvmi`, and VMBDA hotplug volumes could also keep stale PVCs because they were preserved in `kvvm.spec` but not rebuilt from the current disk state.

This change makes the controller restore source PVCs in both cases, which unblocks VM recovery after failed migration.

## What is the expected result?
Reproduce with a VM that has a local-storage disk, including a VMBDA-attached disk:
- cordon all nodes;
- start VM eviction;
- wait until the eviction/migration operation fails;
- uncordon nodes;
- request VM restart.

Expected result:
- migrated target PVCs are restored back to source PVCs in `kvvm.spec`;
- VMBDA hotplug volumes are also rebuilt from the current PVC state;
- `ManualRecoveryRequired` no longer blocks recovery in this case;
- the VM starts again without manual `kvvm.spec` editing.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: vm
type: fix
summary: "A VM can start again after a failed local-disk migration restart when `kvvmi` is already deleted and migrated volumes, including VMBDA-attached volumes, must be restored from target PVCs back to the current source PVCs."
```
