### PR TITLE
chore(ci): replace E2E_IMAGE_BASE_URL with virtlab endpoint

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -18,7 +18,7 @@ on:
   workflow_dispatch:
 
 env:
-  E2E_IMAGE_BASE_URL: "http://share.e2e-test-images.svc.cluster.local"
+  E2E_IMAGE_BASE_URL: "https://e2e-test-images.e2e.virtlab.flant.com"
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.event.number || github.ref }}"


### PR DESCRIPTION
## Description

Replaces the E2E nightly image base URL `E2E_IMAGE_BASE_URL` with `https://e2e-test-images.e2e.virtlab.flant.com`.

Previously it pointed at the in-cluster service `http://share.e2e-test-images.svc.cluster.local`.

## Why do we need it, and what problem does it solve?

Point E2E nightly test image downloads at the new virtlab endpoint.

## Changelog entries

