### PR TITLE
feat(e2e): run selected suites once on enter in fzf script

### DIFF
--- a/test/e2e/scripts/e2e-fzf
+++ b/test/e2e/scripts/e2e-fzf
@@ -371,15 +371,18 @@ def main():
         if args.run or args.repeat > 1:
             return run_repeated(e2e_dir, selected, args.repeat)
         if sys.stdin.isatty():
-            action = input("Action: [Enter] done, [r]un once, [n] repeat, [c]opy: ")
-            if action.lower() == "r":
-                return run_repeated(e2e_dir, selected, 1)
+            action = input("Action: [Enter] run once, [n] repeat, [c]opy, [q]uit: ")
+            if action.lower() == "q":
+                return 0
             if action.lower() == "n":
                 repeat = ask_repeat_count()
                 if repeat is not None:
                     return run_repeated(e2e_dir, selected, repeat)
+                return 0
             if action.lower() == "c":
                 copy_command(command)
+                return 0
+            return run_repeated(e2e_dir, selected, 1)
         return 0
     except RuntimeError as err:
         print(err, file=sys.stderr)


### PR DESCRIPTION
## Description
Change the default action in the `e2e-fzf` interactive prompt so that pressing `Enter` runs the selected suites once instead of doing nothing. The prompt is now `[Enter] run once, [n] repeat, [c]opy, [q]uit`. The former `r` option is dropped (Enter replaces it), and an explicit `q` exits without running.

## Why do we need it, and what problem does it solve?
Previously `Enter` finished the script without running anything, so selecting suites and hitting Enter — the most natural flow — did nothing. Running once now requires the fewest keystrokes.

## What is the expected result?
1. Run `task e2e:fzf`, select one or more suites in fzf.
2. Press `Enter` → selected suites run once.
3. `n` prompts for a repeat count, `c` copies the command, `q` exits without running.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: test
type: chore
summary: Run selected e2e suites once on Enter in the fzf selection script.
impact_level: low
```
