### PR TITLE
fix(test): stop e2e nested-cluster bootstrap racing kvm labelling

### DIFF
--- a/.github/scripts/bash/e2e/wait-virtualization-ready.sh
+++ b/.github/scripts/bash/e2e/wait-virtualization-ready.sh
@@ -118,14 +118,17 @@ virtualization_ready() {
 virt_handler_ready() {
   local count=180
   local virt_handler_ready
-  local workers
+  local nodes_total
   local time_wait=10
 
   for i in $(seq 1 "$count"); do
-    workers="$(kubectl get nodes -o name | grep -c worker || true)"
-    workers=$((workers))
-    if [[ "$workers" -eq 0 ]]; then
-      echo "[WARNING] No worker nodes found, keep waiting"
+    # Count all nodes, not just workers: virt-handler is a per-node DaemonSet, and
+    # the master gets it later (slower to converge). "|| true" so a transient
+    # kubectl error doesn't abort under "set -eo pipefail" (falls back to 0).
+    nodes_total="$(kubectl get nodes -o name | wc -l || true)"
+    nodes_total=$((nodes_total))
+    if [[ "$nodes_total" -eq 0 ]]; then
+      echo "[WARNING] No nodes found (or kubectl failed), keep waiting"
       echo "[INFO] Wait ${time_wait}s virt-handler pods are ready (attempt ${i}/${count})"
       sleep "$time_wait"
       continue
@@ -133,12 +136,12 @@ virt_handler_ready() {
 
     virt_handler_ready="$(kubectl -n d8-virtualization get pods | grep -c "virt-handler.*Running" || true)"
 
-    if [[ "$virt_handler_ready" -ge "$workers" ]]; then
-      echo "[SUCCESS] virt-handlers pods are ready ${virt_handler_ready}/${workers}"
+    if [[ "$virt_handler_ready" -ge "$nodes_total" ]]; then
+      echo "[SUCCESS] virt-handler pods are ready ${virt_handler_ready}/${nodes_total}"
       return 0
     fi
 
-    echo "[INFO] virt-handler pods ${virt_handler_ready}/${workers}"
+    echo "[INFO] virt-handler pods ${virt_handler_ready}/${nodes_total}"
     echo "[INFO] Wait ${time_wait}s virt-handler pods are ready (attempt ${i}/${count})"
     if (( i % 5 == 0 )); then
       echo "[DEBUG] Show pods in namespace d8-virtualization"

--- a/test/dvp-static-cluster/charts/cluster-config/templates/ngc.yaml
+++ b/test/dvp-static-cluster/charts/cluster-config/templates/ngc.yaml
@@ -33,7 +33,9 @@ kind: NodeGroupConfiguration
 metadata:
   name: install-tools.sh
 spec:
-  weight: 98
+  # weight 100: run after 099-detect-kvm so a flaky GitHub fetch can't block
+  # node kvm-enabled labelling.
+  weight: 100
   nodeGroups: ["*"]
   bundles: ["*"]
   content: |
@@ -43,14 +45,16 @@ spec:
     complete -o default -F __start_kubectl k
     EOF
 
-    if [ ! -f /usr/local/bin/k9s ]; then
-      K9S_URL=$(curl -s https://api.github.com/repos/derailed/k9s/releases/latest | jq '.assets[] | select(.name=="k9s_Linux_amd64.tar.gz") | .browser_download_url' -r)
-      curl -L "${K9S_URL}" | tar -xz -C  /usr/bin/ "k9s"
+    # Optional debug tools: "|| true" so a GitHub API flap can't fail the step;
+    # check /usr/bin (extraction dir) to avoid re-downloading on every converge.
+    if [ ! -f /usr/bin/k9s ]; then
+      K9S_URL=$(curl -s https://api.github.com/repos/derailed/k9s/releases/latest | jq -r '.assets[] | select(.name=="k9s_Linux_amd64.tar.gz") | .browser_download_url') || true
+      [ -n "${K9S_URL}" ] && curl -fsSL "${K9S_URL}" | tar -xz -C /usr/bin/ "k9s" || true
     fi
 
-    if [ ! -f /usr/local/bin/stern ]; then
-      STERN_URL=$(curl -s https://api.github.com/repos/stern/stern/releases/latest | jq '.assets[].browser_download_url | select(. | test("linux_amd64"))' -r)
-      curl -L "${STERN_URL}" | tar -xz -C  /usr/bin/ "stern"
+    if [ ! -f /usr/bin/stern ]; then
+      STERN_URL=$(curl -s https://api.github.com/repos/stern/stern/releases/latest | jq -r '.assets[].browser_download_url | select(. | test("linux_amd64"))') || true
+      [ -n "${STERN_URL}" ] && curl -fsSL "${STERN_URL}" | tar -xz -C /usr/bin/ "stern" || true
     fi
 ---
 apiVersion: deckhouse.io/v1alpha1


### PR DESCRIPTION
## Description

Two test-infra fixes that make the nested (`dvp-static-cluster`) e2e bootstrap deterministic.

**1. `install-tools.sh` NodeGroupConfiguration** (`test/dvp-static-cluster/.../ngc.yaml`)
- Moved from `weight: 98` to `weight: 100` so it runs **after** `099_virtualization-detect-kvm`. Fetching `k9s`/`stern` hits the external GitHub API and can flap (rate limit → `jq: Cannot iterate over null` → the bashible step fails and retries), which previously blocked the node from getting the `virtualization.deckhouse.io/kvm-enabled` label.
- Made the fetches non-fatal (`|| true`) and fixed the existence check to look at the real extraction dir `/usr/bin` (was `/usr/local/bin`), so the tools are no longer re-downloaded on every converge (which is what exhausted the GitHub rate limit in the first place).

**2. `wait-virtualization-ready.sh` gate** (`.github/scripts/bash/e2e/`)
- `virt_handler_ready()` counted **worker nodes only** and passed as soon as `virt-handler Running ≥ workers`. On the nested cluster the master gets `kvm-enabled` (and thus its `virt-handler`) ~20 min later than workers, so the gate reported `3/3 SUCCESS` while the master had no `virt-handler` yet. Now it counts **all** nodes, so it waits for `virt-handler` on the master too before e2e starts.

## Why do we need it, and what problem does it solve?

Nightly e2e (`nightly-e2e-replicated`) failed in `SynchronizedBeforeSuite`:

```
precheck affinity-toleration-precheck failed: at least 1 ready KVM-enabled master node is required, got 0
```

Root cause was a bootstrap race, not a regression. On the nested cluster the master is KVM-capable from boot, but its `kvm-enabled` label is applied by the `099_virtualization-detect-kvm` bashible step, which was stuck behind `098_install-tools.sh` retrying on GitHub API rate limits. The readiness gate only waited for worker `virt-handler`s, so e2e started before the master was labelled and the affinity/toleration precheck (which requires a KVM-enabled master) failed instantly (it does a single-shot check with no retry).

Both changes remove the race: labelling no longer waits on the flaky tool fetch, and the gate no longer greenlights e2e until the master's `virt-handler` is up.

## What is the expected result?

`nightly-e2e-replicated` no longer flakes on `affinity-toleration-precheck` with `got 0` KVM-enabled master nodes. The readiness gate logs `virt-handler pods are ready N/N` counting all nodes (e.g. `4/4`) before e2e starts.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ci
type: fix
summary: Fix e2e nested-cluster bootstrap race that made the affinity/toleration precheck fail with 0 KVM-enabled master nodes.
impact_level: low
```
