### PR TITLE
fix(observability): virtualization-audit tls bad record MAC on cert rotation

### DIFF
--- a/images/virtualization-artifact/pkg/audit/server/server.go
+++ b/images/virtualization-artifact/pkg/audit/server/server.go
@@ -63,18 +63,12 @@ func (s *tcpServer) Run(ctx context.Context, opts ...Option) error {
 	var listener net.Listener
 	var err error
 	if o.TLS != nil {
-		// Fail fast if the certificate material is missing or invalid at startup.
-		if _, err = loadServerTLSConfig(o.TLS); err != nil {
+		// The pod is rolled on every certificate rotation (module policy), so the
+		// cert is loaded once at startup; graceful shutdown drains connections so
+		// that roll stays clean for the log-shipper.
+		var cfg *tls.Config
+		if cfg, err = loadServerTLSConfig(o.TLS); err != nil {
 			return err
-		}
-
-		// ponytail: reload cert and client CA from disk on every handshake so
-		// secret rotation needs no pod restart. Handshakes are rare (vector keeps
-		// a persistent connection), so per-handshake disk reads are negligible.
-		cfg := &tls.Config{
-			GetConfigForClient: func(*tls.ClientHelloInfo) (*tls.Config, error) {
-				return loadServerTLSConfig(o.TLS)
-			},
 		}
 		listener, err = tls.Listen("tcp", s.addr, cfg)
 	} else {

--- a/images/virtualization-artifact/pkg/audit/server/server.go
+++ b/images/virtualization-artifact/pkg/audit/server/server.go
@@ -25,10 +25,14 @@ import (
 	"log/slog"
 	"net"
 	"os"
-	"time"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
+
+// maxAuditEventSize bounds a single audit event line. The bufio.Scanner default
+// is 64 KiB, which k8s audit events with large objects (managedFields, VM specs)
+// can exceed — dropping the rest of the connection. 4 MiB leaves generous headroom.
+const maxAuditEventSize = 4 * 1024 * 1024
 
 type Server interface {
 	Run(ctx context.Context, opts ...Option) error
@@ -36,16 +40,14 @@ type Server interface {
 
 func NewServer(addr string, handler func([]byte) error) (Server, error) {
 	return &tcpServer{
-		gracefulShutdownTimeout: 5 * time.Second,
-		addr:                    addr,
-		handler:                 handler,
+		addr:    addr,
+		handler: handler,
 	}, nil
 }
 
 type tcpServer struct {
-	gracefulShutdownTimeout time.Duration
-	addr                    string
-	handler                 func([]byte) error
+	addr    string
+	handler func([]byte) error
 }
 
 func (s *tcpServer) Run(ctx context.Context, opts ...Option) error {
@@ -57,36 +59,25 @@ func (s *tcpServer) Run(ctx context.Context, opts ...Option) error {
 	var listener net.Listener
 	var err error
 	if o.TLS != nil {
-		certPool, err := x509.SystemCertPool()
-		if err != nil {
-			return fmt.Errorf("fail to get system cert pool: %w", err)
-		}
-
-		if caCertPEM, err := os.ReadFile(o.TLS.CaFile); err != nil {
-			return fmt.Errorf("fail to read CA PEM: %w", err)
-		} else if ok := certPool.AppendCertsFromPEM(caCertPEM); !ok {
-			return fmt.Errorf("invalid cert in CA PEM: %w", err)
-		}
-
-		cert, err := tls.LoadX509KeyPair(o.TLS.CertFile, o.TLS.KeyFile)
-		if err != nil {
+		// Fail fast if the certificate material is missing or invalid at startup.
+		if _, err = loadServerTLSConfig(o.TLS); err != nil {
 			return err
 		}
 
-		config := &tls.Config{
-			RootCAs:      certPool,
-			Certificates: []tls.Certificate{cert},
+		// ponytail: reload cert and client CA from disk on every handshake so
+		// secret rotation needs no pod restart. Handshakes are rare (vector keeps
+		// a persistent connection), so per-handshake disk reads are negligible.
+		cfg := &tls.Config{
+			GetConfigForClient: func(*tls.ClientHelloInfo) (*tls.Config, error) {
+				return loadServerTLSConfig(o.TLS)
+			},
 		}
-
-		listener, err = tls.Listen("tcp", s.addr, config)
-		if err != nil {
-			return err
-		}
+		listener, err = tls.Listen("tcp", s.addr, cfg)
 	} else {
 		listener, err = net.Listen("tcp", s.addr)
-		if err != nil {
-			return err
-		}
+	}
+	if err != nil {
+		return err
 	}
 
 	defer listener.Close()
@@ -117,28 +108,54 @@ func (s *tcpServer) Run(ctx context.Context, opts ...Option) error {
 	}
 }
 
+// loadServerTLSConfig reads the server certificate and the client CA from disk
+// and builds a config that requires and verifies a client certificate (mTLS),
+// so only clients holding a certificate signed by our CA can submit audit events.
+func loadServerTLSConfig(t *TLSPair) (*tls.Config, error) {
+	cert, err := tls.LoadX509KeyPair(t.CertFile, t.KeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("load TLS key pair: %w", err)
+	}
+
+	caPEM, err := os.ReadFile(t.CaFile)
+	if err != nil {
+		return nil, fmt.Errorf("read CA file: %w", err)
+	}
+
+	clientCAs := x509.NewCertPool()
+	if !clientCAs.AppendCertsFromPEM(caPEM) {
+		return nil, fmt.Errorf("no valid certificate found in CA file %q", t.CaFile)
+	}
+
+	return &tls.Config{
+		MinVersion:   tls.VersionTLS12,
+		Certificates: []tls.Certificate{cert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    clientCAs,
+	}, nil
+}
+
 func (s *tcpServer) handleConnection(ctx context.Context, conn net.Conn) {
 	defer conn.Close()
 
 	log.Debug("New connection", slog.String("remote", conn.RemoteAddr().String()))
 
 	scanner := bufio.NewScanner(conn)
+	scanner.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), maxAuditEventSize)
 	for scanner.Scan() {
-		select {
-		case <-ctx.Done():
+		if ctx.Err() != nil {
 			return
-		default:
-			line := scanner.Bytes()
+		}
 
-			err := s.handler(line)
-			if err != nil {
-				log.Debug("Error processing line", log.Err(err))
-			}
-			continue
+		if err := s.handler(scanner.Bytes()); err != nil {
+			log.Warn("Failed to process audit event", log.Err(err))
 		}
 	}
 
 	if err := scanner.Err(); err != nil {
-		log.Error("Scanner error", log.Err(err))
+		// A peer dropping the connection mid-stream (pod roll, vector reconnect)
+		// surfaces here as EOF / reset / "bad record MAC". It is expected churn,
+		// not a server fault, so it stays at debug level.
+		log.Debug("Connection closed with error", slog.String("remote", conn.RemoteAddr().String()), log.Err(err))
 	}
 }

--- a/images/virtualization-artifact/pkg/audit/server/server.go
+++ b/images/virtualization-artifact/pkg/audit/server/server.go
@@ -25,6 +25,8 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"sync"
+	"time"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
@@ -40,14 +42,16 @@ type Server interface {
 
 func NewServer(addr string, handler func([]byte) error) (Server, error) {
 	return &tcpServer{
-		addr:    addr,
-		handler: handler,
+		gracefulShutdownTimeout: 5 * time.Second,
+		addr:                    addr,
+		handler:                 handler,
 	}, nil
 }
 
 type tcpServer struct {
-	addr    string
-	handler func([]byte) error
+	gracefulShutdownTimeout time.Duration
+	addr                    string
+	handler                 func([]byte) error
 }
 
 func (s *tcpServer) Run(ctx context.Context, opts ...Option) error {
@@ -82,10 +86,25 @@ func (s *tcpServer) Run(ctx context.Context, opts ...Option) error {
 
 	defer listener.Close()
 
-	// Accept connections in a loop that respects context cancellation
+	var (
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		conns   = map[net.Conn]struct{}{}
+		closing bool
+	)
+
+	// On shutdown: stop accepting and close every active connection. Closing a
+	// tls.Conn sends close_notify, so the peer sees a clean EOF instead of a
+	// truncated record ("bad record MAC") and can reconnect to another replica.
 	go func() {
 		<-ctx.Done()
 		listener.Close()
+		mu.Lock()
+		closing = true
+		for c := range conns {
+			c.Close()
+		}
+		mu.Unlock()
 	}()
 
 	log.Debug("Server started", slog.String("address", s.addr))
@@ -96,6 +115,7 @@ func (s *tcpServer) Run(ctx context.Context, opts ...Option) error {
 			// Check if server is shutting down
 			select {
 			case <-ctx.Done():
+				waitWithTimeout(&wg, s.gracefulShutdownTimeout)
 				return nil
 			default:
 				log.Error("Error accepting connection", log.Err(err))
@@ -103,8 +123,38 @@ func (s *tcpServer) Run(ctx context.Context, opts ...Option) error {
 			}
 		}
 
+		mu.Lock()
+		if closing {
+			mu.Unlock()
+			conn.Close()
+			continue
+		}
+		conns[conn] = struct{}{}
+		mu.Unlock()
+
 		// Handle each connection in its own goroutine
-		go s.handleConnection(ctx, conn)
+		wg.Go(func() {
+			defer func() {
+				mu.Lock()
+				delete(conns, conn)
+				mu.Unlock()
+			}()
+			s.handleConnection(ctx, conn)
+		})
+	}
+}
+
+// waitWithTimeout blocks until the WaitGroup drains or the timeout elapses,
+// so in-flight connections finish cleanly without holding shutdown forever.
+func waitWithTimeout(wg *sync.WaitGroup, timeout time.Duration) {
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout):
 	}
 }
 

--- a/images/virtualization-artifact/pkg/audit/server/server_suite_test.go
+++ b/images/virtualization-artifact/pkg/audit/server/server_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestServer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Audit Server Suite")
+}

--- a/images/virtualization-artifact/pkg/audit/server/server_test.go
+++ b/images/virtualization-artifact/pkg/audit/server/server_test.go
@@ -1,0 +1,373 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"io"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// recorder is a thread-safe handler that records every audit line it receives.
+type recorder struct {
+	mu    sync.Mutex
+	lines [][]byte
+}
+
+func (r *recorder) handle(b []byte) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	// scanner.Bytes() reuses its buffer, so copy before keeping the slice.
+	r.lines = append(r.lines, append([]byte(nil), b...))
+	return nil
+}
+
+func (r *recorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.lines)
+}
+
+func (r *recorder) get() [][]byte {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([][]byte, len(r.lines))
+	copy(out, r.lines)
+	return out
+}
+
+// freeAddr reserves a free loopback port and returns its address. There is a
+// small race before the server rebinds it, acceptable for a unit test.
+func freeAddr() string {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	Expect(err).NotTo(HaveOccurred())
+	addr := l.Addr().String()
+	Expect(l.Close()).To(Succeed())
+	return addr
+}
+
+// issue creates a certificate. With parent == nil it is a self-signed CA;
+// otherwise it is a leaf signed by parent (server or client depending on flags).
+func issue(cn string, parent *x509.Certificate, parentKey *ecdsa.PrivateKey, isCA, server bool) (*x509.Certificate, *ecdsa.PrivateKey, []byte, []byte) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	Expect(err).NotTo(HaveOccurred())
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 62))
+	Expect(err).NotTo(HaveOccurred())
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		BasicConstraintsValid: true,
+	}
+	switch {
+	case isCA:
+		tmpl.IsCA = true
+		tmpl.KeyUsage = x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature
+	case server:
+		tmpl.KeyUsage = x509.KeyUsageDigitalSignature
+		tmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+		tmpl.IPAddresses = []net.IP{net.ParseIP("127.0.0.1")}
+	default:
+		tmpl.KeyUsage = x509.KeyUsageDigitalSignature
+		tmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+	}
+
+	signer, signerKey := tmpl, key
+	if parent != nil {
+		signer, signerKey = parent, parentKey
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, signer, &key.PublicKey, signerKey)
+	Expect(err).NotTo(HaveOccurred())
+	cert, err := x509.ParseCertificate(der)
+	Expect(err).NotTo(HaveOccurred())
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	Expect(err).NotTo(HaveOccurred())
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+
+	return cert, key, certPEM, keyPEM
+}
+
+func writeFile(dir, name string, data []byte) string {
+	p := filepath.Join(dir, name)
+	Expect(os.WriteFile(p, data, 0o600)).To(Succeed())
+	return p
+}
+
+// startServer runs the server in a goroutine on a free address and returns the
+// address, a cancel func, and a channel that yields Run's return value.
+func startServer(handler func([]byte) error, opts ...Option) (string, context.CancelFunc, <-chan error) {
+	addr := freeAddr()
+	srv, err := NewServer(addr, handler)
+	Expect(err).NotTo(HaveOccurred())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runErr := make(chan error, 1)
+	go func() { runErr <- srv.Run(ctx, opts...) }()
+	return addr, cancel, runErr
+}
+
+var _ = Describe("Audit server", func() {
+	var rec *recorder
+
+	BeforeEach(func() {
+		rec = &recorder{}
+	})
+
+	Context("plain TCP", func() {
+		var (
+			addr   string
+			cancel context.CancelFunc
+			runErr <-chan error
+		)
+
+		BeforeEach(func() {
+			addr, cancel, runErr = startServer(rec.handle)
+			// Wait until the listener accepts connections.
+			Eventually(func() error {
+				c, err := net.Dial("tcp", addr)
+				if err == nil {
+					_ = c.Close()
+				}
+				return err
+			}, "2s", "20ms").Should(Succeed())
+		})
+
+		AfterEach(func() {
+			cancel()
+			Eventually(runErr, "2s").Should(Receive(BeNil()))
+		})
+
+		It("delivers newline-delimited lines to the handler in order", func() {
+			conn, err := net.Dial("tcp", addr)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = conn.Close() }()
+
+			_, err = conn.Write([]byte("first\nsecond\nthird\n"))
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(rec.count, "2s").Should(Equal(3))
+			lines := rec.get()
+			Expect(string(lines[0])).To(Equal("first"))
+			Expect(string(lines[1])).To(Equal("second"))
+			Expect(string(lines[2])).To(Equal("third"))
+		})
+
+		It("delivers a line larger than the 64 KiB scanner default intact", func() {
+			big := strings.Repeat("a", 256*1024)
+
+			conn, err := net.Dial("tcp", addr)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = conn.Close() }()
+
+			_, err = conn.Write([]byte(big + "\n"))
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(rec.count, "2s").Should(Equal(1))
+			Expect(rec.get()[0]).To(HaveLen(len(big)))
+		})
+
+		It("does not deliver a line exceeding maxAuditEventSize", func() {
+			conn, err := net.Dial("tcp", addr)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = conn.Close() }()
+
+			oversized := strings.Repeat("a", maxAuditEventSize+1)
+			_, _ = conn.Write([]byte(oversized + "\n"))
+
+			Consistently(rec.count, "500ms").Should(Equal(0))
+		})
+	})
+
+	Context("graceful shutdown", func() {
+		It("returns promptly and closes active connections cleanly", func() {
+			addr, cancel, runErr := startServer(rec.handle)
+			Eventually(func() error {
+				c, err := net.Dial("tcp", addr)
+				if err == nil {
+					_ = c.Close()
+				}
+				return err
+			}, "2s", "20ms").Should(Succeed())
+
+			conn, err := net.Dial("tcp", addr)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = conn.Close() }()
+
+			_, err = conn.Write([]byte("ping\n"))
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(rec.count, "2s").Should(Equal(1))
+
+			cancel()
+
+			// Run must return well within gracefulShutdownTimeout (5s).
+			Eventually(runErr, "3s").Should(Receive(BeNil()))
+
+			// The active connection is closed by the server, so the client sees EOF.
+			Expect(conn.SetReadDeadline(time.Now().Add(2 * time.Second))).To(Succeed())
+			_, err = conn.Read(make([]byte, 1))
+			Expect(err).To(MatchError(io.EOF))
+		})
+	})
+
+	Context("waitWithTimeout", func() {
+		It("returns immediately once the WaitGroup drains", func() {
+			var wg sync.WaitGroup
+			start := time.Now()
+			waitWithTimeout(&wg, time.Second)
+			Expect(time.Since(start)).To(BeNumerically("<", 500*time.Millisecond))
+		})
+
+		It("returns after the timeout when the WaitGroup never drains", func() {
+			var wg sync.WaitGroup
+			wg.Add(1)
+			defer wg.Done()
+
+			start := time.Now()
+			waitWithTimeout(&wg, 100*time.Millisecond)
+			Expect(time.Since(start)).To(BeNumerically(">=", 100*time.Millisecond))
+		})
+	})
+
+	Context("mTLS", func() {
+		var (
+			addr      string
+			cancel    context.CancelFunc
+			runErr    <-chan error
+			caPEM     []byte
+			clientPEM []byte
+			clientKey []byte
+			ca        *x509.Certificate
+			caKey     *ecdsa.PrivateKey
+		)
+
+		BeforeEach(func() {
+			var caCertPEM []byte
+			ca, caKey, caCertPEM, _ = issue("test-ca", nil, nil, true, false)
+			caPEM = caCertPEM
+
+			_, _, serverPEM, serverKey := issue("audit-server", ca, caKey, false, true)
+			_, _, clientPEM, clientKey = issue("audit-client", ca, caKey, false, false)
+
+			dir := GinkgoT().TempDir()
+			caFile := writeFile(dir, "ca.crt", caPEM)
+			certFile := writeFile(dir, "tls.crt", serverPEM)
+			keyFile := writeFile(dir, "tls.key", serverKey)
+
+			addr, cancel, runErr = startServer(rec.handle, WithTLS(caFile, certFile, keyFile))
+		})
+
+		AfterEach(func() {
+			cancel()
+			Eventually(runErr, "3s").Should(Receive(BeNil()))
+		})
+
+		caPool := func() *x509.CertPool {
+			pool := x509.NewCertPool()
+			Expect(pool.AppendCertsFromPEM(caPEM)).To(BeTrue())
+			return pool
+		}
+
+		dialTLS := func(cfg *tls.Config) (*tls.Conn, error) {
+			cfg.ServerName = "127.0.0.1"
+			d := &net.Dialer{Timeout: 2 * time.Second}
+			return tls.DialWithDialer(d, "tcp", addr, cfg)
+		}
+
+		// mTLSRejected reports whether the server refuses the client. Under TLS 1.3
+		// a client-cert rejection is delivered as a post-handshake alert, so dialing
+		// may succeed and the error only surfaces on the first read.
+		mTLSRejected := func(cfg *tls.Config) bool {
+			conn, err := dialTLS(cfg)
+			if err != nil {
+				return true
+			}
+			defer func() { _ = conn.Close() }()
+			Expect(conn.SetDeadline(time.Now().Add(2 * time.Second))).To(Succeed())
+			_, err = conn.Write([]byte("audit-event\n"))
+			if err == nil {
+				_, err = conn.Read(make([]byte, 1))
+			}
+			return err != nil && !errors.Is(err, io.EOF)
+		}
+
+		It("accepts a client with a cert signed by the CA and delivers its lines", func() {
+			pair, err := tls.X509KeyPair(clientPEM, clientKey)
+			Expect(err).NotTo(HaveOccurred())
+
+			var conn *tls.Conn
+			Eventually(func() error {
+				conn, err = dialTLS(&tls.Config{
+					Certificates: []tls.Certificate{pair},
+					RootCAs:      caPool(),
+				})
+				return err
+			}, "2s", "20ms").Should(Succeed())
+			defer func() { _ = conn.Close() }()
+
+			_, err = conn.Write([]byte("audit-event\n"))
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(rec.count, "2s").Should(Equal(1))
+			Expect(string(rec.get()[0])).To(Equal("audit-event"))
+		})
+
+		It("rejects a client presenting no certificate", func() {
+			Eventually(func() bool {
+				return mTLSRejected(&tls.Config{RootCAs: caPool()})
+			}, "2s", "50ms").Should(BeTrue())
+			Expect(rec.count()).To(Equal(0))
+		})
+
+		It("rejects a client whose cert is signed by a different CA", func() {
+			otherCA, otherKey, _, _ := issue("other-ca", nil, nil, true, false)
+			_, _, otherClientPEM, otherClientKey := issue("intruder", otherCA, otherKey, false, false)
+			pair, err := tls.X509KeyPair(otherClientPEM, otherClientKey)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() bool {
+				return mTLSRejected(&tls.Config{
+					Certificates: []tls.Certificate{pair},
+					RootCAs:      caPool(),
+				})
+			}, "2s", "50ms").Should(BeTrue())
+			Expect(rec.count()).To(Equal(0))
+		})
+	})
+})

