### PR TITLE
fix(module): pre-create missing container mount points

### DIFF
--- a/images/virt-handler/mount-points.yaml
+++ b/images/virt-handler/mount-points.yaml
@@ -18,4 +18,6 @@ dirs:
   - /run/kubevirt
   - /run/kubevirt-libvirt-runtimes
   - /run/kubevirt-private
+  # Cilium agent socket, mounted from the host.
+  - /run/cilium
 

--- a/images/virtualization-dra-usb/mount-points.yaml
+++ b/images/virtualization-dra-usb/mount-points.yaml
@@ -1,6 +1,11 @@
 # A list of pre-created mount points for containerd strict mode.
 
 dirs:
+  # Kernel modules, mounted read-only from the host (init-load container).
+  # Use the real path: /lib is a symlink to /usr/lib in the distroless base,
+  # so creating /lib/modules would shadow the symlink. The runtime resolves
+  # the /lib/modules mount to /usr/lib/modules anyway.
+  - /usr/lib/modules
   # Default dir for Container Device Interface
   - /var/run/cdi
   # Default dir for registration kubelet plugins


### PR DESCRIPTION
## Description

Pre-create the missing mount point directories in the distroless-based images so that host volume mounts succeed under containerd strict mode with a read-only root filesystem.

- `virt-handler`: add `/run/cilium`.
- `virtualization-dra-usb`: add `/lib/modules` (used by the `init-load` container).

## Why do we need it, and what problem does it solve?

Under containerd strict mode the container root filesystem is read-only, so containerd cannot create a mountpoint directory on the fly. When the mountpoint does not already exist in the distroless base image, the container fails to start:

```
failed to create containerd task: ... error mounting "/lib/modules" to rootfs at "/lib/modules":
create mountpoint for /lib/modules mount: make mountpoint "/lib/modules":
mkdirat .../rootfs/usr/lib/modules: read-only file system
```

`virtualization-dra-usb` hit this on `/lib/modules` (the `init-load` container mounts the host kernel modules), and `virt-handler` hit it on `/var/run/cilium`. Note `/var/run` is a symlink to `/run`, so the Cilium socket resolves to `/run/cilium`.

`/sys` is intentionally NOT pre-created: it is a kernel pseudo-filesystem that the werf `gitArchive` stage cannot write into (`cannot change permissions of '/sys': Read-only file system`), and the OCI runtime mounts sysfs at `/sys` anyway, so the mountpoint already exists on a read-only rootfs.

## What is the expected result?

`virt-handler` and `virtualization-dra-usb` pods start successfully; the `read-only file system` mountpoint errors are gone.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

```changes
section: module
type: fix
summary: "Pre-create missing container mount points so virt-handler and virtualization-dra pods start under containerd strict mode."
impact_level: low
```
