### PR TITLE
fix(core): increase ephemeral storage overhead to 200M

### DIFF
--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -3,7 +3,7 @@ firmware:
   libvirt: v10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: v1.6.2-v12n.49
+  3p-kubevirt: fix/vm/up-ephemeral-request
   3p-containerized-data-importer: v1.60.3-v12n.20
   distribution: 2.8.3
 package:


### PR DESCRIPTION
## Description
Increase `ephemeralStorageOverheadSize` from 50M to 200M in the 3p-kubevirt dependency.

**This is a temporary hotfix.** The root cause — unbounded growth of virt-launcher stdout/stderr logs — is addressed in a separate task.

Related: https://github.com/deckhouse/3p-kubevirt/pull/134

## Why do we need it, and what problem does it solve?
When a node runs low on ephemeral-storage, the kubelet evicts pods ordered by excess usage (actual usage − request). The `d8v-compute` container accumulates stdout/stderr logs over time; once log size exceeds the 50M request, the pod becomes a prime eviction candidate — which causes the VM running inside it to be killed.

Observed in production:
- Eviction event: `d8v-compute` used ~63M against a 50M request → VM killed.
- Long-running pods show log sizes up to 105M, well above the 50M threshold.

Raising the request to 200M gives significantly more headroom before a virt-launcher pod is selected as an eviction victim, reducing unintended VM downtime caused by log accumulation.

## What is the expected result?
1. Deploy updated virt-launcher with new ephemeral-storage request (200M).
2. Confirm `d8v-compute` container has `resources.requests.ephemeral-storage: 200M`.
3. Verify virt-launcher pods are no longer evicted under moderate node disk pressure.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: core
type: fix
summary: "Fixed unexpected VM termination under node disk pressure — VMs are now resilient to moderate ephemeral storage consumption."
```