### PR TITLE
fix(vi): attach PVC-backed images to VMs in read-only mode

### DIFF
--- a/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/add_volume.go
+++ b/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/add_volume.go
@@ -141,10 +141,16 @@ func (r AddVolumeREST) genMutateRequestHook(opts *subresources.VirtualMachineAdd
 		case opts.PVCName != "" && opts.Image != "":
 			return nil, fmt.Errorf("must specify only one of PersistentVolumeClaimName or Image")
 		case opts.PVCName != "":
+			// Images are immutable: a PVC-backed image should be read-only inside the VM,
+			// like a registry-backed image (ContainerDisk is always read-only).
+			if dd.Disk != nil {
+				dd.Disk.ReadOnly = true
+			}
 			hotplugRequest.VolumeSource = &virtv1.HotplugVolumeSource{
 				PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{
 					PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
 						ClaimName: opts.PVCName,
+						ReadOnly:  true,
 					},
 					Hotpluggable: true,
 				},

--- a/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/add_volume_test.go
+++ b/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/add_volume_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	virtv1 "kubevirt.io/api/core/v1"
+
+	"github.com/deckhouse/virtualization/api/subresources"
+)
+
+var _ = Describe("AddVolumeREST.genMutateRequestHook", func() {
+	mutate := func(opts *subresources.VirtualMachineAddVolume) virtv1.AddVolumeOptions {
+		hook, err := AddVolumeREST{}.genMutateRequestHook(opts)
+		Expect(err).NotTo(HaveOccurred())
+
+		req := httptest.NewRequest(http.MethodPut, "/", strings.NewReader("{}"))
+		Expect(hook(req)).To(Succeed())
+
+		body, err := io.ReadAll(req.Body)
+		Expect(err).NotTo(HaveOccurred())
+
+		var hotplugRequest virtv1.AddVolumeOptions
+		Expect(json.Unmarshal(body, &hotplugRequest)).To(Succeed())
+		return hotplugRequest
+	}
+
+	It("hotplugs a PVC-backed VirtualImage as a read-only disk", func() {
+		hotplugRequest := mutate(&subresources.VirtualMachineAddVolume{
+			Name:       "vi-image",
+			VolumeKind: "VirtualImage",
+			PVCName:    "vi-pvc",
+		})
+
+		Expect(hotplugRequest.Disk.DiskDevice.Disk).NotTo(BeNil())
+		Expect(hotplugRequest.Disk.DiskDevice.Disk.ReadOnly).To(BeTrue())
+
+		pvc := hotplugRequest.VolumeSource.PersistentVolumeClaim
+		Expect(pvc).NotTo(BeNil())
+		Expect(pvc.ClaimName).To(Equal("vi-pvc"))
+		Expect(pvc.ReadOnly).To(BeTrue())
+		Expect(pvc.Hotpluggable).To(BeTrue())
+	})
+
+	It("hotplugs an ISO PVC-backed VirtualImage as a cdrom with a read-only PVC", func() {
+		hotplugRequest := mutate(&subresources.VirtualMachineAddVolume{
+			Name:       "vi-image",
+			VolumeKind: "VirtualImage",
+			PVCName:    "vi-pvc",
+			IsCdrom:    true,
+		})
+
+		Expect(hotplugRequest.Disk.DiskDevice.CDRom).NotTo(BeNil())
+		Expect(hotplugRequest.Disk.DiskDevice.Disk).To(BeNil())
+
+		pvc := hotplugRequest.VolumeSource.PersistentVolumeClaim
+		Expect(pvc).NotTo(BeNil())
+		Expect(pvc.ReadOnly).To(BeTrue())
+	})
+
+	It("hotplugs a registry-backed VirtualImage as a container disk", func() {
+		hotplugRequest := mutate(&subresources.VirtualMachineAddVolume{
+			Name:       "vi-image",
+			VolumeKind: "VirtualImage",
+			Image:      "dvcr.example/vi:tag",
+		})
+
+		Expect(hotplugRequest.Disk.DiskDevice.Disk).NotTo(BeNil())
+		Expect(hotplugRequest.Disk.DiskDevice.Disk.ReadOnly).To(BeFalse())
+
+		cd := hotplugRequest.VolumeSource.ContainerDisk
+		Expect(cd).NotTo(BeNil())
+		Expect(cd.Image).To(Equal("dvcr.example/vi:tag"))
+	})
+
+	It("hotplugs a VirtualDisk as a writable disk", func() {
+		hotplugRequest := mutate(&subresources.VirtualMachineAddVolume{
+			Name:       "vd-data",
+			VolumeKind: "VirtualDisk",
+			PVCName:    "vd-pvc",
+		})
+
+		Expect(hotplugRequest.Disk.DiskDevice.Disk).NotTo(BeNil())
+		Expect(hotplugRequest.Disk.DiskDevice.Disk.ReadOnly).To(BeFalse())
+
+		pvc := hotplugRequest.VolumeSource.PersistentVolumeClaim
+		Expect(pvc).NotTo(BeNil())
+		Expect(pvc.ClaimName).To(Equal("vd-pvc"))
+		Expect(pvc.ReadOnly).To(BeFalse())
+	})
+})

