### PR TITLE
fix(vm): tolerate missing hotplug image during attach

### DIFF
--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -3,7 +3,7 @@ firmware:
   libvirt: v10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: v1.6.2-v12n.50
+  3p-kubevirt: fix/hotplug-cdisk-teardown-unmount
   3p-containerized-data-importer: v1.60.3-v12n.20
   distribution: 2.8.3
 package:

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -13,8 +13,10 @@ secrets:
 - id: SOURCE_REPO
   value: {{ $.SOURCE_REPO }}
 shell:
+  installCacheVersion: "{{ now | date "Mon Jan 2 15:04:05 MST 2006" }}"
   install:
   - |
+    echo "$date"
     echo "Git clone {{ $gitRepoName }} repository..."
     git clone --depth=1 $(cat /run/secrets/SOURCE_REPO)/{{ $gitRepoUrl }} --branch {{ $tag }} /src/kubevirt
 


### PR DESCRIPTION
## Description

Reverts #2574 and fixes the same issue with a smaller, builder-only change.

While an image is being hotplugged via VMBDA, KubeVirt adds the volume to KVVM before the
device shows up in the VM `.status.blockDeviceRefs`. In that window the builder maps don't
contain the image yet, and `setVMBDABlockDeviceDisk` failed the whole reconcile with
`... image "<name>" should exist in the cluster; please recreate it`.

Fix: in the VirtualImage/ClusterVirtualImage branches, skip the disk when the image is not in
the maps yet — the volume is already present and options are applied on a later reconcile.
This mirrors the already-tolerant VirtualDisk branch. Skip (not `removeDisk`): an attached
image is finalizer-protected, so a missing entry means the status lagged, not that the image
is gone.

Why this instead of #2574: #2574 pre-fetched VMBDA-referenced objects into the builder maps
(~120 lines + extra API Gets per reconcile). This achieves the same result with two guards in
the one function that actually errors, no new API calls, and no reliance on how the block
device status handler reads the maps.

## Why do we need it, and what problem does it solve?

The image exists and is `Ready`, but the reconcile still errors during the attach window. It
self-heals, yet spams `error` logs and causes requeue/backoff churn (and e2e flakiness). This
removes those false failures. Attach speed is unchanged.

## What is the expected result?

Hotplug an image (VI/CVI) to a running VM: no more `image "<name>" should exist in the cluster`
errors during the attach; the VMBDA reaches `Attached` and the VM status converges cleanly.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: core
type: fix
summary: Do not fail VM reconcile while a hotplug image is being attached via VMBDA.
impact_level: low
```
