### PR TITLE
docs: add localized disable confirmation messages

### DIFF
--- a/module.yaml
+++ b/module.yaml
@@ -24,3 +24,26 @@ disable:
     - Make sure to remove all resources created using the module (virtual machines, disks, images, etc.).
 
     Stale resources may result in a data loss or further system operation fails.
+  messages:
+    en: |
+      Very important!
+
+      Disabling this module will stop all services responsible for creating and running virtual machines.
+
+      Ensure proper cleanup before disabling this module:
+
+      - Check for active resources using the command: `d8 k get virtualization,cvi -A`.
+      - Make sure to remove all resources created using the module (virtual machines, disks, images, etc.).
+
+      Stale resources may result in a data loss or further system operation fails.
+    ru: |
+      Очень важно!
+
+      Отключение этого модуля остановит все сервисы, отвечающие за создание и запуск виртуальных машин.
+
+      Перед отключением модуля выполните очистку:
+
+      - Проверьте наличие активных ресурсов командой: `d8 k get virtualization,cvi -A`.
+      - Убедитесь, что удалены все ресурсы, созданные с помощью модуля (виртуальные машины, диски, образы и т.д.).
+
+      Оставшиеся ресурсы могут привести к потере данных или сбоям в дальнейшей работе системы.


### PR DESCRIPTION
## Description
Add `disable.messages` with `en` and `ru` texts for the module disable confirmation dialog. Keep existing `disable.message` as the fallback for older Deckhouse versions.


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: docs
type: docs 
summary: "Add disable.messages for the module disable confirmation dialog."
impact_level: low
```
