### PR TITLE
fix(vm): align paravirtualization option type

### DIFF
--- a/images/virtualization-artifact/pkg/builder/vm/option.go
+++ b/images/virtualization-artifact/pkg/builder/vm/option.go
@@ -135,7 +135,7 @@ func WithRunPolicy(runPolicy v1alpha2.RunPolicy) Option {
 	}
 }
 
-func WithEnableParavirtualization(enableParavirtualization bool) Option {
+func WithEnableParavirtualization(enableParavirtualization *bool) Option {
 	return func(vm *v1alpha2.VirtualMachine) {
 		vm.Spec.EnableParavirtualization = enableParavirtualization
 	}

--- a/test/e2e/vm/configuration.go
+++ b/test/e2e/vm/configuration.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmbuilder "github.com/deckhouse/virtualization-controller/pkg/builder/vm"
@@ -129,7 +130,7 @@ func (t *configurationTest) GenerateResources(restartApprovalMode v1alpha2.Resta
 	t.VDRoot = object.NewVDFromCVI("vd-root", t.Framework.Namespace().Name, object.PrecreatedCVIAlpineBIOS)
 
 	t.VM = object.NewMinimalVM("vm", t.Framework.Namespace().Name,
-		vmbuilder.WithEnableParavirtualization(initialEnableParavirtualization),
+		vmbuilder.WithEnableParavirtualization(ptr.To(initialEnableParavirtualization)),
 		vmbuilder.WithRunPolicy(initialRunPolicy),
 		vmbuilder.WithDisks(t.VDRoot),
 		vmbuilder.WithRestartApprovalMode(restartApprovalMode),


### PR DESCRIPTION
## Description

Update the VirtualMachine builder option for `enableParavirtualization` to use the pointer type from `VirtualMachineSpec`, and pass a pointer from the e2e configuration test.

## Why do we need it, and what problem does it solve?

`task e2e:run` failed during the precheck dry-run because the e2e package could not compile after `VirtualMachineSpec.EnableParavirtualization` became `*bool`. This change aligns the builder helper and its e2e caller with the API type.

## What is the expected result?

`task e2e:precheck:prepare` should compile the e2e suite successfully before running tests.

Verified with:

```shell
task e2e:precheck:prepare
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.