### PR TITLE
fix(vm): read ansible-inventory host vars from the vars. annotation prefix

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -808,7 +808,7 @@ The command includes only virtual machines with assigned IP addresses in the `Ru
 1. Optionally set host variables via annotations (for example, the SSH user):
 
    ```bash
-   d8 k -n demo-app annotate vm frontend provisioning.virtualization.deckhouse.io/ansible_user="cloud"
+   d8 k -n demo-app annotate vm frontend vars.provisioning.virtualization.deckhouse.io/ansible_user="cloud"
    ```
 
 1. Run Ansible with a dynamically generated inventory:

--- a/docs/FAQ.ru.md
+++ b/docs/FAQ.ru.md
@@ -808,7 +808,7 @@ ansible -m shell -a "uptime" \
 1. При необходимости задайте переменные хоста через аннотации (например, пользователя для SSH):
 
    ```bash
-   d8 k -n demo-app annotate vm frontend provisioning.virtualization.deckhouse.io/ansible_user="cloud"
+   d8 k -n demo-app annotate vm frontend vars.provisioning.virtualization.deckhouse.io/ansible_user="cloud"
    ```
 
 1. Запустите Ansible с динамически сформированным инвентарём:

--- a/src/cli/internal/cmd/ansibleinventory/ansibleinventory.go
+++ b/src/cli/internal/cmd/ansibleinventory/ansibleinventory.go
@@ -36,6 +36,7 @@ import (
 const (
 	annotationPrefix        = "provisioning.virtualization.deckhouse.io/"
 	groupsAnnotationKey     = annotationPrefix + "groups"
+	varsAnnotationPrefix    = "vars.provisioning.virtualization.deckhouse.io/"
 	ansibleSSHCommonArgs    = `-o ProxyCommand='d8 v port-forward --stdio=true %h %p'`
 	ansibleSSHCommonArgsKey = "ansible_ssh_common_args"
 )
@@ -89,7 +90,7 @@ Arguments:
 Host names format: <vmname>.<namespace> (e.g., myvm.default)
 
 VM annotations:
-  - Annotations with prefix 'provisioning.virtualization.deckhouse.io/' are included
+  - Annotations with prefix 'vars.provisioning.virtualization.deckhouse.io/' are included
     as host variables (prefix is stripped from variable name)
   - Use 'provisioning.virtualization.deckhouse.io/groups' annotation to add VMs to groups
     (comma-separated list of group names)
@@ -353,20 +354,19 @@ func (a *AnsibleInventory) getHostName(vm v1alpha2.VirtualMachine) string {
 func (a *AnsibleInventory) getHostVars(vm v1alpha2.VirtualMachine) map[string]string {
 	hostVars := make(map[string]string)
 
-	// Add annotations as host variables
-	// Only process annotations with prefix provisioning.virtualization.deckhouse.io/
-	if len(vm.Annotations) > 0 {
-		for key, value := range vm.Annotations {
-			if !strings.HasPrefix(key, annotationPrefix) {
-				continue
-			}
-			if key == groupsAnnotationKey {
-				continue
-			}
-			varName := strings.TrimPrefix(key, annotationPrefix)
-			if varName != "" {
-				hostVars[varName] = value
-			}
+	// Add annotations as host variables.
+	// Only annotations with the vars.provisioning.virtualization.deckhouse.io/
+	// prefix become host variables; the prefix is stripped from the variable
+	// name. This matches the annotation scheme used by the virtualization-provisioner
+	// module, where groups live under provisioning.virtualization.deckhouse.io/groups
+	// and host variables live under the separate vars. prefix.
+	for key, value := range vm.Annotations {
+		if !strings.HasPrefix(key, varsAnnotationPrefix) {
+			continue
+		}
+		varName := strings.TrimPrefix(key, varsAnnotationPrefix)
+		if varName != "" {
+			hostVars[varName] = value
 		}
 	}
 
@@ -464,8 +464,8 @@ func usage() string {
   # Add VM to groups (comma-separated):
   #   kubectl annotate vm myvm provisioning.virtualization.deckhouse.io/groups="web,production" -n default
   #
-  # Add custom host variable:
-  #   kubectl annotate vm myvm provisioning.virtualization.deckhouse.io/ansible_user="admin" -n default
+  # Add custom host variable (note the 'vars.' prefix):
+  #   kubectl annotate vm myvm vars.provisioning.virtualization.deckhouse.io/ansible_user="admin" -n default
   #   # This will be available as 'ansible_user' variable in Ansible
   #
   # Note: Only VMs with assigned IP addresses are included in the inventory.


### PR DESCRIPTION
## Description

`d8 v ansible-inventory` and the `virtualization-provisioner` module both build
the Ansible inventory from VM annotations, but used different keys for host
variables. This aligns the CLI with the module: host variables are read from the
`vars.provisioning.virtualization.deckhouse.io/` prefix, and groups from
`provisioning.virtualization.deckhouse.io/groups`. Command help, usage examples
and the FAQ are updated to match.

## Why do we need it, and what problem does it solve?

So that the CLI and the module treat inventory annotations the same way — the
same annotations produce the same inventory regardless of which one generates it.

## What is the expected result?

Annotating a VM with
`vars.provisioning.virtualization.deckhouse.io/ansible_user=cloud` exposes
`ansible_user` as a host variable in `d8 v ansible-inventory` output — the same
key the module uses.

## Checklist
- [ ] The code is covered by unit tests. <!-- the command has no unit tests today; verified via build, go vet and manual review -->
- [ ] e2e tests passed. <!-- not applicable to this CLI command -->
- [x] Documentation updated according to the changes. <!-- command help + FAQ (RU/EN) -->
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: vm
type: fix
summary: The d8 v ansible-inventory command uses the same VM annotations as the virtualization-provisioner module to set Ansible host variables.
```
