### PR TITLE
fix(ci): use deckhouse-prod module source for stage e2e storage

### DIFF
--- a/.github/scripts/bash/e2e/configure-csi-nfs.sh
+++ b/.github/scripts/bash/e2e/configure-csi-nfs.sh
@@ -20,6 +20,25 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=.github/scripts/bash/e2e/common.sh
 source "${SCRIPT_DIR}/common.sh"
 
+apply_csi_nfs_module_config() {
+  local source_field="  source: deckhouse"
+
+  if [ -n "${MODULE_SOURCE_REGISTRY_CFG:-}" ]; then
+    source_field="  source: deckhouse-prod"
+  fi
+
+  kubectl apply -f - <<EOF
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: csi-nfs
+spec:
+  enabled: true
+${source_field}
+  version: 1
+EOF
+}
+
 nfs_ready() {
   local count=90
   local controller
@@ -58,8 +77,12 @@ nfs_ready() {
   exit 1
 }
 
-echo "[INFO] Apply csi-nfs ModuleConfig, ModulePullOverride, snapshot-controller"
-kubectl apply -f mc.yaml
+if [ -n "${MODULE_SOURCE_REGISTRY_CFG:-}" ]; then
+  echo "[INFO] Apply csi-nfs ModuleConfig with deckhouse-prod source (stage profile)"
+else
+  echo "[INFO] Apply csi-nfs ModuleConfig with deckhouse source"
+fi
+apply_csi_nfs_module_config
 
 echo "[INFO] Wait for csi-nfs module to be ready"
 kubectl wait --for=jsonpath='{.status.phase}'=Ready modules csi-nfs --timeout=300s

--- a/.github/scripts/bash/e2e/enable-sdn.sh
+++ b/.github/scripts/bash/e2e/enable-sdn.sh
@@ -26,12 +26,12 @@ apply_sdn_module_source() {
   registry="$(registry_host_from_docker_cfg "$MODULE_SOURCE_REGISTRY_CFG")"
   repo="$(modules_repo_for_registry "$registry")"
 
-  echo "[INFO] Apply ModuleSource deckhouse-prod-sdn config"
+  echo "[INFO] Apply ModuleSource deckhouse-prod config"
   kubectl apply -f - <<EOF
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleSource
 metadata:
-  name: deckhouse-prod-sdn
+  name: deckhouse-prod
 spec:
   registry:
     ca: ""
@@ -45,7 +45,7 @@ apply_sdn_module_config() {
   local source_field=""
 
   if [ -n "${MODULE_SOURCE_REGISTRY_CFG:-}" ]; then
-    source_field="  source: deckhouse-prod-sdn"
+    source_field="  source: deckhouse-prod"
   fi
 
   if kubectl_apply_with_retry 12 10 show_sdn_state <<EOF

--- a/.github/workflows/e2e-nightly-reusable-pipeline.yml
+++ b/.github/workflows/e2e-nightly-reusable-pipeline.yml
@@ -485,6 +485,9 @@ jobs:
         working-directory: ${{ env.SETUP_CLUSTER_TYPE_PATH }}/storage/nfs
         env:
           NAMESPACE: ${{ needs.bootstrap.outputs.namespace }}
+          # csi-nfs is absent in the stage registry; pull it from prod via the same
+          # ModuleSource deckhouse-prod that enable-sdn.sh creates for the stage profile.
+          MODULE_SOURCE_REGISTRY_CFG: ${{ inputs.registry_profile == 'stage' && secrets.PROD_IO_REGISTRY_DOCKER_CFG || '' }}
         run: bash "${E2E_SCRIPT_DIR}/configure-csi-nfs.sh"
 
   configure-virtualization:

--- a/.github/workflows/e2e-test-releases-reusable-pipeline.yml
+++ b/.github/workflows/e2e-test-releases-reusable-pipeline.yml
@@ -449,6 +449,9 @@ jobs:
           NAMESPACE: ${{ needs.bootstrap.outputs.namespace }}
           STORAGE_TYPE: ${{ inputs.storage_type }}
           CONFIGURE_DEFAULT_SC: ${{ inputs.storage_type != 'mixed' }}
+          # csi-nfs is absent in the stage registry; pull it from prod via the same
+          # ModuleSource deckhouse-prod that enable-sdn.sh creates for the stage profile.
+          MODULE_SOURCE_REGISTRY_CFG: ${{ inputs.registry_profile == 'stage' && secrets.PROD_IO_REGISTRY_DOCKER_CFG || '' }}
         run: bash "${E2E_SCRIPT_DIR}/configure-csi-nfs.sh"
 
   configure-virtualization:


### PR DESCRIPTION
## Description

On the stage registry profile, `configure-csi-nfs.sh` now applies `csi-nfs` with `source: deckhouse-prod` instead of a static `mc.yaml` with `source: deckhouse`. The shared prod `ModuleSource` is renamed from `deckhouse-prod-sdn` to `deckhouse-prod`.

## Why do we need it, and what problem does it solve?

Stage e2e failed in `configure-csi-nfs.sh` because `csi-nfs` is absent in the stage registry and only `deckhouse-prod` is available after SDN setup.

## What is the expected result?

NFS storage setup passes on the stage profile; prod profile keeps using the default `deckhouse` source.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ci
type: fix
summary: "Fix nested e2e NFS setup on the stage registry profile by using the deckhouse-prod module source."
impact_level: low
```