### PR TITLE
fix(vm): guard nil pod in inplaceresize to stop virt-controller crash

### DIFF
--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -3,7 +3,7 @@ firmware:
   libvirt: v10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: v1.6.2-v12n.51
+  3p-kubevirt: fix/inplaceresize-nil-pod-panic
   3p-containerized-data-importer: v1.60.3-v12n.20
   distribution: 2.8.3
 package:

--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -3,7 +3,7 @@ firmware:
   libvirt: v10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: fix/inplaceresize-nil-pod-panic
+  3p-kubevirt: v1.6.2-v12n.52
   3p-containerized-data-importer: v1.60.3-v12n.20
   distribution: 2.8.3
 package:

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -3,7 +3,7 @@
 {{- $gitRepoName := "3p-kubevirt" }}
 {{- $gitRepoUrl := (printf "%s/%s" "deckhouse" $gitRepoName) }}
 {{- $tag := get $.Core $gitRepoName }}
-{{- $version := "v1.6.2" }}
+{{- $version := (split "-" $tag)._0 }}
 
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
@@ -13,9 +13,7 @@ secrets:
 - id: SOURCE_REPO
   value: {{ $.SOURCE_REPO }}
 shell:
-  installCacheVersion: "{{ now | date "Mon Jan 2 15:04:05 MST 2006" }}"
   install:
-  - echo "$date"
   - |
     echo "Git clone {{ $gitRepoName }} repository..."
     git clone --depth=1 $(cat /run/secrets/SOURCE_REPO)/{{ $gitRepoUrl }} --branch {{ $tag }} /src/kubevirt
@@ -67,10 +65,8 @@ shell:
       {{ $builderDependencies.altPackages | join " " }}
 
   {{- include "alt packages clean" . | nindent 2 }}
-  
-  installCacheVersion: "{{ now | date "Mon Jan 2 15:04:05 MST 2006" }}"
+
   install:
-  - echo "$date"
   - |
     # Install packages
     PKGS="{{ $builderDependencies.packages | join " " }}"

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -3,7 +3,7 @@
 {{- $gitRepoName := "3p-kubevirt" }}
 {{- $gitRepoUrl := (printf "%s/%s" "deckhouse" $gitRepoName) }}
 {{- $tag := get $.Core $gitRepoName }}
-{{- $version := (split "-" $tag)._0 }}
+{{- $version := "v1.6.2" }}
 
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -13,7 +13,9 @@ secrets:
 - id: SOURCE_REPO
   value: {{ $.SOURCE_REPO }}
 shell:
+  installCacheVersion: "{{ now | date "Mon Jan 2 15:04:05 MST 2006" }}"
   install:
+  - echo "$date"
   - |
     echo "Git clone {{ $gitRepoName }} repository..."
     git clone --depth=1 $(cat /run/secrets/SOURCE_REPO)/{{ $gitRepoUrl }} --branch {{ $tag }} /src/kubevirt
@@ -65,8 +67,10 @@ shell:
       {{ $builderDependencies.altPackages | join " " }}
 
   {{- include "alt packages clean" . | nindent 2 }}
-
+  
+  installCacheVersion: "{{ now | date "Mon Jan 2 15:04:05 MST 2006" }}"
   install:
+  - echo "$date"
   - |
     # Install packages
     PKGS="{{ $builderDependencies.packages | join " " }}"


### PR DESCRIPTION
## Description

Bump `3p-kubevirt` `v1.6.2-v12n.51` → `v1.6.2-v12n.52`, which includes a `virt-controller` crash fix (deckhouse/3p-kubevirt#142): a nil-pod guard in the in-place resize controller `sync()`.

`CurrentVMIPod` returns a nil pod (no error) before the virt-launcher pod exists. If the VMI already has a `VCPUChange`/`MemoryChange` condition in that window, `sync()` dereferenced `pod.Spec.Containers` and crash-looped `virt-controller` (SIGSEGV).

## Why do we need it, and what problem does it solve?

On NFS-backed e2e runs, VMs were stuck in `Pending` with no virt-launcher pod ("The list of pods is empty; nothing to dump"). Root cause: `virt-controller` was crash-looping on the nil-pod panic, so no VMIs/pods were ever created. Slow NFS provisioning widens the "VMI exists, resize condition set, pod not yet created" window, so it reproduces there.

## What is the expected result?

`virt-controller` no longer panics when a resize is evaluated before the pod exists; VMs reach `Running` and the power_state / volume-migration e2e suites pass on NFS storage.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: core
type: fix
summary: Fix virt-controller crash on nil pod during in-place resize that left VMs stuck in Pending with no launcher pod on slow storage.
impact_level: low
```
