### PR TITLE
fix(e2e): compare EnableParavirtualization pointer with HaveValue

### DIFF
--- a/test/e2e/vm/configuration.go
+++ b/test/e2e/vm/configuration.go
@@ -68,7 +68,7 @@ var _ = Describe("VirtualMachineConfiguration", Label(precheck.NoPrecheck), func
 		err = f.GenericClient().Get(ctx, crclient.ObjectKeyFromObject(t.VM), t.VM)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(t.VM.Spec.RunPolicy).To(Equal(initialRunPolicy))
-		Expect(t.VM.Spec.EnableParavirtualization).To(Equal(initialEnableParavirtualization))
+		Expect(t.VM.Spec.EnableParavirtualization).To(HaveValue(Equal(initialEnableParavirtualization)))
 
 		By("Applying changes")
 		err = f.GenericClient().Get(ctx, crclient.ObjectKeyFromObject(t.VM), t.VM)
@@ -98,7 +98,7 @@ var _ = Describe("VirtualMachineConfiguration", Label(precheck.NoPrecheck), func
 		err = f.GenericClient().Get(ctx, crclient.ObjectKeyFromObject(t.VM), t.VM)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(t.VM.Spec.RunPolicy).To(Equal(changedRunPolicy))
-		Expect(t.VM.Spec.EnableParavirtualization).To(Equal(changedEnableParavirtualization))
+		Expect(t.VM.Spec.EnableParavirtualization).To(HaveValue(Equal(changedEnableParavirtualization)))
 
 		Consistently(func(g Gomega) {
 			err := f.GenericClient().Get(ctx, crclient.ObjectKeyFromObject(t.VM), t.VM)


### PR DESCRIPTION
## Description

The `VirtualMachine.Spec.EnableParavirtualization` field is `*bool`, but the
`VirtualMachineConfiguration` e2e test compared it against a `bool` constant using
Gomega's `Equal`, which enforces type equality and therefore failed with:

```
Expected
    <*bool | 0x...>: true
to equal
    <bool>: true
```

Fixed both assertions (initial and changed configuration) to use `HaveValue(Equal(...))`,
which dereferences the pointer before comparing.

## Why do we need it, and what problem does it solve?

The `configuration.go` e2e test failed at the "Checking initial configuration" step for
both the manual and automatic restart-approval entries, blocking the VM configuration suite.

## What is the expected result?

`VirtualMachineConfiguration the configuration should be applied` specs pass for both
`Manual` and `Automatic` restart approval modes.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: test
type: fix
summary: "Fix EnableParavirtualization pointer comparison in VM configuration e2e test."
```
