### PR TITLE
fix(vmclass): pin discovered cpu features at first discovery

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vmclass/internal/discovery.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/internal/discovery.go
@@ -79,14 +79,20 @@ func (h *DiscoveryHandler) Handle(ctx context.Context, s state.VirtualMachineCla
 	var discoveryPool []corev1.Node
 	switch cpuType {
 	case v1alpha2.CPUTypeDiscovery:
-		// Discover features from the discovery nodeSelector pool, then restrict
-		// schedulable nodes to those that expose every discovered feature so
-		// VMs can only land on nodes compatible with the universal CPU model.
-		discoveryPool, err = s.DiscoveryNodes(ctx)
-		if err != nil {
-			return reconcile.Result{}, err
+		// The discovered feature set is the CPU model of already running VMs:
+		// once discovered it is pinned forever, so node composition changes
+		// never mutate the model under running VMs. Only availableNodes is
+		// recomputed each reconcile: schedulable nodes are restricted to those
+		// that expose every pinned feature.
+		if fs := current.Status.CpuFeatures.Enabled; len(fs) > 0 {
+			featuresEnabled = fs
+		} else {
+			discoveryPool, err = s.DiscoveryNodes(ctx)
+			if err != nil {
+				return reconcile.Result{}, err
+			}
+			featuresEnabled = h.discoveryCommonFeatures(discoveryPool)
 		}
-		featuresEnabled = h.discoveryCommonFeatures(discoveryPool)
 		availableNodes = h.nodesWithAllFeatures(availableNodes, featuresEnabled)
 	case v1alpha2.CPUTypeFeatures:
 		featuresEnabled = current.Spec.CPU.Features
@@ -114,14 +120,16 @@ func (h *DiscoveryHandler) Handle(ctx context.Context, s state.VirtualMachineCla
 	cb := conditions.NewConditionBuilder(vmclasscondition.TypeDiscovered).Generation(current.GetGeneration())
 	switch cpuType {
 	case v1alpha2.CPUTypeDiscovery:
+		// A pinned model keeps Discovered=True even if the discovery pool is
+		// currently empty: the model exists and is in use.
+		if len(featuresEnabled) > 0 {
+			cb.Message("").Reason(vmclasscondition.ReasonDiscoverySucceeded).Status(metav1.ConditionTrue)
+			break
+		}
 		if len(discoveryPool) == 0 {
 			cb.Message("No nodes match the discovery nodeSelector; skipping feature discovery.").
 				Reason(vmclasscondition.ReasonDiscoveryFailed).
 				Status(metav1.ConditionFalse)
-			break
-		}
-		if len(featuresEnabled) > 0 {
-			cb.Message("").Reason(vmclasscondition.ReasonDiscoverySucceeded).Status(metav1.ConditionTrue)
 			break
 		}
 		cb.Message("No common CPU features are discovered across discovery nodes.").

--- a/images/virtualization-artifact/pkg/controller/vmclass/internal/discovery_test.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/internal/discovery_test.go
@@ -643,11 +643,11 @@ var _ = Describe("DiscoveryHandler", func() {
 			Expect(changed.Status.AvailableNodes).To(ConsistOf("node1"))
 		})
 
-		It("should recompute features when available nodes change, not reuse cached status", func() {
-			// Regression test: previously the handler cached
-			// Status.CpuFeatures.Enabled forever, so when a node with a rare
-			// CPU feature disappeared from availableNodes, the class kept
-			// advertising that feature and VMs refused to schedule.
+		It("should keep discovered features pinned when node composition changes", func() {
+			// The discovered feature set is the CPU model of already running
+			// VMs: once discovered it must never change. Node composition
+			// changes are reflected only in availableNodes, which is
+			// recomputed against the pinned model each reconcile.
 			nodeOld := newNodeWithLabels("node-old", map[string]string{
 				virtv1.CPUFeatureLabel + "vmx": "true",
 				virtv1.CPUFeatureLabel + "avx": "true",
@@ -661,7 +661,7 @@ var _ = Describe("DiscoveryHandler", func() {
 			handlerOld := newVirtHandlerPod("node-old")
 			handlerNew := newVirtHandlerPod("node-new")
 
-			vmc := newVMClass("test-cache-staleness", v1alpha2.CPUTypeDiscovery, nil, nil)
+			vmc := newVMClass("test-pinned-model", v1alpha2.CPUTypeDiscovery, nil, nil)
 			vmcState, resource := setupDiscoveryEnvironment(vmc,
 				nodeOld, nodeNew,
 				handlerOld, handlerNew)
@@ -684,10 +684,10 @@ var _ = Describe("DiscoveryHandler", func() {
 			Expect(changed.Status.AvailableNodes).To(ConsistOf("node-old", "node-new"))
 			Expect(changed.Status.CpuFeatures.Enabled).To(ConsistOf("vmx", "avx"))
 
-			// Simulate node-old disappearing (e.g. drained, deleted) by
-			// re-running discovery with only node-new in availableNodes. The
-			// next reconcile must drop hle/rtm from Enabled without manual
-			// intervention on the class status.
+			// Simulate node-old disappearing (e.g. drained, deleted). The
+			// class carries the previously discovered status, as it would
+			// after the status update was persisted.
+			vmc.Status.CpuFeatures.Enabled = changed.Status.CpuFeatures.Enabled
 			vmcState, resource = setupDiscoveryEnvironment(vmc,
 				nodeNew,
 				handlerNew)
@@ -698,8 +698,46 @@ var _ = Describe("DiscoveryHandler", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			changed = resource.Changed()
+			// The model is pinned: fma from node-new must not be added.
+			Expect(changed.Status.CpuFeatures.Enabled).To(ConsistOf("vmx", "avx"))
+			// node-new exposes every pinned feature, so it stays schedulable.
 			Expect(changed.Status.AvailableNodes).To(ConsistOf("node-new"))
-			Expect(changed.Status.CpuFeatures.Enabled).To(ConsistOf("vmx", "avx", "fma"))
+		})
+
+		It("should report empty availableNodes when no node exposes the pinned features", func() {
+			// After the pool that produced the model is gone, a node lacking a
+			// pinned feature must not become schedulable, and the class must
+			// honestly report an empty availableNodes instead of weakening the
+			// model.
+			nodeNew := newNodeWithLabels("node-new", map[string]string{
+				virtv1.CPUFeatureLabel + "vmx": "true",
+			})
+			handlerNew := newVirtHandlerPod("node-new")
+
+			vmc := newVMClass("test-pinned-unschedulable", v1alpha2.CPUTypeDiscovery, nil, nil)
+			vmc.Status.CpuFeatures.Enabled = []string{"vmx", "avx"}
+			vmcState, resource := setupDiscoveryEnvironment(vmc, nodeNew, handlerNew)
+
+			ctx := context.Background()
+			mockRecorder := &eventrecord.EventRecorderLoggerMock{
+				EventfFunc: func(involved client.Object, eventtype, reason, messageFmt string, args ...any) {},
+			}
+			handler := NewDiscoveryHandler(mockRecorder)
+
+			_, err := handler.Handle(ctx, vmcState)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = handler.Handle(ctx, vmcState)
+			Expect(err).NotTo(HaveOccurred())
+
+			changed := resource.Changed()
+			Expect(changed.Status.CpuFeatures.Enabled).To(ConsistOf("vmx", "avx"))
+			Expect(changed.Status.AvailableNodes).To(BeEmpty())
+
+			// The model exists and is in use — Discovered stays True even
+			// though nothing is currently schedulable.
+			cond := conditions.FindStatusCondition(changed.Status.Conditions, vmclasscondition.TypeDiscovered.String())
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 		})
 
 		It("should mark Discovered=False when available nodes have no common CPU features", func() {


### PR DESCRIPTION
## Description

For a `VirtualMachineClass` with `cpu.type: Discovery`, the discovered CPU feature set is now pinned once at first discovery and never changes afterwards. Node composition changes are reflected only in `status.availableNodes`, which is recomputed on every reconcile as the nodes matching `spec.nodeSelector` that expose every pinned feature.

## Why do we need it, and what problem does it solve?

The discovered feature set is effectively the CPU model of VMs already running with the class. Since #2501 it was recomputed from the current nodes on every reconcile, so any change in cluster node composition (drain, decommission, scale-out with different hardware) could silently mutate the model under running VMs: a restarted VM got a different guest CPU, and live-migration compatibility was evaluated against a model the VMs were not started with.

With this fix the model stays stable for the lifetime of the class. If nodes lose features required by the pinned model, the class honestly reports it — `status.availableNodes` shrinks (possibly to empty, making the class not Ready) instead of weakening the model to fit the remaining nodes.

## What is the expected result?

1. Create a `VirtualMachineClass` with `cpu.type: Discovery` and wait for `Discovered=True`; note `status.cpuFeatures.enabled`.
2. Change the node composition (drain a node, add a node of a different CPU generation).
3. `status.cpuFeatures.enabled` stays exactly as discovered; `status.availableNodes` lists only the nodes that match `spec.nodeSelector` and expose every pinned feature.
4. If no node exposes all pinned features, `status.availableNodes` becomes empty and the class becomes not Ready; the `Discovered` condition stays `True` because the model exists and is in use.

Re-discovering the model requires recreating the class (same as changing `spec.cpu`, which is immutable).

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: vmclass
type: fix
summary: "The CPU feature set of a VirtualMachineClass with cpu.type Discovery is pinned at first discovery and no longer changes when cluster nodes change; availableNodes always lists only the nodes able to run the discovered model."
```
