### PR TITLE
test(test): add iperf migration continuity checks to release e2e

### DIFF
--- a/test/e2e/release/current_release_smoke.go
+++ b/test/e2e/release/current_release_smoke.go
@@ -203,7 +203,8 @@ func (t *currentReleaseSmokeTest) verifyIPerfContinuityAfterUpgrade() {
 	stopIPerfClient(t.framework, t.iperfClient.vm)
 
 	By("Validating the iperf report spans the module upgrade")
-	report := getIPerfClientReport(t.framework, t.iperfClient.vm, releaseIPerfReportPath)
+	iperfServer := t.getVirtualMachine(t.iperfServer.vm.Name, t.iperfServer.vm.Namespace)
+	report := getIPerfClientReport(t.framework, t.iperfClient.vm, releaseIPerfReportPath, iperfServer)
 	Expect(isExpectedIPerfReportError(report.Error)).To(BeTrue(), "iperf3 report contains an unexpected error: %q", report.Error)
 
 	upgradeStartedAt, err := strconv.ParseInt(mustGetEnv(releaseUpgradeStartedAtEnv), 10, 64)

--- a/test/e2e/release/iperf.go
+++ b/test/e2e/release/iperf.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -116,7 +117,7 @@ func stopIPerfClient(f *framework.Framework, vm *v1alpha2.VirtualMachine) {
 	}).WithTimeout(framework.MiddleTimeout).WithPolling(framework.PollingInterval).Should(Succeed())
 }
 
-func getIPerfClientReport(f *framework.Framework, vm *v1alpha2.VirtualMachine, reportPath string) *iperfReport {
+func getIPerfClientReport(f *framework.Framework, vm *v1alpha2.VirtualMachine, reportPath string, iperfServer *v1alpha2.VirtualMachine) *iperfReport {
 	GinkgoHelper()
 
 	command := fmt.Sprintf("cat %s", reportPath)
@@ -138,6 +139,24 @@ func getIPerfClientReport(f *framework.Framework, vm *v1alpha2.VirtualMachine, r
 	}).WithTimeout(framework.LongTimeout).WithPolling(framework.PollingInterval).Should(Succeed())
 
 	Expect(result).NotTo(BeNil())
+
+	iPerfClientStartTime, err := time.Parse(time.RFC1123, result.Start.Timestamp.Time)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(iPerfClientStartTime.Before(iperfServer.Status.MigrationState.StartTimestamp.Time)).To(BeTrue(), "the iPerfClient connection test should start before the virtual machine is migrated")
+
+	iPerfClientEndTimeSec := int64(result.Start.Timestamp.Timesecs) + int64(result.End.SumSent.End)
+	iPerfClientEndTimeNSec := int64((result.End.SumSent.End - float64(int64(result.End.SumSent.End))) * 1e9)
+	iPerfClientEndTime := time.Unix(iPerfClientEndTimeSec, iPerfClientEndTimeNSec).UTC()
+	Expect(iPerfClientEndTime.After(iperfServer.Status.MigrationState.EndTimestamp.Time)).To(BeTrue(), "the iPerfClient connection test should stop after the virtual machine is migrated")
+
+	zeroBytesIntervalCounter := 0
+	for _, i := range result.Intervals {
+		if i.Sum.Bytes == 0 {
+			zeroBytesIntervalCounter++
+		}
+	}
+	Expect(zeroBytesIntervalCounter).To(BeNumerically("<=", 1), "there should not be more than one zero-byte interval during the migration process")
+
 	return result
 }
 


### PR DESCRIPTION
The release test confirmed that iperf kept running across the upgrade, the added checks make the test actually prove the TCP session was not interrupted by the migration.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

```changes
section: test
type: feature
summary: "The release upgrade e2e test now verifies that a long-running TCP session survives virtual machine live migration during the module upgrade."
impact_level: low
```
