### PR TITLE
chore(ci): switch to prod profile for e2e nested clusters

### DIFF
--- a/.github/scripts/bash/e2e/profile/registry-profile.env
+++ b/.github/scripts/bash/e2e/profile/registry-profile.env
@@ -3,7 +3,7 @@
 #   prod  -> registry.deckhouse.io, install tag = DECKHOUSE_CHANNEL.
 #   stage -> registry-stage.deckhouse.io, install tag = STAGE_DECKHOUSE_VERSION
 #            (stage has only vX.Y.Z tags); SDN is pulled from prod (absent in stage).
-REGISTRY_PROFILE=stage
+REGISTRY_PROFILE=prod
 
 # Release channel (ModuleConfig releaseChannel; also the prod install tag).
 DECKHOUSE_CHANNEL=alpha


### PR DESCRIPTION
## Description
Switch the registry profile for e2e nested clusters from `stage` to `prod` in `.github/scripts/bash/e2e/profile/registry-profile.env`.

## Why do we need it, and what problem does it solve?
Deckhouse 1.76 is now released on the `alpha` channel, so the `prod` profile installs it straight from `registry.deckhouse.io` .

## What is the expected result?
e2e nested clusters are provisioned from `registry.deckhouse.io` on the `alpha` channel (Deckhouse 1.76) and the e2e suite passes.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: chore
summary: Switch e2e nested clusters to the prod registry profile (alpha channel, Deckhouse 1.76).
impact_level: low
```