### PR TITLE
test(e2e): poll guest cpu count after hotplug cpu change

### DIFF
--- a/test/e2e/vm/hotplug_cpu.go
+++ b/test/e2e/vm/hotplug_cpu.go
@@ -186,9 +186,7 @@ func (t *cpuHotplugTest) applyCPUCoreChangeWithQuotaBlockedMigration(initialCore
 	Expect(err).NotTo(HaveOccurred())
 	Expect(t.VM.Status.Resources.CPU.Cores).To(Equal(changedCores))
 
-	guestCPUCount, err = t.getGuestCPUCount()
-	Expect(err).NotTo(HaveOccurred())
-	Expect(guestCPUCount).To(Equal(changedCores))
+	t.untilGuestCPUCount(changedCores, framework.MiddleTimeout)
 }
 
 func (t *cpuHotplugTest) applyCPUCoreChange(initialCores, changedCores int, liveMigration bool) {
@@ -248,9 +246,7 @@ func (t *cpuHotplugTest) applyCPUCoreChange(initialCores, changedCores int, live
 	Expect(err).NotTo(HaveOccurred())
 	Expect(t.VM.Status.Resources.CPU.Cores).To(Equal(changedCores))
 
-	guestCPUCount, err = t.getGuestCPUCount()
-	Expect(err).NotTo(HaveOccurred())
-	Expect(guestCPUCount).To(Equal(changedCores))
+	t.untilGuestCPUCount(changedCores, framework.MiddleTimeout)
 }
 
 func (t *cpuHotplugTest) generateResources(vmName string, cores int, disableInPlaceResize bool) {
@@ -298,6 +294,16 @@ func (t *cpuHotplugTest) getGuestCPUCount() (int, error) {
 	}
 
 	return cpuCount, nil
+}
+
+func (t *cpuHotplugTest) untilGuestCPUCount(expectedCores int, timeout time.Duration) {
+	GinkgoHelper()
+
+	Eventually(func(g Gomega) {
+		count, err := t.getGuestCPUCount()
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(count).To(Equal(expectedCores))
+	}).WithTimeout(timeout).WithPolling(time.Second).Should(Succeed())
 }
 
 func untilVMCPUCoresApplied(key crclient.ObjectKey, expectedCores int, timeout time.Duration) {


### PR DESCRIPTION
## Description

The `HotplugCPU` e2e tests asserted the guest CPU count (`nproc`) once with a bare `Expect` right after the status-based wait. Wrap the post-change guest CPU count assertions in `Eventually` via a new `untilGuestCPUCount(expected, timeout)` helper.

## Why do we need it, and what problem does it solve?

`Status.Resources.CPU.Cores` reports the *desired* topology: after applying the change to libvirt, virt-handler sets `Status.CurrentCPUTopology = Spec.Domain.CPU`, and the controller reads `Spec.Domain.CPU`. So the status flips within ~2s of the controller applying the change — before the guest has actually onlined/offlined the vCPU (the guest reacts to the ACPI event asynchronously).

The test waited on the status (`untilVMCPUCoresApplied` went green immediately) and then checked the guest `nproc` with a bare `Expect`, racing the guest's async apply. This flaked, most visibly on the downscale `4 → 3` in-place case. Polling the guest count with `Eventually` removes the race.

Only the test changes — the product status is legitimate; this fixes the race in the test, not the controller.

## What is the expected result?

`HotplugCPU InPlaceResize` and `LiveMigration` cases pass deterministically, including the `4 → 3` downscale. The point-in-time "not yet applied" negative checks keep their bare `Expect`.

Verified on a cluster (NFS default SC): InPlaceResize 1→2, 1→4, 4→3 and LiveMigration 4→3 all pass (`FOCUS="cpu core changes in-place"` → 3 Passed, 0 Failed). The guest genuinely offlines a vCPU on in-place downscale — it is just asynchronous.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: test
type: fix
summary: Poll the guest CPU count after a hotplug CPU change to avoid racing the guest.
impact_level: low
```
