### PR TITLE
test(core): disable greenteagc in virt-* builds to isolate live-migration TLS regression

### DIFF
--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -13,6 +13,7 @@ secrets:
 - id: SOURCE_REPO
   value: {{ $.SOURCE_REPO }}
 shell:
+  installCacheVersion: '{{ now | date "Mon Jan 2 15:04:05 MST 2006" }}' # force rebuild for greenteagc A/B test
   install:
   - |
     echo "Git clone {{ $gitRepoName }} repository..."
@@ -112,6 +113,11 @@ shell:
 
     - export GOOS=linux
     - export GOARCH=amd64
+    # A/B test: disable Green Tea GC to check live-migration TLS throughput regression.
+    # Toolchain (ALT 20260119, CVE mitigation) bakes GOEXPERIMENT=greenteagc, which is
+    # the only build-setting delta between v1.8.3 (go1.25.10, ~9.4 Gbps) and v1.9.1
+    # (go1.25.11 greenteagc, ~0.3 Gbps) virt-handler binaries.
+    - export GOEXPERIMENT=nogreenteagc
     - export CGO_ENABLED=0
 
     - echo ============== Build container-disk ===================


### PR DESCRIPTION
## Description

Disables the Green Tea GC experiment (`GOEXPERIMENT=nogreenteagc`) for the
`virt-*` binaries built in `virt-artifact`, and bumps `installCacheVersion` to
force a rebuild.

## Why do we need it, and what problem does it solve?

Live migration throughput dropped sharply between releases. Migration data is
tunneled and TLS-encrypted by `virt-handler`, and this change rebuilds it
without the Green Tea GC experiment to confirm whether that is the cause.

## What is the expected result?

1. virt-artifact rebuilds with `nogreenteagc`.
2. Deckhouse rolls out new virt-handler pods and live-migrates VMs onto a node
   with the new virt-launcher.
3. Migrating a VM with TLS on shows restored throughput in
   `vlctl domain stats -o json` (`MigrateDomainJobInfo.MemoryBps`).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: core
type: fix
summary: "Restored live-migration throughput by disabling the Green Tea GC experiment in virt-handler/virt-launcher builds."
impact_level: low
```