### PR TITLE
fix(pvc-artifact): relicense CDI-derived files with recognized header

### DIFF
--- a/images/pvc-artifact/cmd/pvc-importer/importer.go
+++ b/images/pvc-artifact/cmd/pvc-importer/importer.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2018 The CDI Authors.
+Copyright 2026 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// This file was initially copied from the Containerized Data Importer (CDI)
+// project (https://github.com/kubevirt/containerized-data-importer) and adapted
+// for the virtualization module.
 
 package main
 

--- a/images/pvc-artifact/cmd/pvc-target-importer/importer.go
+++ b/images/pvc-artifact/cmd/pvc-target-importer/importer.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2018 The CDI Authors.
+Copyright 2026 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// This file was initially copied from the Containerized Data Importer (CDI)
+// project (https://github.com/kubevirt/containerized-data-importer) and adapted
+// for the virtualization module.
 
 package main
 

--- a/images/pvc-artifact/pkg/common/common.go
+++ b/images/pvc-artifact/pkg/common/common.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2018 The CDI Authors.
+Copyright 2026 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// This file was initially copied from the Containerized Data Importer (CDI)
+// project (https://github.com/kubevirt/containerized-data-importer) and adapted
+// for the virtualization module.
 
 package common
 

--- a/images/pvc-artifact/pkg/image/directio.go
+++ b/images/pvc-artifact/pkg/image/directio.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2023 The CDI Authors.
+Copyright 2026 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// This file was initially copied from the Containerized Data Importer (CDI)
+// project (https://github.com/kubevirt/containerized-data-importer) and adapted
+// for the virtualization module.
 
 package image
 

--- a/images/pvc-artifact/pkg/image/filefmt.go
+++ b/images/pvc-artifact/pkg/image/filefmt.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2018 The CDI Authors.
+Copyright 2026 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// This file was initially copied from the Containerized Data Importer (CDI)
+// project (https://github.com/kubevirt/containerized-data-importer) and adapted
+// for the virtualization module.
 
 package image
 

--- a/images/pvc-artifact/pkg/image/nbdkit.go
+++ b/images/pvc-artifact/pkg/image/nbdkit.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2018 The CDI Authors.
+Copyright 2026 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// This file was initially copied from the Containerized Data Importer (CDI)
+// project (https://github.com/kubevirt/containerized-data-importer) and adapted
+// for the virtualization module.
 
 package image
 

--- a/images/pvc-artifact/pkg/image/qemu.go
+++ b/images/pvc-artifact/pkg/image/qemu.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2018 The CDI Authors.
+Copyright 2026 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// This file was initially copied from the Containerized Data Importer (CDI)
+// project (https://github.com/kubevirt/containerized-data-importer) and adapted
+// for the virtualization module.
 
 package image
 

--- a/images/pvc-artifact/pkg/image/qemu_format_stream.go
+++ b/images/pvc-artifact/pkg/image/qemu_format_stream.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2018 The CDI Authors.
+Copyright 2026 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// This file was initially copied from the Containerized Data Importer (CDI)
+// project (https://github.com/kubevirt/containerized-data-importer) and adapted
+// for the virtualization module.
 
 package image
 

--- a/images/pvc-artifact/pkg/image/validate.go
+++ b/images/pvc-artifact/pkg/image/validate.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2018 The CDI Authors.
+Copyright 2026 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// This file was initially copied from the Containerized Data Importer (CDI)
+// project (https://github.com/kubevirt/containerized-data-importer) and adapted
+// for the virtualization module.
 
 package image
 

--- a/images/pvc-artifact/pkg/importer/data-processor.go
+++ b/images/pvc-artifact/pkg/importer/data-processor.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2018 The CDI Authors.
+Copyright 2026 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// This file was initially copied from the Containerized Data Importer (CDI)
+// project (https://github.com/kubevirt/containerized-data-importer) and adapted
+// for the virtualization module.
 
 package importer
 

--- a/images/pvc-artifact/pkg/importer/errors.go
+++ b/images/pvc-artifact/pkg/importer/errors.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2018 The CDI Authors.
+Copyright 2026 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// This file was initially copied from the Containerized Data Importer (CDI)
+// project (https://github.com/kubevirt/containerized-data-importer) and adapted
+// for the virtualization module.
 
 package importer
 

--- a/images/pvc-artifact/pkg/importer/format-readers.go
+++ b/images/pvc-artifact/pkg/importer/format-readers.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2018 The CDI Authors.
+Copyright 2026 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// This file was initially copied from the Containerized Data Importer (CDI)
+// project (https://github.com/kubevirt/containerized-data-importer) and adapted
+// for the virtualization module.
 
 package importer
 

