### PR TITLE
test(e2e): reduce CPU and memory requests in migration cancel VM

### DIFF
--- a/test/e2e/vm/migration_cancel.go
+++ b/test/e2e/vm/migration_cancel.go
@@ -63,8 +63,8 @@ var _ = DescribeTable("VirtualMachineCancelMigration", Label(precheck.NoPrecheck
 	vm := object.NewMinimalVM("", f.Namespace().Name,
 		vmbuilder.WithName("vm"),
 		vmbuilder.WithBootloader(bootloaderType),
-		vmbuilder.WithCPU(4, ptr.To("100%")),
-		vmbuilder.WithMemory(resource.MustParse("4Gi")),
+		vmbuilder.WithCPU(4, ptr.To("10%")),
+		vmbuilder.WithMemory(resource.MustParse("2Gi")),
 		vmbuilder.WithLiveMigrationPolicy(v1alpha2.PreferSafeMigrationPolicy),
 		vmbuilder.WithBlockDeviceRefs(
 			v1alpha2.BlockDeviceSpecRef{


### PR DESCRIPTION
## Description

`VirtualMachineCancelMigration` provisioned its VM with `cpu 4 @ coreFraction 100%` (a 4000m guaranteed request) and 4Gi. Lower it to `cpu 4 @ 10%` (400m request — guest still sees 4 vCPU for stress-ng) and 2Gi.

## Why do we need it, and what problem does it solve?

The test slows live migration to catch it in-flight by creating memory pressure with `stress-ng` (`--vm --vm-bytes 90% --vm-populate`); the slowdown comes from the memory dirty-page rate, not from CPU. The 4000m guaranteed request is far more than the test needs and makes the migration target pod unschedulable on smaller nodes (`0/N nodes are available: Insufficient cpu`), since the target must land on a different node than the source.

The `cpu 4 @ 100%` sizing was introduced in #2333 when the test was migrated to the new framework; the previous YAML-based test used `cpu 1 @ 50%`. This change restores a sane request: `coreFraction 10%` keeps 4 vCPU available to stress-ng while cutting the scheduling request 10×.

## What is the expected result?

Migration stays slow enough to be cancelled; all cancel variants (BIOS, UEFI, UEFI secure boot) still pass, and the target pod schedules on smaller nodes.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: test
type: fix
summary: Reduce CPU and memory requests in the migration cancel e2e VM.
impact_level: low
```