--- a/templates/virtualization-audit/deployment.yaml
+++ b/templates/virtualization-audit/deployment.yaml
@@ -62,7 +62,6 @@ spec:
       labels:
         app: virtualization-audit
       annotations:
-        checksum/secret: {{ include (print $.Template.BasePath "/virtualization-audit/cert-secret.yaml") . | sha256sum }}
         kubectl.kubernetes.io/default-container: virtualization-audit
     spec:
       {{ include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "virtualization-audit")) | nindent 6 }}

--- a/templates/virtualization-audit/deployment.yaml
+++ b/templates/virtualization-audit/deployment.yaml
@@ -62,6 +62,7 @@ spec:
       labels:
         app: virtualization-audit
       annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/virtualization-audit/cert-secret.yaml") . | sha256sum }}
         kubectl.kubernetes.io/default-container: virtualization-audit
     spec:
       {{ include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "virtualization-audit")) | nindent 6 }}

--- a/templates/virtualization-audit/deployment.yaml
+++ b/templates/virtualization-audit/deployment.yaml
@@ -89,6 +89,16 @@ spec:
               name: audit
               protocol: TCP
             {{- include "delvePorts" (list $delve "delve/virtualization-audit") | nindent 12 }}
+          readinessProbe:
+            tcpSocket:
+              port: audit
+            initialDelaySeconds: 2
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: audit
+            periodSeconds: 10
+            failureThreshold: 3
           resources:
             requests:
               {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 14 }}

