### PR TITLE
chore(core): virt-launcher logs process tree + D-state escalation for stuck VMs

### DIFF
--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -3,7 +3,7 @@ firmware:
   libvirt: v10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: v1.6.2-v12n.48
+  3p-kubevirt: v1.6.2-v12n.49
   3p-containerized-data-importer: v1.60.3-v12n.20
   distribution: 2.8.3
 package:


### PR DESCRIPTION
## Description

Bumps `3p-kubevirt` to a revision that adds a lightweight periodic process-tree snapshot and D-state escalation to the `virt-launcher` monitor (`pkg/virt-launcher/monitor.go`).

The monitor loop already ticks every second and reads `/proc/<pid>/status` to detect zombie QEMU. This change extends that read to also detect the `D` (uninterruptible disk sleep) state, and adds:

- A periodic (30s, V(3)) one-line process-tree snapshot:
  `proctree: tini(1,S)→vl-monitor(2,S)→virt-launcher(3,S) virtqemud(4,S)→qemu(5,R)[vcpu0:R,vcpu1:R,io:R]`
- A D-state escalation line at default log level (not V-gated) with wchan and best-effort `/proc/<pid>/stack`:
  `qemu pid 113382 D-state 10s wchan=__drbd_make_request stack=__drbd_make_request+0x34f/0x610[drbd]→drbd_submit_bio+0x36f/0x3e0[drbd]→...`
- Throttled to one escalation line per 10s (a hang lasts minutes/hours, so the signal is never lost).

All reads are pure `/proc`, no new dependencies, no exec/shell. Behavior is additive; `pidExists` is retained as a backward-compatible wrapper over the new `pidState`, so existing callers and tests are untouched.

## Why do we need it, and what problem does it solve?

When a QEMU process enters D-state — e.g. stuck inside `__drbd_make_request` during a DRBD replication stall, or blocked on a CSI/NFS volume — `SIGKILL` is ignored. The `d8v-vm-*` pod then hangs in `Terminating` for days with zero visibility into why. Diagnosing it required SSH onto the hypervisor.

With this change, the same evidence is in `kubectl logs -n <ns> <d8v-vm-pod> -c d8v-compute` the moment the hang starts.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: core
type: chore
summary: "virt-launcher now logs a periodic process-tree snapshot and escalates D-state QEMU hangs with wchan + kernel stack, so a VM stuck in Terminating is diagnosable from pod logs without node SSH."
impact_level: low
```