### PR TITLE
feat(vm): allow disabling automatic firmware update migrations

### DIFF
--- a/images/hooks/pkg/hooks/migration-config/hook.go
+++ b/images/hooks/pkg/hooks/migration-config/hook.go
@@ -38,18 +38,21 @@ const (
 	parallelOutboundMigrationsPerNodeAnnotation = "virtualization.deckhouse.io/parallel-outbound-migrations-per-node"
 	progressTimeoutAnnotation                   = "virtualization.deckhouse.io/progress-timeout"
 	disableTLSAnnotation                        = "virtualization.deckhouse.io/disable-tls"
+	disableFirmwareUpdateAnnotation             = "virtualization.deckhouse.io/disable-firmware-update"
 
 	bandwidthPerMigrationValuesPath             = "virtualization.internal.virtConfig.bandwidthPerMigration"
 	completionTimeoutPerGiBValuesPath           = "virtualization.internal.virtConfig.completionTimeoutPerGiB"
 	parallelOutboundMigrationsPerNodeValuesPath = "virtualization.internal.virtConfig.parallelOutboundMigrationsPerNode"
 	progressTimeoutValuesPath                   = "virtualization.internal.virtConfig.progressTimeout"
 	disableTLSValuesPath                        = "virtualization.internal.virtConfig.disableTLS"
+	disableFirmwareUpdateValuesPath             = "virtualization.internal.disableFirmwareUpdate"
 
 	defaultBandwidthPerMigration             = "640Mi"
 	defaultCompletionTimeoutPerGiB           = 800
 	defaultParallelOutboundMigrationsPerNode = 1
 	defaultProgressTimeout                   = 150
 	defaultDisableTLS                        = false
+	defaultDisableFirmwareUpdate             = false
 )
 
 // migrationParams defines migration parameters configurable via ModuleConfig annotations.
@@ -80,6 +83,11 @@ var migrationParams = []migrationParam{
 		annotation:   disableTLSAnnotation,
 		valuesPath:   disableTLSValuesPath,
 		defaultValue: defaultDisableTLS,
+	},
+	{
+		annotation:   disableFirmwareUpdateAnnotation,
+		valuesPath:   disableFirmwareUpdateValuesPath,
+		defaultValue: defaultDisableFirmwareUpdate,
 	},
 }
 