--- a/templates/virtualization-audit/log-config.yaml
+++ b/templates/virtualization-audit/log-config.yaml
@@ -60,9 +60,9 @@ metadata:
   name: to-virtualization-audit
 spec:
   buffer:
-    memory:
-      maxEvents: 4096
-    type: Memory
+    disk:
+      maxSize: 512Mi
+    type: Disk
     whenFull: Block
   socket:
     address: virtualization-audit.d8-virtualization.svc:443


### PR DESCRIPTION
## Description

Fix the recurring `D8LogShipperDestinationErrors` alert and the `tls: bad record MAC` log spam on `virtualization-audit`, and harden the audit ingestion path.

Rolling the audit pod on every certificate rotation is a module policy. Rather than avoid the roll, this PR makes the roll clean so it stops dropping audit events.

`server.go`:
- Drain active connections gracefully on shutdown: close them so the `tls.Conn` sends `close_notify` (clean EOF for the peer instead of a truncated record), and wait up to a timeout for in-flight handlers. This is what keeps the policy-driven roll from surfacing as `bad record MAC` / dropped events.
- Enforce mTLS (`RequireAndVerifyClientCert`). Previously `RootCAs` was set but `ClientAuth` was not, leaving the audit ingestion endpoint unauthenticated and the CA loading effectively dead code. The log-shipper already presents a client certificate signed by the same CA.
- Set `MinVersion` to TLS 1.2.
- Raise the `bufio.Scanner` buffer to 4 MiB; the 64 KiB default silently dropped the rest of a connection on large audit events (k8s objects with `managedFields`).
- Log mid-stream connection drops at debug instead of error with a stacktrace — a peer disconnecting is expected churn, not a server fault.

