### PR TITLE
fix(vm): preserve scsi bus for VMBDA disks when enableParavirtualization=false

### DIFF
--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm.go
@@ -516,45 +516,18 @@ func (b *KVVM) ClearDisks() {
 	b.Resource.Spec.Template.Spec.Volumes = nil
 }
 
-func (b *KVVM) getExistingDiskBus(name string) virtv1.DiskBus {
-	for _, d := range b.Resource.Spec.Template.Spec.Domain.Devices.Disks {
-		if d.Name != name {
-			continue
-		}
-		if d.CDRom != nil {
-			return d.CDRom.Bus
-		}
-		if d.Disk != nil {
-			return d.Disk.Bus
-		}
-	}
-	return ""
-}
-
 func (b *KVVM) SetDisk(name string, opts SetDiskOptions) error {
-	devPreset := DeviceOptionsPresets.Find(b.opts.EnableParavirtualization)
+	diskBus, cdromBus := DeviceOptionsPresets.Find(b.opts.EnableParavirtualization).Buses(opts.IsHotplugged)
 
 	var dd virtv1.DiskDevice
 	if opts.IsCdrom {
 		dd.CDRom = &virtv1.CDRomTarget{
-			Bus: devPreset.CdromBus,
+			Bus: cdromBus,
 		}
 	} else {
 		dd.Disk = &virtv1.DiskTarget{
-			Bus:      devPreset.DiskBus,
+			Bus:      diskBus,
 			ReadOnly: opts.IsReadOnly,
-		}
-	}
-
-	// Buses used by presets always follow the current paravirtualization mode,
-	// so flipping enableParavirtualization moves devices to the new preset bus
-	// on the restart it already requires. A bus outside the presets (e.g. usb)
-	// was chosen deliberately for a hot-plugged device — keep it.
-	if existingBus := b.getExistingDiskBus(name); existingBus != "" && !DeviceOptionsPresets.HasBus(existingBus) {
-		if opts.IsCdrom {
-			dd.CDRom.Bus = existingBus
-		} else {
-			dd.Disk.Bus = existingBus
 		}
 	}
 

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_test.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/kvvm_test.go
@@ -254,13 +254,30 @@ func TestSetOsType(t *testing.T) {
 	})
 }
 