--- a/images/pvc-artifact/pkg/importer/registry-datasource.go
+++ b/images/pvc-artifact/pkg/importer/registry-datasource.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2018 The CDI Authors.
+Copyright 2026 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// This file was initially copied from the Containerized Data Importer (CDI)
+// project (https://github.com/kubevirt/containerized-data-importer) and adapted
+// for the virtualization module.
 
 package importer
 

--- a/images/pvc-artifact/pkg/importer/transport.go
+++ b/images/pvc-artifact/pkg/importer/transport.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2020 The CDI Authors.
+Copyright 2026 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// This file was initially copied from the Containerized Data Importer (CDI)
+// project (https://github.com/kubevirt/containerized-data-importer) and adapted
+// for the virtualization module.
 
 package importer
 

--- a/images/pvc-artifact/pkg/importer/util.go
+++ b/images/pvc-artifact/pkg/importer/util.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2018 The CDI Authors.
+Copyright 2026 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// This file was initially copied from the Containerized Data Importer (CDI)
+// project (https://github.com/kubevirt/containerized-data-importer) and adapted
+// for the virtualization module.
 
 package importer
 

--- a/images/pvc-artifact/pkg/monitoring/metrics/pvc-importer/import_metrics.go
+++ b/images/pvc-artifact/pkg/monitoring/metrics/pvc-importer/import_metrics.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2018 The CDI Authors.
+Copyright 2026 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// This file was initially copied from the Containerized Data Importer (CDI)
+// project (https://github.com/kubevirt/containerized-data-importer) and adapted
+// for the virtualization module.
 
 package pvcimporter
 

--- a/images/pvc-artifact/pkg/monitoring/metrics/pvc-importer/metrics.go
+++ b/images/pvc-artifact/pkg/monitoring/metrics/pvc-importer/metrics.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2018 The CDI Authors.
+Copyright 2026 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// This file was initially copied from the Containerized Data Importer (CDI)
+// project (https://github.com/kubevirt/containerized-data-importer) and adapted
+// for the virtualization module.
 
 package pvcimporter
 

--- a/images/pvc-artifact/pkg/system/prlimit.go
+++ b/images/pvc-artifact/pkg/system/prlimit.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2018 The CDI Authors.
+Copyright 2026 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// This file was initially copied from the Containerized Data Importer (CDI)
+// project (https://github.com/kubevirt/containerized-data-importer) and adapted
+// for the virtualization module.
 
 package system
 

--- a/images/pvc-artifact/pkg/util/file.go
+++ b/images/pvc-artifact/pkg/util/file.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2018 The CDI Authors.
+Copyright 2026 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// This file was initially copied from the Containerized Data Importer (CDI)
+// project (https://github.com/kubevirt/containerized-data-importer) and adapted
+// for the virtualization module.
 
 package util
 

--- a/images/pvc-artifact/pkg/util/file_format.go
+++ b/images/pvc-artifact/pkg/util/file_format.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2018 The CDI Authors.
+Copyright 2026 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// This file was initially copied from the Containerized Data Importer (CDI)
+// project (https://github.com/kubevirt/containerized-data-importer) and adapted
+// for the virtualization module.
 
 package util
 

--- a/images/pvc-artifact/pkg/util/prometheus/prometheus.go
+++ b/images/pvc-artifact/pkg/util/prometheus/prometheus.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2018 The CDI Authors.
+Copyright 2026 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// This file was initially copied from the Containerized Data Importer (CDI)
+// project (https://github.com/kubevirt/containerized-data-importer) and adapted
+// for the virtualization module.
 
 package prometheus
 

--- a/images/pvc-artifact/pkg/util/util.go
+++ b/images/pvc-artifact/pkg/util/util.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2018 The CDI Authors.
+Copyright 2026 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// This file was initially copied from the Containerized Data Importer (CDI)
+// project (https://github.com/kubevirt/containerized-data-importer) and adapted
+// for the virtualization module.
 
 package util
 


### PR DESCRIPTION
## Description

The 22 CDI-derived Go files under `images/pvc-artifact` still carry the
`Copyright <year> The CDI Authors.` header. This replaces them with the standard
Flant JSC Apache 2.0 header, followed by a note crediting the Containerized Data
Importer (CDI) project as the origin — the same convention already used in
`images/dvcr-artifact`.

## Why do we need it, and what problem does it solve?

The DMT `license` linter rejects the CDI headers with *"license header does not
match any known license"*, which fails the DMT check on every PR touching
`pvc-artifact`. The Flant JSC header is recognized by the linter, and the CDI
attribution note preserves the origin of the vendored code.

## What is the expected result?

The DMT `license` check passes on `images/pvc-artifact`; no `pvc-artifact` file
reports "license header does not match any known license".

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: core
type: chore
summary: Relicense CDI-derived pvc-artifact files with the recognized Apache 2.0 header.
impact_level: low
```
