### PR TITLE
chore(module): allow ClusterAdmin to read internal virtualization resources

### DIFF
--- a/templates/user-authz-cluster-roles.yaml
+++ b/templates/user-authz-cluster-roles.yaml
@@ -154,3 +154,22 @@ rules:
   - deletecollection
   - patch
   - update
+- apiGroups:
+  - internal.virtualization.deckhouse.io
+  resources:
+  - internalvirtualizationkubevirts
+  - internalvirtualizationvirtualmachines
+  - internalvirtualizationvirtualmachineinstances
+  - internalvirtualizationvirtualmachineinstancemigrations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cdi.internal.virtualization.deckhouse.io
+  resources:
+  - internalvirtualizationdatavolumes
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
## Description

Extended ClusterRole `d8:user-authz:virtualization:cluster-admin`: added `get/list/watch` permissions on internal virtualization resources (API groups `internal.virtualization.deckhouse.io` and `cdi.internal.virtualization.deckhouse.io`).

## Why do we need it, and what problem does it solve?

ClusterAdmin could not read internal virtualization resources needed to collect debug information. Now it has read-only access to the same resources the module already uses internally.

## What is the expected result?

ClusterAdmin can `kubectl get` internal virtualization resources for troubleshooting.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: module
type: chore
summary: "Allow ClusterAdmin to read internal virtualization resources for troubleshooting."
impact_level: low
```
