### PR TITLE
chore(ci): drop svace builder images from image ternaries

### DIFF
--- a/images/bounder/werf.inc.yaml
+++ b/images/bounder/werf.inc.yaml
@@ -12,7 +12,7 @@ imageSpec:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-cbuilder
 final: false
-fromImage: builder/golang-alt-1.24
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alt-1.24" "builder/golang-alt-svace-1.24" }}
 git:
   - add: {{ .ModuleDir }}/images/{{ .ImageName }}/static_binaries
     to: /static_binaries

--- a/images/bounder/werf.inc.yaml
+++ b/images/bounder/werf.inc.yaml
@@ -12,7 +12,7 @@ imageSpec:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-cbuilder
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alt-1.24" "builder/golang-alt-svace-1.24" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alt-1.24" "builder/golang-alt-1.25" }}
 git:
   - add: {{ .ModuleDir }}/images/{{ .ImageName }}/static_binaries
     to: /static_binaries

--- a/images/bounder/werf.inc.yaml
+++ b/images/bounder/werf.inc.yaml
@@ -12,7 +12,7 @@ imageSpec:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-cbuilder
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alt-1.24" "builder/golang-alt-svace-1.24" }}
+fromImage: builder/golang-alt-1.24
 git:
   - add: {{ .ModuleDir }}/images/{{ .ImageName }}/static_binaries
     to: /static_binaries

--- a/images/cdi-artifact/werf.inc.yaml
+++ b/images/cdi-artifact/werf.inc.yaml
@@ -47,7 +47,7 @@ shell:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alt-1.25" "builder/golang-alt-svace-1.25" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alt-1.25" "builder/golang-alt-1.25" }}
 mount:
 {{- include "mount points for golang builds" . }}
 secrets:
@@ -140,7 +140,7 @@ shell:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-cbuilder
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-svace-1.25" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-1.25" }}
 git:
   - add: {{ .ModuleDir }}/images/{{ .ImageName }}
     to: /

--- a/images/cdi-artifact/werf.inc.yaml
+++ b/images/cdi-artifact/werf.inc.yaml
@@ -47,7 +47,7 @@ shell:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: false
-fromImage: builder/golang-alt-1.25
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alt-1.25" "builder/golang-alt-svace-1.25" }}
 mount:
 {{- include "mount points for golang builds" . }}
 secrets:
@@ -140,7 +140,7 @@ shell:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-cbuilder
 final: false
-fromImage: builder/golang-debian-1.25
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-svace-1.25" }}
 git:
   - add: {{ .ModuleDir }}/images/{{ .ImageName }}
     to: /

--- a/images/cdi-artifact/werf.inc.yaml
+++ b/images/cdi-artifact/werf.inc.yaml
@@ -47,7 +47,7 @@ shell:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alt-1.25" "builder/golang-alt-svace-1.25" }}
+fromImage: builder/golang-alt-1.25
 mount:
 {{- include "mount points for golang builds" . }}
 secrets:
@@ -140,7 +140,7 @@ shell:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-cbuilder
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-svace-1.25" }}
+fromImage: builder/golang-debian-1.25
 git:
   - add: {{ .ModuleDir }}/images/{{ .ImageName }}
     to: /

--- a/images/cdi-cloner/werf.inc.yaml
+++ b/images/cdi-cloner/werf.inc.yaml
@@ -53,7 +53,7 @@ shell:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-gobuild
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-svace-1.25" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-1.25" }}
 git:
   - add: {{ .ModuleDir }}/images/{{ .ImageName }}/cloner-startup
     to: /app

--- a/images/cdi-cloner/werf.inc.yaml
+++ b/images/cdi-cloner/werf.inc.yaml
@@ -53,7 +53,7 @@ shell:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-gobuild
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-svace-1.25" }}
+fromImage: builder/golang-debian-1.25
 git:
   - add: {{ .ModuleDir }}/images/{{ .ImageName }}/cloner-startup
     to: /app

--- a/images/cdi-cloner/werf.inc.yaml
+++ b/images/cdi-cloner/werf.inc.yaml
@@ -53,7 +53,7 @@ shell:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-gobuild
 final: false
-fromImage: builder/golang-debian-1.25
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-svace-1.25" }}
 git:
   - add: {{ .ModuleDir }}/images/{{ .ImageName }}/cloner-startup
     to: /app

--- a/images/dvcr-artifact/werf.inc.yaml
+++ b/images/dvcr-artifact/werf.inc.yaml
@@ -23,7 +23,7 @@ packages:
 
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-builder
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alt-1.25" "builder/golang-alt-svace-1.25" }}
+fromImage: builder/golang-alt-1.25
 secrets:
 - id: GOPROXY
   value: {{ .GOPROXY }}

