### PR TITLE
fix(vm): revert migrated volumes when kvvmi is missing (#2506)

### DIFF
--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
@@ -221,6 +221,10 @@ func applyBlockDeviceRefs(
 		}
 	}
 
+	if err := syncAttachedVMBDAHotplugVolumes(kvvm, vdByName, viByName, cviByName, vmbdaByBlockDeviceRef); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -253,6 +257,33 @@ func cleanupRemovedStaticDisks(kvvm *KVVM, specDiskNames, hotpluggableVolumes, v
 		kvvm.Resource.Spec.Template.Spec.Volumes,
 		func(v virtv1.Volume) bool { return isRemovedStatic(v.Name) },
 	)
+}
+
+func syncAttachedVMBDAHotplugVolumes(
+	kvvm *KVVM,
+	vdByName map[string]*v1alpha2.VirtualDisk,
+	viByName map[string]*v1alpha2.VirtualImage,
+	cviByName map[string]*v1alpha2.ClusterVirtualImage,
+	vmbdaByBlockDeviceRef map[v1alpha2.VMBDAObjectRef][]*v1alpha2.VirtualMachineBlockDeviceAttachment,
+) error {
+	kvvmVolumes := kvvm.Resource.Spec.Template.Spec.Volumes
+
+	for ref := range vmbdaByBlockDeviceRef {
+		diskName := GenerateDiskName(v1alpha2.BlockDeviceKind(ref.Kind), ref.Name)
+		if diskName == "" {
+			continue
+		}
+
+		if !slices.ContainsFunc(kvvmVolumes, func(v virtv1.Volume) bool { return v.Name == diskName }) {
+			continue
+		}
+
+		if err := setVMBDABlockDeviceDisk(kvvm, ref, vdByName, viByName, cviByName); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func setBlockDeviceDisk(
@@ -314,6 +345,52 @@ func setBlockDeviceDisk(
 	default:
 		return fmt.Errorf("unknown block device kind %q. %w", bd.Kind, common.ErrUnknownType)
 	}
+}
+
+func setVMBDABlockDeviceDisk(
+	kvvm *KVVM,
+	ref v1alpha2.VMBDAObjectRef,
+	vdByName map[string]*v1alpha2.VirtualDisk,
+	viByName map[string]*v1alpha2.VirtualImage,
+	cviByName map[string]*v1alpha2.ClusterVirtualImage,
+) error {
+	switch ref.Kind {
+	case v1alpha2.VMBDAObjectRefKindVirtualDisk:
+		name := GenerateVDDiskName(ref.Name)
+		vd, ok := vdByName[ref.Name]
+		if !ok || vd == nil {
+			removeDisk(kvvm, name)
+			return nil
+		}
+
+		if vd.Status.Phase == v1alpha2.DiskTerminating || vd.Status.Target.PersistentVolumeClaim == "" {
+			removeDisk(kvvm, name)
+			return nil
+		}
+
+		return kvvm.SetDisk(name, SetDiskOptions{
+			PersistentVolumeClaim: ptr.To(vd.Status.Target.PersistentVolumeClaim),
+			Serial:                GenerateSerialFromObject(vd),
+			IsHotplugged:          true,
+		})
+	case v1alpha2.VMBDAObjectRefKindVirtualImage:
+		return setBlockDeviceDisk(kvvm, v1alpha2.BlockDeviceSpecRef{Kind: v1alpha2.ImageDevice, Name: ref.Name}, 0, true, vdByName, viByName, cviByName)
+	case v1alpha2.VMBDAObjectRefKindClusterVirtualImage:
+		return setBlockDeviceDisk(kvvm, v1alpha2.BlockDeviceSpecRef{Kind: v1alpha2.ClusterImageDevice, Name: ref.Name}, 0, true, vdByName, viByName, cviByName)
+	default:
+		return fmt.Errorf("unknown VMBDA block device kind %q. %w", ref.Kind, common.ErrUnknownType)
+	}
+}
+
+func removeDisk(kvvm *KVVM, name string) {
+	kvvm.Resource.Spec.Template.Spec.Domain.Devices.Disks = slices.DeleteFunc(
+		kvvm.Resource.Spec.Template.Spec.Domain.Devices.Disks,
+		func(d virtv1.Disk) bool { return d.Name == name },
+	)
+	kvvm.Resource.Spec.Template.Spec.Volumes = slices.DeleteFunc(
+		kvvm.Resource.Spec.Template.Spec.Volumes,
+		func(v virtv1.Volume) bool { return v.Name == name },
+	)
 }
 
 func ApplyMigrationVolumes(kvvm *KVVM, vm *v1alpha2.VirtualMachine, vdsByName map[string]*v1alpha2.VirtualDisk) error {

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils_test.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils_test.go
@@ -20,9 +20,185 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	virtv1 "kubevirt.io/api/core/v1"
+
+	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
 )
+
+func newKVVMWithVMBDAVolume(pvcName string) *KVVM {
+	const (
+		vmNamespace = "test-ns"
+		diskName    = "data-disk"
+	)
+
+	kvvm := NewEmptyKVVM(
+		namespacedName("test-vm", vmNamespace),
+		KVVMOptions{},
+	)
+	kvvm.Resource.Spec.Template.Spec.Volumes = []virtv1.Volume{
+		{
+			Name: GenerateVDDiskName(diskName),
+			VolumeSource: virtv1.VolumeSource{
+				PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{
+					PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: pvcName,
+					},
+					Hotpluggable: true,
+				},
+			},
+		},
+	}
+	kvvm.Resource.Spec.Template.Spec.Domain.Devices.Disks = []virtv1.Disk{
+		{Name: GenerateVDDiskName(diskName)},
+	}
+	return kvvm
+}
+
+var _ = Describe("syncAttachedVMBDAHotplugVolumes", func() {
+	const (
+		vmName      = "test-vm"
+		vmNamespace = "test-ns"
+		diskName    = "data-disk"
+		sourcePVC   = "pvc-source"
+		targetPVC   = "pvc-target"
+	)
+
+	It("should switch existing VMBDA volume back to source PVC after migration rollback", func() {
+		kvvm := newKVVMWithVMBDAVolume(targetPVC)
+		vd := &v1alpha2.VirtualDisk{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       diskName,
+				Namespace:  vmNamespace,
+				UID:        "vd-uid",
+				Generation: 2,
+			},
+			Status: v1alpha2.VirtualDiskStatus{
+				Target: v1alpha2.DiskTarget{PersistentVolumeClaim: sourcePVC},
+				Conditions: []metav1.Condition{{
+					Type:               vdcondition.MigratingType.String(),
+					Status:             metav1.ConditionFalse,
+					ObservedGeneration: 2,
+					Reason:             "MigrationReverted",
+				}},
+				MigrationState: v1alpha2.VirtualDiskMigrationState{
+					SourcePVC: sourcePVC,
+					TargetPVC: targetPVC,
+				},
+			},
+		}
+
+		err := syncAttachedVMBDAHotplugVolumes(
+			kvvm,
+			map[string]*v1alpha2.VirtualDisk{diskName: vd},
+			nil,
+			nil,
+			map[v1alpha2.VMBDAObjectRef][]*v1alpha2.VirtualMachineBlockDeviceAttachment{
+				{Kind: v1alpha2.VMBDAObjectRefKindVirtualDisk, Name: diskName}: nil,
+			},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvvm.Resource.Spec.Template.Spec.Volumes).To(HaveLen(1))
+		Expect(kvvm.Resource.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim).NotTo(BeNil())
+		Expect(kvvm.Resource.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName).To(Equal(sourcePVC))
+	})
+
+	It("should remove terminating VirtualDisk attached via VMBDA", func() {
+		kvvm := newKVVMWithVMBDAVolume(sourcePVC)
+		vd := &v1alpha2.VirtualDisk{
+			ObjectMeta: metav1.ObjectMeta{Name: diskName, Namespace: vmNamespace},
+			Status: v1alpha2.VirtualDiskStatus{
+				Phase:  v1alpha2.DiskTerminating,
+				Target: v1alpha2.DiskTarget{PersistentVolumeClaim: sourcePVC},
+			},
+		}
+
+		err := syncAttachedVMBDAHotplugVolumes(
+			kvvm,
+			map[string]*v1alpha2.VirtualDisk{diskName: vd},
+			nil,
+			nil,
+			map[v1alpha2.VMBDAObjectRef][]*v1alpha2.VirtualMachineBlockDeviceAttachment{
+				{Kind: v1alpha2.VMBDAObjectRefKindVirtualDisk, Name: diskName}: nil,
+			},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvvm.Resource.Spec.Template.Spec.Volumes).To(BeEmpty())
+		Expect(kvvm.Resource.Spec.Template.Spec.Domain.Devices.Disks).To(BeEmpty())
+	})
+
+	It("should remove missing VirtualDisk attached via VMBDA", func() {
+		kvvm := newKVVMWithVMBDAVolume(sourcePVC)
+
+		err := syncAttachedVMBDAHotplugVolumes(
+			kvvm,
+			map[string]*v1alpha2.VirtualDisk{},
+			nil,
+			nil,
+			map[v1alpha2.VMBDAObjectRef][]*v1alpha2.VirtualMachineBlockDeviceAttachment{
+				{Kind: v1alpha2.VMBDAObjectRefKindVirtualDisk, Name: diskName}: nil,
+			},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvvm.Resource.Spec.Template.Spec.Volumes).To(BeEmpty())
+		Expect(kvvm.Resource.Spec.Template.Spec.Domain.Devices.Disks).To(BeEmpty())
+	})
+})
+
+var _ = Describe("ApplyMigrationVolumes", func() {
+	const (
+		vmName      = "test-vm"
+		vmNamespace = "test-ns"
+		diskName    = "data-disk"
+		sourcePVC   = "pvc-source"
+		targetPVC   = "pvc-target"
+	)
+
+	It("should switch hotplugged VMBDA disk to migration target PVC", func() {
+		kvvm := newKVVMWithVMBDAVolume(sourcePVC)
+		vm := &v1alpha2.VirtualMachine{
+			Status: v1alpha2.VirtualMachineStatus{
+				BlockDeviceRefs: []v1alpha2.BlockDeviceStatusRef{
+					{
+						Kind:       v1alpha2.DiskDevice,
+						Name:       diskName,
+						Hotplugged: true,
+					},
+				},
+			},
+		}
+		vd := &v1alpha2.VirtualDisk{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       diskName,
+				Namespace:  vmNamespace,
+				UID:        "vd-uid",
+				Generation: 1,
+			},
+			Status: v1alpha2.VirtualDiskStatus{
+				Target: v1alpha2.DiskTarget{PersistentVolumeClaim: sourcePVC},
+				Conditions: []metav1.Condition{{
+					Type:               vdcondition.MigratingType.String(),
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 1,
+					Reason:             "Migrating",
+				}},
+				MigrationState: v1alpha2.VirtualDiskMigrationState{
+					SourcePVC: sourcePVC,
+					TargetPVC: targetPVC,
+				},
+			},
+		}
+
+		err := ApplyMigrationVolumes(kvvm, vm, map[string]*v1alpha2.VirtualDisk{diskName: vd})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvvm.Resource.Spec.Template.Spec.Volumes).To(HaveLen(1))
+		Expect(kvvm.Resource.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim).NotTo(BeNil())
+		Expect(kvvm.Resource.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName).To(Equal(targetPVC))
+		Expect(kvvm.Resource.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.Hotpluggable).To(BeTrue())
+	})
+})
 
 var _ = Describe("cleanupRemovedStaticDisks", func() {
 	const (

--- a/images/virtualization-artifact/pkg/controller/vd/internal/migration.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/migration.go
@@ -411,6 +411,10 @@ func (h MigrationHandler) handleMigratePrepareTarget(ctx context.Context, vd *v1
 	if err != nil {
 		return err
 	}
+	if pvc == nil {
+		log.Debug("Target PersistentVolumeClaim is not ready for migration preparation; skip")
+		return nil
+	}
 
 	log.Info(
 		"The target PersistentVolumeClaim has been created or already exists",
@@ -419,7 +423,10 @@ func (h MigrationHandler) handleMigratePrepareTarget(ctx context.Context, vd *v1
 	)
 
 	if vd.Status.Target.PersistentVolumeClaim == pvc.Name {
-		return errors.New("the target PersistentVolumeClaim name matched the source PersistentVolumeClaim name, please report a bug")
+		log.Debug("Target PersistentVolumeClaim name matches source PersistentVolumeClaim after selection; skip",
+			slog.String("pvc", pvc.Name),
+		)
+		return nil
 	}
 
 	vd.Status.MigrationState = v1alpha2.VirtualDiskMigrationState{
@@ -643,39 +650,62 @@ func (h MigrationHandler) createTargetPersistentVolumeClaim(ctx context.Context,
 	}
 
 	if targetPVCName == sourcePVCName && targetPVCName != "" {
-		return nil, fmt.Errorf("target PersistentVolumeClaim %q matches source PersistentVolumeClaim", targetPVCName)
+		logger.FromContext(ctx).Debug("Target PersistentVolumeClaim name matches source PersistentVolumeClaim; ignoring stale target name",
+			slog.String("targetPVC", targetPVCName),
+			slog.String("sourcePVC", sourcePVCName),
+		)
+		targetPVCName = ""
 	}
 
 	switch len(pvcs) {
 	case 1:
 		if pvcs[0].Name != sourcePVCName {
-			return nil, fmt.Errorf("source PersistentVolumeClaim %q was not found", sourcePVCName)
+			logger.FromContext(ctx).Debug("Source PersistentVolumeClaim was not found among owned PersistentVolumeClaims; skip migration preparation",
+				slog.String("sourcePVC", sourcePVCName),
+				slog.String("ownedPVC", pvcs[0].Name),
+			)
+			return nil, nil
 		}
 		if targetPVCName != "" {
-			return nil, fmt.Errorf("target PersistentVolumeClaim %q was not found", targetPVCName)
+			logger.FromContext(ctx).Debug("Target PersistentVolumeClaim was not found; ignoring stale target name",
+				slog.String("targetPVC", targetPVCName),
+			)
 		}
 	case 2:
 		sourcePVCExists := false
-		var targetPVC *corev1.PersistentVolumeClaim
+		var targetPVC, fallbackTargetPVC *corev1.PersistentVolumeClaim
 		for _, pvc := range pvcs {
 			if pvc.Name == sourcePVCName {
 				sourcePVCExists = true
 				continue
 			}
+			fallbackTargetPVC = &pvc
 			if targetPVCName == "" || pvc.Name == targetPVCName {
 				targetPVC = &pvc
 				break
 			}
 		}
 		if !sourcePVCExists {
-			return nil, fmt.Errorf("source PersistentVolumeClaim %q was not found", sourcePVCName)
+			logger.FromContext(ctx).Debug("Source PersistentVolumeClaim was not found among owned PersistentVolumeClaims; skip migration preparation",
+				slog.String("sourcePVC", sourcePVCName),
+			)
+			return nil, nil
 		}
 		if targetPVC != nil {
 			return targetPVC, nil
 		}
-		return nil, fmt.Errorf("target PersistentVolumeClaim %q was not found", targetPVCName)
+		if fallbackTargetPVC != nil {
+			logger.FromContext(ctx).Debug("Target PersistentVolumeClaim was not found; using the only non-source PersistentVolumeClaim",
+				slog.String("targetPVC", targetPVCName),
+				slog.String("fallbackPVC", fallbackTargetPVC.Name),
+			)
+			return fallbackTargetPVC, nil
+		}
 	default:
-		return nil, fmt.Errorf("unexpected number of PersistentVolumeClaims: %d, expected 1 or 2", len(pvcs))
+		logger.FromContext(ctx).Debug("Unexpected number of owned PersistentVolumeClaims; skip migration preparation",
+			slog.Int("count", len(pvcs)),
+		)
+		return nil, nil
 	}
 
 	pvc := &corev1.PersistentVolumeClaim{

--- a/images/virtualization-artifact/pkg/controller/vd/internal/migration_test.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/migration_test.go
@@ -363,14 +363,18 @@ var _ = Describe("MigrationHandler", func() {
 			size = resource.MustParse("10Gi")
 		})
 
-		It("should return error when target PVC name matches source PVC name", func() {
+		It("should ignore stale target PVC name when it matches source PVC name", func() {
 			sourcePVC := newEmptyPVC("source-pvc", "default")
 			withOwner(sourcePVC, vd)
 			Expect(fakeClient.Create(ctx, sourcePVC)).To(Succeed())
 
+			targetPVC := newEmptyPVC("target-pvc", "default")
+			withOwner(targetPVC, vd)
+			Expect(fakeClient.Create(ctx, targetPVC)).To(Succeed())
+
 			pvc, err := migrationHandler.createTargetPersistentVolumeClaim(ctx, vd, storageClass, size, "source-pvc", "source-pvc", corev1.PersistentVolumeBlock, corev1.ReadWriteOnce)
-			Expect(err).To(MatchError(ContainSubstring("matches source PersistentVolumeClaim")))
-			Expect(pvc).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pvc.Name).To(Equal("target-pvc"))
 		})
 
 		It("should select the only non-source PVC when target PVC name is empty", func() {
@@ -387,7 +391,7 @@ var _ = Describe("MigrationHandler", func() {
 			Expect(pvc.Name).To(Equal("target-pvc"))
 		})
 
-		It("should return error when target PVC name is specified but not found", func() {
+		It("should select the only non-source PVC when target PVC name is specified but not found", func() {
 			sourcePVC := newEmptyPVC("source-pvc", "default")
 			withOwner(sourcePVC, vd)
 			Expect(fakeClient.Create(ctx, sourcePVC)).To(Succeed())
@@ -397,7 +401,17 @@ var _ = Describe("MigrationHandler", func() {
 			Expect(fakeClient.Create(ctx, otherPVC)).To(Succeed())
 
 			pvc, err := migrationHandler.createTargetPersistentVolumeClaim(ctx, vd, storageClass, size, "missing-pvc", "source-pvc", corev1.PersistentVolumeBlock, corev1.ReadWriteOnce)
-			Expect(err).To(MatchError(ContainSubstring("target PersistentVolumeClaim \"missing-pvc\" was not found")))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pvc.Name).To(Equal("other-pvc"))
+		})
+
+		It("should skip when source PVC was not found", func() {
+			ownedPVC := newEmptyPVC("owned-pvc", "default")
+			withOwner(ownedPVC, vd)
+			Expect(fakeClient.Create(ctx, ownedPVC)).To(Succeed())
+
+			pvc, err := migrationHandler.createTargetPersistentVolumeClaim(ctx, vd, storageClass, size, "", "missing-source-pvc", corev1.PersistentVolumeBlock, corev1.ReadWriteOnce)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(pvc).To(BeNil())
 		})
 
@@ -415,7 +429,7 @@ var _ = Describe("MigrationHandler", func() {
 			Expect(pvc.Name).To(Equal("target-pvc"))
 		})
 
-		It("should return error when target PVC cannot be selected unambiguously", func() {
+		It("should skip when target PVC cannot be selected unambiguously", func() {
 			sourcePVC := newEmptyPVC("source-pvc", "default")
 			withOwner(sourcePVC, vd)
 			Expect(fakeClient.Create(ctx, sourcePVC)).To(Succeed())
@@ -429,7 +443,7 @@ var _ = Describe("MigrationHandler", func() {
 			Expect(fakeClient.Create(ctx, secondPVC)).To(Succeed())
 
 			pvc, err := migrationHandler.createTargetPersistentVolumeClaim(ctx, vd, storageClass, size, "", "source-pvc", corev1.PersistentVolumeBlock, corev1.ReadWriteOnce)
-			Expect(err).To(MatchError(ContainSubstring("unexpected number of PersistentVolumeClaims: 3, expected 1 or 2")))
+			Expect(err).NotTo(HaveOccurred())
 			Expect(pvc).To(BeNil())
 		})
 	})

--- a/images/virtualization-artifact/pkg/controller/vm/internal/service/migration_volumes.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/service/migration_volumes.go
@@ -104,8 +104,18 @@ func (s MigrationVolumesService) SyncVolumes(ctx context.Context, vmState state.
 		return reconcile.Result{}, err
 	}
 
-	if kvvmInCluster == nil || kvvmiInCluster == nil {
-		log.Info("Virtualmachine or kvvmi is nil, skip volume migration.")
+	if kvvmInCluster == nil {
+		log.Info("Virtualmachine is nil, skip volume migration.")
+		return reconcile.Result{}, nil
+	}
+
+	if kvvmiInCluster == nil {
+		if s.shouldPatchVolumes(kvvmInCluster, builtKVVM) {
+			log.Info("kvvmi is nil, force revert kvvm volumes to source volumes.")
+			return reconcile.Result{}, s.patchVolumes(ctx, builtKVVM)
+		}
+
+		log.Info("kvvmi is nil and kvvm volumes are already reverted, skip volume migration.")
 		return reconcile.Result{}, nil
 	}
 
@@ -250,6 +260,12 @@ func (s MigrationVolumesService) patchVolumes(ctx context.Context, kvvm *virtv1.
 
 	err = s.client.Patch(ctx, kvvm, client.RawPatch(types.JSONPatchType, patchBytes))
 	return err
+}
+
+func (s MigrationVolumesService) shouldPatchVolumes(currentKVVM, desiredKVVM *virtv1.VirtualMachine) bool {
+	return !equality.Semantic.DeepEqual(currentKVVM.Spec.UpdateVolumesStrategy, desiredKVVM.Spec.UpdateVolumesStrategy) ||
+		!equality.Semantic.DeepEqual(currentKVVM.Spec.Template.Spec.Volumes, desiredKVVM.Spec.Template.Spec.Volumes) ||
+		!equality.Semantic.DeepEqual(currentKVVM.Spec.Template.Spec.Affinity, desiredKVVM.Spec.Template.Spec.Affinity)
 }
 
 func (s MigrationVolumesService) VolumesSynced(ctx context.Context, vmState state.VirtualMachineState) (bool, error) {

--- a/images/virtualization-artifact/pkg/controller/vm/internal/service/migration_volumes_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/service/migration_volumes_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	virtv1 "kubevirt.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/deckhouse/virtualization-controller/pkg/common/testutil"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/reconciler"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/vm/internal/state"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+)
+
+var _ = Describe("MigrationVolumesService", func() {
+	const (
+		vmName    = "vm-test"
+		namespace = "default"
+		sourcePVC = "disk-source"
+		targetPVC = "disk-target"
+	)
+
+	newVM := func() *v1alpha2.VirtualMachine {
+		return &v1alpha2.VirtualMachine{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: v1alpha2.SchemeGroupVersion.String(),
+				Kind:       v1alpha2.VirtualMachineKind,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       vmName,
+				Namespace:  namespace,
+				Generation: 1,
+			},
+			Spec: v1alpha2.VirtualMachineSpec{},
+		}
+	}
+
+	newKVVMWithVolume := func(pvcName string, strategy *virtv1.UpdateVolumesStrategy, nodeLabel string) *virtv1.VirtualMachine {
+		return &virtv1.VirtualMachine{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: virtv1.GroupVersion.String(),
+				Kind:       "VirtualMachine",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      vmName,
+				Namespace: namespace,
+			},
+			Spec: virtv1.VirtualMachineSpec{
+				UpdateVolumesStrategy: strategy,
+				Template: &virtv1.VirtualMachineInstanceTemplateSpec{
+					Spec: virtv1.VirtualMachineInstanceSpec{
+						Affinity: &corev1.Affinity{
+							NodeAffinity: &corev1.NodeAffinity{
+								RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+									NodeSelectorTerms: []corev1.NodeSelectorTerm{
+										{
+											MatchExpressions: []corev1.NodeSelectorRequirement{
+												{
+													Key:      "kubernetes.io/hostname",
+													Operator: corev1.NodeSelectorOpIn,
+													Values:   []string{nodeLabel},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						Volumes: []virtv1.Volume{
+							{
+								Name: "rootdisk",
+								VolumeSource: virtv1.VolumeSource{
+									PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{
+										PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+											ClaimName: pvcName,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	setupState := func(vm *v1alpha2.VirtualMachine, objs ...client.Object) state.VirtualMachineState {
+		allObjects := append([]client.Object{vm}, objs...)
+		fakeClient, err := testutil.NewFakeClientWithObjects(allObjects...)
+		Expect(err).NotTo(HaveOccurred())
+
+		resource := reconciler.NewResource(client.ObjectKeyFromObject(vm), fakeClient,
+			func() *v1alpha2.VirtualMachine {
+				return &v1alpha2.VirtualMachine{}
+			},
+			func(obj *v1alpha2.VirtualMachine) v1alpha2.VirtualMachineStatus {
+				return obj.Status
+			},
+		)
+		Expect(resource.Fetch(context.Background())).To(Succeed())
+
+		return state.New(fakeClient, resource)
+	}
+
+	It("forces volume rollback when kvvmi is missing", func() {
+		ctx := testutil.ContextBackgroundWithNoOpLogger()
+		migrationStrategy := virtv1.UpdateVolumesStrategyMigration
+
+		vm := newVM()
+		kvvmInCluster := newKVVMWithVolume(targetPVC, &migrationStrategy, "target-node")
+		desiredKVVM := newKVVMWithVolume(sourcePVC, nil, "source-node")
+		vmState := setupState(vm, kvvmInCluster)
+
+		service := NewMigrationVolumesService(
+			vmState.Client(),
+			func(context.Context, state.VirtualMachineState) (*virtv1.VirtualMachine, error) {
+				return desiredKVVM.DeepCopy(), nil
+			},
+			10*time.Second,
+		)
+
+		_, err := service.SyncVolumes(ctx, vmState, false)
+		Expect(err).NotTo(HaveOccurred())
+
+		updatedKVVM := &virtv1.VirtualMachine{}
+		Expect(vmState.Client().Get(ctx, types.NamespacedName{Name: vmName, Namespace: namespace}, updatedKVVM)).To(Succeed())
+		Expect(updatedKVVM.Spec.UpdateVolumesStrategy).To(BeNil())
+		Expect(updatedKVVM.Spec.Template.Spec.Volumes).To(HaveLen(1))
+		Expect(updatedKVVM.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim).NotTo(BeNil())
+		Expect(updatedKVVM.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName).To(Equal(sourcePVC))
+		Expect(updatedKVVM.Spec.Template.Spec.Affinity).To(Equal(desiredKVVM.Spec.Template.Spec.Affinity))
+	})
+})

--- a/images/virtualization-artifact/pkg/controller/vm/internal/service/suite_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/service/suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMigrationVolumesService(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "MigrationVolumesService Suite")
+}

--- a/images/virtualization-artifact/pkg/controller/workload-updater/internal/handler/nodeplacement.go
+++ b/images/virtualization-artifact/pkg/controller/workload-updater/internal/handler/nodeplacement.go
@@ -22,6 +22,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	virtv1 "kubevirt.io/api/core/v1"
@@ -37,6 +38,8 @@ import (
 
 const (
 	nodePlacementHandler = "NodePlacementHandler"
+
+	nodePlacementMigrationSettleDelay = time.Minute
 )
 
 func NewNodePlacementHandler(client client.Client, migration OneShotMigration) *NodePlacementHandler {
@@ -66,6 +69,23 @@ func (h *NodePlacementHandler) Handle(ctx context.Context, vm *v1alpha2.VirtualM
 		return reconcile.Result{}, nil
 	}
 
+	// A node placement update is fulfilled via live migration. If the VMI is
+	// not live-migratable (e.g. it has local/non-shared disks), a live
+	// migration can never reconcile the placement, so never trigger it.
+	// The placement sum is intentionally not recorded here: once the VMI
+	// becomes migratable again (e.g. after disks are migrated to shared
+	// storage), the migration must still be able to fire.
+	if !isLiveMigratable(kvvmi) {
+		return reconcile.Result{}, nil
+	}
+
+	// Do not trigger a node placement migration while a volume migration or a
+	// live migration is in progress: a concurrent migration cannot be started
+	// and OnceMigrate already deduplicates against in-flight migrations.
+	if result, skip := shouldSkipNodePlacementMigration(kvvmi); skip {
+		return result, nil
+	}
+
 	sum, err := genNodePlacementSum(kvvmi)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -84,6 +104,34 @@ func (h *NodePlacementHandler) Handle(ctx context.Context, vm *v1alpha2.VirtualM
 
 func (h *NodePlacementHandler) Name() string {
 	return nodePlacementHandler
+}
+
+func shouldSkipNodePlacementMigration(kvvmi *virtv1.VirtualMachineInstance) (reconcile.Result, bool) {
+	volumesChange, _ := conditions.GetKVVMICondition(virtv1.VirtualMachineInstanceVolumesChange, kvvmi.Status.Conditions)
+	if volumesChange.Status == corev1.ConditionTrue || len(kvvmi.Status.MigratedVolumes) > 0 {
+		return reconcile.Result{}, true
+	}
+
+	migrationState := kvvmi.Status.MigrationState
+	if migrationState == nil || migrationState.StartTimestamp == nil {
+		return reconcile.Result{}, false
+	}
+
+	if migrationState.EndTimestamp == nil {
+		return reconcile.Result{}, true
+	}
+
+	settleUntil := migrationState.EndTimestamp.Add(nodePlacementMigrationSettleDelay)
+	if requeueAfter := time.Until(settleUntil); requeueAfter > 0 {
+		return reconcile.Result{RequeueAfter: requeueAfter}, true
+	}
+
+	return reconcile.Result{}, false
+}
+
+func isLiveMigratable(kvvmi *virtv1.VirtualMachineInstance) bool {
+	cond, _ := conditions.GetKVVMICondition(virtv1.VirtualMachineInstanceIsMigratable, kvvmi.Status.Conditions)
+	return cond.Status == corev1.ConditionTrue
 }
 
 func genNodePlacementSum(kvvmi *virtv1.VirtualMachineInstance) (string, error) {

--- a/images/virtualization-artifact/pkg/controller/workload-updater/internal/handler/nodeplacement_test.go
+++ b/images/virtualization-artifact/pkg/controller/workload-updater/internal/handler/nodeplacement_test.go
@@ -31,6 +31,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	vmbuilder "github.com/deckhouse/virtualization-controller/pkg/builder/vm"
+	"github.com/deckhouse/virtualization-controller/pkg/common/annotations"
+	"github.com/deckhouse/virtualization-controller/pkg/common/object"
 	"github.com/deckhouse/virtualization-controller/pkg/common/testutil"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
@@ -63,6 +65,10 @@ var _ = Describe("TestNodePlacementHandler", func() {
 			kvvmi.Status.Conditions = append(kvvmi.Status.Conditions, virtv1.VirtualMachineInstanceCondition{
 				Type:   conditions.VirtualMachineInstanceNodePlacementNotMatched,
 				Status: status,
+			})
+			kvvmi.Status.Conditions = append(kvvmi.Status.Conditions, virtv1.VirtualMachineInstanceCondition{
+				Type:   virtv1.VirtualMachineInstanceIsMigratable,
+				Status: corev1.ConditionTrue,
 			})
 		}
 		return vm, kvvmi
@@ -164,6 +170,118 @@ var _ = Describe("TestNodePlacementHandler", func() {
 		_, err = h.Handle(ctx, vm)
 		Expect(err).NotTo(HaveOccurred())
 	})
+
+	DescribeTable("should skip migration while volume migration is active",
+		func(kvvmiMutate func(*virtv1.VirtualMachineInstance)) {
+			vm, kvvmi := newVMAndKVVMI(true)
+			kvvmiMutate(kvvmi)
+			fakeClient = setupEnvironment(vm, kvvmi)
+
+			mockMigration := &OneShotMigrationMock{
+				OnceMigrateFunc: func(ctx context.Context, vm *v1alpha2.VirtualMachine, annotationKey, annotationExpectedValue string) (bool, error) {
+					Fail("migration should not be executed")
+					return false, nil
+				},
+			}
+
+			h := NewNodePlacementHandler(fakeClient, mockMigration)
+			_, err := h.Handle(ctx, vm)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mockMigration.OnceMigrateCalls()).To(BeEmpty())
+
+			// While a migration is in progress the handler must not record the
+			// placement sum, so it can still fire once the migration settles.
+			updatedKVVMI := &virtv1.VirtualMachineInstance{}
+			Expect(fakeClient.Get(ctx, object.NamespacedName(kvvmi), updatedKVVMI)).To(Succeed())
+			Expect(updatedKVVMI.GetAnnotations()).NotTo(HaveKey(annotations.AnnVMOPWorkloadUpdateNodePlacementSum))
+		},
+		Entry("VolumesChange condition is true", func(kvvmi *virtv1.VirtualMachineInstance) {
+			kvvmi.Status.Conditions = append(kvvmi.Status.Conditions, virtv1.VirtualMachineInstanceCondition{
+				Type:   virtv1.VirtualMachineInstanceVolumesChange,
+				Status: corev1.ConditionTrue,
+			})
+		}),
+		Entry("migrated volumes are present", func(kvvmi *virtv1.VirtualMachineInstance) {
+			kvvmi.Status.MigratedVolumes = []virtv1.StorageMigratedVolumeInfo{
+				{VolumeName: "root"},
+			}
+		}),
+		Entry("migration state is active", func(kvvmi *virtv1.VirtualMachineInstance) {
+			start := metav1.Now()
+			kvvmi.Status.MigrationState = &virtv1.VirtualMachineInstanceMigrationState{
+				StartTimestamp: &start,
+			}
+		}),
+	)
+
+	It("should requeue and skip migration right after a completed migration", func() {
+		vm, kvvmi := newVMAndKVVMI(true)
+		start := metav1.Now()
+		end := metav1.Now()
+		kvvmi.Status.MigrationState = &virtv1.VirtualMachineInstanceMigrationState{
+			StartTimestamp: &start,
+			EndTimestamp:   &end,
+		}
+		fakeClient = setupEnvironment(vm, kvvmi)
+
+		mockMigration := &OneShotMigrationMock{
+			OnceMigrateFunc: func(ctx context.Context, vm *v1alpha2.VirtualMachine, annotationKey, annotationExpectedValue string) (bool, error) {
+				Fail("migration should not be executed while migration state is settling")
+				return false, nil
+			},
+		}
+
+		h := NewNodePlacementHandler(fakeClient, mockMigration)
+		result, err := h.Handle(ctx, vm)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+		Expect(mockMigration.OnceMigrateCalls()).To(BeEmpty())
+
+		updatedKVVMI := &virtv1.VirtualMachineInstance{}
+		Expect(fakeClient.Get(ctx, object.NamespacedName(kvvmi), updatedKVVMI)).To(Succeed())
+		Expect(updatedKVVMI.GetAnnotations()).NotTo(HaveKey(annotations.AnnVMOPWorkloadUpdateNodePlacementSum))
+	})
+
+	DescribeTable("should skip migration and not record placement sum when VMI is not live-migratable",
+		func(migratableStatus corev1.ConditionStatus) {
+			vm := vmbuilder.NewEmpty(name, namespace)
+			kvvmi := newEmptyKVVMI(name, namespace)
+			kvvmi.Status.Conditions = append(kvvmi.Status.Conditions,
+				virtv1.VirtualMachineInstanceCondition{
+					Type:   conditions.VirtualMachineInstanceNodePlacementNotMatched,
+					Status: corev1.ConditionTrue,
+				},
+				virtv1.VirtualMachineInstanceCondition{
+					Type:   virtv1.VirtualMachineInstanceIsMigratable,
+					Status: migratableStatus,
+				},
+			)
+			fakeClient = setupEnvironment(vm, kvvmi)
+
+			mockMigration := &OneShotMigrationMock{
+				OnceMigrateFunc: func(ctx context.Context, vm *v1alpha2.VirtualMachine, annotationKey, annotationExpectedValue string) (bool, error) {
+					Fail("migration should not be executed for a non-migratable VMI")
+					return false, nil
+				},
+			}
+
+			h := NewNodePlacementHandler(fakeClient, mockMigration)
+			_, err := h.Handle(ctx, vm)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mockMigration.OnceMigrateCalls()).To(BeEmpty())
+
+			// The placement sum must not be recorded so that the migration can
+			// still fire once the VMI becomes migratable again.
+			updatedKVVMI := &virtv1.VirtualMachineInstance{}
+			Expect(fakeClient.Get(ctx, object.NamespacedName(kvvmi), updatedKVVMI)).To(Succeed())
+			Expect(updatedKVVMI.GetAnnotations()).NotTo(HaveKey(annotations.AnnVMOPWorkloadUpdateNodePlacementSum))
+		},
+		Entry("LiveMigratable is False", corev1.ConditionFalse),
+		Entry("LiveMigratable is Unknown", corev1.ConditionUnknown),
+	)
 
 	It("should return node placement handler name", func() {
 		h := NewNodePlacementHandler(nil, nil)


### PR DESCRIPTION
## Description
Hotfix for `release-1.9` that combines two fixes backported from:
- #2506 — restore migrated VM volumes when `kvvmi` is already missing and rebuild VMBDA hotplug volumes from the current disk PVC;
- #2497 — skip node placement migration while a KubeVirt VMI has an active volume migration state.

## Why do we need it, and what problem does it solve?
A user could hit a recovery issue during the following flow:
- a VM uses at least one local-storage disk, including a disk attached through VMBDA;
- VM eviction starts volume migration;
- migration fails;
- another automatic node placement migration can be created while volume migration is still active;
- the user uncordons nodes and requests VM restart;
- `kvvmi` is already deleted, while `kvvm.spec` still points to migrated target PVCs.

In that state KubeVirt sets `ManualRecoveryRequired` and refuses to start the VM. The controller could not revert volumes without `kvvmi`, and VMBDA hotplug volumes could also keep stale PVCs because they were preserved in `kvvm.spec` but not rebuilt from the current disk state.

This hotfix makes the controller restore source PVCs in both cases and prevents the workload updater from creating nodeplacement-update VMOPs while volume migration is active, which unblocks VM recovery after failed migration.

## What is the expected result?
Reproduce with a VM that has a local-storage disk, including a VMBDA-attached disk:
- cordon all nodes;
- start VM eviction;
- wait until the eviction/migration operation fails;
- uncordon nodes;
- request VM restart.

Expected result:
- migrated target PVCs are restored back to source PVCs in `kvvm.spec`;
- VMBDA hotplug volumes are also rebuilt from the current PVC state;
- automatic node placement migration is not started while volume migration is active;
- `ManualRecoveryRequired` no longer blocks recovery in this case;
- the VM starts again without manual `kvvm.spec` editing.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: vm
type: fix
summary: Fixed an issue that prevented a VM from starting after a failed migration of a disk on local storage.
```