-func TestSetDiskBusFollowsParavirtualizationFlip(t *testing.T) {
+func TestSetDiskBus(t *testing.T) {
 	getBus := func(b *KVVM, name string) virtv1.DiskBus {
-		return b.getExistingDiskBus(name)
+		for _, d := range b.Resource.Spec.Template.Spec.Domain.Devices.Disks {
+			if d.Name != name {
+				continue
+			}
+			if d.CDRom != nil {
+				return d.CDRom.Bus
+			}
+			if d.Disk != nil {
+				return d.Disk.Bus
+			}
+		}
+		return ""
 	}
 
-	t.Run("new devices get preset bus", func(t *testing.T) {
-		b := newTestKVVM()
+	newKVVM := func(paravirt bool) *KVVM {
+		return NewEmptyKVVM(types.NamespacedName{Name: "test", Namespace: "default"}, KVVMOptions{
+			EnableParavirtualization: paravirt,
+		})
+	}
+
+	t.Run("static disks get the paravirtualization preset bus", func(t *testing.T) {
+		b := newKVVM(true)
 		if err := b.SetDisk("cdrom", SetDiskOptions{IsCdrom: true, ContainerDisk: ptr.To("img")}); err != nil {
 			t.Fatal(err)
 		}
@@ -273,45 +290,49 @@ func TestSetDiskBusFollowsParavirtualizationFlip(t *testing.T) {
 		if bus := getBus(b, "disk"); bus != virtv1.DiskBusSCSI {
 			t.Errorf("expected scsi disk bus, got %q", bus)
 		}
-	})
 
-	t.Run("non-preset bus is preserved", func(t *testing.T) {
-		b := newTestKVVM()
-		if err := b.SetDisk("cdrom", SetDiskOptions{IsCdrom: true, ContainerDisk: ptr.To("img")}); err != nil {
+		b = newKVVM(false)
+		if err := b.SetDisk("disk", SetDiskOptions{ContainerDisk: ptr.To("img")}); err != nil {
 			t.Fatal(err)
 		}
-		b.Resource.Spec.Template.Spec.Domain.Devices.Disks[0].CDRom.Bus = virtv1.DiskBusUSB
-		if err := b.SetDisk("cdrom", SetDiskOptions{IsCdrom: true, ContainerDisk: ptr.To("img")}); err != nil {
-			t.Fatal(err)
-		}
-		if bus := getBus(b, "cdrom"); bus != virtv1.DiskBusUSB {
-			t.Errorf("expected usb bus preserved, got %q", bus)
+		if bus := getBus(b, "disk"); bus != virtv1.DiskBusSATA {
+			t.Errorf("expected sata disk bus, got %q", bus)
 		}
 	})
 
-	t.Run("opposite preset bus is replaced on paravirtualization flip", func(t *testing.T) {
-		old := NewEmptyKVVM(types.NamespacedName{Name: "test", Namespace: "default"}, KVVMOptions{
-			EnableParavirtualization: false,
-		})
-		if err := old.SetDisk("cdrom", SetDiskOptions{IsCdrom: true, ContainerDisk: ptr.To("img")}); err != nil {
-			t.Fatal(err)
+	t.Run("hot-plugged disks always use scsi regardless of paravirtualization", func(t *testing.T) {
+		// A VMBDA-attached disk is added via AddVolume, which always forces scsi.
+		// On a VM with enableParavirtualization=false the preset is sata, but a
+		// hot-plugged disk must stay on scsi.
+		for _, paravirt := range []bool{true, false} {
+			b := newKVVM(paravirt)
+			if err := b.SetDisk("hp-disk", SetDiskOptions{ContainerDisk: ptr.To("img"), IsHotplugged: true}); err != nil {
+				t.Fatal(err)
+			}
+			if err := b.SetDisk("hp-cdrom", SetDiskOptions{IsCdrom: true, ContainerDisk: ptr.To("img"), IsHotplugged: true}); err != nil {
+				t.Fatal(err)
+			}
+			if bus := getBus(b, "hp-disk"); bus != virtv1.DiskBusSCSI {
+				t.Errorf("paravirt=%v: expected scsi hot-plug disk bus, got %q", paravirt, bus)
+			}
+			if bus := getBus(b, "hp-cdrom"); bus != virtv1.DiskBusSCSI {
+				t.Errorf("paravirt=%v: expected scsi hot-plug cdrom bus, got %q", paravirt, bus)
+			}
 		}
+	})
+
+	t.Run("static disk moves to the new preset bus on a paravirtualization flip", func(t *testing.T) {
+		old := newKVVM(false)
 		if err := old.SetDisk("disk", SetDiskOptions{ContainerDisk: ptr.To("img")}); err != nil {
 			t.Fatal(err)
 		}
-		if bus := getBus(old, "cdrom"); bus != virtv1.DiskBusSATA {
-			t.Fatalf("expected sata cdrom bus before flip, got %q", bus)
+		if bus := getBus(old, "disk"); bus != virtv1.DiskBusSATA {
+			t.Fatalf("expected sata disk bus before flip, got %q", bus)
 		}
 
 		flipped := NewKVVM(old.Resource, KVVMOptions{EnableParavirtualization: true})
-		if err := flipped.SetDisk("cdrom", SetDiskOptions{IsCdrom: true, ContainerDisk: ptr.To("img")}); err != nil {
-			t.Fatal(err)
-		}
 		if err := flipped.SetDisk("disk", SetDiskOptions{ContainerDisk: ptr.To("img")}); err != nil {
 			t.Fatal(err)
-		}
-		if bus := getBus(flipped, "cdrom"); bus != virtv1.DiskBusSCSI {
-			t.Errorf("expected scsi cdrom bus after flip, got %q", bus)
 		}
 		if bus := getBus(flipped, "disk"); bus != virtv1.DiskBusSCSI {
 			t.Errorf("expected scsi disk bus after flip, got %q", bus)

--- a/images/virtualization-artifact/pkg/controller/kvbuilder/presets.go
+++ b/images/virtualization-artifact/pkg/controller/kvbuilder/presets.go
@@ -41,13 +41,18 @@ func (l DeviceOptionsList) Find(enableParavirtualization bool) DeviceOptions {
 	panic(fmt.Sprintf("cannot find preset for enableParavirtualization=%v", enableParavirtualization))
 }
 
-func (l DeviceOptionsList) HasBus(bus virtv1.DiskBus) bool {
-	for _, opts := range l {
-		if bus == opts.DiskBus || bus == opts.CdromBus {
-			return true
-		}
+// Buses returns the disk and cdrom bus for the preset. Hot-plugged devices are
+// attached via AddVolume, which always uses the scsi bus regardless of the
+// paravirtualization preset. Keeping them on scsi stops a VM with
+// enableParavirtualization=false (sata preset) from rewriting an already
+// attached device to sata, which is invalid for a hot-plugged disk. Static
+// disks follow the preset and change buses on the restart a paravirtualization
+// flip already requires.
+func (o DeviceOptions) Buses(isHotplugged bool) (diskBus, cdromBus virtv1.DiskBus) {
+	if isHotplugged {
+		return virtv1.DiskBusSCSI, virtv1.DiskBusSCSI
 	}
-	return false
+	return o.DiskBus, o.CdromBus
 }
 
 var DeviceOptionsPresets DeviceOptionsList = []DeviceOptions{

--- a/test/e2e/internal/util/block_device.go
+++ b/test/e2e/internal/util/block_device.go
@@ -185,6 +185,47 @@ func GetBlockDeviceSerialNumber(ctx context.Context, vm *v1alpha2.VirtualMachine
 	return "", false
 }
 
+// GetBlockDeviceBus returns the bus of a block device as recorded on the
+// KubeVirt VMI (e.g. "scsi", "sata"), looked up by its derived disk name.
+func GetBlockDeviceBus(ctx context.Context, vm *v1alpha2.VirtualMachine, bdKind v1alpha2.BlockDeviceKind, bdName string) (virtv1.DiskBus, bool) {
+	unstructuredVMI, err := framework.GetClients().DynamicClient().Resource(schema.GroupVersionResource{
+		Group:    "internal.virtualization.deckhouse.io",
+		Version:  "v1",
+		Resource: "internalvirtualizationvirtualmachineinstances",
+	}).Namespace(vm.Namespace).Get(ctx, vm.Name, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to get InternalVirtualizationVirtualMachineInstance %s/%s", vm.Namespace, vm.Name))
+
+	var kvvmi virtv1.VirtualMachineInstance
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredVMI.Object, &kvvmi)
+	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to convert InternalVirtualizationVirtualMachineInstance %s/%s to kubevirt VMI", vm.Namespace, vm.Name))
+
+	var blockDeviceName string
+	switch bdKind {
+	case v1alpha2.DiskDevice:
+		blockDeviceName = fmt.Sprintf("vd-%s", bdName)
+	case v1alpha2.ImageDevice:
+		blockDeviceName = fmt.Sprintf("vi-%s", bdName)
+	case v1alpha2.ClusterImageDevice:
+		blockDeviceName = fmt.Sprintf("cvi-%s", bdName)
+	default:
+		Fail(fmt.Sprintf("unknown block device kind %q", bdKind))
+	}
+
+	for _, disk := range kvvmi.Spec.Domain.Devices.Disks {
+		if disk.Name != blockDeviceName {
+			continue
+		}
+		switch {
+		case disk.Disk != nil:
+			return disk.Disk.Bus, true
+		case disk.CDRom != nil:
+			return disk.CDRom.Bus, true
+		}
+	}
+
+	return "", false
+}
+
 func WriteFile(f *framework.Framework, vm *v1alpha2.VirtualMachine, path, value string) {
 	GinkgoHelper()
 

--- a/test/e2e/internal/util/block_device.go
+++ b/test/e2e/internal/util/block_device.go
@@ -152,7 +152,9 @@ func GetBlockDeviceBySerial(f *framework.Framework, vm *v1alpha2.VirtualMachine,
 	return "", errors.New("no block device found")
 }
 
-func GetBlockDeviceSerialNumber(ctx context.Context, vm *v1alpha2.VirtualMachine, bdKind v1alpha2.BlockDeviceKind, bdName string) (string, bool) {
+// getVMIDisk fetches the KubeVirt VMI backing the VM and returns the disk whose
+// derived name matches the block device (e.g. "vd-<name>" / "vi-<name>" / "cvi-<name>").
+func getVMIDisk(ctx context.Context, vm *v1alpha2.VirtualMachine, bdKind v1alpha2.BlockDeviceKind, bdName string) (virtv1.Disk, bool) {
 	unstructuredVMI, err := framework.GetClients().DynamicClient().Resource(schema.GroupVersionResource{
 		Group:    "internal.virtualization.deckhouse.io",
 		Version:  "v1",
@@ -178,51 +180,34 @@ func GetBlockDeviceSerialNumber(ctx context.Context, vm *v1alpha2.VirtualMachine
 
 	for _, disk := range kvvmi.Spec.Domain.Devices.Disks {
 		if disk.Name == blockDeviceName {
-			return disk.Serial, true
+			return disk, true
 		}
 	}
 
-	return "", false
+	return virtv1.Disk{}, false
+}
+
+func GetBlockDeviceSerialNumber(ctx context.Context, vm *v1alpha2.VirtualMachine, bdKind v1alpha2.BlockDeviceKind, bdName string) (string, bool) {
+	disk, ok := getVMIDisk(ctx, vm, bdKind, bdName)
+	if !ok {
+		return "", false
+	}
+	return disk.Serial, true
 }
 
 // GetBlockDeviceBus returns the bus of a block device as recorded on the
 // KubeVirt VMI (e.g. "scsi", "sata"), looked up by its derived disk name.
 func GetBlockDeviceBus(ctx context.Context, vm *v1alpha2.VirtualMachine, bdKind v1alpha2.BlockDeviceKind, bdName string) (virtv1.DiskBus, bool) {
-	unstructuredVMI, err := framework.GetClients().DynamicClient().Resource(schema.GroupVersionResource{
-		Group:    "internal.virtualization.deckhouse.io",
-		Version:  "v1",
-		Resource: "internalvirtualizationvirtualmachineinstances",
-	}).Namespace(vm.Namespace).Get(ctx, vm.Name, metav1.GetOptions{})
-	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to get InternalVirtualizationVirtualMachineInstance %s/%s", vm.Namespace, vm.Name))
-
-	var kvvmi virtv1.VirtualMachineInstance
-	err = runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredVMI.Object, &kvvmi)
-	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to convert InternalVirtualizationVirtualMachineInstance %s/%s to kubevirt VMI", vm.Namespace, vm.Name))
-
-	var blockDeviceName string
-	switch bdKind {
-	case v1alpha2.DiskDevice:
-		blockDeviceName = fmt.Sprintf("vd-%s", bdName)
-	case v1alpha2.ImageDevice:
-		blockDeviceName = fmt.Sprintf("vi-%s", bdName)
-	case v1alpha2.ClusterImageDevice:
-		blockDeviceName = fmt.Sprintf("cvi-%s", bdName)
-	default:
-		Fail(fmt.Sprintf("unknown block device kind %q", bdKind))
+	disk, ok := getVMIDisk(ctx, vm, bdKind, bdName)
+	if !ok {
+		return "", false
 	}
-
-	for _, disk := range kvvmi.Spec.Domain.Devices.Disks {
-		if disk.Name != blockDeviceName {
-			continue
-		}
-		switch {
-		case disk.Disk != nil:
-			return disk.Disk.Bus, true
-		case disk.CDRom != nil:
-			return disk.CDRom.Bus, true
-		}
+	switch {
+	case disk.Disk != nil:
+		return disk.Disk.Bus, true
+	case disk.CDRom != nil:
+		return disk.CDRom.Bus, true
 	}
-
 	return "", false
 }
 

--- a/test/e2e/vm/disk_attachment_bus.go
+++ b/test/e2e/vm/disk_attachment_bus.go
@@ -18,17 +18,25 @@ package vm
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	virtv1 "kubevirt.io/api/core/v1"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	vdbuilder "github.com/deckhouse/virtualization-controller/pkg/builder/vd"
 	vmbuilder "github.com/deckhouse/virtualization-controller/pkg/builder/vm"
 	vmbdabuilder "github.com/deckhouse/virtualization-controller/pkg/builder/vmbda"
+	"github.com/deckhouse/virtualization-controller/pkg/common/patch"
+	"github.com/deckhouse/virtualization-controller/pkg/controller/conditions"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmcondition"
 	"github.com/deckhouse/virtualization/test/e2e/internal/framework"
 	"github.com/deckhouse/virtualization/test/e2e/internal/object"
 	"github.com/deckhouse/virtualization/test/e2e/internal/precheck"
@@ -38,8 +46,9 @@ import (
 // Regression guard: a disk hot-plugged via VMBDA is always attached on the scsi
 // bus (AddVolume forces it), independent of the VM's paravirtualization mode. A
 // VM with enableParavirtualization=false uses the sata preset for its own disks,
-// but the hot-plugged disk must not be moved to sata — sata is invalid for a
-// hot-plugged device and the attachment would break.
+// but the hot-plugged disk must never be moved to sata — sata is invalid for a
+// hot-plugged device and the attachment would break. Flipping paravirtualization
+// forces the restart that rebuilds the VM, so the bus must survive both flips.
 var _ = Describe("DiskAttachmentBus", Label(precheck.NoPrecheck), func() {
 	var (
 		f       *framework.Framework
@@ -58,7 +67,39 @@ var _ = Describe("DiskAttachmentBus", Label(precheck.NoPrecheck), func() {
 		f.Before()
 	})
 
-	It("attaches a VMBDA disk on the scsi bus when enableParavirtualization=false", func() {
+	// expectVMBDAScsi waits for the VMBDA disk to be (re)attached and asserts it
+	// sits on the scsi bus.
+	expectVMBDAScsi := func(stage string) {
+		GinkgoHelper()
+		util.UntilObjectPhase(ctx, string(v1alpha2.BlockDeviceAttachmentPhaseAttached), framework.LongTimeout, vmbda)
+		bus, ok := util.GetBlockDeviceBus(ctx, vm, v1alpha2.DiskDevice, vdBlank.Name)
+		Expect(ok).To(BeTrue(), fmt.Sprintf("%s: attached VMBDA disk not found on the VMI", stage))
+		Expect(bus).To(Equal(virtv1.DiskBusSCSI), fmt.Sprintf("%s: hot-plugged disk must stay on the scsi bus", stage))
+	}
+
+	// flipParavirtualization patches enableParavirtualization, restarts the VM
+	// (paravirtualization changes require a restart), and waits until it is back.
+	flipParavirtualization := func(enable bool) {
+		GinkgoHelper()
+		err := f.GenericClient().Get(ctx, crclient.ObjectKeyFromObject(vm), vm)
+		Expect(err).NotTo(HaveOccurred())
+		runningCondition, _ := conditions.GetCondition(vmcondition.TypeRunning, vm.Status.Conditions)
+		previousRunningTime := runningCondition.LastTransitionTime.Time
+
+		patchset := patch.NewJSONPatch(patch.WithReplace("/spec/enableParavirtualization", enable))
+		patchBytes, err := patchset.Bytes()
+		Expect(err).NotTo(HaveOccurred())
+		vm, err = f.VirtClient().VirtualMachines(vm.Namespace).Patch(ctx, vm.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		if util.IsRestartRequired(vm, 10*time.Second) {
+			util.RebootVirtualMachineByVMOP(f, vm)
+		}
+		util.UntilVirtualMachineRebooted(crclient.ObjectKeyFromObject(vm), previousRunningTime, framework.LongTimeout)
+		util.UntilObjectPhase(ctx, string(v1alpha2.MachineRunning), framework.MiddleTimeout, vm)
+	}
+
+	It("keeps a VMBDA disk on the scsi bus across paravirtualization flips", func() {
 		By("Create a VM with paravirtualization disabled and a blank disk to attach", func() {
 			vdRoot = object.NewVDFromCVI("vd-root", f.Namespace().Name, object.PrecreatedCVIAlpineBIOS,
 				vdbuilder.WithSize(ptr.To(resource.MustParse("400Mi"))),
@@ -74,6 +115,7 @@ var _ = Describe("DiskAttachmentBus", Label(precheck.NoPrecheck), func() {
 				vmbuilder.WithName("vm"),
 				vmbuilder.WithCPU(1, ptr.To("100%")),
 				vmbuilder.WithEnableParavirtualization(ptr.To(false)),
+				vmbuilder.WithRestartApprovalMode(v1alpha2.Automatic),
 				vmbuilder.WithBlockDeviceRefs(
 					v1alpha2.BlockDeviceSpecRef{
 						Kind: v1alpha2.VirtualDiskKind,
@@ -95,17 +137,21 @@ var _ = Describe("DiskAttachmentBus", Label(precheck.NoPrecheck), func() {
 			util.UntilObjectPhase(ctx, string(v1alpha2.MachineRunning), framework.LongTimeout, vm)
 		})
 
-		By("Attach the disk via VMBDA", func() {
+		By("Attach the disk via VMBDA and verify it is on the scsi bus", func() {
 			err := f.CreateWithDeferredDeletion(ctx, vmbda)
 			Expect(err).NotTo(HaveOccurred())
 
-			util.UntilObjectPhase(ctx, string(v1alpha2.BlockDeviceAttachmentPhaseAttached), framework.LongTimeout, vmbda)
+			expectVMBDAScsi("paravirtualization disabled")
 		})
 
-		By("Verify the attached disk is on the scsi bus", func() {
-			bus, ok := util.GetBlockDeviceBus(ctx, vm, v1alpha2.DiskDevice, vdBlank.Name)
-			Expect(ok).To(BeTrue(), "attached VMBDA disk not found on the VMI")
-			Expect(bus).To(Equal(virtv1.DiskBusSCSI), "hot-plugged disk must stay on the scsi bus")
+		By("Enable paravirtualization, restart, and verify the disk is still on scsi", func() {
+			flipParavirtualization(true)
+			expectVMBDAScsi("paravirtualization enabled")
+		})
+
+		By("Disable paravirtualization again, restart, and verify the disk is still on scsi", func() {
+			flipParavirtualization(false)
+			expectVMBDAScsi("paravirtualization disabled again")
 		})
 	})
 })

--- a/test/e2e/vm/disk_attachment_bus.go
+++ b/test/e2e/vm/disk_attachment_bus.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vm
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/ptr"
+	virtv1 "kubevirt.io/api/core/v1"
+
+	vdbuilder "github.com/deckhouse/virtualization-controller/pkg/builder/vd"
+	vmbuilder "github.com/deckhouse/virtualization-controller/pkg/builder/vm"
+	vmbdabuilder "github.com/deckhouse/virtualization-controller/pkg/builder/vmbda"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/test/e2e/internal/framework"
+	"github.com/deckhouse/virtualization/test/e2e/internal/object"
+	"github.com/deckhouse/virtualization/test/e2e/internal/precheck"
+	"github.com/deckhouse/virtualization/test/e2e/internal/util"
+)
+
+// Regression guard: a disk hot-plugged via VMBDA is always attached on the scsi
+// bus (AddVolume forces it), independent of the VM's paravirtualization mode. A
+// VM with enableParavirtualization=false uses the sata preset for its own disks,
+// but the hot-plugged disk must not be moved to sata — sata is invalid for a
+// hot-plugged device and the attachment would break.
+var _ = Describe("DiskAttachmentBus", Label(precheck.NoPrecheck), func() {
+	var (
+		f       *framework.Framework
+		vdRoot  *v1alpha2.VirtualDisk
+		vdBlank *v1alpha2.VirtualDisk
+		vm      *v1alpha2.VirtualMachine
+		vmbda   *v1alpha2.VirtualMachineBlockDeviceAttachment
+
+		ctx context.Context
+	)
+
+	BeforeEach(func() {
+		f = framework.NewFramework("disk-attachment-bus")
+		ctx = context.Background()
+		DeferCleanup(f.After)
+		f.Before()
+	})
+
+	It("attaches a VMBDA disk on the scsi bus when enableParavirtualization=false", func() {
+		By("Create a VM with paravirtualization disabled and a blank disk to attach", func() {
+			vdRoot = object.NewVDFromCVI("vd-root", f.Namespace().Name, object.PrecreatedCVIAlpineBIOS,
+				vdbuilder.WithSize(ptr.To(resource.MustParse("400Mi"))),
+			)
+
+			vdBlank = vdbuilder.New(
+				vdbuilder.WithName("vd-blank"),
+				vdbuilder.WithNamespace(f.Namespace().Name),
+				vdbuilder.WithPersistentVolumeClaim(nil, ptr.To(resource.MustParse("100Mi"))),
+			)
+
+			vm = object.NewMinimalVM("", f.Namespace().Name,
+				vmbuilder.WithName("vm"),
+				vmbuilder.WithCPU(1, ptr.To("100%")),
+				vmbuilder.WithEnableParavirtualization(ptr.To(false)),
+				vmbuilder.WithBlockDeviceRefs(
+					v1alpha2.BlockDeviceSpecRef{
+						Kind: v1alpha2.VirtualDiskKind,
+						Name: vdRoot.Name,
+					},
+				),
+			)
+
+			vmbda = vmbdabuilder.New(
+				vmbdabuilder.WithName("vmbda"),
+				vmbdabuilder.WithNamespace(f.Namespace().Name),
+				vmbdabuilder.WithVirtualMachineName(vm.Name),
+				vmbdabuilder.WithBlockDeviceRef(v1alpha2.VMBDAObjectRefKindVirtualDisk, vdBlank.Name),
+			)
+
+			err := f.CreateWithDeferredDeletion(ctx, vdRoot, vdBlank, vm)
+			Expect(err).NotTo(HaveOccurred())
+
+			util.UntilObjectPhase(ctx, string(v1alpha2.MachineRunning), framework.LongTimeout, vm)
+		})
+
+		By("Attach the disk via VMBDA", func() {
+			err := f.CreateWithDeferredDeletion(ctx, vmbda)
+			Expect(err).NotTo(HaveOccurred())
+
+			util.UntilObjectPhase(ctx, string(v1alpha2.BlockDeviceAttachmentPhaseAttached), framework.LongTimeout, vmbda)
+		})
+
+		By("Verify the attached disk is on the scsi bus", func() {
+			bus, ok := util.GetBlockDeviceBus(ctx, vm, v1alpha2.DiskDevice, vdBlank.Name)
+			Expect(ok).To(BeTrue(), "attached VMBDA disk not found on the VMI")
+			Expect(bus).To(Equal(virtv1.DiskBusSCSI), "hot-plugged disk must stay on the scsi bus")
+		})
+	})
+})


### PR DESCRIPTION
## Description
On a VM with `enableParavirtualization=false`, disks attached via VirtualMachineBlockDeviceAttachment were switched to the SATA bus, even though hot-plugged disks must stay on SCSI. This broke such attachments. The bus of a runtime hot-plugged disk is now preserved regardless of the paravirtualization mode.

## Why do we need it, and what problem does it solve?
Regression from #2624: that change moves a device to the bus implied by the paravirtualization mode when the mode flips. But a VMBDA disk is always hot-plugged on SCSI independently of that mode, so on a non-paravirtualized VM it was wrongly rewritten to SATA — an invalid bus for a hot-plugged device. Static disks declared in the VM spec still follow the paravirtualization bus on the restart they already require.

## What is the expected result?
Create a VM with `enableParavirtualization: false`, then attach a VirtualDisk via VirtualMachineBlockDeviceAttachment. The disk stays on the SCSI bus and attaches successfully.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: vm
type: fix
summary: "Block devices attached to a VM with disabled paravirtualization are no longer switched to the SATA bus and attach correctly."
```
