### PR TITLE
fix(vm): respect node placement when picking TSC frequency

### DIFF
--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -3,7 +3,7 @@ firmware:
   libvirt: v10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: v1.6.2-v12n.59
+  3p-kubevirt: fix/virt-launcher/tsc
   distribution: 3.1.1
 package:
   acl: v2.3.1

--- a/build/components/versions.yml
+++ b/build/components/versions.yml
@@ -3,7 +3,7 @@ firmware:
   libvirt: v10.9.0
   edk2: stable202411
 core:
-  3p-kubevirt: fix/virt-launcher/tsc
+  3p-kubevirt: v1.6.2-v12n.60
   distribution: 3.1.1
 package:
   acl: v2.3.1

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -15,8 +15,6 @@ secrets:
 shell:
   install:
   - |
-    echo kek12345
-
     echo "Git clone {{ $gitRepoName }} repository..."
     git clone --depth=1 $(cat /run/secrets/SOURCE_REPO)/{{ $gitRepoUrl }} --branch {{ $tag }} /src/kubevirt
 

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -15,6 +15,8 @@ secrets:
 shell:
   install:
   - |
+    echo kek
+
     echo "Git clone {{ $gitRepoName }} repository..."
     git clone --depth=1 $(cat /run/secrets/SOURCE_REPO)/{{ $gitRepoUrl }} --branch {{ $tag }} /src/kubevirt
 

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -15,7 +15,7 @@ secrets:
 shell:
   install:
   - |
-    echo kek123
+    echo kek12345
 
     echo "Git clone {{ $gitRepoName }} repository..."
     git clone --depth=1 $(cat /run/secrets/SOURCE_REPO)/{{ $gitRepoUrl }} --branch {{ $tag }} /src/kubevirt

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -15,7 +15,7 @@ secrets:
 shell:
   install:
   - |
-    echo kek
+    echo kek1
 
     echo "Git clone {{ $gitRepoName }} repository..."
     git clone --depth=1 $(cat /run/secrets/SOURCE_REPO)/{{ $gitRepoUrl }} --branch {{ $tag }} /src/kubevirt

--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -15,7 +15,7 @@ secrets:
 shell:
   install:
   - |
-    echo kek1
+    echo kek123
 
     echo "Git clone {{ $gitRepoName }} repository..."
     git clone --depth=1 $(cat /run/secrets/SOURCE_REPO)/{{ $gitRepoUrl }} --branch {{ $tag }} /src/kubevirt


### PR DESCRIPTION
## Description

Bumps `3p-kubevirt` to `v1.6.2-v12n.60`. The only change here is the fork tag in `build/components/versions.yml`; the actual fix lives in the fork.

The fork now picks the invariant TSC frequency for a VMI **only among the nodes that VMI can actually be scheduled on** (the pod's nodeSelectors + required node affinity), instead of the cluster-wide minimum.

Fork PR: https://github.com/deckhouse/3p-kubevirt/pull/150

## Why do we need it, and what problem does it solve?

VMs that require a pinned TSC frequency — Windows guests (Hyper-V Reenlightenment, enabled automatically for `osType: Windows`) or `invtsc: require` — could hang in `Pending` forever.

The frequency was chosen as the minimum across **all** schedulable nodes. If that minimum belonged to a node the VM cannot land on (excluded by VMClass CPU-feature selectors, `nodeSelector` or affinity), and the candidate nodes are non-scalable with that frequency outside the ±250 ppm tolerance, the pod's `tsc-frequency-<F>` selector never intersects with the rest of its selectors. The pod stays `Pending`, and since hints are written to the VMI once, it never recovers on its own. Breaks on heterogeneous clusters with per-VM placement constraints.

## What is the expected result?

A Windows VM on a VMClass restricted to a subset of nodes gets a TSC frequency native to one of its candidate nodes and schedules normally. Reproduction steps and the behavior matrix are in the fork PR.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: vm
type: fix
summary: VMs requiring a pinned TSC frequency (Windows/Hyper-V, invtsc) no longer hang in Pending on heterogeneous clusters — the frequency is now picked among the nodes the VM can actually be scheduled on.
```