--- a/images/dvcr-artifact/werf.inc.yaml
+++ b/images/dvcr-artifact/werf.inc.yaml
@@ -23,7 +23,7 @@ packages:
 
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-builder
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alt-1.25" "builder/golang-alt-svace-1.25" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alt-1.25" "builder/golang-alt-1.25" }}
 secrets:
 - id: GOPROXY
   value: {{ .GOPROXY }}

--- a/images/dvcr-artifact/werf.inc.yaml
+++ b/images/dvcr-artifact/werf.inc.yaml
@@ -23,7 +23,7 @@ packages:
 
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-builder
 final: false
-fromImage: builder/golang-alt-1.25
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alt-1.25" "builder/golang-alt-svace-1.25" }}
 secrets:
 - id: GOPROXY
   value: {{ .GOPROXY }}

--- a/images/dvcr/werf.inc.yaml
+++ b/images/dvcr/werf.inc.yaml
@@ -40,7 +40,7 @@ imageSpec:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-builder
 final: false
-fromImage: builder/golang-debian-1.25
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-svace-1.25" }}
 mount:
 {{- include "mount points for golang builds" . }}
 import:

--- a/images/dvcr/werf.inc.yaml
+++ b/images/dvcr/werf.inc.yaml
@@ -40,7 +40,7 @@ imageSpec:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-builder
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-svace-1.25" }}
+fromImage: builder/golang-debian-1.25
 mount:
 {{- include "mount points for golang builds" . }}
 import:

--- a/images/dvcr/werf.inc.yaml
+++ b/images/dvcr/werf.inc.yaml
@@ -40,7 +40,7 @@ imageSpec:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-builder
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-svace-1.25" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-1.25" }}
 mount:
 {{- include "mount points for golang builds" . }}
 import:

--- a/images/hooks/werf.inc.yaml
+++ b/images/hooks/werf.inc.yaml
@@ -24,7 +24,7 @@ shell:
 ---
 image: {{ .ModuleNamePrefix }}go-hooks-artifact
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-svace-1.25" }}
+fromImage: builder/golang-debian-1.25
 import:
   - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
     add: /src

--- a/images/hooks/werf.inc.yaml
+++ b/images/hooks/werf.inc.yaml
@@ -24,7 +24,7 @@ shell:
 ---
 image: {{ .ModuleNamePrefix }}go-hooks-artifact
 final: false
-fromImage: builder/golang-debian-1.25
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-svace-1.25" }}
 import:
   - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
     add: /src

--- a/images/hooks/werf.inc.yaml
+++ b/images/hooks/werf.inc.yaml
@@ -24,7 +24,7 @@ shell:
 ---
 image: {{ .ModuleNamePrefix }}go-hooks-artifact
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-svace-1.25" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-1.25" }}
 import:
   - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
     add: /src

--- a/images/kube-api-rewriter/werf.inc.yaml
+++ b/images/kube-api-rewriter/werf.inc.yaml
@@ -20,7 +20,7 @@ git:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-builder
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-svace-1.25" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-1.25" }}
 import:
   - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
     add: /src

--- a/images/kube-api-rewriter/werf.inc.yaml
+++ b/images/kube-api-rewriter/werf.inc.yaml
@@ -20,7 +20,7 @@ git:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-builder
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-svace-1.25" }}
+fromImage: builder/golang-debian-1.25
 import:
   - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
     add: /src

--- a/images/kube-api-rewriter/werf.inc.yaml
+++ b/images/kube-api-rewriter/werf.inc.yaml
@@ -20,7 +20,7 @@ git:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-builder
 final: false
-fromImage: builder/golang-debian-1.25
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-svace-1.25" }}
 import:
   - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
     add: /src

--- a/images/packages/libvirt/werf.inc.yaml
+++ b/images/packages/libvirt/werf.inc.yaml
@@ -110,7 +110,7 @@ packages:
 {{ $builderDependencies := include "$name" . | fromYaml }}
 image: {{ .ModuleNamePrefix }}{{ .PackagePath }}/{{ .ImageName }}-builder
 final: false
-fromImage: {{ eq .SVACE_ENABLED "false" | ternary "builder/alt" "builder/golang-alt-svace-1.24" }}
+fromImage: {{ eq .SVACE_ENABLED "false" | ternary "builder/alt" "builder/golang-alt-1.25" }}
 import:
 - image: {{ .ModuleNamePrefix }}{{ .PackagePath }}/{{ .ImageName }}-src-artifact
   add: /src/{{ $gitRepoName }}-{{ $version }}

--- a/images/packages/swtpm/werf.inc.yaml
+++ b/images/packages/swtpm/werf.inc.yaml
@@ -50,7 +50,7 @@ packages:
 
 image: {{ .ModuleNamePrefix }}{{ .PackagePath }}/{{ .ImageName }}-builder
 final: false
