### PR TITLE
fix(vm): move disks to preset bus when enableParavirtualization flips

### DIFF
--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
@@ -544,20 +544,15 @@ func (b *KVVM) SetDisk(name string, opts SetDiskOptions) error {
 		}
 	}
 
-	// Keep the bus already recorded for the device (e.g. a volume hot-plugged
-	// on a non-preset bus), unless it is a leftover from the opposite
-	// paravirtualization mode: flipping enableParavirtualization must move
-	// devices to the new preset bus on the restart it already requires.
-	oppositePreset := DeviceOptionsPresets.Find(!b.opts.EnableParavirtualization)
-	if existingBus := b.getExistingDiskBus(name); existingBus != "" {
+	// Buses used by presets always follow the current paravirtualization mode,
+	// so flipping enableParavirtualization moves devices to the new preset bus
+	// on the restart it already requires. A bus outside the presets (e.g. usb)
+	// was chosen deliberately for a hot-plugged device — keep it.
+	if existingBus := b.getExistingDiskBus(name); existingBus != "" && !DeviceOptionsPresets.HasBus(existingBus) {
 		if opts.IsCdrom {
-			if existingBus != oppositePreset.CdromBus {
-				dd.CDRom.Bus = existingBus
-			}
+			dd.CDRom.Bus = existingBus
 		} else {
-			if existingBus != oppositePreset.DiskBus {
-				dd.Disk.Bus = existingBus
-			}
+			dd.Disk.Bus = existingBus
 		}
 	}
 

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
@@ -544,11 +544,20 @@ func (b *KVVM) SetDisk(name string, opts SetDiskOptions) error {
 		}
 	}
 
+	// Keep the bus already recorded for the device (e.g. a volume hot-plugged
+	// on a non-preset bus), unless it is a leftover from the opposite
+	// paravirtualization mode: flipping enableParavirtualization must move
+	// devices to the new preset bus on the restart it already requires.
+	oppositePreset := DeviceOptionsPresets.Find(!b.opts.EnableParavirtualization)
 	if existingBus := b.getExistingDiskBus(name); existingBus != "" {
 		if opts.IsCdrom {
-			dd.CDRom.Bus = existingBus
+			if existingBus != oppositePreset.CdromBus {
+				dd.CDRom.Bus = existingBus
+			}
 		} else {
-			dd.Disk.Bus = existingBus
+			if existingBus != oppositePreset.DiskBus {
+				dd.Disk.Bus = existingBus
+			}
 		}
 	}
 

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_test.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_test.go
@@ -22,6 +22,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	virtv1 "kubevirt.io/api/core/v1"
 
 	"github.com/deckhouse/virtualization-controller/pkg/common/network"