--- a/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/suite_test.go
+++ b/images/virtualization-artifact/pkg/apiserver/registry/vm/rest/suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestRest(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "VM REST Suite")
+}

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
@@ -504,6 +504,7 @@ type SetDiskOptions struct {
 	IsHotplugged bool
 	IsCdrom      bool
 	IsEphemeral  bool
+	IsReadOnly   bool
 
 	Serial string
 
@@ -540,7 +541,8 @@ func (b *KVVM) SetDisk(name string, opts SetDiskOptions) error {
 		}
 	} else {
 		dd.Disk = &virtv1.DiskTarget{
-			Bus: devPreset.DiskBus,
+			Bus:      devPreset.DiskBus,
+			ReadOnly: opts.IsReadOnly,
 		}
 	}
 
@@ -576,6 +578,7 @@ func (b *KVVM) SetDisk(name string, opts SetDiskOptions) error {
 		vs.PersistentVolumeClaim = &virtv1.PersistentVolumeClaimVolumeSource{
 			PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
 				ClaimName: *opts.PersistentVolumeClaim,
+				ReadOnly:  opts.IsReadOnly,
 			},
 			Hotpluggable: opts.IsHotplugged,
 		}

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils.go
@@ -465,6 +465,9 @@ func setBlockDeviceDisk(
 		switch vi.Spec.Storage {
 		case v1alpha2.StorageKubernetes, v1alpha2.StoragePersistentVolumeClaim:
 			opts.PersistentVolumeClaim = ptr.To(vi.Status.Target.PersistentVolumeClaim)
+			// Images are immutable: a PVC-backed image should be read-only inside the VM,
+			// like a registry-backed image (ContainerDisk is always read-only).
+			opts.IsReadOnly = true
 		case v1alpha2.StorageContainerRegistry:
 			opts.ContainerDisk = ptr.To(vi.Status.Target.RegistryURL)
 		default:

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils_test.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_utils_test.go
@@ -375,6 +375,101 @@ var _ = Describe("cleanupRemovedStaticDisks", func() {
 	})
 })
 