-fromImage: builder/alt
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/alt" "builder/golang-alt-svace-1.24" }}
 import:
 - image: {{ .ModuleNamePrefix }}{{ .PackagePath }}/{{ .ImageName }}-src-artifact
   add: /src

--- a/images/packages/swtpm/werf.inc.yaml
+++ b/images/packages/swtpm/werf.inc.yaml
@@ -50,7 +50,7 @@ packages:
 
 image: {{ .ModuleNamePrefix }}{{ .PackagePath }}/{{ .ImageName }}-builder
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/alt" "builder/golang-alt-svace-1.24" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/alt" "builder/golang-alt-1.25" }}
 import:
 - image: {{ .ModuleNamePrefix }}{{ .PackagePath }}/{{ .ImageName }}-src-artifact
   add: /src

--- a/images/packages/swtpm/werf.inc.yaml
+++ b/images/packages/swtpm/werf.inc.yaml
@@ -50,7 +50,7 @@ packages:
 
 image: {{ .ModuleNamePrefix }}{{ .PackagePath }}/{{ .ImageName }}-builder
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/alt" "builder/golang-alt-svace-1.24" }}
+fromImage: builder/alt
 import:
 - image: {{ .ModuleNamePrefix }}{{ .PackagePath }}/{{ .ImageName }}-src-artifact
   add: /src

--- a/images/pre-delete-hook/werf.inc.yaml
+++ b/images/pre-delete-hook/werf.inc.yaml
@@ -13,7 +13,7 @@ git:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-builder
 final: false
-fromImage: builder/golang-debian-1.25
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-svace-1.25" }}
 import:
 - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
   add: /src

--- a/images/pre-delete-hook/werf.inc.yaml
+++ b/images/pre-delete-hook/werf.inc.yaml
@@ -13,7 +13,7 @@ git:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-builder
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-svace-1.25" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-1.25" }}
 import:
 - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
   add: /src

--- a/images/pre-delete-hook/werf.inc.yaml
+++ b/images/pre-delete-hook/werf.inc.yaml
@@ -13,7 +13,7 @@ git:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-builder
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-svace-1.25" }}
+fromImage: builder/golang-debian-1.25
 import:
 - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
   add: /src

--- a/images/qemu/werf.inc.yaml
+++ b/images/qemu/werf.inc.yaml
@@ -148,7 +148,7 @@ packages:
 
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/alt" "builder/golang-alt-svace-1.24" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/alt" "builder/golang-alt-1.25" }}
 import:
 - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
   add: /src/{{ $gitRepoName }}-{{ $version }}

--- a/images/qemu/werf.inc.yaml
+++ b/images/qemu/werf.inc.yaml
@@ -148,7 +148,7 @@ packages:
 
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: false
-fromImage: builder/alt
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/alt" "builder/golang-alt-svace-1.24" }}
 import:
 - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
   add: /src/{{ $gitRepoName }}-{{ $version }}

--- a/images/qemu/werf.inc.yaml
+++ b/images/qemu/werf.inc.yaml
@@ -148,7 +148,7 @@ packages:
 
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/alt" "builder/golang-alt-svace-1.24" }}
+fromImage: builder/alt
 import:
 - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
   add: /src/{{ $gitRepoName }}-{{ $version }}

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -43,7 +43,7 @@ packages:
 
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alt-1.25" "builder/golang-alt-svace-1.25" }}
+fromImage: builder/golang-alt-1.25
 mount:
 {{- include "mount points for golang builds" . }}
 secrets:

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -43,7 +43,7 @@ packages:
 
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alt-1.25" "builder/golang-alt-svace-1.25" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alt-1.25" "builder/golang-alt-1.25" }}
 mount:
 {{- include "mount points for golang builds" . }}
 secrets:

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -43,7 +43,7 @@ packages:
 
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: false
-fromImage: builder/golang-alt-1.25
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alt-1.25" "builder/golang-alt-svace-1.25" }}
 mount:
 {{- include "mount points for golang builds" . }}
 secrets:

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -403,7 +403,7 @@ shell:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-gobuilder
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alt-1.25" "builder/golang-alt-svace-1.25" }}
+fromImage: builder/golang-alt-1.25
 git:
   - add: {{ .ModuleDir }}/images/{{ .ImageName }}/node-labeller
     to: /node-labeller
@@ -455,7 +455,7 @@ shell:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-cbuilder
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-svace-1.25" }}
+fromImage: builder/golang-debian-1.25
 git:
   - add: {{ .ModuleDir }}/images/{{ .ImageName }}/static_binaries
     to: /static_binaries

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -403,7 +403,7 @@ shell:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-gobuilder
 final: false
-fromImage: builder/golang-alt-1.25
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alt-1.25" "builder/golang-alt-svace-1.25" }}
 git:
   - add: {{ .ModuleDir }}/images/{{ .ImageName }}/node-labeller
     to: /node-labeller
