### PR TITLE
fix(ci): retry transient d8 v ssh/scp failures in e2e bootstrap

### DIFF
--- a/.github/scripts/bash/e2e/d8-ssh.sh
+++ b/.github/scripts/bash/e2e/d8-ssh.sh
@@ -20,6 +20,25 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=.github/scripts/bash/e2e/common.sh
 source "${SCRIPT_DIR}/common.sh"
 
+# Retry a d8 command on transient transport failures (websocket "close 1006",
+# "Broken pipe", ssh "exit status 255"). d8 reports all of these as exit 1, so
+# any non-zero exit is retried.
+# ponytail: also retries long readiness waits (deckhouse-queue.sh); their re-run
+# re-checks state and stays within the e2e step timeout, so no per-call opt-out.
+d8_retry() {
+  local i
+  for ((i = 1; i <= 3; i++)); do
+    if "$@"; then
+      return 0
+    fi
+    if [ "$i" -lt 3 ]; then
+      echo "[WARN] d8 command failed (attempt ${i}/3), retrying in 15s..." >&2
+      sleep 15
+    fi
+  done
+  return 1
+}
+
 d8vssh() {
   require_env DEFAULT_USER
   require_env NAMESPACE
@@ -45,7 +64,7 @@ d8vssh() {
     ;;
   esac
 
-  d8 v ssh -i ./tmp/ssh/cloud \
+  d8_retry d8 v ssh -i ./tmp/ssh/cloud \
     --local-ssh=true \
     --local-ssh-opts="-o StrictHostKeyChecking=no" \
     --local-ssh-opts="-o UserKnownHostsFile=/dev/null" \
@@ -60,10 +79,9 @@ d8vscp() {
   local source=$1
   local dest=$2
 
-  d8 v scp -i ./tmp/ssh/cloud \
+  d8_retry d8 v scp -i ./tmp/ssh/cloud \
     --local-ssh=true \
     --local-ssh-opts="-o StrictHostKeyChecking=no" \
     --local-ssh-opts="-o UserKnownHostsFile=/dev/null" \
     "$source" "$dest"
-  echo "d8vscp: ${source} -> ${dest} - done"
 }


### PR DESCRIPTION
## Description

E2E bootstrap tunnels SSH/SCP over a websocket via `d8 v ssh`/`d8 v scp`. A
transient tunnel drop (`websocket: close 1006` / `Broken pipe`, ssh
`exit status 255`, which `d8` reports as exit `1`) fails the whole **Bootstrap
cluster** step even on a healthy cluster.

Wrap the two transport functions in `d8-ssh.sh` with a small `d8_retry` loop
(3 attempts, 15s apart) that retries on any non-zero exit (`d8` masks the ssh
`255` as `1`, so the code can't be matched). All callers get the retry for
free, with no per-call changes.

## Why do we need it, and what problem does it solve?

Removes a class of flaky E2E `Bootstrap cluster` failures caused by transient
tunnel blips. Does not fix a genuinely broken nested cluster (CNI/RBAC) —
tracked separately.

## What is the expected result?

Transient `d8 v ssh`/`d8 v scp` failures are retried instead of failing the
step; real failures still abort after retries are exhausted. Validated
locally: `shellcheck -x` and `bash -n` clean; integration test confirms
recovery on simulated drops and correct exit propagation under `set -e`.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: fix
summary: Retry transient d8 v ssh/scp failures in e2e bootstrap steps.
impact_level: low
```