`deployment.yaml`:
- Add TCP readiness and liveness probes on the audit port (there were none), so the Service does not route to a not-yet-ready pod and a hung server is restarted.

`log-config.yaml`:
- Switch the `to-virtualization-audit` destination buffer from Memory to Disk so undelivered audit events survive a transient sink outage and a log-shipper agent restart.

## Why do we need it, and what problem does it solve?

The cluster fired `D8LogShipperDestinationErrors`, and the audit pod logged `local error: tls: bad record MAC`, while the log-shipper logged `certificate verify failed`, `connection reset/refused`, `unexpected EOF` and dropped audit events.

Root cause: the audit pod is rolled on every certificate rotation (the `checksum/secret` annotation, by module policy), and the server tore down the log-shipper's persistent TLS connection abruptly. In the teardown window:
- events in the log-shipper buffer were dropped (the alert),
- a TLS record cut mid-stream surfaced on the server as `bad record MAC` (reproduced deterministically),
- a CA skew between the log-shipper and the freshly-rolled pod surfaced as `certificate verify failed`.

Graceful drain makes the roll clean (the server sends `close_notify`, so the log-shipper sees a clean EOF), the disk buffer lets the log-shipper re-deliver buffered events instead of dropping them, and the probes keep the Service from routing to a not-ready pod. The mTLS and scanner-buffer fixes close an unauthenticated-ingestion hole and a silent audit-event-loss bug found along the way.

