### PR TITLE
fix: disable the Green Tea GC experiment (GOEXPERIMENT=greenteagc)

### DIFF
--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -113,6 +113,11 @@ shell:
     - export GOOS=linux
     - export GOARCH=amd64
     - export CGO_ENABLED=0
+    # Disable the Green Tea GC experiment baked into the ALT golang toolchain.
+    # It regresses the TLS migration-proxy data path (software AES fallback /
+    # high CPU, low throughput). Dropping only this experiment keeps the
+    # CVE-patched toolchain (version and ALT base) untouched.
+    - export GOEXPERIMENT=nogreenteagc
 
     - echo ============== Build container-disk ===================
     {{- $_ := set $ "ProjectName" (list .ImageName "container-disk" | join "/") }}


### PR DESCRIPTION
## Description

Disable the Green Tea GC experiment (`GOEXPERIMENT=greenteagc`) that is baked
into the container-factory ALT golang toolchain when building KubeVirt Go
binaries. A single `export GOEXPERIMENT=nogreenteagc` is added to the build
`setup` step in `images/virt-artifact/werf.inc.yaml`, so it applies to all
KubeVirt binaries (notably `virt-handler` and `virt-launcher`, which host the
live-migration TLS proxy).

This drops only the GC experiment; the toolchain version and the ALT base image
(and therefore the CVE mitigation from `cc5aff898`) are left untouched.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: vm
type: fix
summary: "Restore live-migration throughput by disabling the Green Tea GC experiment in the KubeVirt build toolchain."