### PR TITLE
fix(ci): automatic node update approval in nested e2e

### DIFF
--- a/test/dvp-static-cluster/charts/cluster-config/templates/nodes.yaml
+++ b/test/dvp-static-cluster/charts/cluster-config/templates/nodes.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ $v.name }}
 spec:
   disruptions:
-    approvalMode: Manual
+    approvalMode: Automatic
   nodeTemplate:
     labels:
       node-role.deckhouse.io/{{ $v.name }}: ""


### PR DESCRIPTION
## Description
Switch static NodeGroups in the nested e2e cluster from `approvalMode: Manual` to `Automatic`.

## Why do we need it, and what problem does it solve?
With `Manual`, bashible set the `waiting-for-approval` annotation and hung waiting for a manual `approved` annotation that never comes in CI, failing with `BashibleStepFailed`. `Automatic` auto-approves node updates so bootstrap completes.

## What is the expected result?
Nested e2e cluster provisions without `BashibleStepFailed`; nodes update automatically.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: fix
summary: Enable automatic node update approval in nested e2e cluster.
impact_level: low
```
