### PR TITLE
fix(uploader): sync ingress with publicDomainTemplate via server-side apply

### DIFF
--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/interfaces.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/interfaces.go
@@ -57,6 +57,9 @@ type Uploader interface {
 	Unprotect(ctx context.Context, sup supplements.Generator, pod *corev1.Pod, svc *corev1.Service, ing *netv1.Ingress) error
 	GetExternalURL(ctx context.Context, ing *netv1.Ingress) string
 	GetInClusterURL(ctx context.Context, svc *corev1.Service) string
+	EnsureIngress(ctx context.Context, obj client.Object, sup supplements.Generator) (*netv1.Ingress, error)
+	IngressHostDrifted(ing *netv1.Ingress) bool
+	ExpectedIngressHost() string
 }
 
 type Stat interface {

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/mock.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/mock.go
@@ -588,6 +588,12 @@ var _ Uploader = &UploaderMock{}
 //			CleanUpFunc: func(ctx context.Context, sup supplements.Generator) (bool, error) {
 //				panic("mock out the CleanUp method")
 //			},
+//			EnsureIngressFunc: func(ctx context.Context, obj client.Object, sup supplements.Generator) (*netv1.Ingress, error) {
+//				panic("mock out the EnsureIngress method")
+//			},
+//			ExpectedIngressHostFunc: func() string {
+//				panic("mock out the ExpectedIngressHost method")
+//			},
 //			GetExternalURLFunc: func(ctx context.Context, ing *netv1.Ingress) string {
 //				panic("mock out the GetExternalURL method")
 //			},
@@ -602,6 +608,9 @@ var _ Uploader = &UploaderMock{}
 //			},
 //			GetServiceFunc: func(ctx context.Context, sup supplements.Generator) (*corev1.Service, error) {
 //				panic("mock out the GetService method")
+//			},
+//			IngressHostDriftedFunc: func(ing *netv1.Ingress) bool {
+//				panic("mock out the IngressHostDrifted method")
 //			},
 //			ProtectFunc: func(ctx context.Context, sup supplements.Generator, pod *corev1.Pod, svc *corev1.Service, ing *netv1.Ingress) error {
 //				panic("mock out the Protect method")
@@ -622,6 +631,12 @@ type UploaderMock struct {
 	// CleanUpFunc mocks the CleanUp method.
 	CleanUpFunc func(ctx context.Context, sup supplements.Generator) (bool, error)
 
+	// EnsureIngressFunc mocks the EnsureIngress method.
+	EnsureIngressFunc func(ctx context.Context, obj client.Object, sup supplements.Generator) (*netv1.Ingress, error)
+
+	// ExpectedIngressHostFunc mocks the ExpectedIngressHost method.
+	ExpectedIngressHostFunc func() string
+
 	// GetExternalURLFunc mocks the GetExternalURL method.
 	GetExternalURLFunc func(ctx context.Context, ing *netv1.Ingress) string
 
@@ -636,6 +651,9 @@ type UploaderMock struct {
 
 	// GetServiceFunc mocks the GetService method.
 	GetServiceFunc func(ctx context.Context, sup supplements.Generator) (*corev1.Service, error)
+
+	// IngressHostDriftedFunc mocks the IngressHostDrifted method.
+	IngressHostDriftedFunc func(ing *netv1.Ingress) bool
 
 	// ProtectFunc mocks the Protect method.
 	ProtectFunc func(ctx context.Context, sup supplements.Generator, pod *corev1.Pod, svc *corev1.Service, ing *netv1.Ingress) error
@@ -654,6 +672,18 @@ type UploaderMock struct {
 			Ctx context.Context
 			// Sup is the sup argument value.
 			Sup supplements.Generator
+		}
+		// EnsureIngress holds details about calls to the EnsureIngress method.
+		EnsureIngress []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Obj is the obj argument value.
+			Obj client.Object
+			// Sup is the sup argument value.
+			Sup supplements.Generator
+		}
+		// ExpectedIngressHost holds details about calls to the ExpectedIngressHost method.
+		ExpectedIngressHost []struct {
 		}
 		// GetExternalURL holds details about calls to the GetExternalURL method.
 		GetExternalURL []struct {
@@ -689,6 +719,11 @@ type UploaderMock struct {
 			Ctx context.Context
 			// Sup is the sup argument value.
 			Sup supplements.Generator
+		}
+		// IngressHostDrifted holds details about calls to the IngressHostDrifted method.
+		IngressHostDrifted []struct {
+			// Ing is the ing argument value.
+			Ing *netv1.Ingress
 		}
 		// Protect holds details about calls to the Protect method.
 		Protect []struct {
@@ -732,15 +767,18 @@ type UploaderMock struct {
 			Ing *netv1.Ingress
 		}
 	}
-	lockCleanUp         sync.RWMutex
-	lockGetExternalURL  sync.RWMutex
-	lockGetInClusterURL sync.RWMutex
-	lockGetIngress      sync.RWMutex
-	lockGetPod          sync.RWMutex
-	lockGetService      sync.RWMutex
-	lockProtect         sync.RWMutex
-	lockStart           sync.RWMutex
-	lockUnprotect       sync.RWMutex
+	lockCleanUp             sync.RWMutex
+	lockEnsureIngress       sync.RWMutex
+	lockExpectedIngressHost sync.RWMutex
+	lockGetExternalURL      sync.RWMutex
+	lockGetInClusterURL     sync.RWMutex
+	lockGetIngress          sync.RWMutex
+	lockGetPod              sync.RWMutex
+	lockGetService          sync.RWMutex
+	lockIngressHostDrifted  sync.RWMutex
+	lockProtect             sync.RWMutex
+	lockStart               sync.RWMutex
+	lockUnprotect           sync.RWMutex
 }
 
 // CleanUp calls CleanUpFunc.
@@ -776,6 +814,73 @@ func (mock *UploaderMock) CleanUpCalls() []struct {
 	mock.lockCleanUp.RLock()
 	calls = mock.calls.CleanUp
 	mock.lockCleanUp.RUnlock()
+	return calls
+}
+
+// EnsureIngress calls EnsureIngressFunc.
+func (mock *UploaderMock) EnsureIngress(ctx context.Context, obj client.Object, sup supplements.Generator) (*netv1.Ingress, error) {
+	if mock.EnsureIngressFunc == nil {
+		panic("UploaderMock.EnsureIngressFunc: method is nil but Uploader.EnsureIngress was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+		Obj client.Object
+		Sup supplements.Generator
+	}{
+		Ctx: ctx,
+		Obj: obj,
+		Sup: sup,
+	}
+	mock.lockEnsureIngress.Lock()
+	mock.calls.EnsureIngress = append(mock.calls.EnsureIngress, callInfo)
+	mock.lockEnsureIngress.Unlock()
+	return mock.EnsureIngressFunc(ctx, obj, sup)
+}
+
+// EnsureIngressCalls gets all the calls that were made to EnsureIngress.
+// Check the length with:
+//
+//	len(mockedUploader.EnsureIngressCalls())
+func (mock *UploaderMock) EnsureIngressCalls() []struct {
+	Ctx context.Context
+	Obj client.Object
+	Sup supplements.Generator
+} {
+	var calls []struct {
+		Ctx context.Context
+		Obj client.Object
+		Sup supplements.Generator
+	}
+	mock.lockEnsureIngress.RLock()
+	calls = mock.calls.EnsureIngress
+	mock.lockEnsureIngress.RUnlock()
+	return calls
+}
+
+// ExpectedIngressHost calls ExpectedIngressHostFunc.
+func (mock *UploaderMock) ExpectedIngressHost() string {
+	if mock.ExpectedIngressHostFunc == nil {
+		panic("UploaderMock.ExpectedIngressHostFunc: method is nil but Uploader.ExpectedIngressHost was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockExpectedIngressHost.Lock()
+	mock.calls.ExpectedIngressHost = append(mock.calls.ExpectedIngressHost, callInfo)
+	mock.lockExpectedIngressHost.Unlock()
+	return mock.ExpectedIngressHostFunc()
+}
+
+// ExpectedIngressHostCalls gets all the calls that were made to ExpectedIngressHost.
+// Check the length with:
+//
+//	len(mockedUploader.ExpectedIngressHostCalls())
+func (mock *UploaderMock) ExpectedIngressHostCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockExpectedIngressHost.RLock()
+	calls = mock.calls.ExpectedIngressHost
+	mock.lockExpectedIngressHost.RUnlock()
 	return calls
 }
 
@@ -956,6 +1061,38 @@ func (mock *UploaderMock) GetServiceCalls() []struct {
 	mock.lockGetService.RLock()
 	calls = mock.calls.GetService
 	mock.lockGetService.RUnlock()
+	return calls
+}
+
+// IngressHostDrifted calls IngressHostDriftedFunc.
+func (mock *UploaderMock) IngressHostDrifted(ing *netv1.Ingress) bool {
+	if mock.IngressHostDriftedFunc == nil {
+		panic("UploaderMock.IngressHostDriftedFunc: method is nil but Uploader.IngressHostDrifted was just called")
+	}
+	callInfo := struct {
+		Ing *netv1.Ingress
+	}{
+		Ing: ing,
+	}
+	mock.lockIngressHostDrifted.Lock()
+	mock.calls.IngressHostDrifted = append(mock.calls.IngressHostDrifted, callInfo)
+	mock.lockIngressHostDrifted.Unlock()
+	return mock.IngressHostDriftedFunc(ing)
+}
+
+// IngressHostDriftedCalls gets all the calls that were made to IngressHostDrifted.
+// Check the length with:
+//
+//	len(mockedUploader.IngressHostDriftedCalls())
+func (mock *UploaderMock) IngressHostDriftedCalls() []struct {
+	Ing *netv1.Ingress
+} {
+	var calls []struct {
+		Ing *netv1.Ingress
+	}
+	mock.lockIngressHostDrifted.RLock()
+	calls = mock.calls.IngressHostDrifted
+	mock.lockIngressHostDrifted.RUnlock()
 	return calls
 }
 

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/upload.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/upload.go
@@ -243,6 +243,17 @@ func (ds UploadDataSource) Sync(ctx context.Context, cvi *v1alpha2.ClusterVirtua
 
 		cvi.Status.Phase = v1alpha2.ImageWaitForUserUpload
 		cvi.Status.Target.RegistryURL = ds.statService.GetDVCRImageName(pod)
+
+		// Re-sync the uploader Ingress when publicDomainTemplate changed after
+		// the supplements were created. Apply is a no-op when fields already match.
+		if ds.uploaderService.IngressHostDrifted(ing) {
+			log.Info("Syncing uploader Ingress: host drifted", "old", ing.Spec.Rules[0].Host, "new", ds.uploaderService.ExpectedIngressHost())
+			ing, err = ds.uploaderService.EnsureIngress(ctx, cvi, supgen)
+			if err != nil {
+				return reconcile.Result{}, err
+			}
+		}
+
 		cvi.Status.ImageUploadURLs = &v1alpha2.ImageUploadURLs{
 			External:  ds.uploaderService.GetExternalURL(ctx, ing),
 			InCluster: ds.uploaderService.GetInClusterURL(ctx, svc),

--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/upload.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/upload.go
@@ -101,6 +101,22 @@ func (ds UploadDataSource) Sync(ctx context.Context, cvi *v1alpha2.ClusterVirtua
 		return reconcile.Result{}, err
 	}
 
+	// Sync the uploader Ingress host before the readiness probe:
+	// IsUploaderReady HTTPS-probes the Ingress host, so a stale host (e.g. after
+	// publicDomainTemplate changed) makes readiness fail with a TLS error.
+	// Initial creation is handled by Start, so skip when the pod is absent.
+	if pod != nil && ds.uploaderService.IngressHostDrifted(ing) {
+		var oldHost string
+		if ing != nil && len(ing.Spec.Rules) > 0 {
+			oldHost = ing.Spec.Rules[0].Host
+		}
+		log.Info("Syncing uploader Ingress: host drifted", "old", oldHost, "new", ds.uploaderService.ExpectedIngressHost())
+		ing, err = ds.uploaderService.EnsureIngress(ctx, cvi, supgen)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
 	isUploaderReady, err := ds.statService.IsUploaderReady(pod, svc, ing, tlsSecret)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -243,17 +259,6 @@ func (ds UploadDataSource) Sync(ctx context.Context, cvi *v1alpha2.ClusterVirtua
 
 		cvi.Status.Phase = v1alpha2.ImageWaitForUserUpload
 		cvi.Status.Target.RegistryURL = ds.statService.GetDVCRImageName(pod)
-
-		// Re-sync the uploader Ingress when publicDomainTemplate changed after
-		// the supplements were created. Apply is a no-op when fields already match.
-		if ds.uploaderService.IngressHostDrifted(ing) {
-			log.Info("Syncing uploader Ingress: host drifted", "old", ing.Spec.Rules[0].Host, "new", ds.uploaderService.ExpectedIngressHost())
-			ing, err = ds.uploaderService.EnsureIngress(ctx, cvi, supgen)
-			if err != nil {
-				return reconcile.Result{}, err
-			}
-		}
-
 		cvi.Status.ImageUploadURLs = &v1alpha2.ImageUploadURLs{
 			External:  ds.uploaderService.GetExternalURL(ctx, ing),
 			InCluster: ds.uploaderService.GetInClusterURL(ctx, svc),

--- a/images/virtualization-artifact/pkg/controller/service/uploader_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/uploader_service.go
@@ -106,8 +106,8 @@ func (s UploaderService) Start(
 		return err
 	}
 
-	ing, err := uploader.NewIngress(s.getIngressSettings(ownerRef, sup)).Create(ctx, s.client)
-	if err != nil && !k8serrors.IsAlreadyExists(err) {
+	ing, err := uploader.NewIngress(s.getIngressSettings(ownerRef, sup)).Apply(ctx, s.client)
+	if err != nil {
 		return err
 	}
 

--- a/images/virtualization-artifact/pkg/controller/service/uploader_service.go
+++ b/images/virtualization-artifact/pkg/controller/service/uploader_service.go
@@ -275,6 +275,41 @@ func (s UploaderService) getServiceSettings(ownerRef *metav1.OwnerReference, sup
 	}
 }
 
+// EnsureIngress reconciles the uploader Ingress with server-side apply and
+// returns the fresh object. It is cheap: callers should invoke it only when the
+// already-fetched Ingress host drifted from the configured UPLOADER_INGRESS_HOST
+// (e.g. after publicDomainTemplate change). When there is no drift, skip the call:
+// Apply is a no-op only when managed fields already match, but avoiding the
+// round-trip entirely keeps steady-state reconcile free of extra writes.
+func (s UploaderService) EnsureIngress(ctx context.Context, obj client.Object, sup supplements.Generator) (*netv1.Ingress, error) {
+	ownerRef := metav1.NewControllerRef(obj, obj.GetObjectKind().GroupVersionKind())
+	ing, err := uploader.NewIngress(s.getIngressSettings(ownerRef, sup)).Apply(ctx, s.client)
+	if err != nil {
+		return nil, err
+	}
+	if err := supplements.EnsureForIngress(ctx, s.client, sup, ing, s.dvcrSettings); err != nil {
+		return nil, err
+	}
+	return ing, nil
+}
+
+// ExpectedIngressHost returns the host the uploader Ingress should expose,
+// derived from UPLOADER_INGRESS_HOST (i.e. the rendered publicDomainTemplate).
+func (s UploaderService) ExpectedIngressHost() string {
+	return s.dvcrSettings.UploaderIngressSettings.Host
+}
+
+// IngressHostDrifted reports whether the given Ingress host differs from the
+// configured one. An absent Ingress (nil) or an Ingress without rules is
+// treated as drift so callers fall back to EnsureIngress / Start.
+func (s UploaderService) IngressHostDrifted(ing *netv1.Ingress) bool {
+	expected := s.ExpectedIngressHost()
+	if ing == nil || len(ing.Spec.Rules) == 0 {
+		return true
+	}
+	return ing.Spec.Rules[0].Host != expected
+}
+
 func (s UploaderService) getIngressSettings(ownerRef *metav1.OwnerReference, sup supplements.Generator) *uploader.IngressSettings {
 	uploaderIng := sup.UploaderIngress()
 	uploaderSvc := sup.UploaderService()

--- a/images/virtualization-artifact/pkg/controller/uploader/uploader_ingress.go
+++ b/images/virtualization-artifact/pkg/controller/uploader/uploader_ingress.go
@@ -52,12 +52,12 @@ func NewIngress(settings *IngressSettings) *Ingress {
 	return &Ingress{settings}
 }
 
+const fieldOwner = "virtualization-controller"
+
 // Apply reconciles the Ingress using server-side apply: it creates the Ingress
 // if absent and updates spec/annotations when they drift (e.g. when
 // publicDomainTemplate changes UPLOADER_INGRESS_HOST). Field ownership is
 // stable across controller restarts.
-const fieldOwner = "virtualization-controller"
-
 func (i *Ingress) Apply(ctx context.Context, c client.Client) (*netv1.Ingress, error) {
 	desired := i.makeSpec()
 	desired.SetGroupVersionKind(netv1.SchemeGroupVersion.WithKind("Ingress"))

--- a/images/virtualization-artifact/pkg/controller/uploader/uploader_ingress.go
+++ b/images/virtualization-artifact/pkg/controller/uploader/uploader_ingress.go
@@ -52,14 +52,21 @@ func NewIngress(settings *IngressSettings) *Ingress {
 	return &Ingress{settings}
 }
 
-func (i *Ingress) Create(ctx context.Context, client client.Client) (*netv1.Ingress, error) {
-	ing := i.makeSpec()
+// Apply reconciles the Ingress using server-side apply: it creates the Ingress
+// if absent and updates spec/annotations when they drift (e.g. when
+// publicDomainTemplate changes UPLOADER_INGRESS_HOST). Field ownership is
+// stable across controller restarts.
+const fieldOwner = "virtualization-controller"
 
-	if err := client.Create(ctx, ing); err != nil {
+func (i *Ingress) Apply(ctx context.Context, c client.Client) (*netv1.Ingress, error) {
+	desired := i.makeSpec()
+	desired.SetGroupVersionKind(netv1.SchemeGroupVersion.WithKind("Ingress"))
+
+	if err := c.Patch(ctx, desired, client.Apply, client.FieldOwner(fieldOwner)); err != nil {
 		return nil, err
 	}
 
-	return ing, nil
+	return desired, nil
 }
 
 // makeSpec fills Ingress structure with uploader settings.

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/upload.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/upload.go
@@ -127,6 +127,22 @@ func (ds UploadDataSource) Sync(ctx context.Context, vd *v1alpha2.VirtualDisk) (
 		return reconcile.Result{}, err
 	}
 
+	// Sync the uploader Ingress host before the readiness probe:
+	// IsUploaderReady HTTPS-probes the Ingress host, so a stale host (e.g. after
+	// publicDomainTemplate changed) makes readiness fail with a TLS error.
+	// Initial creation is handled by Start, so skip when the pod is absent.
+	if pod != nil && ds.uploaderService.IngressHostDrifted(ing) {
+		var oldHost string
+		if ing != nil && len(ing.Spec.Rules) > 0 {
+			oldHost = ing.Spec.Rules[0].Host
+		}
+		log.Info("Syncing uploader Ingress: host drifted", "old", oldHost, "new", ds.uploaderService.ExpectedIngressHost())
+		ing, err = ds.uploaderService.EnsureIngress(ctx, vd, supgen)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
 	isUploaderReady, err := ds.statService.IsUploaderReady(pod, svc, ing, tlsSecret)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -202,18 +218,6 @@ func (ds UploadDataSource) Sync(ctx context.Context, vd *v1alpha2.VirtualDisk) (
 
 				vd.Status.Phase = v1alpha2.DiskWaitForUserUpload
 				setReadyConditionWithWFFCAccounting(vd, cb, metav1.ConditionFalse, vdcondition.WaitForUserUpload, "Waiting for the user upload.")
-
-				// Re-sync the uploader Ingress when publicDomainTemplate changed
-				// after the supplements were created. Apply is a no-op when fields
-				// already match.
-				if ds.uploaderService.IngressHostDrifted(ing) {
-					log.Info("Syncing uploader Ingress: host drifted", "old", ing.Spec.Rules[0].Host, "new", ds.uploaderService.ExpectedIngressHost())
-					ing, err = ds.uploaderService.EnsureIngress(ctx, vd, supgen)
-					if err != nil {
-						return reconcile.Result{}, err
-					}
-				}
-
 				vd.Status.ImageUploadURLs = &v1alpha2.ImageUploadURLs{
 					External:  ds.uploaderService.GetExternalURL(ctx, ing),
 					InCluster: ds.uploaderService.GetInClusterURL(ctx, svc),

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/upload.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/upload.go
@@ -202,6 +202,18 @@ func (ds UploadDataSource) Sync(ctx context.Context, vd *v1alpha2.VirtualDisk) (
 
 				vd.Status.Phase = v1alpha2.DiskWaitForUserUpload
 				setReadyConditionWithWFFCAccounting(vd, cb, metav1.ConditionFalse, vdcondition.WaitForUserUpload, "Waiting for the user upload.")
+
+				// Re-sync the uploader Ingress when publicDomainTemplate changed
+				// after the supplements were created. Apply is a no-op when fields
+				// already match.
+				if ds.uploaderService.IngressHostDrifted(ing) {
+					log.Info("Syncing uploader Ingress: host drifted", "old", ing.Spec.Rules[0].Host, "new", ds.uploaderService.ExpectedIngressHost())
+					ing, err = ds.uploaderService.EnsureIngress(ctx, vd, supgen)
+					if err != nil {
+						return reconcile.Result{}, err
+					}
+				}
+
 				vd.Status.ImageUploadURLs = &v1alpha2.ImageUploadURLs{
 					External:  ds.uploaderService.GetExternalURL(ctx, ing),
 					InCluster: ds.uploaderService.GetInClusterURL(ctx, svc),

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/interfaces.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/interfaces.go
@@ -57,6 +57,9 @@ type Uploader interface {
 	Unprotect(ctx context.Context, sup supplements.Generator, pod *corev1.Pod, svc *corev1.Service, ing *netv1.Ingress) error
 	GetExternalURL(ctx context.Context, ing *netv1.Ingress) string
 	GetInClusterURL(ctx context.Context, svc *corev1.Service) string
+	EnsureIngress(ctx context.Context, obj client.Object, sup supplements.Generator) (*netv1.Ingress, error)
+	IngressHostDrifted(ing *netv1.Ingress) bool
+	ExpectedIngressHost() string
 }
 
 type Stat interface {

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/mock.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/mock.go
@@ -530,6 +530,12 @@ var _ Uploader = &UploaderMock{}
 //			CleanUpSupplementsFunc: func(ctx context.Context, sup supplements.Generator) (bool, error) {
 //				panic("mock out the CleanUpSupplements method")
 //			},
+//			EnsureIngressFunc: func(ctx context.Context, obj client.Object, sup supplements.Generator) (*netv1.Ingress, error) {
+//				panic("mock out the EnsureIngress method")
+//			},
+//			ExpectedIngressHostFunc: func() string {
+//				panic("mock out the ExpectedIngressHost method")
+//			},
 //			GetExternalURLFunc: func(ctx context.Context, ing *netv1.Ingress) string {
 //				panic("mock out the GetExternalURL method")
 //			},
@@ -544,6 +550,9 @@ var _ Uploader = &UploaderMock{}
 //			},
 //			GetServiceFunc: func(ctx context.Context, sup supplements.Generator) (*corev1.Service, error) {
 //				panic("mock out the GetService method")
+//			},
+//			IngressHostDriftedFunc: func(ing *netv1.Ingress) bool {
+//				panic("mock out the IngressHostDrifted method")
 //			},
 //			ProtectFunc: func(ctx context.Context, sup supplements.Generator, pod *corev1.Pod, svc *corev1.Service, ing *netv1.Ingress) error {
 //				panic("mock out the Protect method")
@@ -567,6 +576,12 @@ type UploaderMock struct {
 	// CleanUpSupplementsFunc mocks the CleanUpSupplements method.
 	CleanUpSupplementsFunc func(ctx context.Context, sup supplements.Generator) (bool, error)
 
+	// EnsureIngressFunc mocks the EnsureIngress method.
+	EnsureIngressFunc func(ctx context.Context, obj client.Object, sup supplements.Generator) (*netv1.Ingress, error)
+
+	// ExpectedIngressHostFunc mocks the ExpectedIngressHost method.
+	ExpectedIngressHostFunc func() string
+
 	// GetExternalURLFunc mocks the GetExternalURL method.
 	GetExternalURLFunc func(ctx context.Context, ing *netv1.Ingress) string
 
@@ -581,6 +596,9 @@ type UploaderMock struct {
 
 	// GetServiceFunc mocks the GetService method.
 	GetServiceFunc func(ctx context.Context, sup supplements.Generator) (*corev1.Service, error)
+
+	// IngressHostDriftedFunc mocks the IngressHostDrifted method.
+	IngressHostDriftedFunc func(ing *netv1.Ingress) bool
 
 	// ProtectFunc mocks the Protect method.
 	ProtectFunc func(ctx context.Context, sup supplements.Generator, pod *corev1.Pod, svc *corev1.Service, ing *netv1.Ingress) error
@@ -606,6 +624,18 @@ type UploaderMock struct {
 			Ctx context.Context
 			// Sup is the sup argument value.
 			Sup supplements.Generator
+		}
+		// EnsureIngress holds details about calls to the EnsureIngress method.
+		EnsureIngress []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Obj is the obj argument value.
+			Obj client.Object
+			// Sup is the sup argument value.
+			Sup supplements.Generator
+		}
+		// ExpectedIngressHost holds details about calls to the ExpectedIngressHost method.
+		ExpectedIngressHost []struct {
 		}
 		// GetExternalURL holds details about calls to the GetExternalURL method.
 		GetExternalURL []struct {
@@ -641,6 +671,11 @@ type UploaderMock struct {
 			Ctx context.Context
 			// Sup is the sup argument value.
 			Sup supplements.Generator
+		}
+		// IngressHostDrifted holds details about calls to the IngressHostDrifted method.
+		IngressHostDrifted []struct {
+			// Ing is the ing argument value.
+			Ing *netv1.Ingress
 		}
 		// Protect holds details about calls to the Protect method.
 		Protect []struct {
@@ -684,16 +719,19 @@ type UploaderMock struct {
 			Ing *netv1.Ingress
 		}
 	}
-	lockCleanUp            sync.RWMutex
-	lockCleanUpSupplements sync.RWMutex
-	lockGetExternalURL     sync.RWMutex
-	lockGetInClusterURL    sync.RWMutex
-	lockGetIngress         sync.RWMutex
-	lockGetPod             sync.RWMutex
-	lockGetService         sync.RWMutex
-	lockProtect            sync.RWMutex
-	lockStart              sync.RWMutex
-	lockUnprotect          sync.RWMutex
+	lockCleanUp             sync.RWMutex
+	lockCleanUpSupplements  sync.RWMutex
+	lockEnsureIngress       sync.RWMutex
+	lockExpectedIngressHost sync.RWMutex
+	lockGetExternalURL      sync.RWMutex
+	lockGetInClusterURL     sync.RWMutex
+	lockGetIngress          sync.RWMutex
+	lockGetPod              sync.RWMutex
+	lockGetService          sync.RWMutex
+	lockIngressHostDrifted  sync.RWMutex
+	lockProtect             sync.RWMutex
+	lockStart               sync.RWMutex
+	lockUnprotect           sync.RWMutex
 }
 
 // CleanUp calls CleanUpFunc.
@@ -765,6 +803,73 @@ func (mock *UploaderMock) CleanUpSupplementsCalls() []struct {
 	mock.lockCleanUpSupplements.RLock()
 	calls = mock.calls.CleanUpSupplements
 	mock.lockCleanUpSupplements.RUnlock()
+	return calls
+}
+
+// EnsureIngress calls EnsureIngressFunc.
+func (mock *UploaderMock) EnsureIngress(ctx context.Context, obj client.Object, sup supplements.Generator) (*netv1.Ingress, error) {
+	if mock.EnsureIngressFunc == nil {
+		panic("UploaderMock.EnsureIngressFunc: method is nil but Uploader.EnsureIngress was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+		Obj client.Object
+		Sup supplements.Generator
+	}{
+		Ctx: ctx,
+		Obj: obj,
+		Sup: sup,
+	}
+	mock.lockEnsureIngress.Lock()
+	mock.calls.EnsureIngress = append(mock.calls.EnsureIngress, callInfo)
+	mock.lockEnsureIngress.Unlock()
+	return mock.EnsureIngressFunc(ctx, obj, sup)
+}
+
+// EnsureIngressCalls gets all the calls that were made to EnsureIngress.
+// Check the length with:
+//
+//	len(mockedUploader.EnsureIngressCalls())
+func (mock *UploaderMock) EnsureIngressCalls() []struct {
+	Ctx context.Context
+	Obj client.Object
+	Sup supplements.Generator
+} {
+	var calls []struct {
+		Ctx context.Context
+		Obj client.Object
+		Sup supplements.Generator
+	}
+	mock.lockEnsureIngress.RLock()
+	calls = mock.calls.EnsureIngress
+	mock.lockEnsureIngress.RUnlock()
+	return calls
+}
+
+// ExpectedIngressHost calls ExpectedIngressHostFunc.
+func (mock *UploaderMock) ExpectedIngressHost() string {
+	if mock.ExpectedIngressHostFunc == nil {
+		panic("UploaderMock.ExpectedIngressHostFunc: method is nil but Uploader.ExpectedIngressHost was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockExpectedIngressHost.Lock()
+	mock.calls.ExpectedIngressHost = append(mock.calls.ExpectedIngressHost, callInfo)
+	mock.lockExpectedIngressHost.Unlock()
+	return mock.ExpectedIngressHostFunc()
+}
+
+// ExpectedIngressHostCalls gets all the calls that were made to ExpectedIngressHost.
+// Check the length with:
+//
+//	len(mockedUploader.ExpectedIngressHostCalls())
+func (mock *UploaderMock) ExpectedIngressHostCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockExpectedIngressHost.RLock()
+	calls = mock.calls.ExpectedIngressHost
+	mock.lockExpectedIngressHost.RUnlock()
 	return calls
 }
 
@@ -945,6 +1050,38 @@ func (mock *UploaderMock) GetServiceCalls() []struct {
 	mock.lockGetService.RLock()
 	calls = mock.calls.GetService
 	mock.lockGetService.RUnlock()
+	return calls
+}
+
+// IngressHostDrifted calls IngressHostDriftedFunc.
+func (mock *UploaderMock) IngressHostDrifted(ing *netv1.Ingress) bool {
+	if mock.IngressHostDriftedFunc == nil {
+		panic("UploaderMock.IngressHostDriftedFunc: method is nil but Uploader.IngressHostDrifted was just called")
+	}
+	callInfo := struct {
+		Ing *netv1.Ingress
+	}{
+		Ing: ing,
+	}
+	mock.lockIngressHostDrifted.Lock()
+	mock.calls.IngressHostDrifted = append(mock.calls.IngressHostDrifted, callInfo)
+	mock.lockIngressHostDrifted.Unlock()
+	return mock.IngressHostDriftedFunc(ing)
+}
+
+// IngressHostDriftedCalls gets all the calls that were made to IngressHostDrifted.
+// Check the length with:
+//
+//	len(mockedUploader.IngressHostDriftedCalls())
+func (mock *UploaderMock) IngressHostDriftedCalls() []struct {
+	Ing *netv1.Ingress
+} {
+	var calls []struct {
+		Ing *netv1.Ingress
+	}
+	mock.lockIngressHostDrifted.RLock()
+	calls = mock.calls.IngressHostDrifted
+	mock.lockIngressHostDrifted.RUnlock()
 	return calls
 }
 

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/upload.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/upload.go
@@ -109,6 +109,22 @@ func (ds UploadDataSource) StoreToPVC(ctx context.Context, vi *v1alpha2.VirtualI
 		return reconcile.Result{}, err
 	}
 
+	// Sync the uploader Ingress host before the readiness probe:
+	// IsUploaderReady HTTPS-probes the Ingress host, so a stale host (e.g. after
+	// publicDomainTemplate changed) makes readiness fail with a TLS error.
+	// Initial creation is handled by Start, so skip when the pod is absent.
+	if pod != nil && ds.uploaderService.IngressHostDrifted(ing) {
+		var oldHost string
+		if ing != nil && len(ing.Spec.Rules) > 0 {
+			oldHost = ing.Spec.Rules[0].Host
+		}
+		log.Info("Syncing uploader Ingress: host drifted", "old", oldHost, "new", ds.uploaderService.ExpectedIngressHost())
+		ing, err = ds.uploaderService.EnsureIngress(ctx, vi, supgen)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
 	isUploaderReady, err := ds.statService.IsUploaderReady(pod, svc, ing, tlsSecret)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -194,17 +210,6 @@ func (ds UploadDataSource) StoreToPVC(ctx context.Context, vi *v1alpha2.VirtualI
 					Status(metav1.ConditionFalse).
 					Reason(vicondition.WaitForUserUpload).
 					Message("Waiting for the user upload.")
-
-				// Re-sync the uploader Ingress when publicDomainTemplate changed
-				// after the supplements were created. Apply is a no-op when fields
-				// already match.
-				if ds.uploaderService.IngressHostDrifted(ing) {
-					log.Info("Syncing uploader Ingress: host drifted", "old", ing.Spec.Rules[0].Host, "new", ds.uploaderService.ExpectedIngressHost())
-					ing, err = ds.uploaderService.EnsureIngress(ctx, vi, supgen)
-					if err != nil {
-						return reconcile.Result{}, err
-					}
-				}
 
 				vi.Status.ImageUploadURLs = &v1alpha2.ImageUploadURLs{
 					External:  ds.uploaderService.GetExternalURL(ctx, ing),
@@ -387,6 +392,22 @@ func (ds UploadDataSource) StoreToDVCR(ctx context.Context, vi *v1alpha2.Virtual
 		return reconcile.Result{}, err
 	}
 
+	// Sync the uploader Ingress host before the readiness probe:
+	// IsUploaderReady HTTPS-probes the Ingress host, so a stale host (e.g. after
+	// publicDomainTemplate changed) makes readiness fail with a TLS error.
+	// Initial creation is handled by Start, so skip when the pod is absent.
+	if pod != nil && ds.uploaderService.IngressHostDrifted(ing) {
+		var oldHost string
+		if ing != nil && len(ing.Spec.Rules) > 0 {
+			oldHost = ing.Spec.Rules[0].Host
+		}
+		log.Info("Syncing uploader Ingress: host drifted", "old", oldHost, "new", ds.uploaderService.ExpectedIngressHost())
+		ing, err = ds.uploaderService.EnsureIngress(ctx, vi, supgen)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
 	isUploaderReady, err := ds.statService.IsUploaderReady(pod, svc, ing, tlsSecret)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -497,17 +518,6 @@ func (ds UploadDataSource) StoreToDVCR(ctx context.Context, vi *v1alpha2.Virtual
 
 		vi.Status.Phase = v1alpha2.ImageWaitForUserUpload
 		vi.Status.Target.RegistryURL = ds.statService.GetDVCRImageName(pod)
-
-		// Re-sync the uploader Ingress when publicDomainTemplate changed after
-		// the supplements were created. Apply is a no-op when fields already match.
-		if ds.uploaderService.IngressHostDrifted(ing) {
-			log.Info("Syncing uploader Ingress: host drifted", "old", ing.Spec.Rules[0].Host, "new", ds.uploaderService.ExpectedIngressHost())
-			ing, err = ds.uploaderService.EnsureIngress(ctx, vi, supgen)
-			if err != nil {
-				return reconcile.Result{}, err
-			}
-		}
-
 		vi.Status.ImageUploadURLs = &v1alpha2.ImageUploadURLs{
 			External:  ds.uploaderService.GetExternalURL(ctx, ing),
 			InCluster: ds.uploaderService.GetInClusterURL(ctx, svc),

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/upload.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/upload.go
@@ -195,6 +195,17 @@ func (ds UploadDataSource) StoreToPVC(ctx context.Context, vi *v1alpha2.VirtualI
 					Reason(vicondition.WaitForUserUpload).
 					Message("Waiting for the user upload.")
 
+				// Re-sync the uploader Ingress when publicDomainTemplate changed
+				// after the supplements were created. Apply is a no-op when fields
+				// already match.
+				if ds.uploaderService.IngressHostDrifted(ing) {
+					log.Info("Syncing uploader Ingress: host drifted", "old", ing.Spec.Rules[0].Host, "new", ds.uploaderService.ExpectedIngressHost())
+					ing, err = ds.uploaderService.EnsureIngress(ctx, vi, supgen)
+					if err != nil {
+						return reconcile.Result{}, err
+					}
+				}
+
 				vi.Status.ImageUploadURLs = &v1alpha2.ImageUploadURLs{
 					External:  ds.uploaderService.GetExternalURL(ctx, ing),
 					InCluster: ds.uploaderService.GetInClusterURL(ctx, svc),
@@ -486,6 +497,17 @@ func (ds UploadDataSource) StoreToDVCR(ctx context.Context, vi *v1alpha2.Virtual
 
 		vi.Status.Phase = v1alpha2.ImageWaitForUserUpload
 		vi.Status.Target.RegistryURL = ds.statService.GetDVCRImageName(pod)
+
+		// Re-sync the uploader Ingress when publicDomainTemplate changed after
+		// the supplements were created. Apply is a no-op when fields already match.
+		if ds.uploaderService.IngressHostDrifted(ing) {
+			log.Info("Syncing uploader Ingress: host drifted", "old", ing.Spec.Rules[0].Host, "new", ds.uploaderService.ExpectedIngressHost())
+			ing, err = ds.uploaderService.EnsureIngress(ctx, vi, supgen)
+			if err != nil {
+				return reconcile.Result{}, err
+			}
+		}
+
 		vi.Status.ImageUploadURLs = &v1alpha2.ImageUploadURLs{
 			External:  ds.uploaderService.GetExternalURL(ctx, ing),
 			InCluster: ds.uploaderService.GetInClusterURL(ctx, svc),


### PR DESCRIPTION
## Description

Changing the cluster domain (`publicDomainTemplate`) left existing image-upload endpoints on the old domain, so the upload URL shown for an already-created `VirtualImage` / `VirtualDisk` / `ClusterVirtualImage` (with `dataSource.type=Upload`) kept pointing at the old host and uploads to it failed.

## Why do we need it, and what problem does it solve?

The upload endpoint was created once when an image or disk with `Upload` source first appeared and was never reconciled afterwards. After an administrator changed the cluster domain, the controller restarted with the new domain, but the already-existing endpoints kept their original host. Users kept seeing the old upload URL, so uploading data to an already-created image broke until the image was deleted and recreated.

The endpoint is now reconciled on every upload-flow pass, so its host, TLS host, and upload URL follow the current cluster domain automatically.

## What is the expected result?

1. Create a `VirtualImage` with `dataSource.type=Upload` — the upload URL matches the current cluster domain.
2. Change `publicDomainTemplate` and wait for the controller to pick up the new domain.
3. The upload URL and endpoint host update to the new domain; uploading to the existing image keeps working.

## Checklist

- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: images
type: fix
summary: "Upload endpoint now follows publicDomainTemplate changes instead of keeping the host it was created with."
```
