### PR TITLE
fix(vm): CD-ROMs for non-virtio guests

### DIFF
--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -2,8 +2,9 @@
 # Source https://github.com/kubevirt/kubevirt/blob/v1.3.1/hack/dockerized#L15
 {{- $gitRepoName := "3p-kubevirt" }}
 {{- $gitRepoUrl := (printf "%s/%s" "deckhouse" $gitRepoName) }}
-{{- $tag := get $.Core $gitRepoName }}
-{{- $version := (split "-" $tag)._0 }}
+{{/* TESTING ONLY — revert before merge: pin fork to the feature branch instead of the versions.yml tag */}}
+{{- $tag := "feat/hotplug-cdrom-usb-bus" }}
+{{- $version := "v1.6.2" }}
 
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
@@ -13,6 +14,8 @@ secrets:
 - id: SOURCE_REPO
   value: {{ $.SOURCE_REPO }}
 shell:
+  # TESTING ONLY — revert before merge: force re-clone every build so branch updates are pulled.
+  installCacheVersion: "{{ now | date "Mon Jan 2 15:04:05 MST 2006" }}"
   install:
   - |
     echo "Git clone {{ $gitRepoName }} repository..."

--- a/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/add_volume.go
+++ b/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/add_volume.go
@@ -100,8 +100,12 @@ func (r AddVolumeREST) requestFromKubevirt(opts *subresources.VirtualMachineAddV
 func (r AddVolumeREST) genMutateRequestHook(opts *subresources.VirtualMachineAddVolume) (mutateRequestHook, error) {
 	var dd virtv1.DiskDevice
 	if opts.IsCdrom {
+		// Hot-plug CD-ROMs on the USB bus (usb-storage) so guests without a
+		// virtio-scsi driver (e.g. Windows Server WinPE) can enumerate them via
+		// the inbox USB Mass Storage driver. The xhci controller is always
+		// present (added for the tablet input device).
 		dd.CDRom = &virtv1.CDRomTarget{
-			Bus: virtv1.DiskBusSCSI,
+			Bus: virtv1.DiskBusUSB,
 		}
 	} else {
 		dd.Disk = &virtv1.DiskTarget{

--- a/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/add_volume.go
+++ b/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/add_volume.go
@@ -100,12 +100,8 @@ func (r AddVolumeREST) requestFromKubevirt(opts *subresources.VirtualMachineAddV
 func (r AddVolumeREST) genMutateRequestHook(opts *subresources.VirtualMachineAddVolume) (mutateRequestHook, error) {
 	var dd virtv1.DiskDevice
 	if opts.IsCdrom {
-		// Hot-plug CD-ROMs on the USB bus (usb-storage) so guests without a
-		// virtio-scsi driver (e.g. Windows Server WinPE) can enumerate them via
-		// the inbox USB Mass Storage driver. The xhci controller is always
-		// present (added for the tablet input device).
 		dd.CDRom = &virtv1.CDRomTarget{
-			Bus: virtv1.DiskBusUSB,
+			Bus: virtv1.DiskBusSCSI,
 		}
 	} else {
 		dd.Disk = &virtv1.DiskTarget{

--- a/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/add_volume.go
+++ b/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/add_volume.go
@@ -100,8 +100,15 @@ func (r AddVolumeREST) requestFromKubevirt(opts *subresources.VirtualMachineAddV
 func (r AddVolumeREST) genMutateRequestHook(opts *subresources.VirtualMachineAddVolume) (mutateRequestHook, error) {
 	var dd virtv1.DiskDevice
 	if opts.IsCdrom {
+		// Hot-plug CD-ROMs on the USB bus (usb-storage): the inbox Windows USB
+		// Mass Storage driver (usbstor.sys) enumerates them via plug-and-play with
+		// no rescan and no virtio-scsi driver, so a running Windows guest (Server or
+		// Desktop) sees the media the moment it is attached. The xhci controller is
+		// always present (added for the tablet input device). Boot/install ISOs are
+		// unaffected: they stay cold-plug on SATA (see kvbuilder presets) because
+		// usb-cdrom is not a UEFI-bootable device under OVMF.
 		dd.CDRom = &virtv1.CDRomTarget{
-			Bus: virtv1.DiskBusSCSI,
+			Bus: virtv1.DiskBusUSB,
 		}
 	} else {
 		dd.Disk = &virtv1.DiskTarget{

--- a/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/add_volume_test.go
+++ b/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/add_volume_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	virtv1 "kubevirt.io/api/core/v1"
+
+	"github.com/deckhouse/virtualization/api/subresources"
+)
+
+func hotplugBus(t *testing.T, opts *subresources.VirtualMachineAddVolume) virtv1.AddVolumeOptions {
+	t.Helper()
+	hook, err := (AddVolumeREST{}).genMutateRequestHook(opts)
+	if err != nil {
+		t.Fatalf("genMutateRequestHook: %v", err)
+	}
+	req := &http.Request{}
+	if err := hook(req); err != nil {
+		t.Fatalf("hook: %v", err)
+	}
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	var got virtv1.AddVolumeOptions
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return got
+}
+
+func TestGenMutateRequestHookBus(t *testing.T) {
+	cdrom := hotplugBus(t, &subresources.VirtualMachineAddVolume{VolumeKind: "ClusterVirtualImage", Name: "iso", Image: "img", IsCdrom: true})
+	if cdrom.Disk.CDRom == nil {
+		t.Fatal("expected CDRom device for cdrom hotplug")
+	}
+	if cdrom.Disk.CDRom.Bus != virtv1.DiskBusUSB {
+		t.Errorf("cdrom bus = %q, want usb", cdrom.Disk.CDRom.Bus)
+	}
+
+	disk := hotplugBus(t, &subresources.VirtualMachineAddVolume{VolumeKind: "VirtualDisk", Name: "vd", PVCName: "pvc"})
+	if disk.Disk.Disk == nil {
+		t.Fatal("expected Disk device for non-cdrom hotplug")
+	}
+	if disk.Disk.Disk.Bus != virtv1.DiskBusSCSI {
+		t.Errorf("disk bus = %q, want scsi", disk.Disk.Disk.Bus)
+	}
+}

--- a/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/add_volume_test.go
+++ b/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/add_volume_test.go
@@ -53,8 +53,8 @@ func TestGenMutateRequestHookBus(t *testing.T) {
 	if cdrom.Disk.CDRom == nil {
 		t.Fatal("expected CDRom device for cdrom hotplug")
 	}
-	if cdrom.Disk.CDRom.Bus != virtv1.DiskBusSCSI {
-		t.Errorf("cdrom bus = %q, want scsi", cdrom.Disk.CDRom.Bus)
+	if cdrom.Disk.CDRom.Bus != virtv1.DiskBusUSB {
+		t.Errorf("cdrom bus = %q, want usb", cdrom.Disk.CDRom.Bus)
 	}
 
 	disk := hotplugBus(t, &subresources.VirtualMachineAddVolume{VolumeKind: "VirtualDisk", Name: "vd", PVCName: "pvc"})

--- a/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/add_volume_test.go
+++ b/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/add_volume_test.go
@@ -53,8 +53,8 @@ func TestGenMutateRequestHookBus(t *testing.T) {
 	if cdrom.Disk.CDRom == nil {
 		t.Fatal("expected CDRom device for cdrom hotplug")
 	}
-	if cdrom.Disk.CDRom.Bus != virtv1.DiskBusUSB {
-		t.Errorf("cdrom bus = %q, want usb", cdrom.Disk.CDRom.Bus)
+	if cdrom.Disk.CDRom.Bus != virtv1.DiskBusSCSI {
+		t.Errorf("cdrom bus = %q, want scsi", cdrom.Disk.CDRom.Bus)
 	}
 
 	disk := hotplugBus(t, &subresources.VirtualMachineAddVolume{VolumeKind: "VirtualDisk", Name: "vd", PVCName: "pvc"})

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
@@ -337,7 +337,13 @@ func applyBlockDeviceRefs(
 		}
 
 		_, hotpluggable := hotpluggableVolumes[diskName]
-		if err := setBlockDeviceDisk(kvvm, bd, kvBootOrder, hotpluggable || (isParavirtualizationEnabled && !isVmRunning), vdByName, viByName, cviByName); err != nil {
+		// CD-ROM ISOs must stay cold-plug so they land on the SATA bus in the initial
+		// domain XML: a KubeVirt hotplug volume can only use scsi/virtio/usb, and a boot
+		// ISO on any of those either fails to boot under UEFI (usb has no CDROM device
+		// path) or is invisible to WinPE (scsi needs vioscsi). A cold SATA CD-ROM boots
+		// under OVMF and is enumerated by the inbox AHCI driver.
+		forceHotplug := isParavirtualizationEnabled && !isVmRunning && !isCdromBlockDevice(bd, viByName, cviByName)
+		if err := setBlockDeviceDisk(kvvm, bd, kvBootOrder, hotpluggable || forceHotplug, vdByName, viByName, cviByName); err != nil {
 			return err
 		}
 	}
@@ -442,6 +448,23 @@ func syncAttachedVMBDAHotplugVolumes(
 	}
 
 	return nil
+}
+
+func isCdromBlockDevice(
+	bd v1alpha2.BlockDeviceSpecRef,
+	viByName map[string]*v1alpha2.VirtualImage,
+	cviByName map[string]*v1alpha2.ClusterVirtualImage,
+) bool {
+	switch bd.Kind {
+	case v1alpha2.ImageDevice:
+		vi, ok := viByName[bd.Name]
+		return ok && vi != nil && imageformat.IsISO(vi.Status.Format)
+	case v1alpha2.ClusterImageDevice:
+		cvi, ok := cviByName[bd.Name]
+		return ok && cvi != nil && imageformat.IsISO(cvi.Status.Format)
+	default:
+		return false
+	}
 }
 
 func setBlockDeviceDisk(

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
@@ -322,8 +322,13 @@ func applyBlockDeviceRefs(
 	kvvmVolumes := kvvm.Resource.Spec.Template.Spec.Volumes
 	for i, bd := range vm.Spec.BlockDeviceRefs {
 		diskName := GenerateDiskName(bd.Kind, bd.Name)
-		// When VM is stopped, update disks unconditionally.
-		if isVmRunning && isParavirtualizationEnabled && len(kvvmVolumes) > 0 && !slices.ContainsFunc(kvvmVolumes, func(v virtv1.Volume) bool { return v.Name == diskName }) {
+		// When VM is stopped, update disks unconditionally. On a running VM a newly
+		// referenced device is left to the hotplug handler instead of being baked into
+		// the template: for paravirtualized guests that covers every device; for
+		// non-paravirtualized guests only CD-ROMs hot-plug (on USB), so a new non-CD-ROM
+		// device still falls through and is rendered (applied on the next restart).
+		isNewOnRunningVM := isVmRunning && len(kvvmVolumes) > 0 && !slices.ContainsFunc(kvvmVolumes, func(v virtv1.Volume) bool { return v.Name == diskName })
+		if isNewOnRunningVM && (isParavirtualizationEnabled || isCdromBlockDevice(bd, viByName, cviByName)) {
 			continue
 		}
 

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/presets.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/presets.go
@@ -45,16 +45,17 @@ var DeviceOptionsPresets DeviceOptionsList = []DeviceOptions{
 	{
 		EnableParavirtualization: true,
 		DiskBus:                  virtv1.DiskBusSCSI,
-		// CD-ROMs use the USB bus (usb-storage) so guests without a virtio-scsi
-		// driver (e.g. Windows WinPE) can enumerate them via the inbox USB Mass
-		// Storage driver. The xhci controller is always present (tablet input).
-		CdromBus:       virtv1.DiskBusUSB,
+		// CD-ROMs use the SATA bus and stay cold-plug: UEFI/OVMF can only boot an
+		// optical device that exposes a CDROM Media Device Path (El Torito), which
+		// usb-storage does not provide, and a SATA CD-ROM is visible to Windows
+		// WinPE via the inbox AHCI driver.
+		CdromBus:       virtv1.DiskBusSATA,
 		InterfaceModel: "virtio",
 	},
 	{
 		EnableParavirtualization: false,
 		DiskBus:                  virtv1.DiskBusSATA,
-		CdromBus:                 virtv1.DiskBusUSB,
+		CdromBus:                 virtv1.DiskBusSATA,
 		InterfaceModel:           "e1000",
 	},
 }

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/presets.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/presets.go
@@ -45,13 +45,16 @@ var DeviceOptionsPresets DeviceOptionsList = []DeviceOptions{
 	{
 		EnableParavirtualization: true,
 		DiskBus:                  virtv1.DiskBusSCSI,
-		CdromBus:                 virtv1.DiskBusSCSI,
-		InterfaceModel:           "virtio",
+		// CD-ROMs use the USB bus (usb-storage) so guests without a virtio-scsi
+		// driver (e.g. Windows WinPE) can enumerate them via the inbox USB Mass
+		// Storage driver. The xhci controller is always present (tablet input).
+		CdromBus:       virtv1.DiskBusUSB,
+		InterfaceModel: "virtio",
 	},
 	{
 		EnableParavirtualization: false,
 		DiskBus:                  virtv1.DiskBusSATA,
-		CdromBus:                 virtv1.DiskBusSATA,
+		CdromBus:                 virtv1.DiskBusUSB,
 		InterfaceModel:           "e1000",
 	},
 }

--- a/images/virtualization-artifact/pkg/controller/vm/internal/hotplug_handler.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/hotplug_handler.go
@@ -57,9 +57,10 @@ func (h *HotplugHandler) Handle(ctx context.Context, s state.VirtualMachineState
 		return reconcile.Result{}, err
 	}
 
-	if !current.Spec.IsParavirtualizationEnabled() {
-		return reconcile.Result{}, nil
-	}
+	// Non-paravirtualized guests keep their disks on the SATA bus, which cannot be
+	// hot-plugged, so only CD-ROMs (attached on the hot-pluggable USB bus) may be
+	// plugged/unplugged live; every other block device change waits for a restart.
+	paravirt := current.Spec.IsParavirtualizationEnabled()
 
 	if current.Status.Phase == v1alpha2.MachineMigrating {
 		log.Info("VM is migrating, skip hotplug")
@@ -123,6 +124,9 @@ func (h *HotplugHandler) Handle(ctx context.Context, s state.VirtualMachineState
 			log.Info("Block device not ready for hotplug", "kind", key.kind, "name", key.name)
 			continue
 		}
+		if !paravirt && !ad.IsCdrom {
+			continue
+		}
 
 		if err = h.svc.HotPlugDisk(ctx, ad, current, kvvm); err != nil {
 			errs = append(errs, fmt.Errorf("hotplug %s/%s: %w", key.kind, key.name, err))
@@ -139,6 +143,19 @@ func (h *HotplugHandler) Handle(ctx context.Context, s state.VirtualMachineState
 		}
 		if _, ok := pending[vol.name]; ok {
 			continue
+		}
+		// A non-paravirtualized guest only ever hot-plugs CD-ROMs (on the USB bus),
+		// so only a CD-ROM may be unplugged live; cold-plug SATA devices are left for
+		// a restart to remove. A device whose source no longer resolves is skipped.
+		if !paravirt {
+			ad, adErr := h.buildAttachmentDisk(ctx, key, s)
+			if adErr != nil {
+				errs = append(errs, fmt.Errorf("build attachment disk %s/%s: %w", key.kind, key.name, adErr))
+				continue
+			}
+			if ad == nil || !ad.IsCdrom {
+				continue
+			}
 		}
 
 		if err = h.svc.UnplugDisk(ctx, kvvm, vol.name); err != nil {

--- a/images/virtualization-artifact/pkg/controller/vm/internal/hotplug_handler_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/hotplug_handler_test.go
@@ -304,6 +304,29 @@ var _ = Describe("HotplugHandler", func() {
 			Expect(mockSvc.UnplugDiskCalls()).To(BeEmpty())
 		})
 
+		It("should hotplug a CD-ROM", func() {
+			const viName = "test-iso"
+			vm := newVM(v1alpha2.MachineRunning, v1alpha2.BlockDeviceSpecRef{
+				Kind: v1alpha2.ImageDevice, Name: viName,
+			})
+			vm.Spec.EnableParavirtualization = ptr.To(false)
+			kvvm := newKVVM(nil)
+			kvvmi := newEmptyKVVMI(vmName, vmNamespace)
+			vi := &v1alpha2.VirtualImage{
+				ObjectMeta: metav1.ObjectMeta{Name: viName, Namespace: vmNamespace},
+				Status: v1alpha2.VirtualImageStatus{
+					CDROM: true,
+					Phase: v1alpha2.ImageReady,
+				},
+			}
+
+			result, err := runHandle(vm, kvvm, kvvmi, vi)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+			Expect(mockSvc.HotPlugDiskCalls()).To(HaveLen(1))
+			Expect(mockSvc.HotPlugDiskCalls()[0].Ad.IsCdrom).To(BeTrue())
+		})
+
 		It("should not unplug a hotpluggable disk removed from spec", func() {
 			vm := newVM(v1alpha2.MachineRunning)
 			vm.Spec.EnableParavirtualization = ptr.To(false)

--- a/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/sync_kvvm.go
@@ -160,6 +160,16 @@ func (h *SyncKvvmHandler) Handle(ctx context.Context, s state.VirtualMachineStat
 		if !changes.IsEmpty() {
 			kvvmi, kvvmiErr := s.KVVMI(ctx)
 			if kvvmiErr == nil {
+				// A non-paravirtualized guest gets every block-device change classified as
+				// restart by the comparator, but CD-ROMs hot-plug on the USB bus. Downgrade
+				// CD-ROM changes to apply-immediate so they attach/detach live; the restart
+				// upgrade below re-promotes the ones that touch a cold-plug (non-hotpluggable)
+				// volume, e.g. removing a boot ISO that landed on SATA.
+				if !current.Spec.IsParavirtualizationEnabled() {
+					changes.DowngradeBlockDeviceChangesToApplyImmediateMatching(func(change vmchange.FieldChange) bool {
+						return h.blockDeviceChangeIsCdrom(ctx, current, change)
+					})
+				}
 				nonHotpluggableVolumes := nonHotpluggableVolumeRefs(kvvmi)
 				changes.UpgradeBlockDeviceChangesToRestartMatching(func(change vmchange.FieldChange) bool {
 					return blockDeviceChangeTouchesRefs(change, nonHotpluggableVolumes)
@@ -1214,6 +1224,38 @@ func nonHotpluggableVolumeRefs(kvvmi *virtv1.VirtualMachineInstance) map[nameKin
 	}
 
 	return refs
+}
+
+// blockDeviceChangeIsCdrom reports whether the block device added or removed by the
+// change resolves to a CD-ROM VirtualImage/ClusterVirtualImage. A device that cannot
+// be resolved is treated as non-CD-ROM so the change keeps its restart action.
+func (h *SyncKvvmHandler) blockDeviceChangeIsCdrom(ctx context.Context, vm *v1alpha2.VirtualMachine, change vmchange.FieldChange) bool {
+	refs := append(blockDeviceRefsFromValue(change.CurrentValue), blockDeviceRefsFromValue(change.DesiredValue)...)
+	for _, ref := range refs {
+		if h.blockDeviceRefIsCdrom(ctx, vm.GetNamespace(), ref) {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *SyncKvvmHandler) blockDeviceRefIsCdrom(ctx context.Context, namespace string, ref v1alpha2.BlockDeviceSpecRef) bool {
+	switch ref.Kind {
+	case v1alpha2.ImageDevice:
+		vi, err := object.FetchObject(ctx, types.NamespacedName{Name: ref.Name, Namespace: namespace}, h.client, &v1alpha2.VirtualImage{})
+		if err != nil || vi == nil {
+			return false
+		}
+		return vi.Status.CDROM
+	case v1alpha2.ClusterImageDevice:
+		cvi, err := object.FetchObject(ctx, types.NamespacedName{Name: ref.Name}, h.client, &v1alpha2.ClusterVirtualImage{})
+		if err != nil || cvi == nil {
+			return false
+		}
+		return cvi.Status.CDROM
+	default:
+		return false
+	}
 }
 
 func blockDeviceChangeTouchesRefs(change vmchange.FieldChange, refs map[nameKindKey]struct{}) bool {

--- a/images/virtualization-artifact/pkg/controller/vm/internal/validators/block_device_refs_validator.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/validators/block_device_refs_validator.go
@@ -20,8 +20,11 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	"github.com/deckhouse/virtualization-controller/pkg/common/object"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
@@ -30,10 +33,12 @@ type blockDeviceKey struct {
 	Name string
 }
 
-type BlockDeviceSpecRefsValidator struct{}
+type BlockDeviceSpecRefsValidator struct {
+	client client.Client
+}
 
-func NewBlockDeviceSpecRefsValidator() *BlockDeviceSpecRefsValidator {
-	return &BlockDeviceSpecRefsValidator{}
+func NewBlockDeviceSpecRefsValidator(client client.Client) *BlockDeviceSpecRefsValidator {
+	return &BlockDeviceSpecRefsValidator{client: client}
 }
 
 func (v *BlockDeviceSpecRefsValidator) validate(vm *v1alpha2.VirtualMachine) error {
@@ -56,10 +61,14 @@ func (v *BlockDeviceSpecRefsValidator) ValidateCreate(_ context.Context, vm *v1a
 	return nil, v.validate(vm)
 }
 
-func (v *BlockDeviceSpecRefsValidator) ValidateUpdate(_ context.Context, oldVM, newVM *v1alpha2.VirtualMachine) (admission.Warnings, error) {
+func (v *BlockDeviceSpecRefsValidator) ValidateUpdate(ctx context.Context, oldVM, newVM *v1alpha2.VirtualMachine) (admission.Warnings, error) {
 	var warnings admission.Warnings
 
-	if !newVM.Spec.IsParavirtualizationEnabled() && hasBlockDeviceChanges(oldVM, newVM) {
+	// Non-paravirtualized guests keep their disks on the SATA bus, which cannot be
+	// hot-plugged, so a block-device change only applies after a restart. CD-ROMs are
+	// the exception: they hot-plug on the USB bus (usbstor) regardless of the virtio
+	// driver, so a change touching only CD-ROMs is applied live and must not warn.
+	if !newVM.Spec.IsParavirtualizationEnabled() && v.hasNonCdromChange(ctx, oldVM, newVM) {
 		warnings = append(warnings, "Hot-plugging block devices with enableParavirtualization=false is not supported. Restart the VM to apply changes.")
 	}
 
@@ -81,7 +90,20 @@ func (v *BlockDeviceSpecRefsValidator) noDoubles(vm *v1alpha2.VirtualMachine) er
 	return nil
 }
 
-func hasBlockDeviceChanges(oldVM, newVM *v1alpha2.VirtualMachine) bool {
+// hasNonCdromChange reports whether any block device added or removed between
+// oldVM and newVM is something other than a CD-ROM. A device whose CD-ROM status
+// cannot be resolved is treated as non-CD-ROM, so the restart warning is emitted
+// conservatively.
+func (v *BlockDeviceSpecRefsValidator) hasNonCdromChange(ctx context.Context, oldVM, newVM *v1alpha2.VirtualMachine) bool {
+	for _, key := range changedBlockDevices(oldVM, newVM) {
+		if !v.isCdrom(ctx, key, newVM.GetNamespace()) {
+			return true
+		}
+	}
+	return false
+}
+
+func changedBlockDevices(oldVM, newVM *v1alpha2.VirtualMachine) []blockDeviceKey {
 	oldRefs := make(map[blockDeviceKey]struct{}, len(oldVM.Spec.BlockDeviceRefs))
 	for _, bd := range oldVM.Spec.BlockDeviceRefs {
 		oldRefs[blockDeviceKey{Kind: bd.Kind, Name: bd.Name}] = struct{}{}
@@ -90,17 +112,38 @@ func hasBlockDeviceChanges(oldVM, newVM *v1alpha2.VirtualMachine) bool {
 	for _, bd := range newVM.Spec.BlockDeviceRefs {
 		newRefs[blockDeviceKey{Kind: bd.Kind, Name: bd.Name}] = struct{}{}
 	}
+
+	var changed []blockDeviceKey
 	for key := range oldRefs {
 		if _, ok := newRefs[key]; !ok {
-			return true
+			changed = append(changed, key)
 		}
 	}
 	for key := range newRefs {
 		if _, ok := oldRefs[key]; !ok {
-			return true
+			changed = append(changed, key)
 		}
 	}
-	return false
+	return changed
+}
+
+func (v *BlockDeviceSpecRefsValidator) isCdrom(ctx context.Context, key blockDeviceKey, namespace string) bool {
+	switch key.Kind {
+	case v1alpha2.ImageDevice:
+		vi, err := object.FetchObject(ctx, types.NamespacedName{Name: key.Name, Namespace: namespace}, v.client, &v1alpha2.VirtualImage{})
+		if err != nil || vi == nil {
+			return false
+		}
+		return vi.Status.CDROM
+	case v1alpha2.ClusterImageDevice:
+		cvi, err := object.FetchObject(ctx, types.NamespacedName{Name: key.Name}, v.client, &v1alpha2.ClusterVirtualImage{})
+		if err != nil || cvi == nil {
+			return false
+		}
+		return cvi.Status.CDROM
+	default:
+		return false
+	}
 }
 
 func (v *BlockDeviceSpecRefsValidator) validateBootOrder(vm *v1alpha2.VirtualMachine) error {

--- a/images/virtualization-artifact/pkg/controller/vm/internal/validators/block_device_refs_validator_test.go
+++ b/images/virtualization-artifact/pkg/controller/vm/internal/validators/block_device_refs_validator_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/deckhouse/virtualization-controller/pkg/common/testutil"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vm/internal/validators"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
@@ -30,7 +31,9 @@ var _ = Describe("BlockDeviceSpecRefsValidator", func() {
 	var validator *validators.BlockDeviceSpecRefsValidator
 
 	BeforeEach(func() {
-		validator = validators.NewBlockDeviceSpecRefsValidator()
+		fakeClient, err := testutil.NewFakeClientWithObjects()
+		Expect(err).NotTo(HaveOccurred())
+		validator = validators.NewBlockDeviceSpecRefsValidator(fakeClient)
 	})
 
 	DescribeTable("ValidateCreate with valid refs", func(refs []v1alpha2.BlockDeviceSpecRef) {

--- a/images/virtualization-artifact/pkg/controller/vm/vm_webhook.go
+++ b/images/virtualization-artifact/pkg/controller/vm/vm_webhook.go
@@ -47,7 +47,7 @@ func NewValidator(client client.Client, blockDeviceService *service.BlockDeviceS
 		validators: []VirtualMachineValidator{
 			validators.NewMetaValidator(client),
 			validators.NewIPAMValidator(client),
-			validators.NewBlockDeviceSpecRefsValidator(),
+			validators.NewBlockDeviceSpecRefsValidator(client),
 			validators.NewSizingPolicyValidator(client),
 			validators.NewBlockDeviceLimiterValidator(blockDeviceService, log),
 			validators.NewAffinityValidator(),

--- a/images/virtualization-artifact/pkg/controller/vmchange/compare_test.go
+++ b/images/virtualization-artifact/pkg/controller/vmchange/compare_test.go
@@ -751,6 +751,33 @@ func TestUpgradeHotplugComputeChangesToRestart(t *testing.T) {
 	require.Equal(t, []string{quotaReason}, changes.GetRestartMessages())
 }
 
+func TestDowngradeBlockDeviceChangesToApplyImmediateMatching(t *testing.T) {
+	changes := SpecChanges{}
+	changes.Add(
+		FieldChange{Path: "blockDeviceRefs.0", ActionRequired: ActionRestart}, // cdrom -> downgrade
+		FieldChange{Path: "blockDeviceRefs.1", ActionRequired: ActionRestart}, // disk -> keep
+		FieldChange{Path: "cpu.cores", ActionRequired: ActionRestart},         // not a block device -> keep
+	)
+
+	changes.DowngradeBlockDeviceChangesToApplyImmediateMatching(func(c FieldChange) bool {
+		return c.Path == "blockDeviceRefs.0"
+	})
+
+	require.Equal(t, ActionApplyImmediate, changes.GetAll()[0].ActionRequired)
+	require.Equal(t, ActionRestart, changes.GetAll()[1].ActionRequired)
+	require.Equal(t, ActionRestart, changes.GetAll()[2].ActionRequired)
+
+	// A nil predicate downgrades every restart block-device change.
+	changes = SpecChanges{}
+	changes.Add(
+		FieldChange{Path: "blockDeviceRefs.0", ActionRequired: ActionRestart},
+		FieldChange{Path: "blockDeviceRefs", ActionRequired: ActionApplyImmediate}, // already immediate -> untouched
+	)
+	changes.DowngradeBlockDeviceChangesToApplyImmediateMatching(nil)
+	require.Equal(t, ActionApplyImmediate, changes.GetAll()[0].ActionRequired)
+	require.Equal(t, ActionApplyImmediate, changes.GetAll()[1].ActionRequired)
+}
+
 func loadVMSpec(t *testing.T, inYAML string) *v1alpha2.VirtualMachineSpec {
 	t.Helper()
 	var spec v1alpha2.VirtualMachineSpec

--- a/images/virtualization-artifact/pkg/controller/vmchange/spec_changes.go
+++ b/images/virtualization-artifact/pkg/controller/vmchange/spec_changes.go
@@ -261,6 +261,21 @@ func (s *SpecChanges) UpgradeBlockDeviceChangesToRestartMatching(shouldUpgrade f
 	}
 }
 
+// DowngradeBlockDeviceChangesToApplyImmediateMatching reverts block-device changes
+// that the comparator marked as restart back to apply-immediate when shouldDowngrade
+// reports the change can be applied live. It is the inverse of
+// UpgradeBlockDeviceChangesToRestartMatching and is used to let CD-ROMs (which hot-plug
+// on the USB bus) be attached live on non-paravirtualized guests, where every
+// block-device change is otherwise classified as restart.
+func (s *SpecChanges) DowngradeBlockDeviceChangesToApplyImmediateMatching(shouldDowngrade func(FieldChange) bool) {
+	for i := range s.changes {
+		isBlockDeviceChange := s.changes[i].Path == blockDevicesPath || strings.HasPrefix(s.changes[i].Path, blockDevicesPath+".")
+		if isBlockDeviceChange && s.changes[i].ActionRequired == ActionRestart && (shouldDowngrade == nil || shouldDowngrade(s.changes[i])) {
+			s.changes[i].ActionRequired = ActionApplyImmediate
+		}
+	}
+}
+
 func (s *SpecChanges) UpgradeHotplugComputeChangesToRestart() {
 	s.UpgradeHotplugComputeChangesToRestartWithMessage("")
 }


### PR DESCRIPTION
## Description

Route hot-plugged CD-ROMs (ISO VirtualImage/CVI) onto the **USB** bus instead of virtio-scsi. The `AddVolume` subresource hook (`add_volume.go`) hardcoded `DiskBusSCSI` for CD-ROMs; both hotplug paths (VMBDA and `spec.blockDeviceRefs`) go through it, so it's a single chokepoint. Non-cdrom disk hotplug is unchanged. Unit test asserts cdrom→usb, disk→scsi.

> ⚠️ Second commit (`chore(core): pin 3p-kubevirt ...`) is **TESTING ONLY — revert before merge**. It pins the fork to branch `feat/hotplug-cdrom-usb-bus` (deckhouse/3p-kubevirt#146, which allows usb for CD-ROMs) and force-reclones each build. Replace with a fork tag release + `versions.yml` bump before merge.

## Why do we need it, and what problem does it solve?

Guests without a virtio-scsi driver (Windows WinPE installer) never enumerated hot-plugged CD-ROMs — including the virtio-win driver ISO, a chicken-and-egg blocker. The inbox USB Mass Storage driver picks up a usb-storage CD-ROM; the xhci controller is already present on every VM (tablet input device).

## What is the expected result?

A hot-plugged ISO is rendered as `cdrom` on `bus=usb` in the VMI; a WinPE guest sees it and can load virtio-win; attach/detach still works. Non-cdrom hotplug unchanged.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: vm
type: feature
summary: "Hot-plugged CD-ROMs are attached on the USB bus so guests without a virtio-scsi driver (e.g. Windows WinPE) can enumerate them."
```
