### PR TITLE
fix(e2e): enable featureGates in virtualization module config

### DIFF
--- a/.github/scripts/bash/e2e/configure-virtualization-release.sh
+++ b/.github/scripts/bash/e2e/configure-virtualization-release.sh
@@ -70,6 +70,10 @@ spec:
         type: PersistentVolumeClaim
     virtualMachineCIDRs:
       - 192.168.10.0/24
+    featureGates:
+      - HotplugCPUWithLiveMigration
+      - HotplugMemoryWithLiveMigration
+      - HotplugCPUAndMemoryWithInPlaceResize
   source: deckhouse-dev
   version: 1
 ---

--- a/.github/scripts/bash/e2e/configure-virtualization.sh
+++ b/.github/scripts/bash/e2e/configure-virtualization.sh
@@ -166,6 +166,10 @@ spec:
         type: PersistentVolumeClaim
     virtualMachineCIDRs:
       - 192.168.10.0/24
+    featureGates:
+      - HotplugCPUWithLiveMigration
+      - HotplugMemoryWithLiveMigration
+      - HotplugCPUAndMemoryWithInPlaceResize
   source: deckhouse-dev
   version: 1
 ---


### PR DESCRIPTION
## Description
Enable the `HotplugCPUWithLiveMigration`, `HotplugMemoryWithLiveMigration` and `HotplugCPUAndMemoryWithInPlaceResize` feature gates in the `ModuleConfig/virtualization` applied to the nested e2e cluster, in both the nightly (`configure-virtualization.sh`) and release (`configure-virtualization-release.sh`) setup scripts.

## Why do we need it, and what problem does it solve?
The nested e2e cluster is recreated for every nightly/release run, and its `ModuleConfig/virtualization` is applied without any `featureGates`. As a result the prechecks registered in `test/e2e/internal/precheck/featuregate.go` (`hotpluginplaceresize-precheck`, `hotplugcpuwithlivemigration-precheck`, `hotplugmemorywithlivemigration-precheck`) fail in `SynchronizedBeforeSuite` because `spec.settings.featureGates` is empty and the type assertion in `getFeatureGates` returns `[]interface {}`:

```
[FAILED] precheck hotpluginplaceresize-precheck failed:
HOTPLUG_IN_PLACE_PRECHECK=no to disable this precheck:
failed to get feature gates from virtualization module config spec: []interface {}
```

The corresponding hotplug CPU/memory specs in `test/e2e/vm/hotplug_cpu.go` and `hotplug_memory.go` carry these precheck labels, so the whole suite is blocked until the gates are present in the module config.

## What is the expected result?
1. A nightly/release e2e run provisions the nested cluster.
2. `kubectl get mc virtualization -o yaml` shows all three feature gates under `spec.settings.featureGates`.
3. `SynchronizedBeforeSuite` passes the `hotpluginplaceresize-precheck` and sibling prechecks.
4. The hotplug CPU/memory (InPlaceResize and LiveMigration) e2e specs run instead of being blocked.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: fix
summary: "Enable hotplug feature gates in the virtualization ModuleConfig on the nested e2e cluster so hotplug CPU/memory prechecks stop failing in SynchronizedBeforeSuite."
impact_level: low
```
