### PR TITLE
fix(core): bump builder/golang-alt-1.25 toolchain

### DIFF
--- a/build/base-images/container_factory_images.yml
+++ b/build/base-images/container_factory_images.yml
@@ -44,7 +44,7 @@ builder/golang-1.26: "sha256:d771e7d448312e10eea7036af2f46a69d44461d711a2982f3c6
 builder/golang-alpine-1.25: "sha256:9701f93cec25acec10837e2399f7fda7e4c23303bed6514bfa0ff692396f170b" # from: alpine:3.22.2
 builder/golang-alpine-1.26.4: "sha256:193e8ed6cd7fc19015ab615ccf92d0fe02471e66e3e5abf560b3a87fb05bdb62" # from: alpine:3.22.2
 builder/golang-alpine: "sha256:193e8ed6cd7fc19015ab615ccf92d0fe02471e66e3e5abf560b3a87fb05bdb62" # from: alpine:3.22.2
-builder/golang-alt-1.25: "sha256:603fbc50b120329f25fa2d2162ec051d744edf66230e2362d9f0a5ffb9537c0f" # from: registry.altlinux.org/p11/alt:20260119
+builder/golang-alt-1.25: "sha256:603fbc50b120329f25fa2d2162ec051d744edf66230e2362d9f0a5ffb9537c0f" # from: registry.altlinux.org/p11/alt:20260119 (v1.1.11 container-factory)
 builder/golang-alt-1.26: "sha256:71dffc9bccd6c1ce5ecd78495652c9d209b518ec297a80e358b4a98e33d5b40c" # from: registry.altlinux.org/p11/alt:20260119
 builder/golang-alt: "sha256:71dffc9bccd6c1ce5ecd78495652c9d209b518ec297a80e358b4a98e33d5b40c" # from: registry.altlinux.org/p11/alt:20260119
 builder/golang-artifact-1.25: "sha256:3a6662d203f06e0a136378677fd2da6e726a08db45f77a8e9c50495c111c445a" # from: builder/distroless

--- a/build/base-images/container_factory_images.yml
+++ b/build/base-images/container_factory_images.yml
@@ -44,7 +44,7 @@ builder/golang-1.26: "sha256:d771e7d448312e10eea7036af2f46a69d44461d711a2982f3c6
 builder/golang-alpine-1.25: "sha256:9701f93cec25acec10837e2399f7fda7e4c23303bed6514bfa0ff692396f170b" # from: alpine:3.22.2
 builder/golang-alpine-1.26.4: "sha256:193e8ed6cd7fc19015ab615ccf92d0fe02471e66e3e5abf560b3a87fb05bdb62" # from: alpine:3.22.2
 builder/golang-alpine: "sha256:193e8ed6cd7fc19015ab615ccf92d0fe02471e66e3e5abf560b3a87fb05bdb62" # from: alpine:3.22.2
-builder/golang-alt-1.25: "sha256:713b7c272f5b7afe6a3101d2cb1ae891121162e60ec5127121bbe4625ffe0016" # from: registry.altlinux.org/p11/alt:20260119
+builder/golang-alt-1.25: "sha256:603fbc50b120329f25fa2d2162ec051d744edf66230e2362d9f0a5ffb9537c0f" # from: registry.altlinux.org/p11/alt:20260119
 builder/golang-alt-1.26: "sha256:71dffc9bccd6c1ce5ecd78495652c9d209b518ec297a80e358b4a98e33d5b40c" # from: registry.altlinux.org/p11/alt:20260119
 builder/golang-alt: "sha256:71dffc9bccd6c1ce5ecd78495652c9d209b518ec297a80e358b4a98e33d5b40c" # from: registry.altlinux.org/p11/alt:20260119
 builder/golang-artifact-1.25: "sha256:3a6662d203f06e0a136378677fd2da6e726a08db45f77a8e9c50495c111c445a" # from: builder/distroless

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -43,17 +43,7 @@ packages:
 
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: false
-# Dev: use the dev-registry ALT toolchain image with GOST TLS priority fix
-# (go1.25.11 + greenteagc + gogost, but GOST cipher suites no longer preferred
-# in TLS 1.3 auto-negotiate -> AES-GCM negotiated, fast). Restores live-migration
-# throughput vs the slow 713b7c2 toolchain.
-#
-# TODO: image 78a55067 lives in dev-registry.deckhouse.io/container-factory only.
-# Once base-images (branch go-gost-tls-priority) is released to prod
-# registry.deckhouse.io/container-factory, switch this back to the regular
-# fromImage: builder/golang-alt-1.25 and update the SHA in
-# build/base-images/container_factory_images.yml accordingly.
-from: dev-registry.deckhouse.io/container-factory@sha256:78a55067d15c9f23c0c725336f14329838115a4d860dfe6d6a8f41e66a240f72
+fromImage: builder/golang-alt-1.25
 mount:
 {{- include "mount points for golang builds" . }}
 secrets:

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -43,7 +43,7 @@ packages:
 
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: false
-fromImage: builder/golang-alt-1.25
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alt-1.25" "builder/golang-alt-1.25" }}
 mount:
 {{- include "mount points for golang builds" . }}
 secrets:

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -13,7 +13,6 @@ secrets:
 - id: SOURCE_REPO
   value: {{ $.SOURCE_REPO }}
 shell:
-  installCacheVersion: '{{ now | date "Mon Jan 2 15:04:05 MST 2006" }}' # force rebuild for old-toolchain A/B test
   install:
   - |
     echo "Git clone {{ $gitRepoName }} repository..."
@@ -44,11 +43,11 @@ packages:
 
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: false
-# A/B test: pin this stage to the go1.26.4 toolchain (ALT 20260119, the same new
-# base as v1.9.1 but Go 1.26.4 instead of 1.25.11) to check whether a newer
-# Go version restores live-migration TLS throughput. Only virt-artifact is
-# affected; dvcr and other images keep the new toolchain.
-from: registry.deckhouse.io/container-factory@sha256:71dffc9bccd6c1ce5ecd78495652c9d209b518ec297a80e358b4a98e33d5b40c
+# Dev: use the dev-registry toolchain image (go1.25.11 + greenteagc, but GOST
+# cipher suites not selected in TLS 1.3 auto-negotiate -> AES-GCM, fast).
+# Pending push to prod registry.deckhouse.io/container-factory; switch back to
+# fromImage: builder/golang-alt-1.25 once available there.
+from: dev-registry.deckhouse.io/container-factory@sha256:b370cc95d4ef09c9c877b2bc2601dd9f64639db1170d2374dd05ac82d0387f60
 mount:
 {{- include "mount points for golang builds" . }}
 secrets:

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -13,6 +13,7 @@ secrets:
 - id: SOURCE_REPO
   value: {{ $.SOURCE_REPO }}
 shell:
+  installCacheVersion: '{{ now | date "Mon Jan 2 15:04:05 MST 2006" }}' # force rebuild for old-toolchain A/B test
   install:
   - |
     echo "Git clone {{ $gitRepoName }} repository..."
@@ -43,7 +44,11 @@ packages:
 
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alt-1.25" "builder/golang-alt-1.25" }}
+# A/B test: pin this stage to the go1.26.4 toolchain (ALT 20260119, the same new
+# base as v1.9.1 but Go 1.26.4 instead of 1.25.11) to check whether a newer
+# Go version restores live-migration TLS throughput. Only virt-artifact is
+# affected; dvcr and other images keep the new toolchain.
+from: registry.deckhouse.io/container-factory@sha256:71dffc9bccd6c1ce5ecd78495652c9d209b518ec297a80e358b4a98e33d5b40c
 mount:
 {{- include "mount points for golang builds" . }}
 secrets:

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -43,11 +43,17 @@ packages:
 
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
 final: false
-# Dev: use the dev-registry toolchain image (go1.25.11 + greenteagc, but GOST
-# cipher suites not selected in TLS 1.3 auto-negotiate -> AES-GCM, fast).
-# Pending push to prod registry.deckhouse.io/container-factory; switch back to
-# fromImage: builder/golang-alt-1.25 once available there.
-from: dev-registry.deckhouse.io/container-factory@sha256:b370cc95d4ef09c9c877b2bc2601dd9f64639db1170d2374dd05ac82d0387f60
+# Dev: use the dev-registry ALT toolchain image with GOST TLS priority fix
+# (go1.25.11 + greenteagc + gogost, but GOST cipher suites no longer preferred
+# in TLS 1.3 auto-negotiate -> AES-GCM negotiated, fast). Restores live-migration
+# throughput vs the slow 713b7c2 toolchain.
+#
+# TODO: image 78a55067 lives in dev-registry.deckhouse.io/container-factory only.
+# Once base-images (branch go-gost-tls-priority) is released to prod
+# registry.deckhouse.io/container-factory, switch this back to the regular
+# fromImage: builder/golang-alt-1.25 and update the SHA in
+# build/base-images/container_factory_images.yml accordingly.
+from: dev-registry.deckhouse.io/container-factory@sha256:78a55067d15c9f23c0c725336f14329838115a4d860dfe6d6a8f41e66a240f72
 mount:
 {{- include "mount points for golang builds" . }}
 secrets:


### PR DESCRIPTION
## Description

Bumps `builder/golang-alt-1.25` in `build/base-images/container_factory_images.yml` to the latest build and reverts `images/virt-artifact/werf.inc.yaml` to the regular `fromImage: builder/golang-alt-1.25` (removes the temporary `from:` override from the previous iteration).

## Why do we need it, and what problem does it solve?

Picks up the latest `builder/golang-alt-1.25` toolchain build, which resolves a live-migration throughput regression observed between v1.8.3 and v1.9.1. With the previous toolchain build, live migration of a running VM with TLS enabled was noticeably slower. The new build restores the expected throughput.

## What is the expected result?

1. CI builds module images against the updated toolchain.
2. Deploy the PR build into a test cluster and trigger a live migration of a running VM with TLS on (`VirtualMachineOperation` type `Migrate`).
3. `VirtualMachineOperation` reaches `Completed` / `migrationState.result=Succeeded` with throughput restored to the v1.8.3 level.

## Checklist
- [ ] The code is covered by unit tests. — N/A (base image bump + build config)
- [ ] e2e tests passed. — pending CI
- [ ] Documentation updated according to the changes. — N/A
- [x] Changes were tested in the Kubernetes cluster manually. — injector VM live migration on the virt cluster: `VirtualMachineOperation` `Completed` / `Succeeded` in ~25 s

## Changelog entries

```changes
section: core
type: fix
summary: Fixed reduced throughput during live migration of running VMs compared to v1.8.3.
```