+var _ = Describe("setBlockDeviceDisk", func() {
+	const (
+		viName  = "vi-image"
+		vdName  = "vd-data"
+		viPVC   = "vi-pvc"
+		vdPVC   = "vd-pvc"
+		viImage = "dvcr.example/vi:tag"
+	)
+
+	newVI := func(storage v1alpha2.StorageType, format string) *v1alpha2.VirtualImage {
+		return &v1alpha2.VirtualImage{
+			ObjectMeta: metav1.ObjectMeta{Name: viName, Namespace: "test-ns", UID: "vi-uid"},
+			Spec:       v1alpha2.VirtualImageSpec{Storage: storage},
+			Status: v1alpha2.VirtualImageStatus{
+				Format: format,
+				Target: v1alpha2.VirtualImageStatusTarget{
+					PersistentVolumeClaim: viPVC,
+					RegistryURL:           viImage,
+				},
+			},
+		}
+	}
+
+	setDisk := func(bd v1alpha2.BlockDeviceSpecRef, vi *v1alpha2.VirtualImage, vd *v1alpha2.VirtualDisk) *KVVM {
+		kvvm := NewEmptyKVVM(namespacedName("vm", "vm-ns"), KVVMOptions{EnableParavirtualization: true})
+		err := setBlockDeviceDisk(
+			kvvm, bd, 0, false,
+			map[string]*v1alpha2.VirtualDisk{vdName: vd},
+			map[string]*v1alpha2.VirtualImage{viName: vi},
+			nil,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kvvm.Resource.Spec.Template.Spec.Domain.Devices.Disks).To(HaveLen(1))
+		Expect(kvvm.Resource.Spec.Template.Spec.Volumes).To(HaveLen(1))
+		return kvvm
+	}
+
+	It("attaches a PVC-backed VirtualImage as a read-only disk", func() {
+		vi := newVI(v1alpha2.StoragePersistentVolumeClaim, "qcow2")
+		kvvm := setDisk(v1alpha2.BlockDeviceSpecRef{Kind: v1alpha2.ImageDevice, Name: viName}, vi, nil)
+
+		disk := kvvm.Resource.Spec.Template.Spec.Domain.Devices.Disks[0]
+		Expect(disk.Disk).NotTo(BeNil())
+		Expect(disk.Disk.ReadOnly).To(BeTrue())
+
+		pvc := kvvm.Resource.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim
+		Expect(pvc).NotTo(BeNil())
+		Expect(pvc.ClaimName).To(Equal(viPVC))
+		Expect(pvc.ReadOnly).To(BeTrue())
+	})
+
+	It("attaches an ISO PVC-backed VirtualImage as a cdrom with a read-only PVC", func() {
+		vi := newVI(v1alpha2.StoragePersistentVolumeClaim, "iso")
+		kvvm := setDisk(v1alpha2.BlockDeviceSpecRef{Kind: v1alpha2.ImageDevice, Name: viName}, vi, nil)
+
+		disk := kvvm.Resource.Spec.Template.Spec.Domain.Devices.Disks[0]
+		Expect(disk.CDRom).NotTo(BeNil())
+
+		pvc := kvvm.Resource.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim
+		Expect(pvc).NotTo(BeNil())
+		Expect(pvc.ReadOnly).To(BeTrue())
+	})
+
+	It("attaches a registry-backed VirtualImage as a container disk", func() {
+		vi := newVI(v1alpha2.StorageContainerRegistry, "qcow2")
+		kvvm := setDisk(v1alpha2.BlockDeviceSpecRef{Kind: v1alpha2.ImageDevice, Name: viName}, vi, nil)
+
+		disk := kvvm.Resource.Spec.Template.Spec.Domain.Devices.Disks[0]
+		Expect(disk.Disk).NotTo(BeNil())
+
+		cd := kvvm.Resource.Spec.Template.Spec.Volumes[0].ContainerDisk
+		Expect(cd).NotTo(BeNil())
+		Expect(cd.Image).To(Equal(viImage))
+	})
+
+	It("attaches a VirtualDisk as a writable disk", func() {
+		vd := &v1alpha2.VirtualDisk{
+			ObjectMeta: metav1.ObjectMeta{Name: vdName, Namespace: "test-ns", UID: "vd-uid"},
+			Status: v1alpha2.VirtualDiskStatus{
+				Target: v1alpha2.DiskTarget{PersistentVolumeClaim: vdPVC},
+			},
+		}
+		kvvm := setDisk(v1alpha2.BlockDeviceSpecRef{Kind: v1alpha2.DiskDevice, Name: vdName}, nil, vd)
+
+		disk := kvvm.Resource.Spec.Template.Spec.Domain.Devices.Disks[0]
+		Expect(disk.Disk).NotTo(BeNil())
+		Expect(disk.Disk.ReadOnly).To(BeFalse())
+
+		pvc := kvvm.Resource.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim
+		Expect(pvc).NotTo(BeNil())
+		Expect(pvc.ClaimName).To(Equal(vdPVC))
+		Expect(pvc.ReadOnly).To(BeFalse())
+	})
+})
+
 func namespacedName(name, namespace string) types.NamespacedName {
 	return types.NamespacedName{Name: name, Namespace: namespace}
 }


### PR DESCRIPTION
## Description

`VirtualImage` with `storage: PersistentVolumeClaim` / `Kubernetes` was attached to a VM as a regular writable PVC volume, while registry-backed images (`storage: ContainerRegistry`) are always read-only (ContainerDisk).

Now a PVC-backed image is attached read-only in both paths:

- **In spec** (`.spec.blockDeviceRefs`): the controller sets `readonly: true` on the disk target and `readOnly: true` on the PVC volume source (`kvbuilder`).
- **Hotplug** (VMBDA → `addvolume` subresource): `virtualization-api` sets the same flags when mutating the hotplug request. ISO images are not affected: CD-ROM is read-only by default.

## Why do we need it, and what problem does it solve?

Images are immutable by design, and the documentation states that images are connected in read-only mode. However, a guest OS could write to a PVC-backed image, corrupting it for all VMs using this image.

## What is the expected result?

1. Create a `VirtualImage` with `storage: PersistentVolumeClaim`.
2. Attach it to a VM via `.spec.blockDeviceRefs` or `VirtualMachineBlockDeviceAttachment`.
3. Inside the guest the disk is read-only (`lsblk` shows `RO=1`), writes fail with a write-protect error.

Note: for already attached images the change is applied after VM restart (in-spec attach) or VMBDA re-attach (hotplug). VMs with `enableParavirtualization: false` cannot use read-only non-ISO disks on the SATA bus (KubeVirt restriction).

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: vi
type: fix
summary: "PVC-backed virtual images are now attached to virtual machines in read-only mode, like registry-backed images."
```
