### PR TITLE
fix(images, disks): self-heal uploader ingress tls secret to unblock stuck uploads

### DIFF
--- a/images/virtualization-artifact/pkg/controller/cvi/internal/source/upload.go
+++ b/images/virtualization-artifact/pkg/controller/cvi/internal/source/upload.go
@@ -101,25 +101,38 @@ func (ds UploadDataSource) Sync(ctx context.Context, cvi *v1alpha2.ClusterVirtua
 		return reconcile.Result{}, err
 	}
 
-	// Sync the uploader Ingress host before the readiness probe:
-	// IsUploaderReady HTTPS-probes the Ingress host, so a stale host (e.g. after
-	// publicDomainTemplate changed) makes readiness fail with a TLS error.
-	// Initial creation is handled by Start, so skip when the pod is absent.
-	if pod != nil && ds.uploaderService.IngressHostDrifted(ing) {
+	// Reconcile the uploader Ingress and its TLS secret before the readiness probe.
+	// All uploaders share one public host: if the Ingress host drifts (e.g. after
+	// publicDomainTemplate changed) or its copied TLS secret goes missing,
+	// ingress-nginx serves its default certificate for the whole host and every
+	// upload on it breaks. IsUploaderReady HTTPS-probes that host, so restore both
+	// first. Initial creation is handled by Start, so skip when the pod is absent.
+	tlsCopyMissing := tlsSecret == nil && supplements.ShouldCopyUploaderTLSSecret(ds.dvcrSettings, supgen)
+	if pod != nil && (ds.uploaderService.IngressHostDrifted(ing) || tlsCopyMissing) {
 		var oldHost string
 		if ing != nil && len(ing.Spec.Rules) > 0 {
 			oldHost = ing.Spec.Rules[0].Host
 		}
-		log.Info("Syncing uploader Ingress: host drifted", "old", oldHost, "new", ds.uploaderService.ExpectedIngressHost())
+		log.Info("Reconciling uploader Ingress", "hostDrifted", ds.uploaderService.IngressHostDrifted(ing), "tlsSecretMissing", tlsCopyMissing, "old", oldHost, "new", ds.uploaderService.ExpectedIngressHost())
 		ing, err = ds.uploaderService.EnsureIngress(ctx, cvi, supgen)
 		if err != nil {
 			return reconcile.Result{}, err
+		}
+		if tlsCopyMissing {
+			tlsSecret, err = supplements.GetTLSSecret(ctx, ds.client, supgen)
+			if err != nil {
+				return reconcile.Result{}, err
+			}
 		}
 	}
 
 	isUploaderReady, err := ds.statService.IsUploaderReady(pod, svc, ing, tlsSecret)
 	if err != nil {
-		return reconcile.Result{}, err
+		// A probe error means the public upload endpoint is not reachable yet
+		// (e.g. TLS not settled after a secret restore). Treat as not-ready and
+		// keep retrying instead of failing the reconcile with an empty status.
+		log.Error("Uploader readiness probe failed; treating uploader as not ready", "err", err)
+		isUploaderReady = false
 	}
 
 	switch {

--- a/images/virtualization-artifact/pkg/controller/service/stat_service_test.go
+++ b/images/virtualization-artifact/pkg/controller/service/stat_service_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
+	"github.com/deckhouse/virtualization-controller/pkg/common/annotations"
+)
+
+// genCert produces a self-signed certificate (also usable as its own CA) valid
+// for the given hosts (IPs vs DNS names are detected automatically).
+func genCert(hosts ...string) (tls.Certificate, []byte) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	Expect(err).NotTo(HaveOccurred())
+
+	tmpl := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: hosts[0]},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	for _, h := range hosts {
+		if ip := net.ParseIP(h); ip != nil {
+			tmpl.IPAddresses = append(tmpl.IPAddresses, ip)
+		} else {
+			tmpl.DNSNames = append(tmpl.DNSNames, h)
+		}
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &priv.PublicKey, priv)
+	Expect(err).NotTo(HaveOccurred())
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	Expect(err).NotTo(HaveOccurred())
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	tlsCert, err := tls.X509KeyPair(certPEM, keyPEM)
+	Expect(err).NotTo(HaveOccurred())
+	return tlsCert, certPEM
+}
+
+// tlsServer starts an HTTPS test server presenting cert and replying with status.
+func tlsServer(cert tls.Certificate, status int) *httptest.Server {
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+	}))
+	srv.TLS = &tls.Config{Certificates: []tls.Certificate{cert}}
+	srv.StartTLS()
+	return srv
+}
+
+func readyPod(ready bool) *corev1.Pod {
+	status := corev1.ConditionFalse
+	if ready {
+		status = corev1.ConditionTrue
+	}
+	return &corev1.Pod{
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: status}},
+		},
+	}
+}
+
+func ingWithURL(url string) *netv1.Ingress {
+	return &netv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{annotations.AnnUploadURL: url}},
+	}
+}
+
+func tlsSecret(certPEM []byte) *corev1.Secret {
+	return &corev1.Secret{Data: map[string][]byte{"tls.crt": certPEM}}
+}
+
+var _ = Describe("StatService.IsUploaderReady", func() {
+	var (
+		s   *StatService
+		svc *corev1.Service
+	)
+
+	BeforeEach(func() {
+		s = NewStatService(log.NewNop())
+		svc = &corev1.Service{}
+	})
+
+	It("returns false without probing when the pod is nil", func() {
+		ready, err := s.IsUploaderReady(nil, svc, ingWithURL("https://127.0.0.1:1/upload"), nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ready).To(BeFalse())
+	})
+
+	It("returns false without probing when the pod is not ready", func() {
+		ready, err := s.IsUploaderReady(readyPod(false), svc, ingWithURL("https://127.0.0.1:1/upload"), nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ready).To(BeFalse())
+	})
+
+	It("returns true when the endpoint serves a matching, trusted cert and 200", func() {
+		cert, certPEM := genCert("127.0.0.1")
+		srv := tlsServer(cert, http.StatusOK)
+		defer srv.Close()
+
+		ready, err := s.IsUploaderReady(readyPod(true), svc, ingWithURL(srv.URL+"/upload"), tlsSecret(certPEM))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ready).To(BeTrue())
+	})
+
+	It("returns false (no error) when the endpoint replies non-200", func() {
+		cert, certPEM := genCert("127.0.0.1")
+		srv := tlsServer(cert, http.StatusInternalServerError)
+		defer srv.Close()
+
+		ready, err := s.IsUploaderReady(readyPod(true), svc, ingWithURL(srv.URL+"/upload"), tlsSecret(certPEM))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ready).To(BeFalse())
+	})
+
+	// The production bug: ingress-nginx served a certificate valid for a different
+	// host ("ingress.local") than the upload host, so the probe fails TLS
+	// verification. The probe must surface the error rather than report ready.
+	It("returns an error when the served cert is valid for a different host", func() {
+		cert, certPEM := genCert("ingress.local")
+		srv := tlsServer(cert, http.StatusOK)
+		defer srv.Close()
+
+		// srv.URL is https://127.0.0.1:<port>, which the "ingress.local" cert does
+		// not cover, even though we trust the cert itself via the secret.
+		ready, err := s.IsUploaderReady(readyPod(true), svc, ingWithURL(srv.URL+"/upload"), tlsSecret(certPEM))
+		Expect(err).To(HaveOccurred())
+		Expect(ready).To(BeFalse())
+	})
+
+	It("falls back to the upload-path annotation when no upload URL is set", func() {
+		ing := &netv1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{annotations.AnnUploadPath: "/upload/token"}},
+		}
+		ready, err := s.IsUploaderReady(readyPod(true), svc, ing, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ready).To(BeTrue())
+	})
+})

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/interfaces.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/interfaces.go
@@ -21,6 +21,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/deckhouse/virtualization-controller/pkg/controller/supplements"
@@ -93,6 +94,9 @@ type UploadDataSourceUploaderService interface {
 	GetPod(ctx context.Context, sup supplements.Generator) (*corev1.Pod, error)
 	GetService(ctx context.Context, sup supplements.Generator) (*corev1.Service, error)
 	GetIngress(ctx context.Context, sup supplements.Generator) (*netv1.Ingress, error)
+	EnsureIngress(ctx context.Context, obj client.Object, sup supplements.Generator) (*netv1.Ingress, error)
+	IngressHostDrifted(ing *netv1.Ingress) bool
+	ExpectedIngressHost() string
 }
 
 type UploadDataSourceStatService interface {

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/mock.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/mock.go
@@ -1969,6 +1969,12 @@ var _ UploadDataSourceUploaderService = &UploadDataSourceUploaderServiceMock{}
 //			CleanUpFunc: func(ctx context.Context, sup supplements.Generator) (bool, error) {
 //				panic("mock out the CleanUp method")
 //			},
+//			EnsureIngressFunc: func(ctx context.Context, obj client.Object, sup supplements.Generator) (*netv1.Ingress, error) {
+//				panic("mock out the EnsureIngress method")
+//			},
+//			ExpectedIngressHostFunc: func() string {
+//				panic("mock out the ExpectedIngressHost method")
+//			},
 //			GetExternalURLFunc: func(ctx context.Context, ing *netv1.Ingress) string {
 //				panic("mock out the GetExternalURL method")
 //			},
@@ -1984,6 +1990,9 @@ var _ UploadDataSourceUploaderService = &UploadDataSourceUploaderServiceMock{}
 //			GetServiceFunc: func(ctx context.Context, sup supplements.Generator) (*corev1.Service, error) {
 //				panic("mock out the GetService method")
 //			},
+//			IngressHostDriftedFunc: func(ing *netv1.Ingress) bool {
+//				panic("mock out the IngressHostDrifted method")
+//			},
 //			StartFunc: func(ctx context.Context, settings *uploader.Settings, obj client.Object, sup supplements.Generator, caBundle *datasource.CABundle, opts ...service.Option) error {
 //				panic("mock out the Start method")
 //			},
@@ -1996,6 +2005,12 @@ var _ UploadDataSourceUploaderService = &UploadDataSourceUploaderServiceMock{}
 type UploadDataSourceUploaderServiceMock struct {
 	// CleanUpFunc mocks the CleanUp method.
 	CleanUpFunc func(ctx context.Context, sup supplements.Generator) (bool, error)
+
+	// EnsureIngressFunc mocks the EnsureIngress method.
+	EnsureIngressFunc func(ctx context.Context, obj client.Object, sup supplements.Generator) (*netv1.Ingress, error)
+
+	// ExpectedIngressHostFunc mocks the ExpectedIngressHost method.
+	ExpectedIngressHostFunc func() string
 
 	// GetExternalURLFunc mocks the GetExternalURL method.
 	GetExternalURLFunc func(ctx context.Context, ing *netv1.Ingress) string
@@ -2012,6 +2027,9 @@ type UploadDataSourceUploaderServiceMock struct {
 	// GetServiceFunc mocks the GetService method.
 	GetServiceFunc func(ctx context.Context, sup supplements.Generator) (*corev1.Service, error)
 
+	// IngressHostDriftedFunc mocks the IngressHostDrifted method.
+	IngressHostDriftedFunc func(ing *netv1.Ingress) bool
+
 	// StartFunc mocks the Start method.
 	StartFunc func(ctx context.Context, settings *uploader.Settings, obj client.Object, sup supplements.Generator, caBundle *datasource.CABundle, opts ...service.Option) error
 
@@ -2023,6 +2041,18 @@ type UploadDataSourceUploaderServiceMock struct {
 			Ctx context.Context
 			// Sup is the sup argument value.
 			Sup supplements.Generator
+		}
+		// EnsureIngress holds details about calls to the EnsureIngress method.
+		EnsureIngress []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Obj is the obj argument value.
+			Obj client.Object
+			// Sup is the sup argument value.
+			Sup supplements.Generator
+		}
+		// ExpectedIngressHost holds details about calls to the ExpectedIngressHost method.
+		ExpectedIngressHost []struct {
 		}
 		// GetExternalURL holds details about calls to the GetExternalURL method.
 		GetExternalURL []struct {
@@ -2059,6 +2089,11 @@ type UploadDataSourceUploaderServiceMock struct {
 			// Sup is the sup argument value.
 			Sup supplements.Generator
 		}
+		// IngressHostDrifted holds details about calls to the IngressHostDrifted method.
+		IngressHostDrifted []struct {
+			// Ing is the ing argument value.
+			Ing *netv1.Ingress
+		}
 		// Start holds details about calls to the Start method.
 		Start []struct {
 			// Ctx is the ctx argument value.
@@ -2075,13 +2110,16 @@ type UploadDataSourceUploaderServiceMock struct {
 			Opts []service.Option
 		}
 	}
-	lockCleanUp         sync.RWMutex
-	lockGetExternalURL  sync.RWMutex
-	lockGetInClusterURL sync.RWMutex
-	lockGetIngress      sync.RWMutex
-	lockGetPod          sync.RWMutex
-	lockGetService      sync.RWMutex
-	lockStart           sync.RWMutex
+	lockCleanUp             sync.RWMutex
+	lockEnsureIngress       sync.RWMutex
+	lockExpectedIngressHost sync.RWMutex
+	lockGetExternalURL      sync.RWMutex
+	lockGetInClusterURL     sync.RWMutex
+	lockGetIngress          sync.RWMutex
+	lockGetPod              sync.RWMutex
+	lockGetService          sync.RWMutex
+	lockIngressHostDrifted  sync.RWMutex
+	lockStart               sync.RWMutex
 }
 
 // CleanUp calls CleanUpFunc.
@@ -2117,6 +2155,73 @@ func (mock *UploadDataSourceUploaderServiceMock) CleanUpCalls() []struct {
 	mock.lockCleanUp.RLock()
 	calls = mock.calls.CleanUp
 	mock.lockCleanUp.RUnlock()
+	return calls
+}
+
+// EnsureIngress calls EnsureIngressFunc.
+func (mock *UploadDataSourceUploaderServiceMock) EnsureIngress(ctx context.Context, obj client.Object, sup supplements.Generator) (*netv1.Ingress, error) {
+	if mock.EnsureIngressFunc == nil {
+		panic("UploadDataSourceUploaderServiceMock.EnsureIngressFunc: method is nil but UploadDataSourceUploaderService.EnsureIngress was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+		Obj client.Object
+		Sup supplements.Generator
+	}{
+		Ctx: ctx,
+		Obj: obj,
+		Sup: sup,
+	}
+	mock.lockEnsureIngress.Lock()
+	mock.calls.EnsureIngress = append(mock.calls.EnsureIngress, callInfo)
+	mock.lockEnsureIngress.Unlock()
+	return mock.EnsureIngressFunc(ctx, obj, sup)
+}
+
+// EnsureIngressCalls gets all the calls that were made to EnsureIngress.
+// Check the length with:
+//
+//	len(mockedUploadDataSourceUploaderService.EnsureIngressCalls())
+func (mock *UploadDataSourceUploaderServiceMock) EnsureIngressCalls() []struct {
+	Ctx context.Context
+	Obj client.Object
+	Sup supplements.Generator
+} {
+	var calls []struct {
+		Ctx context.Context
+		Obj client.Object
+		Sup supplements.Generator
+	}
+	mock.lockEnsureIngress.RLock()
+	calls = mock.calls.EnsureIngress
+	mock.lockEnsureIngress.RUnlock()
+	return calls
+}
+
+// ExpectedIngressHost calls ExpectedIngressHostFunc.
+func (mock *UploadDataSourceUploaderServiceMock) ExpectedIngressHost() string {
+	if mock.ExpectedIngressHostFunc == nil {
+		panic("UploadDataSourceUploaderServiceMock.ExpectedIngressHostFunc: method is nil but UploadDataSourceUploaderService.ExpectedIngressHost was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockExpectedIngressHost.Lock()
+	mock.calls.ExpectedIngressHost = append(mock.calls.ExpectedIngressHost, callInfo)
+	mock.lockExpectedIngressHost.Unlock()
+	return mock.ExpectedIngressHostFunc()
+}
+
+// ExpectedIngressHostCalls gets all the calls that were made to ExpectedIngressHost.
+// Check the length with:
+//
+//	len(mockedUploadDataSourceUploaderService.ExpectedIngressHostCalls())
+func (mock *UploadDataSourceUploaderServiceMock) ExpectedIngressHostCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockExpectedIngressHost.RLock()
+	calls = mock.calls.ExpectedIngressHost
+	mock.lockExpectedIngressHost.RUnlock()
 	return calls
 }
 
@@ -2297,6 +2402,38 @@ func (mock *UploadDataSourceUploaderServiceMock) GetServiceCalls() []struct {
 	mock.lockGetService.RLock()
 	calls = mock.calls.GetService
 	mock.lockGetService.RUnlock()
+	return calls
+}
+
+// IngressHostDrifted calls IngressHostDriftedFunc.
+func (mock *UploadDataSourceUploaderServiceMock) IngressHostDrifted(ing *netv1.Ingress) bool {
+	if mock.IngressHostDriftedFunc == nil {
+		panic("UploadDataSourceUploaderServiceMock.IngressHostDriftedFunc: method is nil but UploadDataSourceUploaderService.IngressHostDrifted was just called")
+	}
+	callInfo := struct {
+		Ing *netv1.Ingress
+	}{
+		Ing: ing,
+	}
+	mock.lockIngressHostDrifted.Lock()
+	mock.calls.IngressHostDrifted = append(mock.calls.IngressHostDrifted, callInfo)
+	mock.lockIngressHostDrifted.Unlock()
+	return mock.IngressHostDriftedFunc(ing)
+}
+
+// IngressHostDriftedCalls gets all the calls that were made to IngressHostDrifted.
+// Check the length with:
+//
+//	len(mockedUploadDataSourceUploaderService.IngressHostDriftedCalls())
+func (mock *UploadDataSourceUploaderServiceMock) IngressHostDriftedCalls() []struct {
+	Ing *netv1.Ingress
+} {
+	var calls []struct {
+		Ing *netv1.Ingress
+	}
+	mock.lockIngressHostDrifted.RLock()
+	calls = mock.calls.IngressHostDrifted
+	mock.lockIngressHostDrifted.RUnlock()
 	return calls
 }
 

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/step/wait_for_user_upload_step.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/step/wait_for_user_upload_step.go
@@ -34,6 +34,7 @@ import (
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/supplements"
 	vdsupplements "github.com/deckhouse/virtualization-controller/pkg/controller/vd/internal/supplements"
+	"github.com/deckhouse/virtualization-controller/pkg/logger"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
 )
@@ -108,7 +109,11 @@ func (s WaitForUserUploadStep) Take(ctx context.Context, vd *v1alpha2.VirtualDis
 
 	isUploaderReady, err := s.stat.IsUploaderReady(s.pod, s.svc, s.ing, tlsSecret)
 	if err != nil {
-		return nil, fmt.Errorf("check uploader readiness: %w", err)
+		// A probe error means the public upload endpoint is not reachable yet
+		// (e.g. TLS not settled after a secret restore). Treat as not-ready and
+		// keep retrying instead of failing the reconcile with an empty status.
+		logger.FromContext(ctx).Error("Uploader readiness probe failed; treating uploader as not ready", "err", err)
+		isUploaderReady = false
 	}
 
 	if isUploaderReady {

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/upload.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/upload.go
@@ -26,6 +26,7 @@ import (
 	"github.com/deckhouse/virtualization-controller/pkg/common/steptaker"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/service"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/supplements"
 	"github.com/deckhouse/virtualization-controller/pkg/controller/vd/internal/source/step"
 	vdsupplements "github.com/deckhouse/virtualization-controller/pkg/controller/vd/internal/supplements"
 	"github.com/deckhouse/virtualization-controller/pkg/dvcr"
@@ -94,6 +95,30 @@ func (ds UploadDataSource) Sync(ctx context.Context, vd *v1alpha2.VirtualDisk) (
 	}
 	if pvc != nil {
 		ctx = logger.ToContext(ctx, log.With("pvc.name", pvc.Name, "pvc.status.phase", pvc.Status.Phase))
+	}
+
+	tlsSecret, err := supplements.GetTLSSecret(ctx, ds.client, supgen.Generator)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("fetch uploader tls secret: %w", err)
+	}
+
+	// Reconcile the uploader Ingress and its TLS secret before the readiness probe.
+	// All uploaders share one public host: if the Ingress host drifts (e.g. after
+	// publicDomainTemplate changed) or its copied TLS secret goes missing,
+	// ingress-nginx serves its default certificate for the whole host and every
+	// upload on it breaks. IsUploaderReady HTTPS-probes that host, so restore both
+	// first. Initial creation is handled by Start, so skip when the pod is absent.
+	tlsCopyMissing := tlsSecret == nil && supplements.ShouldCopyUploaderTLSSecret(ds.dvcrSettings, supgen.Generator)
+	if pod != nil && (ds.uploaderService.IngressHostDrifted(ing) || tlsCopyMissing) {
+		var oldHost string
+		if ing != nil && len(ing.Spec.Rules) > 0 {
+			oldHost = ing.Spec.Rules[0].Host
+		}
+		log.Info("Reconciling uploader Ingress", "hostDrifted", ds.uploaderService.IngressHostDrifted(ing), "tlsSecretMissing", tlsCopyMissing, "old", oldHost, "new", ds.uploaderService.ExpectedIngressHost())
+		ing, err = ds.uploaderService.EnsureIngress(ctx, vd, supgen)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
 	}
 
 	return steptaker.NewStepTakers[*v1alpha2.VirtualDisk](

--- a/images/virtualization-artifact/pkg/controller/vd/internal/source/upload_test.go
+++ b/images/virtualization-artifact/pkg/controller/vd/internal/source/upload_test.go
@@ -136,12 +136,17 @@ var _ = Describe("UploadDataSource", func() {
 		}
 
 		uploaderSvc = &UploadDataSourceUploaderServiceMock{
-			GetPodFunc:          func(_ context.Context, _ supplements.Generator) (*corev1.Pod, error) { return nil, nil },
-			GetServiceFunc:      func(_ context.Context, _ supplements.Generator) (*corev1.Service, error) { return nil, nil },
-			GetIngressFunc:      func(_ context.Context, _ supplements.Generator) (*netv1.Ingress, error) { return nil, nil },
-			CleanUpFunc:         func(_ context.Context, _ supplements.Generator) (bool, error) { return false, nil },
-			GetExternalURLFunc:  func(_ context.Context, _ *netv1.Ingress) string { return "https://upload.example.com" },
-			GetInClusterURLFunc: func(_ context.Context, _ *corev1.Service) string { return "http://upload.svc/upload" },
+			GetPodFunc:              func(_ context.Context, _ supplements.Generator) (*corev1.Pod, error) { return nil, nil },
+			GetServiceFunc:          func(_ context.Context, _ supplements.Generator) (*corev1.Service, error) { return nil, nil },
+			GetIngressFunc:          func(_ context.Context, _ supplements.Generator) (*netv1.Ingress, error) { return nil, nil },
+			CleanUpFunc:             func(_ context.Context, _ supplements.Generator) (bool, error) { return false, nil },
+			GetExternalURLFunc:      func(_ context.Context, _ *netv1.Ingress) string { return "https://upload.example.com" },
+			GetInClusterURLFunc:     func(_ context.Context, _ *corev1.Service) string { return "http://upload.svc/upload" },
+			IngressHostDriftedFunc:  func(_ *netv1.Ingress) bool { return false },
+			ExpectedIngressHostFunc: func() string { return "upload.example.com" },
+			EnsureIngressFunc: func(_ context.Context, _ client.Object, _ supplements.Generator) (*netv1.Ingress, error) {
+				return nil, nil
+			},
 		}
 
 		stat = &UploadDataSourceStatServiceMock{
@@ -252,6 +257,20 @@ var _ = Describe("UploadDataSource", func() {
 		It("reports Provisioning while the uploader is not yet ready", func() {
 			stat.IsUploaderReadyFunc = func(_ *corev1.Pod, _ *corev1.Service, _ *netv1.Ingress, _ *corev1.Secret) (bool, error) {
 				return false, nil
+			}
+
+			cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+			res, err := newSyncer(cl).Sync(ctx, vd)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.RequeueAfter).ToNot(BeZero())
+
+			Expect(vd.Status.Phase).To(Equal(v1alpha2.DiskProvisioning))
+			ExpectCondition(vd, metav1.ConditionFalse, vdcondition.Provisioning, true)
+		})
+
+		It("treats a readiness probe error as not-ready instead of failing the reconcile", func() {
+			stat.IsUploaderReadyFunc = func(_ *corev1.Pod, _ *corev1.Service, _ *netv1.Ingress, _ *corev1.Secret) (bool, error) {
+				return false, errors.New("tls handshake failed")
 			}
 
 			cl := fake.NewClientBuilder().WithScheme(scheme).Build()

--- a/images/virtualization-artifact/pkg/controller/vi/internal/source/upload.go
+++ b/images/virtualization-artifact/pkg/controller/vi/internal/source/upload.go
@@ -103,25 +103,38 @@ func (ds UploadDataSource) StoreToPVC(ctx context.Context, vi *v1alpha2.VirtualI
 		return reconcile.Result{}, err
 	}
 
-	// Sync the uploader Ingress host before the readiness probe:
-	// IsUploaderReady HTTPS-probes the Ingress host, so a stale host (e.g. after
-	// publicDomainTemplate changed) makes readiness fail with a TLS error.
-	// Initial creation is handled by Start, so skip when the pod is absent.
-	if pod != nil && ds.uploaderService.IngressHostDrifted(ing) {
+	// Reconcile the uploader Ingress and its TLS secret before the readiness probe.
+	// All uploaders share one public host: if the Ingress host drifts (e.g. after
+	// publicDomainTemplate changed) or its copied TLS secret goes missing,
+	// ingress-nginx serves its default certificate for the whole host and every
+	// upload on it breaks. IsUploaderReady HTTPS-probes that host, so restore both
+	// first. Initial creation is handled by Start, so skip when the pod is absent.
+	tlsCopyMissing := tlsSecret == nil && supplements.ShouldCopyUploaderTLSSecret(ds.dvcrSettings, supgen)
+	if pod != nil && (ds.uploaderService.IngressHostDrifted(ing) || tlsCopyMissing) {
 		var oldHost string
 		if ing != nil && len(ing.Spec.Rules) > 0 {
 			oldHost = ing.Spec.Rules[0].Host
 		}
-		log.Info("Syncing uploader Ingress: host drifted", "old", oldHost, "new", ds.uploaderService.ExpectedIngressHost())
+		log.Info("Reconciling uploader Ingress", "hostDrifted", ds.uploaderService.IngressHostDrifted(ing), "tlsSecretMissing", tlsCopyMissing, "old", oldHost, "new", ds.uploaderService.ExpectedIngressHost())
 		ing, err = ds.uploaderService.EnsureIngress(ctx, vi, supgen)
 		if err != nil {
 			return reconcile.Result{}, err
+		}
+		if tlsCopyMissing {
+			tlsSecret, err = supplements.GetTLSSecret(ctx, ds.client, supgen)
+			if err != nil {
+				return reconcile.Result{}, err
+			}
 		}
 	}
 
 	isUploaderReady, err := ds.statService.IsUploaderReady(pod, svc, ing, tlsSecret)
 	if err != nil {
-		return reconcile.Result{}, err
+		// A probe error means the public upload endpoint is not reachable yet
+		// (e.g. TLS not settled after a secret restore). Treat as not-ready and
+		// keep retrying instead of failing the reconcile with an empty status.
+		log.Error("Uploader readiness probe failed; treating uploader as not ready", "err", err)
+		isUploaderReady = false
 	}
 
 	switch {
@@ -267,25 +280,38 @@ func (ds UploadDataSource) StoreToDVCR(ctx context.Context, vi *v1alpha2.Virtual
 		return reconcile.Result{}, err
 	}
 
-	// Sync the uploader Ingress host before the readiness probe:
-	// IsUploaderReady HTTPS-probes the Ingress host, so a stale host (e.g. after
-	// publicDomainTemplate changed) makes readiness fail with a TLS error.
-	// Initial creation is handled by Start, so skip when the pod is absent.
-	if pod != nil && ds.uploaderService.IngressHostDrifted(ing) {
+	// Reconcile the uploader Ingress and its TLS secret before the readiness probe.
+	// All uploaders share one public host: if the Ingress host drifts (e.g. after
+	// publicDomainTemplate changed) or its copied TLS secret goes missing,
+	// ingress-nginx serves its default certificate for the whole host and every
+	// upload on it breaks. IsUploaderReady HTTPS-probes that host, so restore both
+	// first. Initial creation is handled by Start, so skip when the pod is absent.
+	tlsCopyMissing := tlsSecret == nil && supplements.ShouldCopyUploaderTLSSecret(ds.dvcrSettings, supgen)
+	if pod != nil && (ds.uploaderService.IngressHostDrifted(ing) || tlsCopyMissing) {
 		var oldHost string
 		if ing != nil && len(ing.Spec.Rules) > 0 {
 			oldHost = ing.Spec.Rules[0].Host
 		}
-		log.Info("Syncing uploader Ingress: host drifted", "old", oldHost, "new", ds.uploaderService.ExpectedIngressHost())
+		log.Info("Reconciling uploader Ingress", "hostDrifted", ds.uploaderService.IngressHostDrifted(ing), "tlsSecretMissing", tlsCopyMissing, "old", oldHost, "new", ds.uploaderService.ExpectedIngressHost())
 		ing, err = ds.uploaderService.EnsureIngress(ctx, vi, supgen)
 		if err != nil {
 			return reconcile.Result{}, err
+		}
+		if tlsCopyMissing {
+			tlsSecret, err = supplements.GetTLSSecret(ctx, ds.client, supgen)
+			if err != nil {
+				return reconcile.Result{}, err
+			}
 		}
 	}
 
 	isUploaderReady, err := ds.statService.IsUploaderReady(pod, svc, ing, tlsSecret)
 	if err != nil {
-		return reconcile.Result{}, err
+		// A probe error means the public upload endpoint is not reachable yet
+		// (e.g. TLS not settled after a secret restore). Treat as not-ready and
+		// keep retrying instead of failing the reconcile with an empty status.
+		log.Error("Uploader readiness probe failed; treating uploader as not ready", "err", err)
+		isUploaderReady = false
 	}
 
 	switch {


### PR DESCRIPTION
## Description

Uploading an image or disk (a `VirtualImage`, `ClusterVirtualImage`, or `VirtualDisk` with an `Upload` data source) could hang forever in `Pending` with an empty status and no upload URL, so the image simply could not be uploaded.

It happened when the shared upload host started serving an invalid TLS certificate — for example after another, broken upload resource left the host serving a default self-signed certificate. In that state every upload on the cluster was blocked, not just the broken one, and recovery required manually finding and deleting the offending resource.

The controller now restores the upload host certificate on its own during reconcile, so affected uploads recover automatically, and a not-yet-ready upload endpoint no longer leaves the resource with an empty status.

This PR also restores a disk-specific regression: a recent refactor of the `VirtualDisk` upload flow dropped the upload-host self-healing for disks, so after the upload host changed (for example when `publicDomainTemplate` was updated) an in-flight disk upload could get stuck. The self-healing is reinstated for disks, matching how images already behave.

## Why do we need it, and what problem does it solve?

One abandoned or broken upload resource could silently break image and disk uploads across the whole cluster, with nothing in the resource status explaining why. Admins had to locate and delete the offending resource by hand. This change makes uploads self-heal and makes the failure state visible to the user.

## What is the expected result?

1. Create a `VirtualImage` (or `VirtualDisk`) with `dataSource.type: Upload` — it reaches `WaitForUserUpload` with a working upload URL.
2. If the shared upload host's TLS certificate goes missing/invalid, the affected resources recover automatically within a few reconciles instead of staying stuck in `Pending`.
3. If the upload host changes (for example after `publicDomainTemplate` is updated), in-flight upload disks follow the new host and recover automatically.
4. While the upload endpoint is not ready, the resource status shows a non-empty message instead of being empty.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: images
type: fix
summary: "Upload-type VirtualImage and ClusterVirtualImage no longer get stuck in Pending when the shared upload host certificate becomes invalid."
---
section: disks
type: fix
summary: "Upload-type VirtualDisk no longer gets stuck in Pending when the shared upload host certificate becomes invalid."
---
section: disks
type: fix
summary: "Upload-type VirtualDisk again recovers automatically when the upload host changes, for example after publicDomainTemplate is updated."
```
