### PR TITLE
fix(kubevirt): build bpf_bridge.o without the svace wrapper

### DIFF
--- a/images/virt-artifact/werf.inc.yaml
+++ b/images/virt-artifact/werf.inc.yaml
@@ -205,10 +205,10 @@ shell:
     {{- include "image-build.build" (set $ "BuildCommand" `go build -ldflags="-s -w" -o /kubevirt-binaries/sidecars ./cmd/sidecars/`) | nindent 6 }}
 
     - echo ============== Build bpf_bridge.o =====================
-    {{- $_ := set $ "ProjectName" (list $.ImageName "bpf-bridge-obj" | join "/") }}
+    # eBPF object: build clang directly without the Svace wrapper.
+    # Svace cannot process the BPF translation unit (0 units, hard error), which breaks the setup stage.
     - mkdir -p /kubevirt-binaries/network-bpf-bridge-binding-assets
-    - |
-    {{- include "image-build.build" (set $ "BuildCommand" `clang -O2 -g -target bpf -I/usr/include -c ./pkg/network/bpfbridge/bpf/bpf_bridge.c -o /kubevirt-binaries/network-bpf-bridge-binding-assets/bpf_bridge.o`) | nindent 6 }}
+    - clang -O2 -g -target bpf -I/usr/include -c ./pkg/network/bpfbridge/bpf/bpf_bridge.c -o /kubevirt-binaries/network-bpf-bridge-binding-assets/bpf_bridge.o
 
     - echo ============== Build virtctl ==========================
     {{- $_ := set $ "ProjectName" (list .ImageName "virtctl" | join "/") }}


### PR DESCRIPTION
## Description

The `virt-artifact` image `setup` stage builds every component through the Svace analysis wrapper (`image-build.build` → `svace build --init --clear-build-dir <cmd>`). The last step compiles the eBPF object `bpf_bridge.o` with `clang -O2 -g -target bpf`.

Svace cannot process this BPF translation unit. In the failing build it reported:

```
Assembled build object: null
  0 C/C++ units are ready.
*** build: C/C++ compilations were detected, but none have been processed
successfully. Please report a bug to Svace developers.
```

`svace build` then exits non-zero, which fails the whole `virt-artifact/setup` stage:

```
Building stage virt-artifact/setup (812.78 seconds) FAILED
error building stage setup: container run failed: Status: , Code: 255
```

This PR compiles `bpf_bridge.o` with `clang` directly, bypassing the Svace wrapper. The neighbouring native C step (`container-disk`, `gcc -static`) is unaffected and keeps being analyzed.

## Why do we need it, and what problem does it solve?

Running an eBPF object through a static analyzer is pointless — Svace's frontend does not support the BPF translation unit and hard-fails instead of skipping it, blocking every image build on branches that include the `bpf_bridge.o` step.

## What is the expected result?

`virt-artifact/setup` completes; `bpf_bridge.o` is produced by clang and the Svace analysis continues for the remaining Go/C components.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: kubevirt
type: fix
summary: Build the bpf_bridge.o eBPF object without the Svace wrapper to fix the virt-artifact build.
```