## What is the expected result?

1. Rotate the `virtualization-audit-tls` secret (or wait for rotation). The audit pod rolls, as per policy.
2. During the roll the server closes connections cleanly (`close_notify`) and the log-shipper re-delivers buffered events.
3. No `D8LogShipperDestinationErrors`, no `bad record MAC` / `certificate verify failed` around the rotation.
4. Audit events keep flowing; large events (>64 KiB) are no longer truncated.
5. Connections without a valid client certificate are rejected at handshake (mTLS).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

### Manual verification

The original `local error: tls: bad record MAC` was reproduced deterministically on the cluster (real TLS handshake, then a forged application record written past the TLS layer). On the build with this fix, the same scenario shows:

- **mTLS enforced** — a client with no certificate gets a TLS `handshake failure` (alert 40); a client presenting the audit certificate handshakes successfully.
- **No error spam** — the forged record produces zero `bad record MAC` / `Scanner error` lines at error level (downgraded to debug); the connection is drained instead of logging a stacktrace.
- **Session really established** — the probe line on the authenticated connection surfaced as `warn: Failed to process audit event: ... parsing JSON`, i.e. the exact code path that previously logged `bad record MAC`.

> Still worth a dedicated stand check: the disk-buffer re-delivery behavior of the log-shipper socket sink across a real pod roll.

## Changelog entries
```changes
section: observability
type: fix
summary: Fixed loss of audit events and false `D8LogShipperDestinationErrors` alerts during certificate rotation of the `virtualization-audit` pod.
```
