### PR TITLE
fix(dra): restrict external usbip access

### DIFF
--- a/images/virtualization-dra/internal/consts/consts.go
+++ b/images/virtualization-dra/internal/consts/consts.go
@@ -17,6 +17,8 @@ limitations under the License.
 package consts
 
 const (
+	// USBGatewayLabelShort is used in Cilium policies because virtualization.deckhouse.io node labels are excluded by Cilium.
+	USBGatewayLabelShort      = "usb-gateway"
 	USBGatewayLabel           = "virtualization.deckhouse.io/usb-gateway"
 	USBGatewayNodeLabel       = "virtualization.deckhouse.io/usb-gateway-node"
 	USBGatewayHighSpeedLabel  = "virtualization.deckhouse.io/usb-gateway-high-speed"

--- a/images/virtualization-dra/internal/usb-gateway/mark.go
+++ b/images/virtualization-dra/internal/usb-gateway/mark.go
@@ -41,7 +41,8 @@ func NewMarker(dynamicClient dynamic.Interface, nodeName string) *Marker {
 func (m Marker) Mark(ctx context.Context, any, hs, ss bool) error {
 	var (
 		addLabels = map[string]string{
-			consts.USBGatewayLabel: "true",
+			consts.USBGatewayLabel:      "true",
+			consts.USBGatewayLabelShort: "true",
 		}
 		removeLabels []string
 	)
@@ -72,7 +73,7 @@ func (m Marker) Mark(ctx context.Context, any, hs, ss bool) error {
 }
 
 func (m Marker) Unmark(ctx context.Context) error {
-	err := m.labeler.Label(ctx, m.nodeName, "", nil, []string{consts.USBGatewayLabel, consts.USBGatewayHighSpeedLabel, consts.USBGatewaySuperSpeedLabel})
+	err := m.labeler.Label(ctx, m.nodeName, "", nil, []string{consts.USBGatewayLabel, consts.USBGatewayLabelShort, consts.USBGatewayHighSpeedLabel, consts.USBGatewaySuperSpeedLabel})
 	if err != nil {
 		return fmt.Errorf("failed to unlabel node %s: %w", m.nodeName, err)
 	}

--- a/templates/virtualization-dra/ciliumclusterwidenetworkpolicy-usbip.yaml
+++ b/templates/virtualization-dra/ciliumclusterwidenetworkpolicy-usbip.yaml
@@ -1,0 +1,32 @@
+{{- if eq (include "virtualization-dra.isEnabled" .) "true"}}
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: d8-virtualization-deny-external-usbip
+  {{- include "helm_lib_module_labels" (list . (dict "app" "virtualization-dra")) | nindent 2 }}
+spec:
+  nodeSelector:
+    matchLabels:
+      # Cilium excludes virtualization.deckhouse.io node labels from node selector matching,
+      # so policies use the short usb-gateway label instead.
+      usb-gateway: "true"
+  enableDefaultDeny:
+    ingress: false
+  ingressDeny:
+    - fromEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: {{ include "virtualization_dra.usbipd_port" . | quote }}
+              protocol: TCP
+    - fromNodes:
+        - matchExpressions:
+            - key: "usb-gateway"
+              operator: NotIn
+              values:
+                - "true"
+      toPorts:
+        - ports:
+            - port: {{ include "virtualization_dra.usbipd_port" . | quote }}
+              protocol: TCP
+{{- end }}

--- a/tools/kubeconform/kubeconform.sh
+++ b/tools/kubeconform/kubeconform.sh
@@ -86,6 +86,8 @@ if [[ ! -d schemas ]]; then
   curl -LOs https://raw.githubusercontent.com/deckhouse/deckhouse/4a9b5fc21f29c4310e3739508a066dd43a87d681/modules/460-log-shipper/crds/cluster-log-destination.yaml
   echo " Descheduler"
   curl -LOs https://raw.githubusercontent.com/deckhouse/deckhouse/main/modules/400-descheduler/crds/deschedulers.yaml
+  echo " CiliumClusterwideNetworkPolicy"
+  curl -LOs https://raw.githubusercontent.com/deckhouse/deckhouse/refs/heads/main/modules/021-cni-cilium/crds/cilium/ciliumclusterwidenetworkpolicies.yaml
 
   # Transform CRDs to JSON schemas.
   export FILENAME_FORMAT='{kind}-{group}-{version}'
@@ -108,6 +110,17 @@ if [[ ! -d schemas ]]; then
   # Any field present in the Custom Resource (CR) that isn’t defined in the schema—such as metadata.labels—will cause validation to fail.
   find -iname "descheduler-deckhouse-*.json" | while read f ; do jq '(.properties.metadata) |= {type: "object"}' "$f" > tmp.json && mv tmp.json "$f" ; done
 
+  cd ..
+fi
+
+if [[ ! -f schemas/ciliumclusterwidenetworkpolicy-cilium-v2.json ]]; then
+  cd schemas
+  echo Download Cilium CRDs ...
+  echo " CiliumClusterwideNetworkPolicy"
+  curl -LOs https://raw.githubusercontent.com/deckhouse/deckhouse/refs/heads/main/modules/021-cni-cilium/crds/cilium/ciliumclusterwidenetworkpolicies.yaml
+  export FILENAME_FORMAT='{kind}-{group}-{version}'
+  echo Transform Cilium CRDs ...
+  ../kubeconform.git/scripts/openapi2jsonschema.py ciliumclusterwidenetworkpolicies.yaml
   cd ..
 fi
 


### PR DESCRIPTION
## Description
Added a CiliumClusterwideNetworkPolicy for virtualization-dra USB/IP gateway nodes. The policy denies access to the USB/IP port from outside the cluster and from cluster nodes that are not marked as USB gateway nodes.

## Why do we need it, and what problem does it solve?
USB/IP runs on the node network and exposes the USB/IP daemon port on node interfaces. Without network restrictions, a publicly reachable node interface could expose shared USB devices to unauthorized consumers.

## What is the expected result?
The USB/IP daemon port is reachable only from cluster nodes marked as USB gateway nodes. External traffic and traffic from non-gateway cluster nodes is denied by Cilium host policy.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: module
type: fix
summary: "Restricted unauthorized access to the virtualization USB/IP gateway port."
```