### PR TITLE
feat(vmpool): enable VirtualMachinePool in EE/SE+ without a feature gate

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vmpool/vmpool_controller.go
+++ b/images/virtualization-artifact/pkg/controller/vmpool/vmpool_controller.go
@@ -38,10 +38,11 @@ const (
 
 // SetupController wires the VirtualMachinePool controller into the manager.
 //
-// The resource is gated behind the VirtualMachinePool feature gate: while the
-// gate is off the controller is not set up at all (the CRD is still installed,
-// so objects can be created — they simply are not reconciled). See ADR
-// "VirtualMachinePool", section "Feature gate".
+// The resource is available only in paid editions (EE/SE+): in CE the controller
+// is not set up at all (the CRD is still installed, so objects can be created —
+// they simply are not reconciled). The edition check rides on the
+// VirtualMachinePool feature gate, which is locked on in EE/SE+ and off in CE.
+// See ADR "VirtualMachinePool", section "Feature gate".
 func SetupController(
 	ctx context.Context,
 	mgr manager.Manager,

--- a/images/virtualization-artifact/pkg/controller/vmpool/vmpool_scale_webhook.go
+++ b/images/virtualization-artifact/pkg/controller/vmpool/vmpool_scale_webhook.go
@@ -42,9 +42,9 @@ const ScaleWebhookPath = "/validate-virtualization-deckhouse-io-v1alpha2-virtual
 // SetupScaleWebhook registers the guard that rejects anonymous scale-down via
 // the scale subresource for pools with scaleDownPolicy: Explicit.
 func SetupScaleWebhook(mgr manager.Manager) {
-	// Gated like the controller: while the feature gate is off the guard is not
-	// registered (the CRD's scale subresource is still served, just unguarded —
-	// there is no controller to act on it either).
+	// Gated like the controller: in CE the guard is not registered (the CRD's
+	// scale subresource is still served, just unguarded — there is no controller
+	// to act on it either).
 	if !featuregates.Default().Enabled(featuregates.VirtualMachinePool) {
 		return
 	}

--- a/images/virtualization-artifact/pkg/controller/vmpool/vmpool_webhook.go
+++ b/images/virtualization-artifact/pkg/controller/vmpool/vmpool_webhook.go
@@ -39,7 +39,7 @@ const maxPoolNameLength = 57
 
 // SetupValidationWebhook validates the pool's template specs on create/update, so
 // a bad template is rejected up front instead of only as a FailedCreate event.
-// Self-gated by the feature gate.
+// Gated like the controller: registered only in EE/SE+.
 func SetupValidationWebhook(mgr manager.Manager, log *log.Logger) error {
 	if !featuregates.Default().Enabled(featuregates.VirtualMachinePool) {
 		return nil

--- a/images/virtualization-artifact/pkg/featuregates/featuregate.go
+++ b/images/virtualization-artifact/pkg/featuregates/featuregate.go
@@ -77,8 +77,8 @@ var featureSpecs = map[featuregate.Feature]featuregate.FeatureSpec{
 		PreRelease:    featuregate.Alpha,
 	},
 	VirtualMachinePool: {
-		Default:       false,
-		LockToDefault: version.GetEdition() == version.EditionCE,
+		Default:       version.GetEdition() == version.EditionEE,
+		LockToDefault: true,
 		PreRelease:    featuregate.Alpha,
 	},
 }

--- a/openapi/config-values.yaml
+++ b/openapi/config-values.yaml
@@ -226,11 +226,9 @@ properties:
       - `HotplugCPUWithLiveMigration` — enable live changing of cpu cores number via LiveMigration. (Not available in CE);
       - `HotplugMemoryWithLiveMigration` — enable live changing of memory size via LiveMigration. (Not available in CE);
       - `HotplugCPUAndMemoryWithInPlaceResize` - enable live changing of cpu cores number or memory size via InPlaceResize. (Not available in CE);
-      - `VirtualMachinePool` — enable the VirtualMachinePool resource for group management of virtual machines. (Not available in CE);
     items:
       type: string
       enum:
         - "HotplugCPUWithLiveMigration"
         - "HotplugMemoryWithLiveMigration"
         - "HotplugCPUAndMemoryWithInPlaceResize"
-        - "VirtualMachinePool"

--- a/openapi/doc-ru-config-values.yaml
+++ b/openapi/doc-ru-config-values.yaml
@@ -156,6 +156,5 @@ properties:
       - `HotplugCPUWithLiveMigration` — включить изменение количества ядер процессора без перезагрузки через живую миграцию. (Не доступно в CE);
       - `HotplugMemoryWithLiveMigration` — включить изменение размера памяти без перезагрузки через живую миграцию. (Не доступно в CE);
       - `HotplugCPUAndMemoryWithInPlaceResize` - включить изменение количества ядер процессора или размера памяти без перезагрузки через InPlaceResize (Не доступно в CE)
-      - `VirtualMachinePool` — включить ресурс VirtualMachinePool для группового управления виртуальными машинами. (Не доступно в CE)
     items:
       type: string

--- a/templates/virtualization-controller/validation-webhook.yaml
+++ b/templates/virtualization-controller/validation-webhook.yaml
@@ -252,7 +252,7 @@ webhooks:
       - name: 'match-virtualization'
         expression: 'request.name == "virtualization"'
     {{- end }}
-  {{- if has "VirtualMachinePool" .Values.virtualization.internal.moduleConfig.featureGates }}
+  {{- if ne .Values.global.deckhouseEdition "CE" }}
   - name: "vmpool-scale.virtualization-controller.validate.d8-virtualization"
     rules:
       - apiGroups:   ["virtualization.deckhouse.io"]


### PR DESCRIPTION
## Description

VirtualMachinePool needed a feature gate to be turned on manually in the paid editions (EE/SE+). Since the resource has not been released yet, we remove that gate before release: VirtualMachinePool now works in EE/SE+ out of the box, and stays unavailable in CE (a paid-only feature). There is nothing for users to enable, and nothing to migrate — the gate never shipped.


## Why do we need it, and what problem does it solve?

Requiring users to flip a feature gate adds friction with no benefit. Removing it before release means the resource just works in the editions that ship it.

## What is the expected result?

In EE/SE+ VirtualMachinePool works without any feature-gate configuration; in CE it is not available. Users neither set nor see a VirtualMachinePool feature gate.

## Checklist
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: vmpool
type: chore
summary: "VirtualMachinePool is available in EE/SE+ without a feature gate."
impact_level: low
```

