### PR TITLE
feat(vmop): explain why a migration is queued behind concurrency limits

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle.go
@@ -73,6 +73,12 @@ const (
 
 	reasonTargetNodeIncomingMigrationLimitExceeded  = "TargetNodeIncomingMigrationLimitExceeded"
 	messageTargetNodeIncomingMigrationLimitExceeded = "Target node has no free inbound migration slots."
+	messageInboundMigrationLimitFmt                 = "Waiting for a free migration slot: node %q has no free inbound migration slot (%d in progress)."
+
+	// migrationConcurrencyLimitReached is set by KubeVirt on a pending migration
+	// blocked by the cluster or per-node outbound concurrency limit; its message
+	// already describes the limit and current counts.
+	migrationConcurrencyLimitReached = "MigrationConcurrencyLimitReached"
 )
 
 type Base interface {
@@ -610,12 +616,12 @@ func (h LifecycleHandler) getInProgressReasonAndMessage(
 	case virtv1.MigrationPhaseUnset, virtv1.MigrationPending:
 		reason = vmopcondition.ReasonMigrationPending
 		message = messageMigrationPending
-		if _, found := conditions.GetKVVMIMCondition(virtv1.VirtualMachineInstanceMigrationConditionType(reasonTargetNodeIncomingMigrationLimitExceeded), mig.Status.Conditions); found {
-			message = messageTargetNodeIncomingMigrationLimitExceeded
-		} else if waiting, err := h.isWaitingForInboundMigrationSlot(ctx, mig); err != nil {
+		if inboundMsg, err := h.inboundMigrationLimitMessage(ctx, mig); err != nil {
 			return reason, message, err
-		} else if waiting {
-			message = messageTargetNodeIncomingMigrationLimitExceeded
+		} else if inboundMsg != "" {
+			message = inboundMsg
+		} else if cond, found := conditions.GetKVVMIMCondition(virtv1.VirtualMachineInstanceMigrationConditionType(migrationConcurrencyLimitReached), mig.Status.Conditions); found && cond.Message != "" {
+			message = cond.Message
 		}
 	case virtv1.MigrationScheduling:
 		reason = vmopcondition.ReasonTargetScheduling
@@ -775,18 +781,36 @@ func humanizeMigrationFailedMessage(message string) string {
 	return message
 }
 
-func (h LifecycleHandler) isWaitingForInboundMigrationSlot(ctx context.Context, mig *virtv1.VirtualMachineInstanceMigration) (bool, error) {
-	if mig == nil || mig.Spec.VMIName == "" {
-		return false, nil
-	}
+// inboundMigrationLimitMessage explains why a pending migration cannot start yet
+// when the controller's inbound limiter has no free slot on the target node.
+// The limit is enforced by the inbound limiter (annotation-based) or reported as
+// a migration condition; the target node and current occupancy are read from VMI
+// annotations, so no access to the limiter itself is needed. Returns an empty
+// string when the migration is not inbound-limited.
+func (h LifecycleHandler) inboundMigrationLimitMessage(ctx context.Context, mig *virtv1.VirtualMachineInstanceMigration) (string, error) {
+	_, hasCondition := conditions.GetKVVMIMCondition(virtv1.VirtualMachineInstanceMigrationConditionType(reasonTargetNodeIncomingMigrationLimitExceeded), mig.Status.Conditions)
 
 	var kvvmi virtv1.VirtualMachineInstance
-	err := h.client.Get(ctx, types.NamespacedName{Namespace: mig.Namespace, Name: mig.Spec.VMIName}, &kvvmi)
-	if err != nil {
-		return false, client.IgnoreNotFound(err)
+	if mig.Spec.VMIName != "" {
+		if err := h.client.Get(ctx, types.NamespacedName{Namespace: mig.Namespace, Name: mig.Spec.VMIName}, &kvvmi); client.IgnoreNotFound(err) != nil {
+			return "", err
+		}
 	}
 
-	return livemigration.IsInboundMigrationSlotWaiting(&kvvmi), nil
+	if !hasCondition && !livemigration.IsInboundMigrationSlotWaiting(&kvvmi) {
+		return "", nil
+	}
+
+	node := livemigration.InboundMigrationWaitingTargetNode(&kvvmi)
+	if node == "" {
+		return messageTargetNodeIncomingMigrationLimitExceeded, nil
+	}
+
+	inbound, err := livemigration.CountAcquiredSlotsOnNode(ctx, h.client, node)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(messageInboundMigrationLimitFmt, node, inbound), nil
 }
 
 func (h LifecycleHandler) getTargetPod(ctx context.Context, mig *virtv1.VirtualMachineInstanceMigration) (*corev1.Pod, error) {

--- a/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle_test.go
+++ b/images/virtualization-artifact/pkg/controller/vmop/migration/internal/handler/lifecycle_test.go
@@ -42,6 +42,7 @@ import (
 	genericservice "github.com/deckhouse/virtualization-controller/pkg/controller/vmop/service"
 	"github.com/deckhouse/virtualization-controller/pkg/eventrecord"
 	"github.com/deckhouse/virtualization-controller/pkg/featuregates"
+	"github.com/deckhouse/virtualization-controller/pkg/livemigration"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmcondition"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2/vmopcondition"
@@ -387,6 +388,58 @@ var _ = Describe("LifecycleHandler", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(reason).To(Equal(vmopcondition.ReasonMigrationPending))
 			Expect(msg).To(Equal(messageTargetNodeIncomingMigrationLimitExceeded))
+		})
+
+		It("should name the target node and occupancy for the inbound limit", func() {
+			mig := newSimpleMigration("vmop-test", name)
+			mig.UID = "self-uid"
+			mig.Status.Phase = virtv1.MigrationPending
+
+			// The migrating VM is waiting for an inbound slot on node-a.
+			vmi := &virtv1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name, Annotations: map[string]string{
+					livemigration.InboundMigrationSlotAnnotation:       livemigration.InboundMigrationSlotWaiting,
+					livemigration.InboundMigrationTargetNodeAnnotation: "node-a",
+				}},
+			}
+			// Another VM already migrating into node-a occupies the slot.
+			occupant := &virtv1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "occupant", Annotations: map[string]string{
+					livemigration.InboundMigrationSlotAnnotation:       livemigration.InboundMigrationSlotAcquired,
+					livemigration.InboundMigrationTargetNodeAnnotation: "node-a",
+				}},
+			}
+
+			fakeClient, err := testutil.NewFakeClientWithObjects(mig, vmi, occupant)
+			Expect(err).NotTo(HaveOccurred())
+
+			h := LifecycleHandler{client: fakeClient}
+			reason, msg, err := h.getInProgressReasonAndMessage(ctx, mig)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(reason).To(Equal(vmopcondition.ReasonMigrationPending))
+			Expect(msg).To(Equal(fmt.Sprintf(messageInboundMigrationLimitFmt, "node-a", 1)))
+		})
+
+		It("should surface the concurrency-limit condition set by KubeVirt", func() {
+			const limitMsg = `Waiting for a free migration slot: node "node-a" has no free outbound migration slot (1/1 running).`
+
+			mig := newSimpleMigration("vmop-test", name)
+			mig.UID = "self-uid"
+			mig.Status.Phase = virtv1.MigrationPending
+			mig.Status.Conditions = []virtv1.VirtualMachineInstanceMigrationCondition{{
+				Type:    virtv1.VirtualMachineInstanceMigrationConditionType(migrationConcurrencyLimitReached),
+				Status:  corev1.ConditionTrue,
+				Message: limitMsg,
+			}}
+
+			fakeClient, err := testutil.NewFakeClientWithObjects(mig)
+			Expect(err).NotTo(HaveOccurred())
+
+			h := LifecycleHandler{client: fakeClient}
+			reason, msg, err := h.getInProgressReasonAndMessage(ctx, mig)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(reason).To(Equal(vmopcondition.ReasonMigrationPending))
+			Expect(msg).To(Equal(limitMsg))
 		})
 
 		DescribeTable("should build in-progress reason and message", func(

--- a/images/virtualization-artifact/pkg/livemigration/inbound_limiter.go
+++ b/images/virtualization-artifact/pkg/livemigration/inbound_limiter.go
@@ -236,6 +236,28 @@ func IsInboundMigrationSlotWaiting(kvvmi *virtv1.VirtualMachineInstance) bool {
 	return kvvmi.Annotations[InboundMigrationSlotAnnotation] == InboundMigrationSlotWaiting
 }
 
+func IsInboundMigrationSlotAcquired(kvvmi *virtv1.VirtualMachineInstance) bool {
+	return kvvmi.Annotations[InboundMigrationSlotAnnotation] == InboundMigrationSlotAcquired
+}
+
+// CountAcquiredSlotsOnNode returns how many VMIs currently hold an inbound
+// migration slot on the given target node.
+func CountAcquiredSlotsOnNode(ctx context.Context, c client.Reader, node string) (int, error) {
+	var vmis virtv1.VirtualMachineInstanceList
+	if err := c.List(ctx, &vmis); err != nil {
+		return 0, err
+	}
+
+	count := 0
+	for i := range vmis.Items {
+		kvvmi := &vmis.Items[i]
+		if IsInboundMigrationSlotAcquired(kvvmi) && InboundMigrationWaitingTargetNode(kvvmi) == node {
+			count++
+		}
+	}
+	return count, nil
+}
+
 func InboundMigrationWaitingTargetNode(kvvmi *virtv1.VirtualMachineInstance) string {
 	return kvvmi.Annotations[InboundMigrationTargetNodeAnnotation]
 }

--- a/images/virtualization-artifact/pkg/livemigration/inbound_limiter_test.go
+++ b/images/virtualization-artifact/pkg/livemigration/inbound_limiter_test.go
@@ -183,4 +183,22 @@ var _ = Describe("InboundMigrationLimiter", func() {
 		limiter := NewInboundMigrationLimiter(false, 1)
 		Expect(limiter.Restore(ctx, fakeClient)).To(Succeed())
 	})
+
+	It("Should count only acquired slots on the given node", func() {
+		onNode := newKVVMI("on-node", "m1")
+		MarkInboundMigrationSlotAcquired(onNode, targetNode)
+
+		otherNode := newKVVMI("other-node", "m2")
+		MarkInboundMigrationSlotAcquired(otherNode, "other-node")
+
+		waiting := newKVVMI("waiting", "m3")
+		MarkInboundMigrationSlotWaiting(waiting, targetNode)
+
+		fakeClient, err := testutil.NewFakeClientWithObjects(onNode, otherNode, waiting)
+		Expect(err).NotTo(HaveOccurred())
+
+		count, err := CountAcquiredSlotsOnNode(ctx, fakeClient, targetNode)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(count).To(Equal(1))
+	})
 })


### PR DESCRIPTION
## Description

When a migration (a firmware update, a node drain, or a manual migrate) cannot start immediately because a concurrency limit is already taken, the operation used to sit in `Pending` for a long time with only a generic "queued, waiting for the queue to be processed" message — indistinguishable from a stuck one.

This surfaces the concrete reason on the pending operation for all three limits, naming the node and current counts:

- **inbound** (target node): `node "worker-0" has no free inbound migration slot (1 in progress)` — from the controller's own inbound limiter.
- **cluster / per-node outbound**: taken from a `MigrationConcurrencyLimitReached` condition that KubeVirt now sets on the migration, e.g. `the cluster live migration limit is reached (3/3 running)` or `node "worker-0" has no free outbound migration slot (1/1 running)`.

The cluster/outbound limits are enforced by KubeVirt, so the reason is reported at the source (see the paired 3p-kubevirt change) and this controller only reads the resulting condition — no duplication of KubeVirt's limit algorithm. The inbound limit is enforced by this controller's own limiter and is reported here.

## Why do we need it, and what problem does it solve?

Migrations queued behind a concurrency limit looked identical to stuck ones, so users waited and escalated with nothing actionable to look at. This makes the limit, the node, and the numbers visible directly on the operation, so a queued migration is recognizable at a glance without digging into controller logs.

## What is the expected result?

Start a migration while a migration limit (inbound, cluster, or per-node outbound) is already taken:

1. The operation stays `Pending` (unchanged behavior).
2. Its message names the limit that is reached, the node, and the current counts, instead of the generic queued message.
3. Once a slot frees up, the migration proceeds as before.

> Note: the cluster/outbound reason relies on the paired 3p-kubevirt change that sets the `MigrationConcurrencyLimitReached` condition; without it, those cases fall back to the generic queued message. The inbound reason works independently.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: vmop
type: feature
summary: "A migration waiting for a free concurrency slot now names the limit that is reached (inbound, cluster, or node outbound) with the node and current counts, instead of a generic pending message."
```