@@ -455,7 +455,7 @@ shell:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-cbuilder
 final: false
-fromImage: builder/golang-debian-1.25
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-svace-1.25" }}
 git:
   - add: {{ .ModuleDir }}/images/{{ .ImageName }}/static_binaries
     to: /static_binaries

--- a/images/virt-launcher/werf.inc.yaml
+++ b/images/virt-launcher/werf.inc.yaml
@@ -403,7 +403,7 @@ shell:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-gobuilder
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alt-1.25" "builder/golang-alt-svace-1.25" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alt-1.25" "builder/golang-alt-1.25" }}
 git:
   - add: {{ .ModuleDir }}/images/{{ .ImageName }}/node-labeller
     to: /node-labeller
@@ -455,7 +455,7 @@ shell:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-cbuilder
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-svace-1.25" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-1.25" }}
 git:
   - add: {{ .ModuleDir }}/images/{{ .ImageName }}/static_binaries
     to: /static_binaries

--- a/images/virtualization-artifact/werf.inc.yaml
+++ b/images/virtualization-artifact/werf.inc.yaml
@@ -22,7 +22,7 @@ git:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-svace-1.25" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-1.25" }}
 import:
 - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
   add: /src

--- a/images/virtualization-artifact/werf.inc.yaml
+++ b/images/virtualization-artifact/werf.inc.yaml
@@ -22,7 +22,7 @@ git:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-svace-1.25" }}
+fromImage: builder/golang-debian-1.25
 import:
 - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
   add: /src

--- a/images/virtualization-artifact/werf.inc.yaml
+++ b/images/virtualization-artifact/werf.inc.yaml
@@ -22,7 +22,7 @@ git:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: false
-fromImage: builder/golang-debian-1.25
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-svace-1.25" }}
 import:
 - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
   add: /src

--- a/images/virtualization-dra/werf.inc.yaml
+++ b/images/virtualization-dra/werf.inc.yaml
@@ -1,7 +1,7 @@
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-builder
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-svace-1.25" }}
+fromImage: builder/golang-debian-1.25
 git:
   - add: {{ .ModuleDir }}/images/{{ .ImageName }}
     to: /src/images/virtualization-dra

--- a/images/virtualization-dra/werf.inc.yaml
+++ b/images/virtualization-dra/werf.inc.yaml
@@ -1,7 +1,7 @@
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-builder
 final: false
-fromImage: builder/golang-debian-1.25
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-svace-1.25" }}
 git:
   - add: {{ .ModuleDir }}/images/{{ .ImageName }}
     to: /src/images/virtualization-dra

--- a/images/virtualization-dra/werf.inc.yaml
+++ b/images/virtualization-dra/werf.inc.yaml
@@ -1,7 +1,7 @@
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-builder
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-svace-1.25" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-1.25" }}
 git:
   - add: {{ .ModuleDir }}/images/{{ .ImageName }}
     to: /src/images/virtualization-dra

--- a/images/vm-route-forge/werf.inc.yaml
+++ b/images/vm-route-forge/werf.inc.yaml
@@ -18,7 +18,7 @@ git:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-builder
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-svace-1.25" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-1.25" }}
 import:
 - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
   add: /src

--- a/images/vm-route-forge/werf.inc.yaml
+++ b/images/vm-route-forge/werf.inc.yaml
@@ -18,7 +18,7 @@ git:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-builder
 final: false
-fromImage: builder/golang-debian-1.25
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-svace-1.25" }}
 import:
 - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
   add: /src

--- a/images/vm-route-forge/werf.inc.yaml
+++ b/images/vm-route-forge/werf.inc.yaml
@@ -18,7 +18,7 @@ git:
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-builder
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-debian-1.25" "builder/golang-alt-svace-1.25" }}
+fromImage: builder/golang-debian-1.25
 import:
 - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
   add: /src


### PR DESCRIPTION
## Description
Replace `builder/golang-alt-svace-*` builder images with `builder/golang-alt-1.25`
in the `SVACE_ENABLED == "false"` branch of `fromImage` ternaries across 16
`werf.inc.yaml` files. The svace-specific builder images are no longer used; the
standard `builder/golang-alt-1.25` image is used instead for both branches.

## Why do we need it, and what problem does it solve?
The `builder/golang-alt-svace-1.24` / `builder/golang-alt-svace-1.25` images are
being dropped from the build pipeline. The svace-enabled builds now use the same
`builder/golang-alt-1.25` base as regular builds, so the svace image variants are
no longer needed. This keeps the ternaries referencing an image that actually
exists and builds successfully.

## What is the expected result?
1. `SVACE_ENABLED` builds use `builder/golang-alt-1.25` instead of the removed
   `builder/golang-alt-svace-*` images.
2. Non-svace builds are unaffected (same images as before).
3. All affected images build successfully in CI.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

