### PR TITLE
fix(vm): fix affinity when migrating VM with local disks (release 1.9)

### DIFF
--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
@@ -278,6 +278,13 @@ func syncAttachedVMBDAHotplugVolumes(
 			continue
 		}
 
+		if vd, ok := vdByName[ref.Name]; ok && vd != nil {
+			migrating, _ := conditions.GetCondition(vdcondition.MigratingType, vd.Status.Conditions)
+			if migrating.Status == metav1.ConditionTrue {
+				continue
+			}
+		}
+
 		if err := setVMBDABlockDeviceDisk(kvvm, ref, vdByName, viByName, cviByName); err != nil {
 			return err
 		}

--- a/images/virtualization-artifact/pkg/controller/vm/internal/service/migration_volumes.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/service/migration_volumes.go
@@ -142,6 +142,10 @@ func (s MigrationVolumesService) SyncVolumes(ctx context.Context, vmState state.
 
 	kvvmSynced := equality.Semantic.DeepEqual(builtKVVMWithMigrationVolumes.Spec.Template.Spec.Volumes, kvvmInCluster.Spec.Template.Spec.Volumes)
 	if kvvmSynced {
+		if !equality.Semantic.DeepEqual(builtKVVMWithMigrationVolumes.Spec.Template.Spec.Affinity, kvvmInCluster.Spec.Template.Spec.Affinity) {
+			log.Info("kvvm volumes are synced but affinity drifted, re-patch affinity.")
+			return reconcile.Result{}, s.patchVolumes(ctx, builtKVVMWithMigrationVolumes)
+		}
 		if vmop != nil && (!readWriteOnceDisksSynced || !storageClassChangedDisksSynced) {
 			return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 		}

--- a/images/virtualization-artifact/pkg/controller/vm/internal/state/state.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/state/state.go
@@ -408,11 +408,16 @@ func (s *state) PVNodeAffinityTerms(ctx context.Context) ([]corev1.NodeSelectorT
 		return nil, fmt.Errorf("collect block device refs: %w", err)
 	}
 
+	vmMigrating, err := s.isVolumeMigrating(ctx, refs)
+	if err != nil {
+		return nil, err
+	}
+
 	var perPVTerms [][]corev1.NodeSelectorTerm
 	namespace := s.vm.Current().GetNamespace()
 
 	for _, ref := range refs {
-		pvcName, err := s.resolvePVCName(ctx, ref.Kind, ref.Name)
+		pvcName, err := s.resolvePVCName(ctx, ref.Kind, ref.Name, vmMigrating)
 		if err != nil {
 			return nil, fmt.Errorf("resolve PVC name for %s/%s: %w", ref.Kind, ref.Name, err)
 		}
@@ -431,6 +436,26 @@ func (s *state) PVNodeAffinityTerms(ctx context.Context) ([]corev1.NodeSelectorT
 	}
 
 	return nodeaffinity.IntersectTerms(perPVTerms), nil
+}
+
+func (s *state) isVolumeMigrating(ctx context.Context, refs []blockDeviceRef) (bool, error) {
+	for _, ref := range refs {
+		if ref.Kind != v1alpha2.DiskDevice {
+			continue
+		}
+		vd, err := s.VirtualDisk(ctx, ref.Name)
+		if err != nil {
+			return false, err
+		}
+		if vd == nil {
+			continue
+		}
+		migrating, _ := conditions.GetCondition(vdcondition.MigratingType, vd.Status.Conditions)
+		if migrating.Status == metav1.ConditionTrue {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (s *state) collectBlockDeviceRefs(ctx context.Context) ([]blockDeviceRef, error) {
@@ -471,7 +496,7 @@ func (s *state) collectBlockDeviceRefs(ctx context.Context) ([]blockDeviceRef, e
 	return refs, nil
 }
 
-func (s *state) resolvePVCName(ctx context.Context, kind v1alpha2.BlockDeviceKind, name string) (string, error) {
+func (s *state) resolvePVCName(ctx context.Context, kind v1alpha2.BlockDeviceKind, name string, vmMigrating bool) (string, error) {
 	switch kind {
 	case v1alpha2.DiskDevice:
 		vd, err := s.VirtualDisk(ctx, name)
@@ -481,10 +506,7 @@ func (s *state) resolvePVCName(ctx context.Context, kind v1alpha2.BlockDeviceKin
 		if vd == nil {
 			return "", nil
 		}
-		migrating, _ := conditions.GetCondition(vdcondition.MigratingType, vd.Status.Conditions)
-		if migrating.Status == metav1.ConditionTrue &&
-			conditions.IsLastUpdated(migrating, vd) &&
-			vd.Status.MigrationState.TargetPVC != "" {
+		if vmMigrating {
 			return vd.Status.MigrationState.TargetPVC, nil
 		}
 		return vd.Status.Target.PersistentVolumeClaim, nil

--- a/images/virtualization-artifact/pkg/controller/vm/internal/state/state_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/state/state_test.go
@@ -643,7 +643,7 @@ var _ = Describe("PVNodeAffinityTerms", func() {
 			"affinity should fall back to source when migration is not in progress")
 	})
 
-	It("should fall back to source PVC when Migrating condition is stale (older generation)", func() {
+	It("should use target PVC while migrating even when the Migrating condition is stale (older generation)", func() {
 		vm := makeVM(v1alpha2.BlockDeviceSpecRef{Kind: v1alpha2.DiskDevice, Name: "local-disk"})
 
 		vd := makeVD("local-disk", "pvc-source")
@@ -669,8 +669,8 @@ var _ = Describe("PVNodeAffinityTerms", func() {
 		terms, err := s.PVNodeAffinityTerms(ctx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(terms).To(HaveLen(1))
-		Expect(terms[0].MatchExpressions[0].Values).To(ConsistOf(node1),
-			"affinity should fall back to source when Migrating condition is not last-updated")
+		Expect(terms[0].MatchExpressions[0].Values).To(ConsistOf(node2),
+			"a migrating disk must never pin to the source node, even with a stale Migrating condition")
 	})
 })
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Fixes intermittent unschedulable migration of VMs with local-storage disks attached via VMBDA. Three coordinated changes:

1. **`state.go` (`resolvePVCName` / `PVNodeAffinityTerms`)** — during a volume migration, derive the VM pod's node affinity from the migration **target**, never the source PVC's bound node.
2. **`migration_volumes.go` (`SyncVolumes`)** — when volumes are already synced but the affinity drifted, re-patch it.
3. **`kvvm_utils.go` (`syncAttachedVMBDAHotplugVolumes`)** — skip disks that are migrating, leaving their hotplug volume to the migration flow. Prevents the main sync from reverting the hotplug volume to the source PVC.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
Migrating a VM with local disks attached through VMBDA failed intermittently . The migration target pod was pinned to the source node — KubeVirt copies the VM-pod node affinity and forbids the source node via anti-affinity, so the pod was unschedulable and the migration timed out.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
A VM with VMBDA-attached local-storage disks evicts/migrates reliably

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

