### PR TITLE
chore(vmclass): discovered features should be frozen after first discovery

### DIFF
--- a/images/virtualization-artifact/pkg/controller/vmclass/internal/discovery.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/internal/discovery.go
@@ -75,18 +75,25 @@ func (h *DiscoveryHandler) Handle(ctx context.Context, s state.VirtualMachineCla
 		return reconcile.Result{}, err
 	}
 
-	var featuresEnabled []string
-	var discoveryPool []corev1.Node
+	var (
+		featuresEnabled []string
+		discoveryPool   []corev1.Node
+	)
 	switch cpuType {
 	case v1alpha2.CPUTypeDiscovery:
-		// Discover features from the discovery nodeSelector pool, then restrict
-		// schedulable nodes to those that expose every discovered feature so
-		// VMs can only land on nodes compatible with the universal CPU model.
-		discoveryPool, err = s.DiscoveryNodes(ctx)
-		if err != nil {
-			return reconcile.Result{}, err
+		// Discover features only once from the discovery nodeSelector pool and
+		// persist them in status. After that, keep the discovered model stable
+		// and only recalculate which schedulable nodes still expose all of its
+		// features.
+		if fs := current.Status.CpuFeatures.Enabled; len(fs) > 0 {
+			featuresEnabled = fs
+		} else {
+			discoveryPool, err = s.DiscoveryNodes(ctx)
+			if err != nil {
+				return reconcile.Result{}, err
+			}
+			featuresEnabled = h.discoveryCommonFeatures(discoveryPool)
 		}
-		featuresEnabled = h.discoveryCommonFeatures(discoveryPool)
 		availableNodes = h.nodesWithAllFeatures(availableNodes, featuresEnabled)
 	case v1alpha2.CPUTypeFeatures:
 		featuresEnabled = current.Spec.CPU.Features
@@ -114,17 +121,23 @@ func (h *DiscoveryHandler) Handle(ctx context.Context, s state.VirtualMachineCla
 	cb := conditions.NewConditionBuilder(vmclasscondition.TypeDiscovered).Generation(current.GetGeneration())
 	switch cpuType {
 	case v1alpha2.CPUTypeDiscovery:
-		if len(discoveryPool) == 0 {
-			cb.Message("No nodes match the discovery nodeSelector; skipping feature discovery.").
-				Reason(vmclasscondition.ReasonDiscoveryFailed).
-				Status(metav1.ConditionFalse)
-			break
-		}
 		if len(featuresEnabled) > 0 {
 			cb.Message("").Reason(vmclasscondition.ReasonDiscoverySucceeded).Status(metav1.ConditionTrue)
 			break
 		}
-		cb.Message("No common CPU features are discovered across discovery nodes.").
+		if len(current.Status.CpuFeatures.Enabled) == 0 {
+			if len(discoveryPool) == 0 {
+				cb.Message("No nodes match the discovery nodeSelector; skipping feature discovery.").
+					Reason(vmclasscondition.ReasonDiscoveryFailed).
+					Status(metav1.ConditionFalse)
+				break
+			}
+			cb.Message("No common CPU features are discovered across discovery nodes.").
+				Reason(vmclasscondition.ReasonDiscoveryFailed).
+				Status(metav1.ConditionFalse)
+			break
+		}
+		cb.Message("No available nodes expose all discovered CPU features.").
 			Reason(vmclasscondition.ReasonDiscoveryFailed).
 			Status(metav1.ConditionFalse)
 	default:

--- a/images/virtualization-artifact/pkg/controller/vmclass/internal/discovery.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/internal/discovery.go
@@ -121,25 +121,25 @@ func (h *DiscoveryHandler) Handle(ctx context.Context, s state.VirtualMachineCla
 	cb := conditions.NewConditionBuilder(vmclasscondition.TypeDiscovered).Generation(current.GetGeneration())
 	switch cpuType {
 	case v1alpha2.CPUTypeDiscovery:
-		if len(featuresEnabled) > 0 {
-			cb.Message("").Reason(vmclasscondition.ReasonDiscoverySucceeded).Status(metav1.ConditionTrue)
-			break
-		}
-		if len(current.Status.CpuFeatures.Enabled) == 0 {
-			if len(discoveryPool) == 0 {
-				cb.Message("No nodes match the discovery nodeSelector; skipping feature discovery.").
+		if len(featuresEnabled) == 0 {
+			if len(current.Status.CpuFeatures.Enabled) == 0 {
+				if len(discoveryPool) == 0 {
+					cb.Message("No nodes match the discovery nodeSelector, can't discover common CPU features.").
+						Reason(vmclasscondition.ReasonDiscoveryFailed).
+						Status(metav1.ConditionFalse)
+					break
+				}
+				cb.Message("No common CPU features are discovered across discovery nodes.").
 					Reason(vmclasscondition.ReasonDiscoveryFailed).
 					Status(metav1.ConditionFalse)
 				break
 			}
-			cb.Message("No common CPU features are discovered across discovery nodes.").
+			cb.Message("No available nodes expose all discovered CPU features.").
 				Reason(vmclasscondition.ReasonDiscoveryFailed).
 				Status(metav1.ConditionFalse)
 			break
 		}
-		cb.Message("No available nodes expose all discovered CPU features.").
-			Reason(vmclasscondition.ReasonDiscoveryFailed).
-			Status(metav1.ConditionFalse)
+		cb.Message("").Reason(vmclasscondition.ReasonDiscoverySucceeded).Status(metav1.ConditionTrue)
 	default:
 		cb.Message(fmt.Sprintf("Discovery not needed for cpu.type %q", cpuType)).
 			Reason(vmclasscondition.ReasonDiscoverySkip).

--- a/images/virtualization-artifact/pkg/controller/vmclass/internal/discovery_test.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/internal/discovery_test.go
@@ -18,6 +18,7 @@ package internal
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -697,7 +698,48 @@ var _ = Describe("DiscoveryHandler", func() {
 			Expect(changed.Status.CpuFeatures.Enabled).To(ConsistOf("vmx", "avx"))
 		})
 
-		It("should mark Discovered=False when discovery pool has no common CPU features", func() {
+		It("should set condition Discovered=False with no-discovery-nodes message when discovery.nodeSelector matches no virt-handler nodes", func() {
+			node1 := newNodeWithLabels("node1", map[string]string{
+				"node.deckhouse.io/group":      "worker",
+				virtv1.CPUFeatureLabel + "vmx": "true",
+			})
+			node2 := newNodeWithLabels("node2", map[string]string{
+				"node.deckhouse.io/group":      "compute",
+				virtv1.CPUFeatureLabel + "vmx": "true",
+			})
+			virtHandler1 := newVirtHandlerPod("node1")
+			virtHandler2 := newVirtHandlerPod("node2")
+
+			vmc := newVMClass("test-no-discovery-nodes", v1alpha2.CPUTypeDiscovery, nil, &metav1.LabelSelector{
+				MatchLabels: map[string]string{"node.deckhouse.io/group": "master"},
+			})
+			vmcState, resource := setupDiscoveryEnvironment(vmc,
+				node1, node2,
+				virtHandler1, virtHandler2)
+
+			ctx := context.Background()
+			mockRecorder := &eventrecord.EventRecorderLoggerMock{
+				EventfFunc: func(involved client.Object, eventtype, reason, messageFmt string, args ...any) {},
+			}
+			handler := NewDiscoveryHandler(mockRecorder)
+
+			_, err := handler.Handle(ctx, vmcState)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = handler.Handle(ctx, vmcState)
+			Expect(err).NotTo(HaveOccurred())
+
+			changed := resource.Changed()
+			Expect(changed.Status.AvailableNodes).To(ConsistOf("node1", "node2"))
+			Expect(changed.Status.CpuFeatures.Enabled).To(BeEmpty())
+
+			cond := conditions.FindStatusCondition(changed.Status.Conditions, vmclasscondition.TypeDiscovered.String())
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal(vmclasscondition.ReasonDiscoveryFailed.String()))
+			Expect(cond.Message).To(Equal("No nodes match the discovery nodeSelector, can't discover common CPU features."))
+		})
+
+		It("should set condition Discovered=False with discovery-pool message when discovery pool has no common CPU features", func() {
 			// Pick two labels that exist on opposite nodes so there is no
 			// common CPU feature between discovery nodes.
 			node1 := newNodeWithLabels("node1", map[string]string{
@@ -733,6 +775,61 @@ var _ = Describe("DiscoveryHandler", func() {
 			Expect(cond).NotTo(BeNil())
 			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
 			Expect(cond.Reason).To(Equal(vmclasscondition.ReasonDiscoveryFailed.String()))
+			Expect(cond.Message).To(Equal("No common CPU features are discovered across discovery nodes."))
+		})
+
+		It("should keep condition Discovered=True when discovered features have no matching schedulable nodes", func() {
+			node1 := newNodeWithLabels("node1", map[string]string{
+				"node.deckhouse.io/group":       "worker",
+				virtv1.CPUFeatureLabel + "vmx":  "true",
+				virtv1.CPUFeatureLabel + "avx":  "true",
+				virtv1.CPUFeatureLabel + "sse2": "true",
+			})
+			node2 := newNodeWithLabels("node2", map[string]string{
+				"node.deckhouse.io/group":      "compute",
+				virtv1.CPUFeatureLabel + "vmx": "true",
+			})
+
+			virtHandler1 := newVirtHandlerPod("node1")
+			virtHandler2 := newVirtHandlerPod("node2")
+
+			vmc := newVMClass("test-no-available-nodes-for-discovered-model", v1alpha2.CPUTypeDiscovery, &v1alpha2.NodeSelector{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "node.deckhouse.io/group",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"compute"},
+					},
+				},
+			}, &metav1.LabelSelector{
+				MatchLabels: map[string]string{"node.deckhouse.io/group": "worker"},
+			})
+			vmc.Status.CpuFeatures.Enabled = []string{"vmx", "avx", "sse2"}
+
+			vmcState, resource := setupDiscoveryEnvironment(vmc,
+				node1, node2,
+				virtHandler1, virtHandler2)
+
+			ctx := context.Background()
+			mockRecorder := &eventrecord.EventRecorderLoggerMock{
+				EventfFunc: func(involved client.Object, eventtype, reason, messageFmt string, args ...any) {},
+			}
+			handler := NewDiscoveryHandler(mockRecorder)
+
+			_, err := handler.Handle(ctx, vmcState)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = handler.Handle(ctx, vmcState)
+			Expect(err).NotTo(HaveOccurred())
+
+			changed := resource.Changed()
+			Expect(changed.Status.AvailableNodes).To(BeEmpty())
+			Expect(changed.Status.CpuFeatures.Enabled).To(ConsistOf("vmx", "avx", "sse2"))
+
+			cond := conditions.FindStatusCondition(changed.Status.Conditions, vmclasscondition.TypeDiscovered.String())
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(cond.Reason).To(Equal(vmclasscondition.ReasonDiscoverySucceeded.String()))
+			Expect(cond.Message).To(BeEmpty())
 		})
 
 		It("should populate enabled from spec.cpu.features and keep all matching nodes for Features type", func() {
@@ -965,6 +1062,85 @@ var _ = Describe("DiscoveryHandler", func() {
 			Expect(changed.Status.AvailableNodes).To(ConsistOf("node1", "node2"))
 			Expect(changed.Status.CpuFeatures.Enabled).To(ConsistOf("vmx", "avx", "sse2"))
 			Expect(changed.Status.CpuFeatures.NotEnabledCommon).To(BeEmpty())
+		})
+
+		It("should emit warning event when availableNodes become empty", func() {
+			node1 := newNodeWithLabels("node1", map[string]string{
+				"node.deckhouse.io/group":      "worker",
+				virtv1.CPUFeatureLabel + "vmx": "true",
+			})
+			virtHandler1 := newVirtHandlerPod("node1")
+
+			vmc := newVMClass("test-empty-available-nodes-event", v1alpha2.CPUTypeDiscovery, &v1alpha2.NodeSelector{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "node.deckhouse.io/group",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"compute"},
+					},
+				},
+			}, nil)
+			vmc.Status.AvailableNodes = []string{"node1"}
+			vmc.Status.CpuFeatures.Enabled = []string{"vmx"}
+
+			vmcState, _ := setupDiscoveryEnvironment(vmc,
+				node1,
+				virtHandler1)
+
+			ctx := context.Background()
+			var capturedEventType, capturedReason, capturedMessage string
+			mockRecorder := &eventrecord.EventRecorderLoggerMock{
+				EventfFunc: func(involved client.Object, eventtype, reason, messageFmt string, args ...any) {
+					capturedEventType = eventtype
+					capturedReason = reason
+					capturedMessage = fmt.Sprintf(messageFmt, args...)
+				},
+			}
+			handler := NewDiscoveryHandler(mockRecorder)
+
+			_, err := handler.Handle(ctx, vmcState)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = handler.Handle(ctx, vmcState)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(capturedEventType).To(Equal(corev1.EventTypeWarning))
+			Expect(capturedReason).To(Equal(v1alpha2.ReasonVMClassAvailableNodesListEmpty))
+			Expect(capturedMessage).To(ContainSubstring("now it's empty"))
+			Expect(capturedMessage).To(ContainSubstring("removed nodes: [\"node1\"]"))
+		})
+
+		It("should ignore nodes without virt-handler for discovery and scheduling", func() {
+			node1 := newNodeWithLabels("node1", map[string]string{
+				virtv1.CPUFeatureLabel + "vmx": "true",
+				virtv1.CPUFeatureLabel + "svm": "true",
+			})
+			node2 := newNodeWithLabels("node2", map[string]string{
+				virtv1.CPUFeatureLabel + "vmx": "true",
+				virtv1.CPUFeatureLabel + "svm": "true",
+			})
+			virtHandler1 := newVirtHandlerPod("node1")
+			// no virt-handler on node2, so it must not participate
+			// either in discovery or in availableNodes.
+
+			vmc := newVMClass("test-ignore-nodes-without-virt-handler", v1alpha2.CPUTypeDiscovery, nil, nil)
+			vmcState, resource := setupDiscoveryEnvironment(vmc,
+				node1, node2,
+				virtHandler1)
+
+			ctx := context.Background()
+			mockRecorder := &eventrecord.EventRecorderLoggerMock{
+				EventfFunc: func(involved client.Object, eventtype, reason, messageFmt string, args ...any) {},
+			}
+			handler := NewDiscoveryHandler(mockRecorder)
+
+			_, err := handler.Handle(ctx, vmcState)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = handler.Handle(ctx, vmcState)
+			Expect(err).NotTo(HaveOccurred())
+
+			changed := resource.Changed()
+			Expect(changed.Status.AvailableNodes).To(ConsistOf("node1"))
+			Expect(changed.Status.CpuFeatures.Enabled).To(ConsistOf("svm", "vmx"))
 		})
 
 		It("should report notEnabledCommon for Discovery when spec.nodeSelector shrinks availableNodes below the discovery pool", func() {

--- a/images/virtualization-artifact/pkg/controller/vmclass/internal/discovery_test.go
+++ b/images/virtualization-artifact/pkg/controller/vmclass/internal/discovery_test.go
@@ -643,11 +643,10 @@ var _ = Describe("DiscoveryHandler", func() {
 			Expect(changed.Status.AvailableNodes).To(ConsistOf("node1"))
 		})
 
-		It("should recompute features when available nodes change, not reuse cached status", func() {
-			// Regression test: previously the handler cached
-			// Status.CpuFeatures.Enabled forever, so when a node with a rare
-			// CPU feature disappeared from availableNodes, the class kept
-			// advertising that feature and VMs refused to schedule.
+		It("should keep discovered features stable and only recalculate availableNodes", func() {
+			// Discovery features are computed once and then frozen in status.
+			// Later reconciles must only narrow availableNodes to nodes exposing
+			// all previously discovered features, not recompute the model.
 			nodeOld := newNodeWithLabels("node-old", map[string]string{
 				virtv1.CPUFeatureLabel + "vmx": "true",
 				virtv1.CPUFeatureLabel + "avx": "true",
@@ -672,9 +671,6 @@ var _ = Describe("DiscoveryHandler", func() {
 			}
 			handler := NewDiscoveryHandler(mockRecorder)
 
-			// Two passes are required: first sets the Discovered condition to
-			// Unknown (addAllUnknown requeue), second performs the actual
-			// discovery and writes Status.CpuFeatures.
 			_, err := handler.Handle(ctx, vmcState)
 			Expect(err).NotTo(HaveOccurred())
 			_, err = handler.Handle(ctx, vmcState)
@@ -684,14 +680,13 @@ var _ = Describe("DiscoveryHandler", func() {
 			Expect(changed.Status.AvailableNodes).To(ConsistOf("node-old", "node-new"))
 			Expect(changed.Status.CpuFeatures.Enabled).To(ConsistOf("vmx", "avx"))
 
-			// Simulate node-old disappearing (e.g. drained, deleted) by
-			// re-running discovery with only node-new in availableNodes. The
-			// next reconcile must drop hle/rtm from Enabled without manual
-			// intervention on the class status.
+			// Simulate a persisted status on the class and a changed cluster
+			// topology where only node-new remains. The discovered model must
+			// stay {vmx,avx}, while availableNodes is recalculated against it.
+			vmc.Status.CpuFeatures.Enabled = append([]string{}, changed.Status.CpuFeatures.Enabled...)
 			vmcState, resource = setupDiscoveryEnvironment(vmc,
 				nodeNew,
 				handlerNew)
-			// Replay the same reconcile pattern again on the fresh state.
 			_, err = handler.Handle(ctx, vmcState)
 			Expect(err).NotTo(HaveOccurred())
 			_, err = handler.Handle(ctx, vmcState)
@@ -699,12 +694,12 @@ var _ = Describe("DiscoveryHandler", func() {
 
 			changed = resource.Changed()
 			Expect(changed.Status.AvailableNodes).To(ConsistOf("node-new"))
-			Expect(changed.Status.CpuFeatures.Enabled).To(ConsistOf("vmx", "avx", "fma"))
+			Expect(changed.Status.CpuFeatures.Enabled).To(ConsistOf("vmx", "avx"))
 		})
 
-		It("should mark Discovered=False when available nodes have no common CPU features", func() {
+		It("should mark Discovered=False when discovery pool has no common CPU features", func() {
 			// Pick two labels that exist on opposite nodes so there is no
-			// common CPU feature between availableNodes.
+			// common CPU feature between discovery nodes.
 			node1 := newNodeWithLabels("node1", map[string]string{
 				virtv1.CPUFeatureLabel + "hle": "true",
 			})
@@ -930,10 +925,9 @@ var _ = Describe("DiscoveryHandler", func() {
 
 		It("should leave notEnabledCommon empty for Discovery when availableNodes match the discovered model", func() {
 			// UF5: for Discovery, availableNodes are filtered by nodesWithAllFeatures
-			// against the discovered intersection, so commonFeatures(availableNodes)
-			// collapses back to the enabled set and notEnabledCommon stays empty.
-			// A non-empty result is only possible when spec.nodeSelector excludes
-			// part of the discovery pool, shrinking the common set below the model.
+			// against the frozen discovered model, so commonFeatures(availableNodes)
+			// may include extra features only when the schedulable set becomes
+			// narrower than the original discovery pool.
 			node1 := newNodeWithLabels("node1", map[string]string{
 				virtv1.CPUFeatureLabel + "vmx":  "true",
 				virtv1.CPUFeatureLabel + "avx":  "true",


### PR DESCRIPTION

## Description
<!---
  Describe your changes with technical details.
-->

- Use first time discovered feature set to filter availableNodes on later reconciles.
- Add errors in case no availableNodes are present in the cluster.


## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->

It fixes regression in #2501: vmclass.Status.Features.Enabled becomes mutable.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->

CPU features in `vmclass.Status.Features.Enabled` is immutable after first discovery. New nodes that matches spec.nodeSelector should also match discovered features.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: vmclass
type: chore
summary: "Ensure vmclass contract: discovered CPU features should be frozen after the first discovery."
```
