### PR TITLE
fix(vm): set AgentReady from VMI instead of stale phase

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm/internal/agent.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/agent.go
@@ -69,23 +69,15 @@ func (h *AgentHandler) syncAgentReady(vm *v1alpha2.VirtualMachine, kvvmi *virtv1
 		return
 	}
 
-	cb := conditions.NewConditionBuilder(vmcondition.TypeAgentReady).Generation(vm.GetGeneration())
-
-	defer func() {
-		phase := vm.Status.Phase
-		if phase == v1alpha2.MachinePending || phase == v1alpha2.MachineStarting || phase == v1alpha2.MachineStopped {
-			conditions.RemoveCondition(vmcondition.TypeAgentReady, &vm.Status.Conditions)
-		} else {
-			conditions.SetCondition(cb, &vm.Status.Conditions)
-		}
-	}()
-
 	if kvvmi == nil {
-		cb.Status(metav1.ConditionFalse).
-			Reason(vmcondition.ReasonAgentNotReady).
-			Message("VirtualMachine is not running.")
+		conditions.RemoveCondition(vmcondition.TypeAgentReady, &vm.Status.Conditions)
 		return
 	}
+
+	cb := conditions.NewConditionBuilder(vmcondition.TypeAgentReady).Generation(vm.GetGeneration())
+	defer func() {
+		conditions.SetCondition(cb, &vm.Status.Conditions)
+	}()
 
 	for _, c := range kvvmi.Status.Conditions {
 		if c.Type == virtv1.VirtualMachineInstanceAgentConnected {

--- a/images/virtualization-artifact/pkg/controller/vm/internal/agent_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/agent_test.go
@@ -94,10 +94,13 @@ var _ = Describe("AgentHandler Tests", func() {
 	}
 
 	DescribeTable("AgentReady Condition Tests",
-		func(phase v1alpha2.MachinePhase, agentConnected bool, expectedStatus metav1.ConditionStatus, expectedExistence bool) {
+		func(phase v1alpha2.MachinePhase, kvvmiExists, agentConnected bool, expectedStatus metav1.ConditionStatus, expectedExistence bool) {
 			vm := newVM(phase)
-			kvvmi := newKVVMI(agentConnected, false)
-			fakeClient, resource, vmState = setupEnvironment(vm, kvvmi)
+			if kvvmiExists {
+				fakeClient, resource, vmState = setupEnvironment(vm, newKVVMI(agentConnected, false))
+			} else {
+				fakeClient, resource, vmState = setupEnvironment(vm)
+			}
 
 			reconcile()
 
@@ -111,23 +114,20 @@ var _ = Describe("AgentHandler Tests", func() {
 				Expect(cond.Status).To(Equal(expectedStatus))
 			}
 		},
-		Entry("Should add AgentReady as True if agent is connected", v1alpha2.MachineRunning, true, metav1.ConditionTrue, true),
-		Entry("Should add AgentReady as False if agent is not connected", v1alpha2.MachineRunning, false, metav1.ConditionFalse, true),
+		Entry("Should add AgentReady as True if agent is connected", v1alpha2.MachineRunning, true, true, metav1.ConditionTrue, true),
+		Entry("Should add AgentReady as False if agent is not connected", v1alpha2.MachineRunning, true, false, metav1.ConditionFalse, true),
 
-		Entry("Should add AgentReady as True if agent is connected", v1alpha2.MachineStopping, true, metav1.ConditionTrue, true),
-		Entry("Should add AgentReady as False if agent is not connected", v1alpha2.MachineStopping, false, metav1.ConditionFalse, true),
+		Entry("Should add AgentReady as True if agent is connected", v1alpha2.MachineStopping, true, true, metav1.ConditionTrue, true),
+		Entry("Should add AgentReady as False if agent is not connected", v1alpha2.MachineStopping, true, false, metav1.ConditionFalse, true),
 
-		Entry("Should add AgentReady as True if agent is connected", v1alpha2.MachineMigrating, true, metav1.ConditionTrue, true),
-		Entry("Should add AgentReady as False if agent is not connected", v1alpha2.MachineMigrating, false, metav1.ConditionFalse, true),
+		Entry("Should add AgentReady as True if agent is connected", v1alpha2.MachineMigrating, true, true, metav1.ConditionTrue, true),
+		Entry("Should add AgentReady as False if agent is not connected", v1alpha2.MachineMigrating, true, false, metav1.ConditionFalse, true),
 
-		Entry("Should not add AgentReady if VM is in Pending phase and the agent is connected", v1alpha2.MachinePending, true, metav1.ConditionUnknown, false),
-		Entry("Should not add AgentReady if VM is in Pending phase and the agent is not connected", v1alpha2.MachinePending, false, metav1.ConditionUnknown, false),
+		Entry("Should not add AgentReady if VM is in Pending phase and there is no instance", v1alpha2.MachinePending, false, false, metav1.ConditionUnknown, false),
+		Entry("Should not add AgentReady if VM is in Stopped phase and there is no instance", v1alpha2.MachineStopped, false, false, metav1.ConditionUnknown, false),
+		Entry("Should not add AgentReady if VM is in Starting phase and there is no instance", v1alpha2.MachineStarting, false, false, metav1.ConditionUnknown, false),
 
-		Entry("Should not add AgentReady if VM is in Starting phase and the agent is connected", v1alpha2.MachineStarting, true, metav1.ConditionUnknown, false),
-		Entry("Should not add AgentReady if VM is in Starting phase and the agent is not connected", v1alpha2.MachineStarting, false, metav1.ConditionUnknown, false),
-
-		Entry("Should not add AgentReady if VM is in Stopped phase and the agent is connected", v1alpha2.MachineStopped, true, metav1.ConditionUnknown, false),
-		Entry("Should not add AgentReady if VM is in Stopped phase and the agent is not connected", v1alpha2.MachineStopped, false, metav1.ConditionUnknown, false),
+		Entry("Should add AgentReady as True if agent is connected while phase still lags at Starting", v1alpha2.MachineStarting, true, true, metav1.ConditionTrue, true),
 	)
 
 	DescribeTable("AgentVersionNotSupported Condition Tests",


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section:
type:
summary:
```
