### PR TITLE
fix(virt-handler): release migration proxy ports when target VMI vanishes

### DIFF
--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -3,7 +3,7 @@ firmware:
   libvirt: v10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: v1.6.2-v12n.54
+  3p-kubevirt: fix/volume-umount-retries
   3p-containerized-data-importer: v1.60.3-v12n.21
   distribution: 3.1.1
 package:

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -15,6 +15,8 @@ secrets:
 shell:
   install:
   - |
+    echo 'Cache bust install: {{ now | date "Mon Jan 2 15:04:05 MST 2006" }}'
+  - |
     echo "Git clone {{ $gitRepoName }} repository..."
     git clone --depth=1 $(cat /run/secrets/SOURCE_REPO)/{{ $gitRepoUrl }} --branch {{ $tag }} /src/kubevirt
 
@@ -68,6 +70,8 @@ shell:
 
   install:
   - |
+    echo 'Cache bust install: {{ now | date "Mon Jan 2 15:04:05 MST 2006" }}'
+  - |
     # Install packages
     PKGS="{{ $builderDependencies.packages | join " " }}"
     for pkg in $PKGS; do
@@ -87,6 +91,7 @@ shell:
     done
 
   setup:
+    - echo 'Cache bust setup: {{ now | date "Mon Jan 2 15:04:05 MST 2006" }}'
     - mkdir /kubevirt-binaries
     - mkdir /kubevirt-config-files
     - cd /kubevirt


### PR DESCRIPTION
## Description
virt-handler's migration-proxy port pool (`--migration-port-range 4135-4199`, 65 ports per node, up to 4 per incoming migration) leaks: target proxies are only released in `finalCleanup` on the target node, which never runs if the VMI is deleted or turns final before target-side finalization. The `execute()` early-return branches and the label-filtered informer drop the VMI without calling `StopTargetListener`, so every migration canceled or failed mid-flight leaks up to 4 listening ports.

3p-kubevirt (`fix/volume-umount-retries`, commit 6bf6198b42) now stops the target listener and cleans conntrack state in the best-effort cleanup branch of `execute()` and in the informer `deleteFunc`, which still sees the VMI UID both when the VMI is deleted and when the target label is removed after an abort.

This PR points `versions.yml` at the 3p-kubevirt working branch and adds the werf cache-bust lines so CI re-clones and rebuilds the kubevirt image while the ref is a moving branch.

## Why do we need it, and what problem does it solve?
After ~16 leaked migrations a node rejects ALL incoming migrations: virt-handler loops `not enough ports available for starting 4 migration proxies`, the target virt-launcher panics after ~5 min (`timed out waiting for domain to be defined`), and every migration targeting the node fails with `target pod shutdown during migration` (misreported as `TargetDiskError`). Reproduced on virtlab-rd-2 with 64/65 ports leaked by e2e suites that intentionally cancel migrations; e2e migration tests flaked cluster-wide until virt-handler was restarted.

## What is the expected result?
Canceled/failed migrations release their proxy ports on the target node. `ss -tln | grep -cE ':41[3-9][0-9] '` on a node stays near zero when no migrations are in flight, and e2e volume-migration suites no longer cascade into `target pod shutdown during migration` failures after revert tests.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: vm
type: fix
summary: "Live migrations no longer permanently fail on a node after canceled or interrupted migrations exhaust virt-handler's migration proxy port pool."
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)