### PR TITLE
fix(module): handle Debian usbip kernel modules

### DIFF
--- a/templates/virtualization-dra/nodegroupconfiguration-usbip.yaml
+++ b/templates/virtualization-dra/nodegroupconfiguration-usbip.yaml
@@ -33,7 +33,7 @@ spec:
 
     modules_exist=true
     for module in "${modules[@]}"; do
-      if [[ ! -e "${module_dir}/${module}" && ! -e "${module_dir}/${module}.zst" ]]; then
+      if [[ ! -e "${module_dir}/${module}" && ! -e "${module_dir}/${module}.zst" && ! -e "${module_dir}/${module}.xz" ]]; then
         modules_exist=false
         break
       fi
@@ -45,7 +45,11 @@ spec:
     fi
 
     if bb-is-distro-like? "debian"; then
-      packages=("linux-modules-extra-${kernel_release}")
+      if [[ "$bundle" == "debian" ]]; then
+        packages=("linux-image-${kernel_release}")
+      else
+        packages=("linux-modules-extra-${kernel_release}")
+      fi
     elif bb-is-distro-like? "rhel" || bb-is-distro-like? "centos" || bb-is-distro-like? "fedora"; then
       packages=("kernel-modules-extra-${kernel_release}" "kernel-modules-extra")
     elif [[ "$bundle" == "altlinux" ]]; then


### PR DESCRIPTION
## Description
Update the USB/IP kernel module installation NodeGroupConfiguration:

- detect xz-compressed kernel modules (`*.ko.xz`) in addition to plain `*.ko` and zstd-compressed `*.ko.zst` modules;
- use Debian's `linux-image-${kernel_release}` package for Debian hosts instead of Ubuntu-specific `linux-modules-extra-${kernel_release}`;
- keep `linux-modules-extra-${kernel_release}` for other Debian-like distributions such as Ubuntu.

## Why do we need it, and what problem does it solve?
On Debian 13, USB/IP kernel modules are already provided by the kernel image package and are stored as `*.ko.xz` files. The previous check did not recognize this extension, so Bashible treated the modules as missing and tried to install `linux-modules-extra-${kernel_release}`.

Debian does not provide `linux-modules-extra-*` packages, so this resulted in `Unable to locate package` errors and repeated Bashible failures.

## What is the expected result?
On Debian 13 nodes with USB/IP modules present as `*.ko.xz`, Bashible detects the modules and skips package installation.

If the modules are missing on Debian, Bashible tries the Debian kernel image package instead of the Ubuntu-specific `linux-modules-extra-*` package.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: module
type: fix
summary: Detect xz-compressed USB/IP kernel modules on Debian and avoid installing Ubuntu-specific kernel module packages.
impact_level: low
```
