### PR TITLE
fix(module): include per-version changelog in release image

### DIFF
--- a/werf.yaml
+++ b/werf.yaml
@@ -132,6 +132,10 @@ import:
   add: /go-hooks
   to: /prep-bundle/hooks/go
   after: setup
+- image: tools/yq
+  add: /usr/bin/yq
+  to: /usr/bin/yq
+  before: install
 git:
   - add: /
     to: /prep-bundle
@@ -149,6 +153,7 @@ git:
       - Chart.yaml
       - module.yaml
       - .helmignore
+      - CHANGELOG
     excludePaths:
       - build/components/README.md
       - docs/images/*.drawio
@@ -162,6 +167,33 @@ git:
 shell:
   install:
     - ls -la /prep-bundle
+    # Build changelog.yaml for the release image: the console renders a module's
+    # per-release changelog from it. Reshape our per-section {summary, pull_request}
+    # entries into features/fixes/chore -> readable category -> markdown strings (PR
+    # linked), the shape the console renderer shows cleanly. Then drop CHANGELOG so
+    # only the single file lands in the bundle.
+    - |
+      src="/prep-bundle/CHANGELOG/CHANGELOG-{{ env "MODULES_MODULE_TAG" "dev" }}.yml"
+      if [ -f "$src" ]; then
+        yq -o=yaml '
+          {
+            "core":"Core","vm":"Virtual machines","vmop":"VM operations","vmbda":"Block device attachments",
+            "vmclass":"VM classes","vmip":"VM IP addresses","vmipl":"VM IP address leases",
+            "vd":"Virtual disks","vi":"Virtual images","cvi":"Cluster virtual images",
+            "vdsnapshot":"Disk snapshots","vmsnapshot":"VM snapshots","vmrestore":"VM restores","vmpool":"VM pools",
+            "disks":"Disks","images":"Images","module":"Module","observability":"Observability",
+            "network":"Network","cli":"CLI","api":"API"
+          } as $names |
+          {
+            "features": ( [ to_entries[] | { "key": ($names[.key] // .key), "value": [ (.value.features // [])[] | (.summary | sub("\n+$"; "")) + " ([#" + (.pull_request | sub(".*/pull/"; "") | sub("/.*"; "")) + "](" + .pull_request + "))" ] } | select(.value | length > 0) ] | from_entries ),
+            "fixes":    ( [ to_entries[] | { "key": ($names[.key] // .key), "value": [ (.value.fixes    // [])[] | (.summary | sub("\n+$"; "")) + " ([#" + (.pull_request | sub(".*/pull/"; "") | sub("/.*"; "")) + "](" + .pull_request + "))" ] } | select(.value | length > 0) ] | from_entries ),
+            "chore":    ( [ to_entries[] | { "key": ($names[.key] // .key), "value": [ (.value.chore    // [])[] | (.summary | sub("\n+$"; "")) + " ([#" + (.pull_request | sub(".*/pull/"; "") | sub("/.*"; "")) + "](" + .pull_request + "))" ] } | select(.value | length > 0) ] | from_entries )
+          } | with_entries(select(.value | length > 0))
+        ' "$src" > /prep-bundle/changelog.yaml
+      else
+        touch /prep-bundle/changelog.yaml
+      fi
+    - rm -rf /prep-bundle/CHANGELOG
 ---
 image: release-channel-version
 fromImage: builder/scratch
@@ -172,6 +204,7 @@ import:
   after: install
   includePaths:
     - module.yaml
+    - changelog.yaml
 shell:
   install:
     - echo  '{"version":"{{ env "MODULES_MODULE_TAG" "dev" }}"}' > version.json


### PR DESCRIPTION
## Description

The Deckhouse console showed no changelog for any virtualization module release: the changelog it renders is read from a `changelog.yaml` file inside the release image, and that file was never packaged into the image. The release image now carries the per-version changelog, so it shows up in the console's release list.

## Why do we need it, and what problem does it solve?

Users open a module release in the console (Updates → Releases → Changelog) to see what changed between versions. For virtualization that panel was always empty — the release image only shipped `version.json` and `module.yaml`. Reported for v1.9.1, but it affected every release.

## What is the expected result?

After a release build, the `release:<tag>` image contains `changelog.yaml` with the entry for that version, and the console shows the changelog for each release instead of an empty panel.

## Example

The build reshapes `CHANGELOG/CHANGELOG-<tag>.yml` into the unified console format (`features`/`fixes`/`chore` → readable category → entries, with the PR linked). Empty types/categories are dropped, so a release that only touches one type renders cleanly.

Source — `CHANGELOG/CHANGELOG-v1.9.1.yml` (excerpt):

```yaml
core:
  fixes:
    - summary: Update VMOP migration elapsed time every ten seconds while migration is in progress.
      pull_request: https://github.com/deckhouse/virtualization/pull/2495
vd:
  fixes:
    - summary: Fixed cancellation of virtual disk storage class changes and cancellation of local disk migration.
      pull_request: https://github.com/deckhouse/virtualization/pull/2502
```

Generated `changelog.yaml` shipped in `release:v1.9.1` (rendered by the console):

```yaml
fixes:
  Core:
    - Update VMOP migration elapsed time every ten seconds while migration is in progress. ([#2495](https://github.com/deckhouse/virtualization/pull/2495))
    - Select VirtualDisk migration target PVC strictly to avoid using an unrelated PVC. ([#2493](https://github.com/deckhouse/virtualization/pull/2493))
    - Fix metadata patch failing with "the server rejected our request" for objects without finalizers, labels or annotations. ([#2479](https://github.com/deckhouse/virtualization/pull/2479))
  Virtual disks:
    - Fixed cancellation of virtual disk storage class changes and cancellation of local disk migration. ([#2502](https://github.com/deckhouse/virtualization/pull/2502))
  Virtual machines:
    - Fixed an issue that prevented a VM from starting after a failed migration of a disk on local storage. ([#2509](https://github.com/deckhouse/virtualization/pull/2509))
    - Fixed live migration of VMs with disks on local storage attached via VirtualMachineBlockDeviceAttachment (hotplug). The target node no longer matches the source node. ([#2508](https://github.com/deckhouse/virtualization/pull/2508))
    - Fixed a false reboot requirement for VMs with only the Main network after upgrading to v1.9.1. Such VMs now do not receive the RestartRequired status if their configuration has not actually changed. ([#2475](https://github.com/deckhouse/virtualization/pull/2475))
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: module
type: fix
summary: The module changelog is now shown in the Deckhouse console for each release.
```
