### PR TITLE
chore(ci): pin prometheus CRD schemas for kubeconform

### DIFF
--- a/tools/kubeconform/kubeconform.sh
+++ b/tools/kubeconform/kubeconform.sh
@@ -69,17 +69,17 @@ if [[ ! -d schemas ]]; then
   echo "  VerticalPodAutoscaler"
   curl -LOs https://raw.githubusercontent.com/deckhouse/deckhouse/main/modules/302-vertical-pod-autoscaler/crds/verticalpodautoscaler.yaml
   echo "  ScrapeConfig"
-  curl -LOs https://raw.githubusercontent.com/deckhouse/deckhouse/main/modules/200-operator-prometheus/crds/scrapeconfigs.yaml
+  curl -LOs https://raw.githubusercontent.com/deckhouse/deckhouse/4a9b5fc21f29c4310e3739508a066dd43a87d681/modules/200-operator-prometheus/crds/scrapeconfigs.yaml
   echo "  ServiceMonitor"
-  curl -LOs https://raw.githubusercontent.com/deckhouse/deckhouse/main/modules/200-operator-prometheus/crds/servicemonitors.yaml
+  curl -LOs https://raw.githubusercontent.com/deckhouse/deckhouse/4a9b5fc21f29c4310e3739508a066dd43a87d681/modules/200-operator-prometheus/crds/servicemonitors.yaml
   echo "  PrometheusRule"
-  curl -LOs https://raw.githubusercontent.com/deckhouse/deckhouse/main/modules/200-operator-prometheus/crds/internal/prometheusrules.yaml
+  curl -LOs https://raw.githubusercontent.com/deckhouse/deckhouse/4a9b5fc21f29c4310e3739508a066dd43a87d681/modules/200-operator-prometheus/crds/internal/prometheusrules.yaml
   echo "  NodeGroupConfiguration"
   curl -LOs https://raw.githubusercontent.com/deckhouse/deckhouse/main/modules/040-node-manager/crds/nodegroupconfiguration.yaml
   echo "  Certificate"
   curl -LOs https://raw.githubusercontent.com/deckhouse/deckhouse/main/modules/101-cert-manager/crds/cert-manager/cert-manager.io_certificates.yaml
   echo "  GrafanaDashboardDefinition"
-  curl -LOs https://raw.githubusercontent.com/deckhouse/deckhouse/main/modules/300-prometheus/crds/grafanadashboarddefinition.yaml
+  curl -LOs https://raw.githubusercontent.com/deckhouse/deckhouse/4a9b5fc21f29c4310e3739508a066dd43a87d681/modules/300-prometheus/crds/grafanadashboarddefinition.yaml
   echo " ClusterLoggingConfig"
   curl -LOs https://raw.githubusercontent.com/deckhouse/deckhouse/4a9b5fc21f29c4310e3739508a066dd43a87d681/modules/460-log-shipper/crds/cluster-logging-config.yaml
   echo " ClusterLogDestination"


### PR DESCRIPTION
## Description
The kubeconform validation script (`tools/kubeconform/kubeconform.sh`) downloads
Deckhouse CRD manifests and converts them into JSON schemas used to validate the
rendered Helm templates.

The `ServiceMonitor`, `PrometheusRule`, `ScrapeConfig` and
`GrafanaDashboardDefinition` CRDs were fetched from the `main` branch of
`deckhouse/deckhouse`. These files were moved upstream, so the `main` URLs now
return `404`. As a result the schemas were never downloaded and kubeconform
reported the affected resources as `NO SCHEMA`.

This change pins those four downloads to commit
`4a9b5fc21f29c4310e3739508a066dd43a87d681` — the same commit already used for the
log-shipper CRDs in this script — where the manifests are still available
(verified with `curl`, all four return `200`). The remaining downloads
(`VerticalPodAutoscaler`, `NodeGroupConfiguration`, `Certificate`,
`Descheduler`) still resolve on `main` and were left untouched.

## Why do we need it, and what problem does it solve?
kubeconform CI was failing with `NO SCHEMA` for all `ServiceMonitor`,
`PrometheusRule` and `GrafanaDashboardDefinition` resources rendered by the
module, because the upstream schema files had moved and could no longer be
downloaded from `main`. Pinning to a stable commit restores schema validation
for these resources and unblocks CI.

## What is the expected result?
1. Remove the cached `tools/kubeconform/schemas` directory (if present).
2. Run `tools/kubeconform/kubeconform.sh` from `tools/kubeconform`.
3. The schemas download successfully and the previously `NO SCHEMA` resources
   are validated instead of skipped.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: fix
summary: Pin prometheus CRD schema downloads for kubeconform to a stable commit.
impact_level: low
```
