### PR TITLE
fix(core): release inbound migration slot when VMI is deleted

### DIFF
--- a/images/virtualization-artifact/pkg/controller/livemigration/internal/watcher/kvvmi.go
+++ b/images/virtualization-artifact/pkg/controller/livemigration/internal/watcher/kvvmi.go
@@ -42,7 +42,7 @@ func (w *KVVMIWatcher) Watch(mgr manager.Manager, ctr controller.Controller) err
 			&handler.TypedEnqueueRequestForObject[*virtv1.VirtualMachineInstance]{},
 			predicate.TypedFuncs[*virtv1.VirtualMachineInstance]{
 				CreateFunc: func(e event.TypedCreateEvent[*virtv1.VirtualMachineInstance]) bool { return false },
-				DeleteFunc: func(e event.TypedDeleteEvent[*virtv1.VirtualMachineInstance]) bool { return false },
+				DeleteFunc: func(e event.TypedDeleteEvent[*virtv1.VirtualMachineInstance]) bool { return true },
 				UpdateFunc: func(e event.TypedUpdateEvent[*virtv1.VirtualMachineInstance]) bool {
 					return !equality.Semantic.DeepEqual(e.ObjectOld.Status, e.ObjectNew.Status)
 				},

--- a/images/virtualization-artifact/pkg/controller/livemigration/internal/watcher/kvvmi.go
+++ b/images/virtualization-artifact/pkg/controller/livemigration/internal/watcher/kvvmi.go
@@ -42,7 +42,6 @@ func (w *KVVMIWatcher) Watch(mgr manager.Manager, ctr controller.Controller) err
 			&handler.TypedEnqueueRequestForObject[*virtv1.VirtualMachineInstance]{},
 			predicate.TypedFuncs[*virtv1.VirtualMachineInstance]{
 				CreateFunc: func(e event.TypedCreateEvent[*virtv1.VirtualMachineInstance]) bool { return false },
-				DeleteFunc: func(e event.TypedDeleteEvent[*virtv1.VirtualMachineInstance]) bool { return true },
 				UpdateFunc: func(e event.TypedUpdateEvent[*virtv1.VirtualMachineInstance]) bool {
 					return !equality.Semantic.DeepEqual(e.ObjectOld.Status, e.ObjectNew.Status)
 				},

--- a/images/virtualization-artifact/pkg/controller/livemigration/live_migration_controller.go
+++ b/images/virtualization-artifact/pkg/controller/livemigration/live_migration_controller.go
@@ -52,7 +52,7 @@ func SetupController(
 	handlers := []Handler{
 		internal.NewDynamicSettingsHandler(client, limiter),
 	}
-	r := NewReconciler(client, handlers...)
+	r := NewReconciler(client, limiter, handlers...)
 
 	c, err := controller.New(ControllerName, mgr, controller.Options{
 		Reconciler:       r,

--- a/images/virtualization-artifact/pkg/controller/livemigration/live_migration_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/livemigration/live_migration_reconciler.go
@@ -43,7 +43,7 @@ type Handler interface {
 }
 
 type InboundSlotReleaser interface {
-	ReleaseByVMI(namespace, name string)
+	ReleaseByKVVMI(namespace, name string)
 }
 
 type Reconciler struct {
@@ -87,7 +87,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	if kvvmi.IsEmpty() {
 		log.Info("Reconcile observe an absent VirtualMachineInstance: it may be deleted; releasing inbound migration slot")
-		r.limiter.ReleaseByVMI(req.Namespace, req.Name)
+		r.limiter.ReleaseByKVVMI(req.Namespace, req.Name)
 		return reconcile.Result{}, nil
 	}
 

--- a/images/virtualization-artifact/pkg/controller/livemigration/live_migration_reconciler.go
+++ b/images/virtualization-artifact/pkg/controller/livemigration/live_migration_reconciler.go
@@ -42,15 +42,21 @@ type Handler interface {
 	Name() string
 }
 
+type InboundSlotReleaser interface {
+	ReleaseByVMI(namespace, name string)
+}
+
 type Reconciler struct {
 	handlers []Handler
 	client   client.Client
+	limiter  InboundSlotReleaser
 }
 
-func NewReconciler(client client.Client, handlers ...Handler) *Reconciler {
+func NewReconciler(client client.Client, limiter InboundSlotReleaser, handlers ...Handler) *Reconciler {
 	return &Reconciler{
 		handlers: handlers,
 		client:   client,
+		limiter:  limiter,
 	}
 }
 
@@ -80,7 +86,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	if kvvmi.IsEmpty() {
-		log.Info("Reconcile observe an absent VirtualMachineInstance: it may be deleted")
+		log.Info("Reconcile observe an absent VirtualMachineInstance: it may be deleted; releasing inbound migration slot")
+		r.limiter.ReleaseByVMI(req.Namespace, req.Name)
 		return reconcile.Result{}, nil
 	}
 

--- a/images/virtualization-artifact/pkg/livemigration/inbound_limiter.go
+++ b/images/virtualization-artifact/pkg/livemigration/inbound_limiter.go
@@ -121,6 +121,29 @@ func (l *InboundMigrationLimiter) Release(kvvmi *virtv1.VirtualMachineInstance, 
 	}
 }
 
+// ReleaseByVMI frees any slot held by the given VMI on any node, regardless of
+// the migration UID. A deleted VMI can no longer have an active migration, so
+// dropping every owner keyed by this VMI is safe. This covers the case where a
+// VMI is removed before its migration reaches a terminal state, which would
+// otherwise leak the slot and starve subsequent inbound migrations to that node.
+func (l *InboundMigrationLimiter) ReleaseByVMI(namespace, name string) {
+	prefix := namespace + "/" + name + "/"
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	for targetNode, owners := range l.slots {
+		for owner := range owners {
+			if strings.HasPrefix(owner, prefix) {
+				delete(owners, owner)
+			}
+		}
+		if len(owners) == 0 {
+			delete(l.slots, targetNode)
+		}
+	}
+}
+
 // Restore rebuilds the in-memory registry after a controller restart or leader
 // change by scanning VMIs annotated with inbound-migration-slot=acquired.
 //

--- a/images/virtualization-artifact/pkg/livemigration/inbound_limiter.go
+++ b/images/virtualization-artifact/pkg/livemigration/inbound_limiter.go
@@ -121,12 +121,12 @@ func (l *InboundMigrationLimiter) Release(kvvmi *virtv1.VirtualMachineInstance, 
 	}
 }
 
-// ReleaseByVMI frees any slot held by the given VMI on any node, regardless of
+// ReleaseByKVVMI frees any slot held by the given VMI on any node, regardless of
 // the migration UID. A deleted VMI can no longer have an active migration, so
 // dropping every owner keyed by this VMI is safe. This covers the case where a
 // VMI is removed before its migration reaches a terminal state, which would
 // otherwise leak the slot and starve subsequent inbound migrations to that node.
-func (l *InboundMigrationLimiter) ReleaseByVMI(namespace, name string) {
+func (l *InboundMigrationLimiter) ReleaseByKVVMI(namespace, name string) {
 	prefix := namespace + "/" + name + "/"
 
 	l.mu.Lock()

--- a/images/virtualization-artifact/pkg/livemigration/inbound_limiter_test.go
+++ b/images/virtualization-artifact/pkg/livemigration/inbound_limiter_test.go
@@ -96,7 +96,7 @@ var _ = Describe("InboundMigrationLimiter", func() {
 		Expect(limiter.TryAcquire(first, targetNode)).To(BeTrue())
 		Expect(limiter.TryAcquire(newKVVMI("second", "second-migration"), targetNode)).To(BeFalse())
 
-		limiter.ReleaseByVMI(namespace, "first")
+		limiter.ReleaseByKVVMI(namespace, "first")
 		Expect(limiter.TryAcquire(newKVVMI("second", "second-migration"), targetNode)).To(BeTrue())
 	})
 
@@ -105,7 +105,7 @@ var _ = Describe("InboundMigrationLimiter", func() {
 		Expect(limiter.TryAcquire(newKVVMI("vm", "vm-migration"), targetNode)).To(BeTrue())
 		Expect(limiter.TryAcquire(newKVVMI("vm-2", "vm-2-migration"), targetNode)).To(BeTrue())
 
-		limiter.ReleaseByVMI(namespace, "vm")
+		limiter.ReleaseByKVVMI(namespace, "vm")
 		// "vm-2" must still hold its slot: only one of the two is free now.
 		Expect(limiter.TryAcquire(newKVVMI("third", "third-migration"), targetNode)).To(BeTrue())
 		Expect(limiter.TryAcquire(newKVVMI("fourth", "fourth-migration"), targetNode)).To(BeFalse())

--- a/images/virtualization-artifact/pkg/livemigration/inbound_limiter_test.go
+++ b/images/virtualization-artifact/pkg/livemigration/inbound_limiter_test.go
@@ -90,6 +90,27 @@ var _ = Describe("InboundMigrationLimiter", func() {
 		Expect(limiter.TryAcquire(newKVVMI("second", "second-migration"), targetNode)).To(BeTrue())
 	})
 
+	It("Should release the slot by VMI when the migration UID is unknown", func() {
+		limiter := NewInboundMigrationLimiter(true, 1)
+		first := newKVVMI("first", "first-migration")
+		Expect(limiter.TryAcquire(first, targetNode)).To(BeTrue())
+		Expect(limiter.TryAcquire(newKVVMI("second", "second-migration"), targetNode)).To(BeFalse())
+
+		limiter.ReleaseByVMI(namespace, "first")
+		Expect(limiter.TryAcquire(newKVVMI("second", "second-migration"), targetNode)).To(BeTrue())
+	})
+
+	It("Should not release a different VMI sharing a name prefix", func() {
+		limiter := NewInboundMigrationLimiter(true, 2)
+		Expect(limiter.TryAcquire(newKVVMI("vm", "vm-migration"), targetNode)).To(BeTrue())
+		Expect(limiter.TryAcquire(newKVVMI("vm-2", "vm-2-migration"), targetNode)).To(BeTrue())
+
+		limiter.ReleaseByVMI(namespace, "vm")
+		// "vm-2" must still hold its slot: only one of the two is free now.
+		Expect(limiter.TryAcquire(newKVVMI("third", "third-migration"), targetNode)).To(BeTrue())
+		Expect(limiter.TryAcquire(newKVVMI("fourth", "fourth-migration"), targetNode)).To(BeFalse())
+	})
+
 	It("Should respect a limit greater than one", func() {
 		limiter := NewInboundMigrationLimiter(true, 2)
 		Expect(limiter.TryAcquire(newKVVMI("first", "first-migration"), targetNode)).To(BeTrue())


### PR DESCRIPTION
## Description

The inbound migration limiter caps concurrent inbound live migrations per node with an in-memory slot registry (default limit `1`). A slot was only released when the owning VMI reached a terminal `MigrationState` (`Handle` observing `Completed`/`Failed`), and the KVVMI watcher dropped delete events (`DeleteFunc` returned `false`). So a VMI deleted mid-migration leaked its slot forever.

This change:
- Reconciles on VMI delete (`DeleteFunc` → `true`).
- Releases any slot held by the deleted VMI in the reconciler when the VMI is absent, via a new `InboundMigrationLimiter.ReleaseByVMI(namespace, name)`.
- Wires the limiter into the reconciler.

## Why do we need it, and what problem does it solve?

A VMI can disappear before its migration reaches a terminal state — test cleanup deletes the VM, or the source launcher goes unresponsive (`No command socket found for vmi`) and the VMI is removed. In those cases `Release` was never called, so the in-memory slot stayed occupied by a ghost owner.

With the default limit of 1 inbound migration per node, one leaked slot starves **every** subsequent inbound migration to that node. Since the migration target node is effectively fixed (source node excluded, control-plane tainted), all later migrations queue on the same node, wait for a slot past the target launcher's `--qemu-timeout` (~5 min), and the target panics with `timed out waiting for domain to be defined` → `migration is not completed`.

This was observed in the Replicated E2E nightly: dozens of migrations succeeded, then from one point on **every** migration failed with the VMI stuck at `inbound-migration-slot: waiting` on the same target node and no live VMI holding the slot — the ghost-slot signature.

Releasing on delete is safe: a deleted VMI cannot have an active migration — the migration controller fails the migration when `vmi == nil` (`FailedReasonVMIDoesNotExist`), and the limiter's own invariant (`isInActiveMigration`, `Restore`) only ever tracks a live VMI with a non-terminal `MigrationState`.

## What is the expected result?

A VMI deleted mid-migration frees its inbound slot immediately, so subsequent inbound migrations to that node are no longer starved. Covered by unit tests for `ReleaseByVMI` (release by VMI when the migration UID is unknown; must not release a different VMI that shares a name prefix).

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: core
type: fix
summary: Release the inbound migration slot when a VMI is deleted mid-migration to avoid starving further migrations to the node.
impact_level: low
```
