### PR TITLE
fix(vm): clarify missing default VirtualMachineClass error

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm/internal/defaulter/defaulters_suite_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/defaulter/defaulters_suite_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Set default class in virtualMachineClasName", func() {
 	})
 
 	Context("creating VM with empty virtualMachineClassName", func() {
-		It("should keep virtualMachineClassName empty if no default class", func() {
+		It("should return a clear error if no default class", func() {
 			// Initialize fake client with some classes.
 			name := "single-custom-class"
 			setup(
@@ -107,7 +107,7 @@ var _ = Describe("Set default class in virtualMachineClasName", func() {
 
 			vm := newVMWithEmptyClass("vm-with-empty-class")
 			err := classDefaulter.Default(ctx, vm)
-			Expect(err).Should(BeNil())
+			Expect(err).Should(MatchError(ContainSubstring("spec.virtualMachineClassName is empty and no default VirtualMachineClass is configured")))
 			Expect(vm.Spec.VirtualMachineClassName).Should(BeEmpty())
 		})
 

--- a/images/virtualization-artifact/pkg/controller/vm/internal/defaulter/virtual_machine_class_name.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/defaulter/virtual_machine_class_name.go
@@ -22,6 +22,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/deckhouse/virtualization-controller/pkg/common/annotations"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
@@ -56,10 +57,8 @@ func (v *VirtualMachineClassNameDefaulter) Default(ctx context.Context, vm *v1al
 		return err
 	}
 
-	// "No default class" is not a mutating error, validators will complain
-	// about missing field during validation phase later.
 	if defaultClass == nil {
-		return nil
+		return fmt.Errorf("spec.virtualMachineClassName is empty and no default VirtualMachineClass is configured; set spec.virtualMachineClassName explicitly or mark one VirtualMachineClass as default with the %q annotation set to %q", annotations.AnnVirtualMachineClassDefault, "true")
 	}
 
 	vm.Spec.VirtualMachineClassName = defaultClass.GetName()


### PR DESCRIPTION
## Description

Changed the VM mutating webhook behavior for VirtualMachines created without `spec.virtualMachineClassName`. If no default `VirtualMachineClass` is configured, the VM class defaulter now returns an explicit error instead of leaving the field empty and letting CRD schema validation produce a generic `should be at least 1 chars long` message.

Updated the VM defaulter unit test to cover this missing default class case.

## Why do we need it, and what problem does it solve?

When a user applies a VM manifest without `spec.virtualMachineClassName` and the cluster has no default `VirtualMachineClass`, the API currently returns an unclear schema validation error. The actual problem is that the VM class cannot be defaulted.

After this change, users get a direct explanation: either set `spec.virtualMachineClassName` explicitly or mark one `VirtualMachineClass` as default with the `virtualmachineclass.virtualization.deckhouse.io/is-default-class=true` annotation.

## What is the expected result?

Apply a VirtualMachine manifest without `spec.virtualMachineClassName` in a cluster where no `VirtualMachineClass` has the default annotation.

The request should be rejected by the webhook with a clear error explaining that no default `VirtualMachineClass` is configured and how to fix it.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: vm
type: fix
summary: "VirtualMachine creation without an explicit VM class now reports a clear error when no default VirtualMachineClass is configured."
```