### PR TITLE
fix(e2e): check target migration via API dry run

### DIFF
--- a/test/e2e/internal/precheck/target_migration.go
+++ b/test/e2e/internal/precheck/target_migration.go
@@ -19,7 +19,6 @@ package precheck
 import (
 	"context"
 	"fmt"
-	"slices"
 
 	. "github.com/onsi/ginkgo/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -68,16 +67,6 @@ func (t *targetMigrationPrecheck) Run(ctx context.Context, f *framework.Framewor
 }
 
 func checkTargetMigrationFeature(ctx context.Context, f *framework.Framework) error {
-	mc, err := f.GetVirtualizationModuleConfig(ctx)
-	if err != nil {
-		return fmt.Errorf("%s=no to disable this precheck: failed to get virtualization module config: %w", targetMigrationPrecheckEnvName, err)
-	}
-
-	enabled := slices.Contains(mc.Spec.Settings.FeatureGates, targetMigrationFeatureName)
-	if !enabled {
-		return fmt.Errorf("%s=no to disable this precheck: %s feature should be enabled", targetMigrationPrecheckEnvName, targetMigrationFeatureName)
-	}
-
 	vmop := &v1alpha2.VirtualMachineOperation{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "target-migration-precheck",
@@ -94,7 +83,7 @@ func checkTargetMigrationFeature(ctx context.Context, f *framework.Framework) er
 		},
 	}
 
-	err = f.GenericClient().Create(ctx, vmop, &client.CreateOptions{
+	err := f.GenericClient().Create(ctx, vmop, &client.CreateOptions{
 		DryRun: []string{metav1.DryRunAll},
 	})
 	if err != nil {


### PR DESCRIPTION
## Description
Target migration precheck now validates the feature by creating a dry-run `VirtualMachineOperation`, without reading `ModuleConfig` feature gates.

## Why do we need it, and what problem does it solve?
The precheck used `ModuleConfig` as the source of truth, but it does not reliably reflect whether target migration is actually available. The API dry run checks the real behavior instead.

## What is the expected result?
Run target migration precheck: it should pass when the API accepts a target migration operation and fail when the operation is not supported.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.