### PR TITLE
chore(module): fix lint and failed test

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vm/internal/migrating_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/migrating_test.go
@@ -196,7 +196,7 @@ var _ = Describe("MigratingHandler", func() {
 			Expect(exists).To(BeTrue())
 			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
 			Expect(cond.Reason).To(Equal(vmcondition.ReasonMigratingPending.String()))
-			Expect(cond.Message).To(Equal("Migration is in progress: scheduling the migration target."))
+			Expect(cond.Message).To(Equal("Migration is in progress: target pod is being scheduled."))
 		})
 
 		It("Should set active progress message when vmop is in progress with target preparing reason", func() {

--- a/src/cli/internal/cmd/vnc/vnc_test.go
+++ b/src/cli/internal/cmd/vnc/vnc_test.go
@@ -129,7 +129,7 @@ var _ = Describe("VNC", func() {
 				// stay alive until ctx is canceled, not return immediately.
 				port := ln.Addr().(*net.TCPAddr).Port
 				Expect(port).To(BeNumerically(">", 0))
-				fmt.Fprintf(cmd.OutOrStdout(), "{\"port\":%d}\n", port)
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "{\"port\":%d}\n", port)
 				<-ctx.Done()
 				close(connectDone)
 				return ctx.Err()


### PR DESCRIPTION
## Description
Two small fixes to unblock CI:

- `src/cli`: check the return value of `fmt.Fprintf` in the VNC test to satisfy the `errcheck` linter.
- `vm` controller: update the `migrating_test.go` expectation to match the clearer condition wording introduced in #2558 (`"Migration is in progress: target pod is being scheduled."`).

## Why do we need it, and what problem does it solve?
The linter failed on `internal/cmd/vnc/vnc_test.go` (`errcheck`), and the migrating condition unit test broke after the user-facing message was reworded. Both kept the pipeline red without any functional regression.

## What is the expected result?
1. `task lint` passes for `./src/cli`.
2. `go test ./pkg/controller/vm/internal/` passes.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
Not applicable — lint and test-only changes, no user-facing behavior change.
