### PR TITLE
chore(ci): add sds-elastic e2e tests

### DIFF
--- a/.github/scripts/bash/e2e/cleanup-nightly-resources.sh
+++ b/.github/scripts/bash/e2e/cleanup-nightly-resources.sh
@@ -23,6 +23,10 @@ source "${SCRIPT_DIR}/common.sh"
 LABEL_SELECTOR="${LABEL_SELECTOR:-test=nightly-e2e}"
 KEEP_HOURS="${KEEP_HOURS:-47}"
 FRIDAY_KEEP_HOURS="${FRIDAY_KEEP_HOURS:-71}"
+# sds-elastic (Ceph) nested clusters are heavy, so they are torn down sooner (~1 day)
+# and are not granted the Friday extension. Matched by storage type in the resource name.
+ELASTIC_KEEP_HOURS="${ELASTIC_KEEP_HOURS:-23}"
+ELASTIC_NAME_PATTERN="${ELASTIC_NAME_PATTERN:-sds-elastic}"
 
 current_date_seconds="$(date -u +%s)"
 
@@ -35,20 +39,28 @@ collect_items_json() {
 
 should_keep() {
   local created_at="$1"
+  local name="$2"
   local resource_created_at_seconds
   local age_seconds
   local weekday_of_day
+  local keep_hours="${KEEP_HOURS}"
+  local friday_keep_hours="${FRIDAY_KEEP_HOURS}"
+
+  if [[ "${name}" == *"${ELASTIC_NAME_PATTERN}"* ]]; then
+    keep_hours="${ELASTIC_KEEP_HOURS}"
+    friday_keep_hours="${ELASTIC_KEEP_HOURS}"
+  fi
 
   resource_created_at_seconds="$(date -d "${created_at}" -u +%s)"
   age_seconds="$(( current_date_seconds - resource_created_at_seconds ))"
   weekday_of_day="$(date -d "${created_at}" -u +%u)"
 
-  if [ "${age_seconds}" -lt "$(( KEEP_HOURS * 3600 ))" ]; then
+  if [ "${age_seconds}" -lt "$(( keep_hours * 3600 ))" ]; then
     echo "keep"
     return 0
   fi
 
-  if [ "${weekday_of_day}" -eq 5 ] && [ "${age_seconds}" -lt "$(( FRIDAY_KEEP_HOURS * 3600 ))" ]; then
+  if [ "${weekday_of_day}" -eq 5 ] && [ "${age_seconds}" -lt "$(( friday_keep_hours * 3600 ))" ]; then
     echo "keep"
     return 0
   fi
@@ -69,7 +81,7 @@ cleanup_kind() {
     created_at="$(echo "${item}" | jq -r '.created_at')"
     [ -z "${name}" ] && continue
 
-    decision="$(should_keep "${created_at}")"
+    decision="$(should_keep "${created_at}" "${name}")"
     if [ "${decision}" = "keep" ]; then
       printf "%-63s %22s\n" "[INFO] Keep ${kind}/${name}:" "created_at ${created_at}"
       continue

--- a/.github/scripts/bash/e2e/configure-sds-elastic.sh
+++ b/.github/scripts/bash/e2e/configure-sds-elastic.sh
@@ -22,6 +22,8 @@ source "${SCRIPT_DIR}/wait-sds-elastic.sh"
 
 ELASTIC_CLUSTER_NAME=elastic
 ELASTIC_STORAGE_CLASS=nested-ceph-rbd
+# StorageClassMigration needs a second RBD storage class as a migration target.
+ELASTIC_STORAGE_CLASSES=(nested-ceph-rbd nested-ceph-rbd-r3)
 
 # sds-elastic (Ceph via Rook) is Experimental, so enable it and its dependencies
 # (sds-node-configurator, csi-ceph). On the stage profile the modules are absent in
@@ -108,17 +110,19 @@ kubectl apply -f ./elastic-cluster.yaml
 echo "[INFO] Wait for ElasticCluster to be ready"
 elastic_cluster_ready "${ELASTIC_CLUSTER_NAME}"
 
-echo "[INFO] Create ElasticStorageClass (RBD, replica-2)"
+echo "[INFO] Create ElasticStorageClasses (RBD: replica-2 default + replica-3 migration target)"
 kubectl apply -f ./elastic-storage-class.yaml
 
-echo "[INFO] Wait for StorageClass ${ELASTIC_STORAGE_CLASS} to appear"
-for i in $(seq 1 30); do
-  if kubectl get storageclass "${ELASTIC_STORAGE_CLASS}" >/dev/null 2>&1; then
-    echo "[SUCCESS] StorageClass ${ELASTIC_STORAGE_CLASS} is present"
-    break
-  fi
-  echo "[INFO] Wait 10s for StorageClass ${ELASTIC_STORAGE_CLASS} (attempt ${i}/30)"
-  sleep 10
+for sc in "${ELASTIC_STORAGE_CLASSES[@]}"; do
+  echo "[INFO] Wait for StorageClass ${sc} to appear"
+  for i in $(seq 1 30); do
+    if kubectl get storageclass "${sc}" >/dev/null 2>&1; then
+      echo "[SUCCESS] StorageClass ${sc} is present"
+      break
+    fi
+    echo "[INFO] Wait 10s for StorageClass ${sc} (attempt ${i}/30)"
+    sleep 10
+  done
 done
 
 echo "[INFO] Set default cluster storage class to ${ELASTIC_STORAGE_CLASS}"

--- a/.github/scripts/bash/e2e/configure-sds-elastic.sh
+++ b/.github/scripts/bash/e2e/configure-sds-elastic.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/scripts/bash/e2e/wait-sds-elastic.sh
+source "${SCRIPT_DIR}/wait-sds-elastic.sh"
+
+ELASTIC_CLUSTER_NAME=elastic
+ELASTIC_STORAGE_CLASS=nested-ceph-rbd
+
+# sds-elastic (Ceph via Rook) is Experimental, so enable it and its dependencies
+# (sds-node-configurator, csi-ceph). On the stage profile the modules are absent in
+# the stage registry, so pull them from the deckhouse-prod ModuleSource created by
+# enable-sdn.sh; otherwise use the default deckhouse source.
+apply_module_configs() {
+  local source_field="  source: deckhouse"
+
+  if [ -n "${MODULE_SOURCE_REGISTRY_CFG:-}" ]; then
+    source_field="  source: deckhouse-prod"
+  fi
+
+  kubectl apply -f - <<EOF
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: sds-node-configurator
+spec:
+  enabled: true
+  version: 1
+${source_field}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: csi-ceph
+spec:
+  enabled: true
+  version: 1
+${source_field}
+  settings:
+    cephfsEnabled: false
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: sds-elastic
+spec:
+  enabled: true
+  version: 1
+${source_field}
+  settings:
+    dataNodes:
+      nodeSelector:
+        node-role.deckhouse.io/worker: ""
+EOF
+}
+
+echo "[INFO] Allow experimental modules (sds-elastic is Experimental)"
+kubectl patch mc deckhouse --type=merge \
+  -p '{"spec":{"settings":{"allowExperimentalModules":true}}}'
+
+d8_queue
+
+if [ -n "${MODULE_SOURCE_REGISTRY_CFG:-}" ]; then
+  echo "[INFO] Apply sds-elastic ModuleConfigs with deckhouse-prod source (stage profile)"
+else
+  echo "[INFO] Apply sds-elastic ModuleConfigs with deckhouse source"
+fi
+apply_module_configs
+
+echo "[INFO] Wait for sds-node-configurator to be ready"
+kubectl wait --for=jsonpath='{.status.phase}'=Ready modules sds-node-configurator --timeout=300s
+
+echo "[INFO] Wait for csi-ceph to be ready"
+kubectl wait --for=jsonpath='{.status.phase}'=Ready modules csi-ceph --timeout=600s
+
+echo "[INFO] Wait for sds-elastic to be ready"
+kubectl wait --for=jsonpath='{.status.phase}'=Ready modules sds-elastic --timeout=600s
+
+echo "[INFO] Wait for raw block devices to be discovered"
+elastic_blockdevices_ready
+
+echo "[INFO] Label consumable block devices as OSDs (app=elastic-osd)"
+for bd in $(kubectl get blockdevices.storage.deckhouse.io -o json | jq -r '.items[] | select(.status.consumable == true) | .metadata.name'); do
+  echo "[INFO] Label blockdevice ${bd} app=elastic-osd"
+  kubectl label blockdevice "${bd}" app=elastic-osd --overwrite
+done
+
+echo "[INFO] Create ElasticCluster (host networking)"
+kubectl apply -f ./elastic-cluster.yaml
+
+echo "[INFO] Wait for ElasticCluster to be ready"
+elastic_cluster_ready "${ELASTIC_CLUSTER_NAME}"
+
+echo "[INFO] Create ElasticStorageClass (RBD, replica-2)"
+kubectl apply -f ./elastic-storage-class.yaml
+
+echo "[INFO] Wait for StorageClass ${ELASTIC_STORAGE_CLASS} to appear"
+for i in $(seq 1 30); do
+  if kubectl get storageclass "${ELASTIC_STORAGE_CLASS}" >/dev/null 2>&1; then
+    echo "[SUCCESS] StorageClass ${ELASTIC_STORAGE_CLASS} is present"
+    break
+  fi
+  echo "[INFO] Wait 10s for StorageClass ${ELASTIC_STORAGE_CLASS} (attempt ${i}/30)"
+  sleep 10
+done
+
+echo "[INFO] Set default cluster storage class to ${ELASTIC_STORAGE_CLASS}"
+kubectl patch mc global --type='json' \
+  -p='[{"op": "replace", "path": "/spec/settings/defaultClusterStorageClass", "value": "'"${ELASTIC_STORAGE_CLASS}"'"}]'
+
+echo "[INFO] Show existing storageclasses and volumesnapshotclasses"
+kubectl get storageclass
+kubectl get volumesnapshotclass || echo "[WARNING] No volumesnapshotclasses found"

--- a/.github/scripts/bash/e2e/power-off-nested-vms.sh
+++ b/.github/scripts/bash/e2e/power-off-nested-vms.sh
@@ -20,9 +20,9 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=.github/scripts/bash/e2e/common.sh
 source "${SCRIPT_DIR}/common.sh"
 
-# Constants (nested cluster: 1 master + 3 workers x2)
-REQUIRED_MEM_GI=86
-REQUIRED_CPU=26
+# Constants ((nested cluster: 1 master + 3 workers) x3: replicated + nfs + sds-elastic)
+REQUIRED_MEM_GI=129
+REQUIRED_CPU=39
 MIN_MEM_GI_PER_NODE=12
 MIN_CPU_PER_NODE=4
 MIN_NODES_FOR_PLACEMENT=3

--- a/.github/scripts/bash/e2e/render-dvp-static-values.sh
+++ b/.github/scripts/bash/e2e/render-dvp-static-values.sh
@@ -63,7 +63,8 @@ envsubst "${envsubst_variables}" \
 additional_disk_count="${ADDITIONAL_DISK_COUNT:-1}"
 if (( additional_disk_count > 1 )); then
   for (( d = 2; d <= additional_disk_count; d++ )); do
-    ADDITIONAL_DISK_SIZE="${ADDITIONAL_DISK_SIZE}" yq eval --inplace \
+    # ADDITIONAL_DISK_SIZE is exported by the workflow step env and read by yq's env().
+    yq eval --inplace \
       '(.instances.additionalNodes[] | select(.name == "worker") | .cfg.additionalDisks) += [{"size": env(ADDITIONAL_DISK_SIZE)}]' \
       values.yaml
   done

--- a/.github/scripts/bash/e2e/render-dvp-static-values.sh
+++ b/.github/scripts/bash/e2e/render-dvp-static-values.sh
@@ -57,6 +57,18 @@ envsubst_variables="$(grep -oE '\$\{[A-Z0-9_]+\}' values.yaml.tmpl | sort -u | t
 envsubst "${envsubst_variables}" \
   < values.yaml.tmpl > values.yaml
 
+# The template defines one additional worker disk. When ADDITIONAL_DISK_COUNT > 1
+# (e.g. sds-elastic runs several Ceph OSDs per node), append the extra disks, each
+# of ADDITIONAL_DISK_SIZE, to every worker node group.
+additional_disk_count="${ADDITIONAL_DISK_COUNT:-1}"
+if (( additional_disk_count > 1 )); then
+  for (( d = 2; d <= additional_disk_count; d++ )); do
+    ADDITIONAL_DISK_SIZE="${ADDITIONAL_DISK_SIZE}" yq eval --inplace \
+      '(.instances.additionalNodes[] | select(.name == "worker") | .cfg.additionalDisks) += [{"size": env(ADDITIONAL_DISK_SIZE)}]' \
+      values.yaml
+  done
+fi
+
 mkdir -p tmp
 touch tmp/discovered-values.yaml
 

--- a/.github/scripts/bash/e2e/wait-sds-elastic.sh
+++ b/.github/scripts/bash/e2e/wait-sds-elastic.sh
@@ -74,10 +74,12 @@ elastic_blockdevices_ready() {
 }
 
 # Waits until the ElasticCluster reaches phase Ready and Ceph reports HEALTH_OK.
-# Rook cluster bring-up (mon/mgr/osd) can take many minutes, so the timeout is generous.
+# Rook cluster bring-up (mon/mgr/osd) on nested VMs is slow: with several OSDs per node
+# plus occasional sds-node-configurator restarts a full bring-up can take ~50 min, so the
+# timeout is deliberately generous (240 x 15s = 60 min).
 elastic_cluster_ready() {
   local ec_name="$1"
-  local count=120
+  local count=240
   local phase
   local health
 
@@ -96,7 +98,7 @@ elastic_cluster_ready() {
       echo "[DEBUG] ElasticCluster status"
       kubectl get ec "$ec_name" -o wide || true
       echo "[DEBUG] CephCluster status"
-      kubectl -n d8-csi-ceph get cephcluster -o wide 2>/dev/null || true
+      kubectl get cephcluster -A -o wide 2>/dev/null || true
       echo "[DEBUG] Show queue (first 25 lines)"
       d8 s queue list | head -n25 || echo "No queues"
     fi
@@ -111,7 +113,7 @@ elastic_cluster_ready() {
   kubectl get lvmvolumegroup -o wide || true
   echo "::endgroup::"
   echo "::group::CephCluster"
-  kubectl -n d8-csi-ceph get cephcluster -o yaml 2>/dev/null || true
+  kubectl get cephcluster -A -o yaml 2>/dev/null || true
   echo "::endgroup::"
   echo "::group::deckhouse logs"
   d8 s logs | tail -n 100 || true

--- a/.github/scripts/bash/e2e/wait-sds-elastic.sh
+++ b/.github/scripts/bash/e2e/wait-sds-elastic.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/scripts/bash/e2e/common.sh
+source "${SCRIPT_DIR}/common.sh"
+# shellcheck source=.github/scripts/bash/e2e/deckhouse.sh
+source "${SCRIPT_DIR}/deckhouse.sh"
+
+# Waits until at least one Consumable BlockDevice per worker node is discovered by
+# sds-node-configurator. These are the raw additional disks that back the Ceph OSDs.
+elastic_blockdevices_ready() {
+  local count=60
+  local workers
+  local blockdevices
+
+  workers="$(kubectl get nodes -o name | grep -c worker || true)"
+  workers=$((workers))
+
+  if [[ "$workers" -eq 0 ]]; then
+    echo "[ERROR] No worker nodes found"
+    return 1
+  fi
+
+  for i in $(seq 1 "$count"); do
+    blockdevices="$(kubectl get blockdevices.storage.deckhouse.io -o json | jq '[.items[] | select(.status.consumable == true)] | length' || echo 0)"
+    blockdevices=$((blockdevices))
+    if [[ "$blockdevices" -ge "$workers" ]]; then
+      echo "[SUCCESS] Consumable blockdevices (${blockdevices}) is greater or equal to workers (${workers})"
+      kubectl get blockdevices.storage.deckhouse.io -o wide
+      return 0
+    fi
+
+    echo "[INFO] Wait 10s until consumable blockdevices >= ${workers} (attempt ${i}/${count})"
+    if (( i % 5 == 0 )); then
+      echo "[DEBUG] Show blockdevices"
+      kubectl get blockdevices.storage.deckhouse.io -o wide || true
+      echo "[DEBUG] Show queue (first 25 lines)"
+      d8 s queue list | head -n25 || echo "No queues"
+    fi
+    sleep 10
+  done
+
+  echo "[ERROR] Consumable blockdevices did not reach ${workers} in time"
+  echo "[DEBUG] Show cluster nodes"
+  kubectl get nodes || true
+  echo "[DEBUG] Show blockdevices"
+  kubectl get blockdevices.storage.deckhouse.io -o wide || true
+  echo "[DEBUG] Show deckhouse logs"
+  echo "::group::deckhouse logs"
+  d8 s logs | tail -n 100 || true
+  echo "::endgroup::"
+  return 1
+}
+
+# Waits until the ElasticCluster reaches phase Ready and Ceph reports HEALTH_OK.
+# Rook cluster bring-up (mon/mgr/osd) can take many minutes, so the timeout is generous.
+elastic_cluster_ready() {
+  local ec_name="$1"
+  local count=120
+  local phase
+  local health
+
+  for i in $(seq 1 "$count"); do
+    phase="$(kubectl get ec "$ec_name" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")"
+    health="$(kubectl get ec "$ec_name" -o jsonpath='{.status.health.status}' 2>/dev/null || echo "")"
+
+    if [[ "$phase" == "Ready" && "$health" == "HEALTH_OK" ]]; then
+      echo "[SUCCESS] ElasticCluster ${ec_name} is Ready (${health})"
+      kubectl get ec "$ec_name" -o wide
+      return 0
+    fi
+
+    echo "[INFO] Wait 15s for ElasticCluster ${ec_name} (phase=${phase:-<none>}, health=${health:-<none>}) (attempt ${i}/${count})"
+    if (( i % 5 == 0 )); then
+      echo "[DEBUG] ElasticCluster status"
+      kubectl get ec "$ec_name" -o wide || true
+      echo "[DEBUG] CephCluster status"
+      kubectl -n d8-csi-ceph get cephcluster -o wide 2>/dev/null || true
+      echo "[DEBUG] Show queue (first 25 lines)"
+      d8 s queue list | head -n25 || echo "No queues"
+    fi
+    sleep 15
+  done
+
+  echo "[ERROR] ElasticCluster ${ec_name} did not become Ready/HEALTH_OK in time"
+  echo "::group::ElasticCluster"
+  kubectl get ec "$ec_name" -o yaml || true
+  echo "::endgroup::"
+  echo "::group::LVMVolumeGroups"
+  kubectl get lvmvolumegroup -o wide || true
+  echo "::endgroup::"
+  echo "::group::CephCluster"
+  kubectl -n d8-csi-ceph get cephcluster -o yaml 2>/dev/null || true
+  echo "::endgroup::"
+  echo "::group::deckhouse logs"
+  d8 s logs | tail -n 100 || true
+  echo "::endgroup::"
+  return 1
+}

--- a/.github/scripts/bash/e2e/wait-sds-elastic.sh
+++ b/.github/scripts/bash/e2e/wait-sds-elastic.sh
@@ -22,12 +22,15 @@ source "${SCRIPT_DIR}/common.sh"
 # shellcheck source=.github/scripts/bash/e2e/deckhouse.sh
 source "${SCRIPT_DIR}/deckhouse.sh"
 
-# Waits until at least one Consumable BlockDevice per worker node is discovered by
-# sds-node-configurator. These are the raw additional disks that back the Ceph OSDs.
+# Waits until the raw additional disks that back the Ceph OSDs are discovered by
+# sds-node-configurator. Expects ELASTIC_OSD_DISKS_PER_NODE consumable BlockDevices
+# per worker node (one OSD per additional disk).
 elastic_blockdevices_ready() {
   local count=60
   local workers
   local blockdevices
+  local disks_per_node="${ELASTIC_OSD_DISKS_PER_NODE:-1}"
+  local expected
 
   workers="$(kubectl get nodes -o name | grep -c worker || true)"
   workers=$((workers))
@@ -37,16 +40,18 @@ elastic_blockdevices_ready() {
     return 1
   fi
 
+  expected=$(( workers * disks_per_node ))
+
   for i in $(seq 1 "$count"); do
     blockdevices="$(kubectl get blockdevices.storage.deckhouse.io -o json | jq '[.items[] | select(.status.consumable == true)] | length' || echo 0)"
     blockdevices=$((blockdevices))
-    if [[ "$blockdevices" -ge "$workers" ]]; then
-      echo "[SUCCESS] Consumable blockdevices (${blockdevices}) is greater or equal to workers (${workers})"
+    if [[ "$blockdevices" -ge "$expected" ]]; then
+      echo "[SUCCESS] Consumable blockdevices (${blockdevices}) is greater or equal to expected (${expected} = ${workers} workers x ${disks_per_node} disks)"
       kubectl get blockdevices.storage.deckhouse.io -o wide
       return 0
     fi
 
-    echo "[INFO] Wait 10s until consumable blockdevices >= ${workers} (attempt ${i}/${count})"
+    echo "[INFO] Wait 10s until consumable blockdevices >= ${expected} (attempt ${i}/${count})"
     if (( i % 5 == 0 )); then
       echo "[DEBUG] Show blockdevices"
       kubectl get blockdevices.storage.deckhouse.io -o wide || true
@@ -56,7 +61,7 @@ elastic_blockdevices_ready() {
     sleep 10
   done
 
-  echo "[ERROR] Consumable blockdevices did not reach ${workers} in time"
+  echo "[ERROR] Consumable blockdevices did not reach ${expected} in time"
   echo "[DEBUG] Show cluster nodes"
   kubectl get nodes || true
   echo "[DEBUG] Show blockdevices"

--- a/.github/scripts/bash/e2e/wait-virtualization-ready.sh
+++ b/.github/scripts/bash/e2e/wait-virtualization-ready.sh
@@ -177,6 +177,11 @@ enable_maintenance_mode() {
     echo "[INFO] Switch csi-nfs module to maintenance mode"
     kubectl patch mc csi-nfs --type merge --patch '{"spec":{"maintenance":"NoResourceReconciliation"}}'
     ;;
+  sds-elastic)
+    echo "[INFO] Switch sds-elastic and csi-ceph modules to maintenance mode"
+    kubectl patch mc sds-elastic --type merge --patch '{"spec":{"maintenance":"NoResourceReconciliation"}}'
+    kubectl patch mc csi-ceph --type merge --patch '{"spec":{"maintenance":"NoResourceReconciliation"}}'
+    ;;
   local)
     echo "[INFO] Switch sds-local-volume module to maintenance mode"
     kubectl patch mc sds-local-volume --type merge --patch '{"spec":{"maintenance":"NoResourceReconciliation"}}'

--- a/.github/workflows/e2e-nightly-reusable-pipeline.yml
+++ b/.github/workflows/e2e-nightly-reusable-pipeline.yml
@@ -567,9 +567,6 @@ jobs:
       - configure-virtualization
     steps:
       - uses: actions/checkout@v6
-        # TEMPORARY: pin e2e test code to the feature branch. REVERT BEFORE MERGE.
-        with:
-          ref: chore/ci/add-sds-elastic-e2e-tests
 
       - name: Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v5
@@ -608,7 +605,6 @@ jobs:
 
       - name: Run E2E
         id: e2e-report
-        continue-on-error: true # TEMPORARY: don't fail the job on test failures. REVERT BEFORE MERGE.
         env:
           TIMEOUT: ${{ inputs.e2e_timeout }}
           CSI: ${{ inputs.storage_type }}
@@ -712,8 +708,7 @@ jobs:
       - configure-storage
       - configure-virtualization
       - e2e-test
-    # TEMPORARY: keep the cluster for debugging even on success. REVERT to "cancelled() || success()" BEFORE MERGE.
-    if: cancelled()
+    if: cancelled() || success()
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/e2e-nightly-reusable-pipeline.yml
+++ b/.github/workflows/e2e-nightly-reusable-pipeline.yml
@@ -43,7 +43,7 @@ on:
       storage_type:
         required: true
         type: string
-        description: "Storage type (ceph or replicated or etc.)"
+        description: "Storage type (replicated, nfs, sds-elastic, etc.)"
       nested_storageclass_name:
         required: true
         type: string
@@ -489,6 +489,18 @@ jobs:
           # ModuleSource deckhouse-prod that enable-sdn.sh creates for the stage profile.
           MODULE_SOURCE_REGISTRY_CFG: ${{ inputs.registry_profile == 'stage' && secrets.PROD_IO_REGISTRY_DOCKER_CFG || '' }}
         run: bash "${E2E_SCRIPT_DIR}/configure-csi-nfs.sh"
+
+      - name: Configure sds-elastic storage
+        if: ${{ inputs.storage_type == 'sds-elastic' }}
+        id: storage-sds-elastic-setup
+        working-directory: ${{ env.SETUP_CLUSTER_TYPE_PATH }}/storage/sds-elastic
+        env:
+          NAMESPACE: ${{ needs.bootstrap.outputs.namespace }}
+          # sds-elastic, csi-ceph and sds-node-configurator are absent in the stage
+          # registry; pull them from prod via the same ModuleSource deckhouse-prod that
+          # enable-sdn.sh creates for the stage profile.
+          MODULE_SOURCE_REGISTRY_CFG: ${{ inputs.registry_profile == 'stage' && secrets.PROD_IO_REGISTRY_DOCKER_CFG || '' }}
+        run: bash "${E2E_SCRIPT_DIR}/configure-sds-elastic.sh"
 
   configure-virtualization:
     name: Configure Virtualization

--- a/.github/workflows/e2e-nightly-reusable-pipeline.yml
+++ b/.github/workflows/e2e-nightly-reusable-pipeline.yml
@@ -40,6 +40,11 @@ on:
         type: string
         default: "50Gi"
         description: "Set additional disk size for workers node in cluster config"
+      cluster_config_additional_disk_count:
+        required: false
+        type: string
+        default: "1"
+        description: "Number of additional disks per worker node (each of cluster_config_additional_disk_size). sds-elastic uses more than one to run multiple Ceph OSDs per node."
       storage_type:
         required: true
         type: string
@@ -257,6 +262,7 @@ jobs:
           APT_MIRROR_URL: ${{ inputs.apt_mirror_url }}
           CLUSTER_CONFIG_WORKERS_MEMORY: ${{ inputs.cluster_config_workers_memory }}
           ADDITIONAL_DISK_SIZE: ${{ inputs.cluster_config_additional_disk_size }}
+          ADDITIONAL_DISK_COUNT: ${{ inputs.cluster_config_additional_disk_count }}
           ENABLED_MODULES: ""
           NESTED_CLUSTER_NETWORK_NAME: ${{ inputs.nested_cluster_network_name }}
         run: bash "${E2E_SCRIPT_DIR}/render-dvp-static-values.sh"
@@ -500,6 +506,8 @@ jobs:
           # registry; pull them from prod via the same ModuleSource deckhouse-prod that
           # enable-sdn.sh creates for the stage profile.
           MODULE_SOURCE_REGISTRY_CFG: ${{ inputs.registry_profile == 'stage' && secrets.PROD_IO_REGISTRY_DOCKER_CFG || '' }}
+          # One OSD per additional disk per worker; the wait expects workers x this count.
+          ELASTIC_OSD_DISKS_PER_NODE: ${{ inputs.cluster_config_additional_disk_count }}
         run: bash "${E2E_SCRIPT_DIR}/configure-sds-elastic.sh"
 
   configure-virtualization:

--- a/.github/workflows/e2e-nightly-reusable-pipeline.yml
+++ b/.github/workflows/e2e-nightly-reusable-pipeline.yml
@@ -559,6 +559,9 @@ jobs:
       - configure-virtualization
     steps:
       - uses: actions/checkout@v6
+        # TEMPORARY: pin e2e test code to the feature branch. REVERT BEFORE MERGE.
+        with:
+          ref: chore/ci/add-sds-elastic-e2e-tests
 
       - name: Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v5
@@ -597,6 +600,7 @@ jobs:
 
       - name: Run E2E
         id: e2e-report
+        continue-on-error: true # TEMPORARY: don't fail the job on test failures. REVERT BEFORE MERGE.
         env:
           TIMEOUT: ${{ inputs.e2e_timeout }}
           CSI: ${{ inputs.storage_type }}
@@ -700,7 +704,8 @@ jobs:
       - configure-storage
       - configure-virtualization
       - e2e-test
-    if: cancelled() || success()
+    # TEMPORARY: keep the cluster for debugging even on success. REVERT to "cancelled() || success()" BEFORE MERGE.
+    if: cancelled()
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -16,6 +16,12 @@ name: E2E Nightly
 
 on:
   workflow_dispatch:
+  # TEMPORARY: run on PR to exercise the sds-elastic pipeline. REVERT BEFORE MERGE.
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - main
+      - chore/ci/add-sds-elastic-e2e-tests
 
 env:
   E2E_IMAGE_BASE_URL: "http://share.e2e-test-images.svc.cluster.local"
@@ -30,6 +36,7 @@ defaults:
 
 jobs:
   cleanup-nested-clusters:
+    if: github.event_name != 'pull_request' # TEMPORARY: skip on PR. REVERT BEFORE MERGE.
     name: Cleanup nested clusters
     runs-on: ubuntu-latest
     steps:
@@ -51,6 +58,7 @@ jobs:
         run: bash .github/scripts/bash/e2e/cleanup-nightly-resources.sh
 
   power-off-vms-for-nested:
+    if: github.event_name != 'pull_request' # TEMPORARY: skip on PR. REVERT BEFORE MERGE.
     name: Power off VMs for nested clusters
     needs: cleanup-nested-clusters
     runs-on: ubuntu-latest
@@ -70,7 +78,8 @@ jobs:
 
   set-vars:
     name: Set vars
-    needs: power-off-vms-for-nested
+    # TEMPORARY: decoupled from power-off (skipped on PR). UNCOMMENT BEFORE MERGE.
+    # needs: power-off-vms-for-nested
     runs-on: ubuntu-latest
     outputs:
       date_start: ${{ steps.vars.outputs.date_start }}
@@ -95,6 +104,7 @@ jobs:
         run: bash .github/scripts/bash/e2e/resolve-registry-profile.sh
 
   e2e-replicated:
+    if: github.event_name != 'pull_request' # TEMPORARY: skip on PR. REVERT BEFORE MERGE.
     name: E2E Pipeline (Replicated)
     needs:
       - set-vars
@@ -128,6 +138,7 @@ jobs:
       E2E_ARTIFACTS_GPG_PASSPHRASE: ${{ secrets.E2E_ARTIFACTS_GPG_PASSPHRASE }}
 
   e2e-nfs:
+    if: github.event_name != 'pull_request' # TEMPORARY: skip on PR. REVERT BEFORE MERGE.
     name: E2E Pipeline (NFS)
     needs:
       - set-vars
@@ -171,7 +182,7 @@ jobs:
       nested_storageclass_name: nested-ceph-rbd
       nested_cluster_network_name: cn-4006-for-e2e-test
       branch: main
-      virtualization_tag: main
+      virtualization_tag: pr2608 # TEMPORARY: use PR image. REVERT to main BEFORE MERGE.
       deckhouse_channel: ${{ needs.set-vars.outputs.deckhouse_channel }}
       deckhouse_version: ${{ needs.set-vars.outputs.deckhouse_version }}
       registry_profile: ${{ needs.set-vars.outputs.registry_profile }}
@@ -237,7 +248,7 @@ jobs:
         env:
           EXPECTED_STORAGE_TYPES: '["replicated","nfs","sds-elastic"]'
           LOOP_API_BASE_URL: ${{ secrets.LOOP_API_BASE_URL }}
-          LOOP_CHANNEL_ID: ${{ secrets.LOOP_CHANNEL_ID }}
+          LOOP_CHANNEL_ID: ${{ secrets.LOOP_TEST_CHANNEL_ID }} # TEMPORARY: report to test channel. REVERT to LOOP_CHANNEL_ID BEFORE MERGE.
           LOOP_TOKEN: ${{ secrets.LOOP_TOKEN }}
         with:
           script: |

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -16,12 +16,6 @@ name: E2E Nightly
 
 on:
   workflow_dispatch:
-  # TEMPORARY: run on PR to exercise the sds-elastic pipeline. REVERT BEFORE MERGE.
-  pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
-    branches:
-      - main
-      - chore/ci/add-sds-elastic-e2e-tests
 
 env:
   E2E_IMAGE_BASE_URL: "http://share.e2e-test-images.svc.cluster.local"
@@ -36,7 +30,6 @@ defaults:
 
 jobs:
   cleanup-nested-clusters:
-    if: github.event_name != 'pull_request' # TEMPORARY: skip on PR. REVERT BEFORE MERGE.
     name: Cleanup nested clusters
     runs-on: ubuntu-latest
     steps:
@@ -60,7 +53,6 @@ jobs:
         run: bash .github/scripts/bash/e2e/cleanup-nightly-resources.sh
 
   power-off-vms-for-nested:
-    if: github.event_name != 'pull_request' # TEMPORARY: skip on PR. REVERT BEFORE MERGE.
     name: Power off VMs for nested clusters
     needs: cleanup-nested-clusters
     runs-on: ubuntu-latest
@@ -80,8 +72,7 @@ jobs:
 
   set-vars:
     name: Set vars
-    # TEMPORARY: decoupled from power-off (skipped on PR). UNCOMMENT BEFORE MERGE.
-    # needs: power-off-vms-for-nested
+    needs: power-off-vms-for-nested
     runs-on: ubuntu-latest
     outputs:
       date_start: ${{ steps.vars.outputs.date_start }}
@@ -106,7 +97,6 @@ jobs:
         run: bash .github/scripts/bash/e2e/resolve-registry-profile.sh
 
   e2e-replicated:
-    if: github.event_name != 'pull_request' # TEMPORARY: skip on PR. REVERT BEFORE MERGE.
     name: E2E Pipeline (Replicated)
     needs:
       - set-vars
@@ -140,7 +130,6 @@ jobs:
       E2E_ARTIFACTS_GPG_PASSPHRASE: ${{ secrets.E2E_ARTIFACTS_GPG_PASSPHRASE }}
 
   e2e-nfs:
-    if: github.event_name != 'pull_request' # TEMPORARY: skip on PR. REVERT BEFORE MERGE.
     name: E2E Pipeline (NFS)
     needs:
       - set-vars
@@ -184,7 +173,7 @@ jobs:
       nested_storageclass_name: nested-ceph-rbd
       nested_cluster_network_name: cn-4006-for-e2e-test
       branch: main
-      virtualization_tag: pr2608 # TEMPORARY: use PR image. REVERT to main BEFORE MERGE.
+      virtualization_tag: main
       deckhouse_channel: ${{ needs.set-vars.outputs.deckhouse_channel }}
       deckhouse_version: ${{ needs.set-vars.outputs.deckhouse_version }}
       registry_profile: ${{ needs.set-vars.outputs.registry_profile }}
@@ -252,7 +241,7 @@ jobs:
         env:
           EXPECTED_STORAGE_TYPES: '["replicated","nfs","sds-elastic"]'
           LOOP_API_BASE_URL: ${{ secrets.LOOP_API_BASE_URL }}
-          LOOP_CHANNEL_ID: ${{ secrets.LOOP_TEST_CHANNEL_ID }} # TEMPORARY: report to test channel. REVERT to LOOP_CHANNEL_ID BEFORE MERGE.
+          LOOP_CHANNEL_ID: ${{ secrets.LOOP_CHANNEL_ID }}
           LOOP_TOKEN: ${{ secrets.LOOP_TOKEN }}
         with:
           script: |

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -160,12 +160,47 @@ jobs:
       BOOTSTRAP_DEV_PROXY: ${{ secrets.BOOTSTRAP_DEV_PROXY }}
       E2E_ARTIFACTS_GPG_PASSPHRASE: ${{ secrets.E2E_ARTIFACTS_GPG_PASSPHRASE }}
 
+  e2e-sds-elastic:
+    name: E2E Pipeline (Sds Elastic)
+    needs:
+      - set-vars
+    uses: ./.github/workflows/e2e-nightly-reusable-pipeline.yml
+    with:
+      storage_type: sds-elastic
+      pipeline_job_name: "E2E Pipeline (Elastic)"
+      nested_storageclass_name: nested-ceph-rbd
+      nested_cluster_network_name: cn-4006-for-e2e-test
+      branch: main
+      virtualization_tag: main
+      deckhouse_channel: ${{ needs.set-vars.outputs.deckhouse_channel }}
+      deckhouse_version: ${{ needs.set-vars.outputs.deckhouse_version }}
+      registry_profile: ${{ needs.set-vars.outputs.registry_profile }}
+      default_user: cloud
+      go_version: "1.24.13"
+      e2e_timeout: "3.5h"
+      e2e_focus_tests: "VirtualDiskProvisioning|VirtualDiskSnapshots|VirtualImageCreation|VirtualDiskResizing|DiskAttachment|BlockDeviceHotplug|Migration|StorageClassMigration|RWOVirtualDiskMigration|VMSOP|Restore|DataExports"
+      e2e_image_base_url: ${{ needs.set-vars.outputs.e2e_image_base_url }}
+      date_start: ${{ needs.set-vars.outputs.date_start }}
+      randuuid4c: ${{ needs.set-vars.outputs.randuuid4c }}
+      cluster_config_workers_memory: "9Gi"
+      cluster_config_additional_disk_size: "50Gi"
+      cluster_config_k8s_version: "Automatic"
+      apt_mirror_enabled: true
+    secrets:
+      DEV_REGISTRY_DOCKER_CFG: ${{ secrets.DEV_REGISTRY_DOCKER_CFG }}
+      VIRT_E2E_NIGHTLY_SA_TOKEN: ${{ secrets.VIRT_E2E_NIGHTLY_SA_TOKEN }}
+      REGISTRY_DOCKER_CFG: ${{ needs.set-vars.outputs.registry_profile == 'stage' && secrets.STAGE_IO_REGISTRY_DOCKER_CFG || secrets.PROD_IO_REGISTRY_DOCKER_CFG }}
+      PROD_IO_REGISTRY_DOCKER_CFG: ${{ secrets.PROD_IO_REGISTRY_DOCKER_CFG }}
+      BOOTSTRAP_DEV_PROXY: ${{ secrets.BOOTSTRAP_DEV_PROXY }}
+      E2E_ARTIFACTS_GPG_PASSPHRASE: ${{ secrets.E2E_ARTIFACTS_GPG_PASSPHRASE }}
+
   report-to-channel:
     runs-on: ubuntu-latest
     name: End-to-End tests report
     needs:
       - e2e-replicated
       - e2e-nfs
+      - e2e-sds-elastic
     if: ${{ always()}}
     steps:
       - uses: actions/checkout@v6
@@ -200,7 +235,7 @@ jobs:
         id: render-report
         uses: actions/github-script@v7
         env:
-          EXPECTED_STORAGE_TYPES: '["replicated","nfs"]'
+          EXPECTED_STORAGE_TYPES: '["replicated","nfs","sds-elastic"]'
           LOOP_API_BASE_URL: ${{ secrets.LOOP_API_BASE_URL }}
           LOOP_CHANNEL_ID: ${{ secrets.LOOP_CHANNEL_ID }}
           LOOP_TOKEN: ${{ secrets.LOOP_TOKEN }}

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -161,7 +161,7 @@ jobs:
       E2E_ARTIFACTS_GPG_PASSPHRASE: ${{ secrets.E2E_ARTIFACTS_GPG_PASSPHRASE }}
 
   e2e-sds-elastic:
-    name: E2E Pipeline (Sds Elastic)
+    name: E2E Pipeline (Elastic)
     needs:
       - set-vars
     uses: ./.github/workflows/e2e-nightly-reusable-pipeline.yml

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -55,6 +55,8 @@ jobs:
           LABEL_SELECTOR: test=nightly-e2e
           KEEP_HOURS: "47"
           FRIDAY_KEEP_HOURS: "71"
+          # Ceph (sds-elastic) nested clusters are torn down after ~1 day.
+          ELASTIC_KEEP_HOURS: "23"
         run: bash .github/scripts/bash/e2e/cleanup-nightly-resources.sh
 
   power-off-vms-for-nested:

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -197,6 +197,8 @@ jobs:
       randuuid4c: ${{ needs.set-vars.outputs.randuuid4c }}
       cluster_config_workers_memory: "9Gi"
       cluster_config_additional_disk_size: "50Gi"
+      # Two 50Gi disks per worker -> two Ceph OSDs per node for more throughput.
+      cluster_config_additional_disk_count: "2"
       cluster_config_k8s_version: "Automatic"
       apt_mirror_enabled: true
     secrets:

--- a/test/dvp-static-cluster/storage/sds-elastic/elastic-cluster.yaml
+++ b/test/dvp-static-cluster/storage/sds-elastic/elastic-cluster.yaml
@@ -1,0 +1,16 @@
+# ElasticCluster with host networking (network omitted -> provider "host").
+# replica-2 (AvailabilityWithoutConsistency in ElasticStorageClass) relies on
+# failure-domain=host across the 3 worker nodes, each exposing a raw additional disk.
+apiVersion: storage.deckhouse.io/v1alpha1
+kind: ElasticCluster
+metadata:
+  name: elastic
+spec:
+  storage:
+    nodeSelector:
+      matchExpressions:
+        - key: storage.deckhouse.io/sds-elastic-node
+          operator: Exists
+    blockDeviceSelector:
+      matchLabels:
+        app: elastic-osd

--- a/test/dvp-static-cluster/storage/sds-elastic/elastic-storage-class.yaml
+++ b/test/dvp-static-cluster/storage/sds-elastic/elastic-storage-class.yaml
@@ -1,0 +1,11 @@
+# ElasticStorageClass backed by Ceph RBD, replica-2.
+# AvailabilityWithoutConsistency == replica-2 (more usable space, host failure-domain).
+# Creates a K8s StorageClass (provisioner rbd.csi.ceph.com) plus a VolumeSnapshotClass.
+apiVersion: storage.deckhouse.io/v1alpha1
+kind: ElasticStorageClass
+metadata:
+  name: nested-ceph-rbd
+spec:
+  clusterRef: elastic
+  type: RBD
+  replication: AvailabilityWithoutConsistency

--- a/test/dvp-static-cluster/storage/sds-elastic/elastic-storage-class.yaml
+++ b/test/dvp-static-cluster/storage/sds-elastic/elastic-storage-class.yaml
@@ -1,6 +1,11 @@
-# ElasticStorageClass backed by Ceph RBD, replica-2.
-# AvailabilityWithoutConsistency == replica-2 (more usable space, host failure-domain).
-# Creates a K8s StorageClass (provisioner rbd.csi.ceph.com) plus a VolumeSnapshotClass.
+# ElasticStorageClasses backed by Ceph RBD.
+# Two classes are provisioned so StorageClassMigration can migrate a VM disk between
+# them: both use provisioner rbd.csi.ceph.com and the same (Block) volume mode, which
+# is what getTargetStorageClass requires to pick a migration target.
+# Creates K8s StorageClasses plus VolumeSnapshotClasses.
+#
+# nested-ceph-rbd    -- default/template, replica-2 (AvailabilityWithoutConsistency).
+# nested-ceph-rbd-r3 -- migration target, replica-3 (ConsistencyAndAvailability).
 apiVersion: storage.deckhouse.io/v1alpha1
 kind: ElasticStorageClass
 metadata:
@@ -9,3 +14,12 @@ spec:
   clusterRef: elastic
   type: RBD
   replication: AvailabilityWithoutConsistency
+---
+apiVersion: storage.deckhouse.io/v1alpha1
+kind: ElasticStorageClass
+metadata:
+  name: nested-ceph-rbd-r3
+spec:
+  clusterRef: elastic
+  type: RBD
+  replication: ConsistencyAndAvailability


### PR DESCRIPTION
## Description

Nightly E2E only ran against replicated and NFS storage, so Ceph/RBD-specific behavior was never validated in CI. Storage-layer breakages that surface only on Ceph — snapshot consistency, restore, online disk resize, RWO block-volume live migration, storage-class migration, disk hotplug — could ship unnoticed.

This adds a third nightly pipeline running on **sds-elastic** (Ceph RBD via Rook), configured with **host networking** and **replica-2**, and focused on the storage-sensitive Ginkgo suites. Cluster bootstrap already provides 3 worker nodes each with a raw additional disk, which satisfies the replica-2 host failure-domain requirement.

## Why do we need it, and what problem does it solve?

Ceph is a common production backend for the module. Without dedicated coverage, regressions that only manifest on Ceph are caught by users rather than CI. The new pipeline runs the storage-focused test subset nightly so such regressions surface early, alongside the existing replicated and NFS runs.

## What is the expected result?

The E2E Nightly workflow gains an `E2E Pipeline (Sds Elastic)` job that bootstraps a nested cluster, enables sds-elastic (Ceph RBD, replica-2, host network) via a dedicated storage-configuration step, waits for the Ceph cluster to become healthy, and runs the storage-focused suites (provisioning, snapshots, image creation, resize, disk attachment/hotplug, migration, restore, data exports). Its result is included in the nightly report next to replicated and NFS.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

