### PR TITLE
fix(vm): dynamic domain wait timeout

### DIFF
--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -3,7 +3,7 @@ firmware:
   libvirt: v10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: v1.6.2-v12n.58
+  3p-kubevirt: v1.6.2-v12n.59
   distribution: 3.1.1
 package:
   acl: v2.3.1


### PR DESCRIPTION
## Description

Under inbound-slot contention the migration target's virt-launcher panicked with `timed out waiting for domain to be defined` (~240–360s) and an otherwise valid live migration failed. While a migration waits for a free inbound slot, the target had no domain defined yet, so its fixed domain-wait deadline expired.

This bumps `3p-kubevirt` to `v1.6.2-v12n.59`, which keeps the target's domain-wait alive while the migration is held by the inbound migration limiter. The deadline is extended only by an explicit keepalive and is bounded by a hard ceiling, so ordinary requests don't reset it and a genuinely stuck target still times out.

## Why do we need it, and what problem does it solve?

Live migrations that had to queue for an inbound slot were failing by target timeout instead of proceeding once a slot freed up. Users saw valid migrations fail under contention.

## What is the expected result?

Migrations that wait for an inbound slot succeed instead of failing by target timeout; existing migration e2e stays green.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: vm
type: fix
summary: "Live migrations no longer fail by target timeout while waiting for a free inbound migration slot."
```
