### PR TITLE
test(core): A/B virt-artifact build against pre-CVE base image for live-migration regression

### DIFF
--- a/build/base-images/base-images-pins.yml
+++ b/build/base-images/base-images-pins.yml
@@ -7,6 +7,8 @@
 #
 # Consumed by .werf/defines/parse-base-images-map.tmpl.
 fromContainerFactory:
-  # CVE mitigation (08-06-2026): requires the ALT 20260119 based toolchain
-  # provided by container-factory instead of the deckhouse_images build.
-  - builder/golang-alt-1.25
+  # A/B test: pin temporarily commented to build virt-* against the pre-CVE
+  # toolchain (ALT 20250625 / go1.25.10, the v1.8.3 base) instead of the
+  # ALT 20260119 toolchain (go1.25.11). If live-migration throughput is
+  # restored, the regression is in the toolchain; if not, it is elsewhere.
+  # - builder/golang-alt-1.25

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -13,6 +13,7 @@ secrets:
 - id: SOURCE_REPO
   value: {{ $.SOURCE_REPO }}
 shell:
+  installCacheVersion: '{{ now | date "Mon Jan 2 15:04:05 MST 2006" }}' # force rebuild for old-toolchain A/B test
   install:
   - |
     echo "Git clone {{ $gitRepoName }} repository..."


### PR DESCRIPTION
## Description

Temporarily disables the `builder/golang-alt-1.25` pin so the `virt-*`
binaries are built with the pre-CVE toolchain (the v1.8.3 base) instead of
the current toolchain (the v1.9.1 base). `installCacheVersion` forces a
rebuild.

## Why do we need it, and what problem does it solve?

Live migration throughput dropped sharply between releases. This A/B
experiment rebuilds virt-handler/virt-launcher against the older base image to
confirm whether the regression originates in the toolchain.

## What is the expected result?

1. virt-artifact rebuilds against the pre-CVE base image.
2. Deckhouse rolls out new virt-handler pods and live-migrates VMs onto a node
   with the new virt-launcher.
3. Migrating a VM with TLS on shows restored throughput in
   `vlctl domain stats -o json` (`MigrateDomainJobInfo.MemoryBps`).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: core
type: fix
summary: "Restored live-migration throughput by building virt-handler/virt-launcher against the pre-CVE base image."
impact_level: low
```
