### PR TITLE
fix(dra): load xz-compressed usbip kernel modules

### DIFF
--- a/images/virtualization-dra/cmd/usb/dra/app/init.go
+++ b/images/virtualization-dra/cmd/usb/dra/app/init.go
@@ -127,26 +127,33 @@ func (o *initOptions) getPreInstalledModules(kernelRelease string) ([]string, er
 		filepath.Join("/lib/modules", kernelRelease, "kernel/drivers/usb/usbip/vhci-hcd.ko"),
 	}
 
-	for i, m := range modules {
-		exists, err := fileExists(m)
+	for i, base := range modules {
+		resolved, err := resolveModulePath(base)
 		if err != nil {
 			return nil, err
 		}
-
-		if !exists {
-			m += ".zst"
-			exists, err = fileExists(m)
-			if err != nil {
-				return nil, err
-			}
-			if !exists {
-				return nil, fmt.Errorf("module %s not found", m)
-			}
-			modules[i] = m
-		}
+		modules[i] = resolved
 	}
 
 	return modules, nil
+}
+
+// resolveModulePath returns the module path as-is or with the first matching
+// compression suffix, since pre-installed modules may be shipped compressed
+// (.ko.zst, .ko.xz) depending on the host distribution.
+func resolveModulePath(base string) (string, error) {
+	for _, suffix := range []string{"", ".zst", ".xz", ".gz"} {
+		candidate := base + suffix
+		exists, err := fileExists(candidate)
+		if err != nil {
+			return "", err
+		}
+		if exists {
+			return candidate, nil
+		}
+	}
+
+	return "", fmt.Errorf("module %s not found", base)
 }
 
 func fileExists(path string) (bool, error) {

--- a/images/virtualization-dra/go.mod
+++ b/images/virtualization-dra/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/onsi/gomega v1.35.1
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/pflag v1.0.9
+	github.com/ulikunitz/xz v0.5.15
 	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.45.0
 	google.golang.org/grpc v1.79.3

--- a/images/virtualization-dra/go.sum
+++ b/images/virtualization-dra/go.sum
@@ -142,6 +142,8 @@ github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtse
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tetratelabs/wazero v1.9.0 h1:IcZ56OuxrtaEz8UYNRHBrUa9bYeX9oVY93KspZZBf/I=
 github.com/tetratelabs/wazero v1.9.0/go.mod h1:TSbcXCfFP0L2FGkRPxHphadXPjo1T6W+CseNNY7EkjM=
+github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
+github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/urfave/cli v1.19.1/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=

--- a/images/virtualization-dra/pkg/modprobe/modprobe.go
+++ b/images/virtualization-dra/pkg/modprobe/modprobe.go
@@ -17,6 +17,7 @@ limitations under the License.
 package modprobe
 
 import (
+	"compress/gzip"
 	"errors"
 	"fmt"
 	"io"
@@ -26,6 +27,7 @@ import (
 	"strings"
 
 	"github.com/klauspost/compress/zstd"
+	"github.com/ulikunitz/xz"
 	"golang.org/x/sys/unix"
 )
 
@@ -40,7 +42,7 @@ func LoadModules(modules ...string) error {
 }
 
 func loadModule(path string) error {
-	if strings.HasSuffix(path, ".zst") {
+	if isCompressed(path) {
 		uncompressedPath, err := uncompressModuleToTmp(path)
 		if err != nil {
 			return fmt.Errorf("uncompress module %s: %w", path, err)
@@ -86,17 +88,40 @@ func uncompressModuleToTmp(path string) (string, error) {
 	}
 	defer in.Close()
 
-	decoder, err := zstd.NewReader(in)
+	decoder, err := newDecompressor(path, in)
 	if err != nil {
 		return "", err
 	}
-	defer decoder.Close()
+	if closer, ok := decoder.(io.Closer); ok {
+		defer func() { _ = closer.Close() }()
+	}
 
 	if _, err := io.Copy(uncompress, decoder); err != nil {
 		return "", err
 	}
 
 	return uncompress.Name(), nil
+}
+
+// isCompressed reports whether the module is stored in one of the compression
+// formats the kernel supports for modules (MODULE_COMPRESS_{GZIP,XZ,ZSTD}).
+func isCompressed(path string) bool {
+	return strings.HasSuffix(path, ".zst") ||
+		strings.HasSuffix(path, ".xz") ||
+		strings.HasSuffix(path, ".gz")
+}
+
+func newDecompressor(path string, in io.Reader) (io.Reader, error) {
+	switch {
+	case strings.HasSuffix(path, ".zst"):
+		return zstd.NewReader(in)
+	case strings.HasSuffix(path, ".xz"):
+		return xz.NewReader(in)
+	case strings.HasSuffix(path, ".gz"):
+		return gzip.NewReader(in)
+	default:
+		return nil, fmt.Errorf("unsupported compression format: %s", path)
+	}
 }
 
 func KernelRelease() (string, error) {

--- a/templates/virtualization-dra/nodegroupconfiguration-usbip.yaml
+++ b/templates/virtualization-dra/nodegroupconfiguration-usbip.yaml
@@ -33,7 +33,7 @@ spec:
 
     modules_exist=true
     for module in "${modules[@]}"; do
-      if [[ ! -e "${module_dir}/${module}" && ! -e "${module_dir}/${module}.zst" && ! -e "${module_dir}/${module}.xz" ]]; then
+      if [[ ! -e "${module_dir}/${module}" && ! -e "${module_dir}/${module}.zst" && ! -e "${module_dir}/${module}.xz" && ! -e "${module_dir}/${module}.gz" ]]; then
         modules_exist=false
         break
       fi


### PR DESCRIPTION
## Description

On nodes where the pre-installed usbip kernel modules are shipped compressed, the DRA USB driver failed to initialize with `module ...usbip-core.ko.zst not found`, so USB passthrough was unavailable on those nodes. Kernel modules can be compressed with any of the three formats the kernel supports (zstd, xz, gzip), but only `.ko` and `.ko.zst` were recognized. The driver now finds and decompresses `.ko.xz` and `.ko.gz` too, and the node-configuration check that installs the modules recognizes the same set of formats.

## Why do we need it, and what problem does it solve?

Some distributions (e.g. the observed node shipped `.ko.xz`) compress kernel modules with xz or gzip instead of zstd. USB passthrough silently stayed broken on such nodes because the driver only knew about zstd. This makes module loading work regardless of the host's chosen compression format.

## What is the expected result?

On a node whose usbip modules are `.ko.xz` (or `.ko.gz`), the DRA USB driver init loads the modules successfully and USB passthrough works, instead of failing with `module not found`.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section:  core
type: fix
summary: "USB passthrough now works on nodes where usbip kernel modules are compressed with xz or gzip, not only zstd."
impact_level: low
```
