### PR TITLE
fix(vm): resolve hotplug teardown mount leak (bump 3p-kubevirt)

### DIFF
--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -3,7 +3,7 @@ firmware:
   libvirt: v10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: v1.6.2-v12n.50
+  3p-kubevirt: fix/hotplug-unmount-orphaned-mount-on-teardown
   3p-containerized-data-importer: v1.60.3-v12n.20
   distribution: 2.8.3
 package:

--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -3,7 +3,7 @@ firmware:
   libvirt: v10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: fix/hotplug-unmount-orphaned-mount-on-teardown
+  3p-kubevirt: v1.6.2-v12n.51
   3p-containerized-data-importer: v1.60.3-v12n.20
   distribution: 2.8.3
 package:

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -3,7 +3,7 @@
 {{- $gitRepoName := "3p-kubevirt" }}
 {{- $gitRepoUrl := (printf "%s/%s" "deckhouse" $gitRepoName) }}
 {{- $tag := get $.Core $gitRepoName }}
-{{- $version := "v1.6.2" }}
+{{- $version := (split "-" $tag)._0 }}
 
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -3,7 +3,7 @@
 {{- $gitRepoName := "3p-kubevirt" }}
 {{- $gitRepoUrl := (printf "%s/%s" "deckhouse" $gitRepoName) }}
 {{- $tag := get $.Core $gitRepoName }}
-{{- $version := (split "-" $tag)._0 }}
+{{- $version := "v1.6.2" }}
 
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact


### PR DESCRIPTION
## Description

Bumps `3p-kubevirt` to `v1.6.2-v12n.51`, which contains the virt-handler hotplug
mount-record fix ([3p-kubevirt#139](https://github.com/deckhouse/3p-kubevirt/pull/139)).

## Why do we need it, and what problem does it solve?

Stopping or deleting a VM with hotplugged images (via VMBDA) could leave the
`virt-launcher` pod stuck in `Terminating` (orphaned hotplug bind mount →
kubelet `device or resource busy`), blocking VM/namespace deletion and requiring
a manual force-delete. Surfaced by the `ImageHotplug` e2e hanging on teardown.

## What is the expected result?

Detach + stop/delete a VM with hotplugged images: the `virt-launcher` pod
terminates cleanly and the VM/namespace delete without manual intervention.
Verified on a nested cluster — `FOCUS=ImageHotplug` e2e passes (11/11).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: vm
type: fix
summary: Fixed a volume mount leak that could leave a VM with hotplugged images stuck in the Terminating state during deletion.
```