@@ -249,6 +250,71 @@ func TestSetOsType(t *testing.T) {
 
 		if builder.Resource.Spec.Template.Spec.Domain.Devices.TPM != nil {
 			t.Error("TPM should be removed after changing from Windows to Generic OS")
+		}
+	})
+}
+
+func TestSetDiskBusFollowsParavirtualizationFlip(t *testing.T) {
+	getBus := func(b *KVVM, name string) virtv1.DiskBus {
+		return b.getExistingDiskBus(name)
+	}
+
+	t.Run("new devices get preset bus", func(t *testing.T) {
+		b := newTestKVVM()
+		if err := b.SetDisk("cdrom", SetDiskOptions{IsCdrom: true, ContainerDisk: ptr.To("img")}); err != nil {
+			t.Fatal(err)
+		}
+		if err := b.SetDisk("disk", SetDiskOptions{ContainerDisk: ptr.To("img")}); err != nil {
+			t.Fatal(err)
+		}
+		if bus := getBus(b, "cdrom"); bus != virtv1.DiskBusSCSI {
+			t.Errorf("expected scsi cdrom bus, got %q", bus)
+		}
+		if bus := getBus(b, "disk"); bus != virtv1.DiskBusSCSI {
+			t.Errorf("expected scsi disk bus, got %q", bus)
+		}
+	})
+
+	t.Run("non-preset bus is preserved", func(t *testing.T) {
+		b := newTestKVVM()
+		if err := b.SetDisk("cdrom", SetDiskOptions{IsCdrom: true, ContainerDisk: ptr.To("img")}); err != nil {
+			t.Fatal(err)
+		}
+		b.Resource.Spec.Template.Spec.Domain.Devices.Disks[0].CDRom.Bus = virtv1.DiskBusUSB
+		if err := b.SetDisk("cdrom", SetDiskOptions{IsCdrom: true, ContainerDisk: ptr.To("img")}); err != nil {
+			t.Fatal(err)
+		}
+		if bus := getBus(b, "cdrom"); bus != virtv1.DiskBusUSB {
+			t.Errorf("expected usb bus preserved, got %q", bus)
+		}
+	})
+
+	t.Run("opposite preset bus is replaced on paravirtualization flip", func(t *testing.T) {
+		old := NewEmptyKVVM(types.NamespacedName{Name: "test", Namespace: "default"}, KVVMOptions{
+			EnableParavirtualization: false,
+		})
+		if err := old.SetDisk("cdrom", SetDiskOptions{IsCdrom: true, ContainerDisk: ptr.To("img")}); err != nil {
+			t.Fatal(err)
+		}
+		if err := old.SetDisk("disk", SetDiskOptions{ContainerDisk: ptr.To("img")}); err != nil {
+			t.Fatal(err)
+		}
+		if bus := getBus(old, "cdrom"); bus != virtv1.DiskBusSATA {
+			t.Fatalf("expected sata cdrom bus before flip, got %q", bus)
+		}
+
+		flipped := NewKVVM(old.Resource, KVVMOptions{EnableParavirtualization: true})
+		if err := flipped.SetDisk("cdrom", SetDiskOptions{IsCdrom: true, ContainerDisk: ptr.To("img")}); err != nil {
+			t.Fatal(err)
+		}
+		if err := flipped.SetDisk("disk", SetDiskOptions{ContainerDisk: ptr.To("img")}); err != nil {
+			t.Fatal(err)
+		}
+		if bus := getBus(flipped, "cdrom"); bus != virtv1.DiskBusSCSI {
+			t.Errorf("expected scsi cdrom bus after flip, got %q", bus)
+		}
+		if bus := getBus(flipped, "disk"); bus != virtv1.DiskBusSCSI {
+			t.Errorf("expected scsi disk bus after flip, got %q", bus)
 		}
 	})
 }

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/presets.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/presets.go
@@ -41,6 +41,15 @@ func (l DeviceOptionsList) Find(enableParavirtualization bool) DeviceOptions {
 	panic(fmt.Sprintf("cannot find preset for enableParavirtualization=%v", enableParavirtualization))
 }
 
+func (l DeviceOptionsList) HasBus(bus virtv1.DiskBus) bool {
+	for _, opts := range l {
+		if bus == opts.DiskBus || bus == opts.CdromBus {
+			return true
+		}
+	}
+	return false
+}
+
 var DeviceOptionsPresets DeviceOptionsList = []DeviceOptions{
 	{
 		EnableParavirtualization: true,


### PR DESCRIPTION
## Description

Virtual machines created without paravirtualization keep all their disks and CD-ROMs on the SATA bus forever, even after `enableParavirtualization` is turned on and the VM is restarted. The recorded bus of an existing device always took priority over the bus implied by the paravirtualization setting.

Now, when the paravirtualization mode changes, devices move to the bus of the new mode on the restart this change already requires. Devices hot-plugged on a non-default bus (for example USB) keep their bus as before.

## Why do we need it, and what problem does it solve?

The typical Windows installation flow is: create a VM without paravirtualization, boot the installation ISO, install the OS and virtio drivers, then enable paravirtualization. Before this fix the flip had no effect on storage: the system disk and ISO drives stayed on SATA.

Because of that, removing an installation ISO from `spec.blockDeviceRefs` of a running VM could never complete: a SATA CD-ROM cannot be hot-unplugged, so the guest kept seeing the drive with the ISO inserted, and the hypervisor retried the detach indefinitely. On virtio-scsi, where the devices land after this fix, a CD-ROM drive is removed from the running guest cleanly.

## What is the expected result?

1. Create a Windows VM with `enableParavirtualization: false`, an installation ISO and a virtio drivers ISO — all devices are on SATA, the installer boots.
2. Install the OS, the virtio drivers and the guest agent.
3. Set `enableParavirtualization: true` — the VM requires a restart; after it, the system disk and the CD-ROMs are on the virtio-scsi bus.
4. Remove the ISO references from `spec.blockDeviceRefs` of the running VM — the CD-ROM drives disappear from the guest OS without a restart.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes. — not needed: no user-facing API changes, behavior now matches what `enableParavirtualization` documentation already implies.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: vm
type: fix
summary: "Disks and CD-ROMs now move to the virtio-scsi bus after enabling paravirtualization, so ISO drives can be unplugged from a running VM."
```
