### PR TITLE
fix(dra): drop redundant /sys hostPath mount breaking container start

### DIFF
--- a/templates/virtualization-dra/daemonset.yaml
+++ b/templates/virtualization-dra/daemonset.yaml
@@ -154,11 +154,6 @@ spec:
           metadata:
             description: |
               Allow read-write access to /var/run hostPath volume.
-        - path: /sys
-          readOnly: false
-          metadata:
-            description: |
-              Allow read-write access to /sys hostPath volume.
 {{- end }}
 
 ---
@@ -281,8 +276,6 @@ spec:
               mountPath: /var/lib/kubelet/plugins_registry
             - name: plugins
               mountPath: /var/lib/kubelet/plugins
-            - name: sys
-              mountPath: /sys
             - name: var-run
               mountPath: /var/run
       volumes:
@@ -297,9 +290,6 @@ spec:
         - name: plugins
           hostPath:
             path: /var/lib/kubelet/plugins
-        - name: sys
-          hostPath:
-            path: /sys
         - name: var-run
           hostPath:
             path: /var/run


### PR DESCRIPTION
## Description

The `virtualization-dra` USB DaemonSet pods never start — they stay in `CrashLoopBackOff` on every node, so USB device passthrough is unavailable. The main container is privileged and runs with a read-only root filesystem while also bind-mounting the host `/sys`. Under containerd this combination makes the runtime fail to set up the `/sys/fs/cgroup` mount on the read-only rootfs, and the container never starts.

A privileged container already gets a read-write `/sys` from the runtime, so the explicit `/sys` mount is redundant. It is removed together with its volume and the now-dead `/sys` entry in the SecurityPolicy host-path allow-list.

## Why do we need it, and what problem does it solve?

Without this, the DRA component cannot run at all, and USB devices cannot be passed through to VMs. Verified on a cluster: a privileged pod with a read-only rootfs and an explicit `/sys` mount crash-loops with the cgroup mount error, while the same pod without that mount starts fine and still has read-write access to `/sys/bus/usb`.

## What is the expected result?

`virtualization-dra` pods reach `Running` on all nodes (no `CrashLoopBackOff`), and USB device passthrough works.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: vm
type: fix
summary: "USB device passthrough pods no longer fail to start on nodes with a read-only container root filesystem."
```