--- a/images/hooks/pkg/hooks/migration-config/hook_test.go
+++ b/images/hooks/pkg/hooks/migration-config/hook_test.go
@@ -85,6 +85,7 @@ var _ = Describe("MigrationConfig", func() {
 			parallelOutboundMigrationsPerNodeAnnotation: "5",
 			progressTimeoutAnnotation:                   "300",
 			disableTLSAnnotation:                        "true",
+			disableFirmwareUpdateAnnotation:             "true",
 		}))
 
 		values.GetMock.Set(func(path string) gjson.Result {
@@ -98,6 +99,8 @@ var _ = Describe("MigrationConfig", func() {
 			case progressTimeoutValuesPath:
 				return gjson.Result{Type: gjson.Number, Num: defaultProgressTimeout}
 			case disableTLSValuesPath:
+				return gjson.Result{Type: gjson.False}
+			case disableFirmwareUpdateValuesPath:
 				return gjson.Result{Type: gjson.False}
 			}
 			return gjson.Result{}
@@ -115,6 +118,7 @@ var _ = Describe("MigrationConfig", func() {
 		Expect(setValues).To(HaveKeyWithValue(parallelOutboundMigrationsPerNodeValuesPath, 5))
 		Expect(setValues).To(HaveKeyWithValue(progressTimeoutValuesPath, 300))
 		Expect(setValues).To(HaveKeyWithValue(disableTLSValuesPath, true))
+		Expect(setValues).To(HaveKeyWithValue(disableFirmwareUpdateValuesPath, true))
 	})
 
 	It("Should set defaults when no annotations present", func() {
@@ -132,6 +136,8 @@ var _ = Describe("MigrationConfig", func() {
 				return gjson.Result{Type: gjson.Number, Num: 9999}
 			case disableTLSValuesPath:
 				return gjson.Result{Type: gjson.True}
+			case disableFirmwareUpdateValuesPath:
+				return gjson.Result{Type: gjson.True}
 			}
 			return gjson.Result{}
 		})
@@ -148,6 +154,7 @@ var _ = Describe("MigrationConfig", func() {
 		Expect(setValues).To(HaveKeyWithValue(parallelOutboundMigrationsPerNodeValuesPath, defaultParallelOutboundMigrationsPerNode))
 		Expect(setValues).To(HaveKeyWithValue(progressTimeoutValuesPath, defaultProgressTimeout))
 		Expect(setValues).To(HaveKeyWithValue(disableTLSValuesPath, defaultDisableTLS))
+		Expect(setValues).To(HaveKeyWithValue(disableFirmwareUpdateValuesPath, defaultDisableFirmwareUpdate))
 	})
 
 	It("Should not set values when current matches target", func() {
@@ -157,6 +164,7 @@ var _ = Describe("MigrationConfig", func() {
 			parallelOutboundMigrationsPerNodeAnnotation: "1",
 			progressTimeoutAnnotation:                   "150",
 			disableTLSAnnotation:                        "false",
+			disableFirmwareUpdateAnnotation:             "false",
 		}))
 
 		values.GetMock.Set(func(path string) gjson.Result {
@@ -170,6 +178,8 @@ var _ = Describe("MigrationConfig", func() {
 			case progressTimeoutValuesPath:
 				return gjson.Result{Type: gjson.Number, Num: defaultProgressTimeout}
 			case disableTLSValuesPath:
+				return gjson.Result{Type: gjson.False}
+			case disableFirmwareUpdateValuesPath:
 				return gjson.Result{Type: gjson.False}
 			}
 			return gjson.Result{}

--- a/images/virtualization-artifact/cmd/virtualization-controller/main.go
+++ b/images/virtualization-artifact/cmd/virtualization-controller/main.go
@@ -91,8 +91,9 @@ const (
 	virtualMachineCIDRsEnv                     = "VIRTUAL_MACHINE_CIDRS"
 	virtualMachineIPLeasesRetentionDurationEnv = "VIRTUAL_MACHINE_IP_LEASES_RETENTION_DURATION"
 
-	FirmwareImageEnv      = "FIRMWARE_IMAGE"
-	VirtControllerNameEnv = "VIRT_CONTROLLER_NAME"
+	FirmwareImageEnv         = "FIRMWARE_IMAGE"
+	VirtControllerNameEnv    = "VIRT_CONTROLLER_NAME"
+	DisableFirmwareUpdateEnv = "DISABLE_FIRMWARE_UPDATE"
 
 	SdnEnabledEnv  = "SDN_ENABLED"
 	clusterUUIDEnv = "CLUSTER_UUID"
@@ -141,6 +142,17 @@ func main() {
 
 	var virtControllerName string
 	pflag.StringVar(&virtControllerName, "virt-controller-name", getEnv(VirtControllerNameEnv, "virt-controller"), "Virt controller name")
+
+	var disableFirmwareUpdate bool
+	disableFirmwareUpdateRaw := os.Getenv(DisableFirmwareUpdateEnv)
+	if disableFirmwareUpdateRaw != "" {
+		disableFirmwareUpdate, err = strconv.ParseBool(disableFirmwareUpdateRaw)
+		if err != nil {
+			slog.Default().Error(err.Error())
+			os.Exit(1)
+		}
+	}
+	pflag.BoolVar(&disableFirmwareUpdate, "disable-firmware-update", disableFirmwareUpdate, "disable automatic firmware update migrations")
 
 	var leaderElection bool
 	pflag.BoolVar(&leaderElection, "leader-election", true, "Leader election")
@@ -458,7 +470,7 @@ func main() {
 	}
 
 	workloadUpdaterLogger := logger.NewControllerLogger(workloadupdater.ControllerName, logLevel, logOutput, logDebugVerbosity, logDebugControllerList)
-	if err = workloadupdater.SetupController(ctx, mgr, workloadUpdaterLogger, firmwareImage, controllerNamespace, virtControllerName); err != nil {
+	if err = workloadupdater.SetupController(ctx, mgr, workloadUpdaterLogger, firmwareImage, controllerNamespace, virtControllerName, disableFirmwareUpdate); err != nil {
 		log.Error(err.Error())
 		os.Exit(1)
 	}

--- a/images/virtualization-artifact/pkg/controller/workload-updater/internal/handler/firmware.go
+++ b/images/virtualization-artifact/pkg/controller/workload-updater/internal/handler/firmware.go
@@ -40,22 +40,24 @@ type firmwareMigration interface {
 	OnceMigrate(ctx context.Context, vm *v1alpha2.VirtualMachine, annotationKey, annotationExpectedValue string) (bool, error)
 }
 
-func NewFirmwareHandler(client client.Client, migration firmwareMigration, firmwareImage, namespace, virtControllerName string) *FirmwareHandler {
+func NewFirmwareHandler(client client.Client, migration firmwareMigration, firmwareImage, namespace, virtControllerName string, disableFirmwareUpdate bool) *FirmwareHandler {
 	return &FirmwareHandler{
-		client:             client,
-		oneShotMigration:   migration,
-		firmwareImage:      firmwareImage,
-		namespace:          namespace,
-		virtControllerName: virtControllerName,
+		client:                client,
+		oneShotMigration:      migration,
+		firmwareImage:         firmwareImage,
+		namespace:             namespace,
+		virtControllerName:    virtControllerName,
+		disableFirmwareUpdate: disableFirmwareUpdate,
 	}
 }
 
 type FirmwareHandler struct {
-	client             client.Client
-	oneShotMigration   firmwareMigration
-	firmwareImage      string
-	namespace          string
-	virtControllerName string
+	client                client.Client
+	oneShotMigration      firmwareMigration
+	firmwareImage         string
+	namespace             string
+	virtControllerName    string
+	disableFirmwareUpdate bool
 }
 
 func (h *FirmwareHandler) Handle(ctx context.Context, vm *v1alpha2.VirtualMachine) (reconcile.Result, error) {
@@ -69,6 +71,11 @@ func (h *FirmwareHandler) Handle(ctx context.Context, vm *v1alpha2.VirtualMachin
 
 	log := logger.FromContext(ctx).With(logger.SlogHandler(firmwareHandler))
 	ctx = logger.ToContext(ctx, log)
+
+	if h.disableFirmwareUpdate {
+		log.Info("Automatic firmware update is disabled by environment")
+		return reconcile.Result{}, nil
+	}
 
 	if ready, err := h.isVirtControllerUpToDate(ctx); err != nil {
 		return reconcile.Result{}, err

--- a/images/virtualization-artifact/pkg/controller/workload-updater/internal/handler/firmware_test.go
+++ b/images/virtualization-artifact/pkg/controller/workload-updater/internal/handler/firmware_test.go
@@ -128,7 +128,7 @@ var _ = Describe("TestFirmwareHandler", func() {
 				},
 			}
 
-			h := NewFirmwareHandler(fakeClient, mockMigration, firmwareImage, virtControllerNamespace, virtControllerName)
+			h := NewFirmwareHandler(fakeClient, mockMigration, firmwareImage, virtControllerNamespace, virtControllerName, false)
 			_, err := h.Handle(ctx, vm)
 
 			if needMigrate {
@@ -155,15 +155,33 @@ var _ = Describe("TestFirmwareHandler", func() {
 				migrationCalled = true
 				return false, nil
 			},
-		}, firmwareImage, virtControllerNamespace, virtControllerName)
+		}, firmwareImage, virtControllerNamespace, virtControllerName, false)
 
 		_, err := h.Handle(ctx, vm)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(migrationCalled).To(BeTrue())
 	})
 
+	It("should skip migration when firmware update is disabled", func() {
+		vm := newVMNeedMigrate()
+		deploy := newVirtController(true, firmwareImage)
+		fakeClient = setupFirmwareEnvironment(vm, deploy)
+
+		migrationCalled := false
+		h := NewFirmwareHandler(fakeClient, &firmwareMigrationStub{
+			onceMigrate: func(ctx context.Context, vm *v1alpha2.VirtualMachine, annotationKey, annotationExpectedValue string) (bool, error) {
+				migrationCalled = true
+				return false, nil
+			},
+		}, firmwareImage, virtControllerNamespace, virtControllerName, true)
+
+		_, err := h.Handle(ctx, vm)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(migrationCalled).To(BeFalse())
+	})
+
 	It("should return nil when vm is nil", func() {
-		h := NewFirmwareHandler(nil, nil, firmwareImage, virtControllerNamespace, virtControllerName)
+		h := NewFirmwareHandler(nil, nil, firmwareImage, virtControllerNamespace, virtControllerName, false)
 
 		_, err := h.Handle(ctx, nil)
 		Expect(err).NotTo(HaveOccurred())
@@ -174,7 +192,7 @@ var _ = Describe("TestFirmwareHandler", func() {
 		now := metav1.Now()
 		vm.DeletionTimestamp = &now
 
-		h := NewFirmwareHandler(nil, nil, firmwareImage, virtControllerNamespace, virtControllerName)
+		h := NewFirmwareHandler(nil, nil, firmwareImage, virtControllerNamespace, virtControllerName, false)
 		_, err := h.Handle(ctx, vm)
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -187,7 +205,7 @@ var _ = Describe("TestFirmwareHandler", func() {
 			onceMigrate: func(ctx context.Context, vm *v1alpha2.VirtualMachine, annotationKey, annotationExpectedValue string) (bool, error) {
 				return false, nil
 			},
-		}, firmwareImage, virtControllerNamespace, virtControllerName)
+		}, firmwareImage, virtControllerNamespace, virtControllerName, false)
 
 		_, err := h.Handle(ctx, vm)
 		Expect(err).To(HaveOccurred())
@@ -202,7 +220,7 @@ var _ = Describe("TestFirmwareHandler", func() {
 
 		DescribeTable("should evaluate FirmwareUpToDate condition",
 			func(vm *v1alpha2.VirtualMachine, expected bool) {
-				h := NewFirmwareHandler(nil, nil, firmwareImage, virtControllerNamespace, virtControllerName)
+				h := NewFirmwareHandler(nil, nil, firmwareImage, virtControllerNamespace, virtControllerName, false)
 				Expect(h.needUpdate(vm)).To(Equal(expected))
 			},
 			Entry("FirmwareUpToDate is False", buildVMWithConditions([]metav1.Condition{{
@@ -222,7 +240,8 @@ var _ = Describe("TestFirmwareHandler", func() {
 
 	Describe("isVirtControllerUpToDate", func() {
 		It("should return error when deployment is not found", func() {
-			h := NewFirmwareHandler(setupFirmwareEnvironment(newVMNeedMigrate()), nil, firmwareImage, virtControllerNamespace, virtControllerName)
+			fakeClient := setupFirmwareEnvironment(newVMNeedMigrate())
+			h := NewFirmwareHandler(fakeClient, nil, firmwareImage, virtControllerNamespace, virtControllerName, false)
 
 			ready, err := h.isVirtControllerUpToDate(ctx)
 			Expect(err).To(HaveOccurred())
@@ -231,7 +250,8 @@ var _ = Describe("TestFirmwareHandler", func() {
 
 		DescribeTable("should evaluate deployment state and launcher image",
 			func(deploy *appsv1.Deployment, expectedReady bool) {
-				h := NewFirmwareHandler(setupFirmwareEnvironment(newVMNeedMigrate(), deploy), nil, firmwareImage, virtControllerNamespace, virtControllerName)
+				fakeClient := setupFirmwareEnvironment(newVMNeedMigrate(), deploy)
+				h := NewFirmwareHandler(fakeClient, nil, firmwareImage, virtControllerNamespace, virtControllerName, false)
 
 				ready, err := h.isVirtControllerUpToDate(ctx)
 				Expect(err).NotTo(HaveOccurred())
@@ -310,7 +330,7 @@ var _ = Describe("TestFirmwareHandler", func() {
 	})
 
 	It("should return firmware handler name", func() {
-		h := NewFirmwareHandler(nil, nil, firmwareImage, virtControllerNamespace, virtControllerName)
+		h := NewFirmwareHandler(nil, nil, firmwareImage, virtControllerNamespace, virtControllerName, false)
 		Expect(h.Name()).To(Equal(firmwareHandler))
 	})
 })

--- a/images/virtualization-artifact/pkg/controller/workload-updater/workload_updater_controller.go
+++ b/images/virtualization-artifact/pkg/controller/workload-updater/workload_updater_controller.go
@@ -42,11 +42,12 @@ func SetupController(
 	firmwareImage,
 	namespace,
 	virtControllerName string,
+	disableFirmwareUpdate bool,
 ) error {
 	client := mgr.GetClient()
 
 	handlers := []Handler{
-		handler.NewFirmwareHandler(client, service.NewOneShotMigrationService(client, "firmware-update-"), firmwareImage, namespace, virtControllerName),
+		handler.NewFirmwareHandler(client, service.NewOneShotMigrationService(client, "firmware-update-"), firmwareImage, namespace, virtControllerName, disableFirmwareUpdate),
 		handler.NewNodePlacementHandler(client, service.NewOneShotMigrationService(client, "nodeplacement-update-")),
 	}
 	isMemoryHotplug := featuregates.Default().Enabled(featuregates.HotplugMemoryWithLiveMigration)

--- a/openapi/values.yaml
+++ b/openapi/values.yaml
@@ -143,6 +143,9 @@ properties:
             type: integer
           disableTLS:
             type: boolean
+      disableFirmwareUpdate:
+        type: boolean
+        default: false
       moduleConfig:
         type: object
         additionalProperties: true

--- a/templates/virtualization-controller/_helpers.tpl
+++ b/templates/virtualization-controller/_helpers.tpl
@@ -108,6 +108,8 @@ true
 {{- end }}
 - name: FIRMWARE_IMAGE
   value: {{ include "helm_lib_module_image" (list . "virtLauncher") }}
+- name: DISABLE_FIRMWARE_UPDATE
+  value: {{ .Values.virtualization.internal.disableFirmwareUpdate | default false | quote }}
 - name: CLUSTER_UUID
   value: {{ .Values.global.discovery.clusterUUID }}
 - name: CLUSTER_POD_SUBNET_CIDR


### PR DESCRIPTION
## Description
Added a ModuleConfig annotation-driven switch for automatic firmware update migrations.

When `virtualization.deckhouse.io/disable-firmware-update=true` is set on `ModuleConfig/virtualization`, the existing module hook copies this value into internal Helm values, the controller Deployment receives `DISABLE_FIRMWARE_UPDATE=true`, and the workload-updater firmware handler skips creating `firmware-update-*` VMOPs.

The controller no longer needs to read `ModuleConfig` at runtime for this check.

## Why do we need it, and what problem does it solve?
Operators need a way to temporarily prevent system-initiated firmware update migrations while keeping the module and VM status reconciliation running.

Using the ModuleConfig annotation keeps the switch in the module configuration flow and avoids adding runtime `ModuleConfig` reads or extra controller RBAC permissions.

## What is the expected result?
Set the annotation:

```bash
d8 k annotate moduleconfig virtualization virtualization.deckhouse.io/disable-firmware-update=true --overwrite
```

After the module values are rendered and the controller Deployment is updated, VMs may still report `FirmwareUpToDate=False`, but workload-updater does not create `firmware-update-*` VMOPs while the switch is enabled.

Remove or set the annotation to `false` to restore automatic firmware update migrations.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.