### PR TITLE
docs: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,9 @@
 *                                                         @Isteb4k
 /.github/                                                 @universal-itengineer @nevermarine
 
-/crds/                                                    @fl64 @prismagod @goganat
-/docs/                                                    @fl64 @prismagod @goganat
-/openapi/                                                 @fl64 @prismagod @goganat
+/crds/                                                    @fl64 @z9r5 @goganat
+/docs/                                                    @fl64 @z9r5 @goganat
+/openapi/                                                 @fl64 @z9r5 @goganat
 /monitoring/                                              @fl64 @Isteb4k
 /tests/                                                   @hardcoretime @danilrwx
 


### PR DESCRIPTION
## Description
Updated codeowners for documentation directories: `/crds/`, `/docs/`, and `/openapi/`.


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->


## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: docs
type: docs
summary: "Updated codeowners for `/crds/`, `/docs/`, and `/openapi/`."
impact_level: low
```
