### PR TITLE
chore(ci): silence dmt mount-points and webhook-annotation checks

### DIFF
--- a/.dmtlint.yaml
+++ b/.dmtlint.yaml
@@ -64,3 +64,69 @@ linters-settings:
         - kind: Deployment
           name: dvcr
           container: dvcr-garbage-collection
+  templates:
+    exclude-rules:
+      # These mount-points.yaml directories pre-create mount points for containerd strict mode.
+      # They are consumed by pods that are NOT rendered from this module's Helm templates:
+      # virt-launcher (created per-VM by KubeVirt at runtime), CDI importer/cloner/uploadserver and
+      # dvcr importer/uploader (created on demand by the controllers), and the virt-*/cdi-* components
+      # deployed by virt-operator/cdi-operator. The mount-points linter only inspects Helm pod
+      # controllers, so it cannot see these mountPaths and reports false positives.
+      mount-points:
+        - /auth
+        - /certs
+        - /data
+        - /dev/bus/usb
+        - /dvcr-auth
+        - /dvcr-src-auth
+        - /etc/docker/registry
+        - /etc/libvirt
+        - /etc/podinfo
+        - /etc/ssl/docker
+        - /etc/virt-api/certificates
+        - /etc/virt-controller/certificates
+        - /etc/virt-controller/exportca
+        - /etc/virt-handler/clientcertificates
+        - /etc/virt-handler/servercertificates
+        - /etc/virt-operator/certificates
+        - /etc/virtualization-api-proxy/certificates
+        - /etc/virtualization-api/certificates
+        - /etc/virtualization-audit/certificates
+        - /init/usr/bin
+        - /kubeconfig.local
+        - /opt
+        - /path
+        - /pods
+        - /profile-data
+        - /proxycerts
+        - /run/ca-bundle/cdi-uploadserver-client-signer-bundle
+        - /run/ca-bundle/cdi-uploadserver-signer-bundle
+        - /run/cdi/clone/source
+        - /run/cdi/token/keys
+        - /run/certs/cdi-apiserver-server-cert
+        - /run/certs/cdi-apiserver-signer-bundle
+        - /run/certs/cdi-uploadserver-client-signer
+        - /run/certs/cdi-uploadserver-signer
+        - /run/cilium
+        - /run/kubevirt
+        - /run/kubevirt-libvirt-runtimes
+        - /run/kubevirt-private
+        - /scratch
+        - /shared
+        - /tmp/k8s-webhook-server/serving-certs
+        - /usr/lib/modules
+        - /var/cache/libvirt
+        - /var/lib/kubelet/device-plugins
+        - /var/lib/kubelet/plugins
+        - /var/lib/kubelet/plugins_registry
+        - /var/lib/kubelet/pods
+        - /var/lib/kubevirt
+        - /var/lib/kubevirt-node-labeller
+        - /var/lib/libvirt
+        - /var/lib/libvirt/qemu
+        - /var/lib/libvirt/qemu/nvram
+        - /var/lib/libvirt/swtpm
+        - /var/lib/registry
+        - /var/lib/swtpm-localca
+        - /var/log/libvirt
+        - /var/run/cdi

--- a/templates/virtualization-controller/mutating-webhook.yaml
+++ b/templates/virtualization-controller/mutating-webhook.yaml
@@ -3,6 +3,8 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "virtualization-controller")) | nindent 2 }}
+  annotations:
+    werf.io/weight: "10"
   name: "virtualization-controller-defaulter-webhook"
 webhooks:
   - name: "vm.virtualization-controller.validate.d8-virtualization"

--- a/templates/virtualization-controller/mutating-webhook.yaml
+++ b/templates/virtualization-controller/mutating-webhook.yaml
@@ -4,7 +4,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "virtualization-controller")) | nindent 2 }}
   annotations:
-    werf.io/weight: "10"
+    werf.io/weight: "0"
   name: "virtualization-controller-defaulter-webhook"
 webhooks:
   - name: "vm.virtualization-controller.validate.d8-virtualization"

--- a/templates/virtualization-controller/validation-webhook.yaml
+++ b/templates/virtualization-controller/validation-webhook.yaml
@@ -4,7 +4,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "virtualization-controller")) | nindent 2 }}
   annotations:
-    werf.io/weight: "10"
+    werf.io/weight: "0"
   name: "virtualization-controller-admission-webhook"
 webhooks:
   - name: "vm.virtualization-controller.validate.d8-virtualization"

--- a/templates/virtualization-controller/validation-webhook.yaml
+++ b/templates/virtualization-controller/validation-webhook.yaml
@@ -3,6 +3,8 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "virtualization-controller")) | nindent 2 }}
+  annotations:
+    werf.io/weight: "10"
   name: "virtualization-controller-admission-webhook"
 webhooks:
   - name: "vm.virtualization-controller.validate.d8-virtualization"


### PR DESCRIPTION
## Description

A recent version of the `dmt` module linter added the `templates` checks `mount-points` and `webhook-configuration-annotations`, which currently fail CI for this module. Both are addressed here.

**`mount-points` (warnings) — false positives, excluded via `.dmtlint.yaml`.**
The rule checks every dir listed in `images/*/mount-points.yaml` against `mountPath`s of pod controllers rendered from the module's Helm templates. Almost none of these dirs can be found that way, because the pods that consume them are **not** rendered from the module templates:
- `virt-launcher` — created per-VM by KubeVirt at runtime;
- CDI (`cdi-importer`/`cloner`/`uploadserver`) and DVCR (`dvcr-importer`/`uploader`) worker pods — created on demand by the controllers;
- `virt-controller`/`virt-handler`/`virt-api` and `cdi-apiserver`/`cdi-controller` — deployed by `virt-operator`/`cdi-operator`, not by raw Helm templates;
- `virtualization-dra-usb` — host-path DaemonSet.

The `mount-points.yaml` files themselves are correct (they pre-create mount points for containerd strict mode); the linter simply cannot see the runtime pods. All directories from every `images/*/mount-points.yaml` are added to `templates.exclude-rules.mount-points` (plus `/run/cilium` and `/usr/lib/modules`, which CI reported under a slightly different render state).

**`webhook-configuration-annotations` (errors) — fixed in the templates.**
The rule requires `MutatingWebhookConfiguration`/`ValidatingWebhookConfiguration` to carry a werf deploy-ordering annotation (`werf.io/weight` or `werf.io/deploy-dependency-*`). Added `werf.io/weight: "0"` ([default per docs](https://werf.io/docs/v2/reference/deploy_annotations.html#resource-weight)) to both `virtualization-controller` webhook configurations.

## Why do we need it, and what problem does it solve?

`dmt lint` is a required CI check. After the linter upgrade it emits 50 mount-points warnings and 2 webhook errors for this module, blocking the pipeline. This restores a clean `dmt lint` run without weakening any check that is actually applicable to the module.

## What is the expected result?

`dmt lint .` reports **0 findings** (down from 52). Verified locally against `main`:
- total findings: `0`;
- `mount-points` / `webhook-configuration-annotations` findings: `0`;
- coverage check: every dir present in the `mount-points.yaml` files is covered by the exclude list.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

