### PR TITLE
test(e2e): bump VI-derived disk size to 450Mi

### DIFF
--- a/test/e2e/blockdevice/virtual_image_creation.go
+++ b/test/e2e/blockdevice/virtual_image_creation.go
@@ -519,7 +519,7 @@ func runVirtualMachineFromImageDisk(ctx context.Context, f *framework.Framework,
 	// The disk that boots the VM is the scenario's main resource, so it uses the
 	// same default StorageClass as every other resource in this spec.
 	vd := object.NewVDFromVI("vd-from-"+vi.Name, f.Namespace().Name, vi,
-		vdbuilder.WithSize(ptr.To(resource.MustParse("400Mi"))),
+		vdbuilder.WithSize(ptr.To(resource.MustParse("450Mi"))),
 		vdbuilder.WithStorageClass(defaultStorageClass()),
 	)
 	createVirtualDiskAndRunVM(ctx, f, vd, opts...)


### PR DESCRIPTION
## Description

Bump the size of the `VirtualDisk` restored from a `VirtualImage` in the `VirtualImageCreation` e2e suite from 400Mi to 450Mi. The change is in the shared `runVirtualMachineFromImageDisk` helper (`test/e2e/blockdevice/virtual_image_creation.go`), so it covers every context that boots a VM from a restored image disk (from a VirtualDisk, from a VirtualDiskSnapshot, from a VirtualImage on DVCR/PVC).

## Why do we need it, and what problem does it solve?

A `VirtualImage` created from a 400Mi `VirtualDisk` grows past 400Mi after the `VD -> VI -> VD` round-trip: `qemu-img convert` aligns the virtual size up to a block boundary and the image carries extra overhead. Restoring a disk from such an image with a 400Mi request tripped the insufficient-PVC-size precheck and left the VD in `Failed`:

```
The specified pvc size is insufficient: 419430400 (400Mi) < 434110464
```

The VD observer's `Never: entered Failed phase` invariant then failed the spec. This flaked the `from a VirtualDisk` and `from a VirtualDiskSnapshot` DVCR specs (and any other restored-image-disk path).

## What is the expected result?

`VirtualImageCreation` e2e specs pass: the restored disk (450Mi) clears the precheck, becomes Ready, and boots its VM. Plain alpine 400Mi disks elsewhere are unchanged.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: test
type: chore
summary: "Bump the VI-derived disk size in the VirtualImageCreation e2e suite to clear the PVC-size precheck."
impact_level: low
```
