### PR TITLE
fix(cli): keep collect-debug-info going when secondary resources are absent

### DIFF
--- a/src/cli/internal/cmd/collectdebuginfo/collectdebuginfo.go
+++ b/src/cli/internal/cmd/collectdebuginfo/collectdebuginfo.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 
@@ -118,24 +119,48 @@ func (b *DebugBundle) Run(cmd *cobra.Command, args []string) error {
 }
 
 func (b *DebugBundle) collectResources(ctx context.Context, client kubeclient.Client, namespace, vmName string) error {
-	if err := b.collectVMResources(ctx, client, namespace, vmName); err != nil {
-		return fmt.Errorf("failed to collect VM resources: %w", err)
+	// The target VM is required; everything collected below is best-effort (see skipError).
+	vm, err := client.VirtualMachines(namespace).Get(ctx, vmName, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return fmt.Errorf("VirtualMachine %q not found in namespace %q", vmName, namespace)
+		}
+		if errors.IsForbidden(err) || errors.IsUnauthorized(err) {
+			return fmt.Errorf("not allowed to read VirtualMachine %q in namespace %q; check your RBAC permissions", vmName, namespace)
+		}
+		return fmt.Errorf("failed to read VirtualMachine %q in namespace %q: %w", vmName, namespace, err)
 	}
 
-	if err := b.collectBlockDevices(ctx, client, namespace, vmName); err != nil {
+	if err := b.collectVMResources(ctx, client, vm); err != nil {
+		return fmt.Errorf("failed to collect VirtualMachine resources: %w", err)
+	}
+
+	if err := b.collectBlockDevices(ctx, client, vm); err != nil {
 		return fmt.Errorf("failed to collect block devices: %w", err)
 	}
 
-	if err := b.collectPods(ctx, client, namespace, vmName); err != nil {
-		return fmt.Errorf("failed to collect pods: %w", err)
+	if err := b.collectPods(ctx, client, vm.Namespace, vm.Name); err != nil {
+		return fmt.Errorf("failed to collect workload pods: %w", err)
 	}
 
 	return nil
 }
 
-func (b *DebugBundle) handleError(resourceType, resourceName string, err error) bool {
-	if errors.IsForbidden(err) || errors.IsUnauthorized(err) {
-		_, _ = fmt.Fprintf(b.stderr, "Warning: Skipping %s/%s: permission denied\n", resourceType, resourceName)
+// skipError reports whether a secondary-resource error is safe to swallow so the
+// best-effort collection can continue, logging what was skipped to stderr.
+func (b *DebugBundle) skipError(resourceType, resourceName string, err error) bool {
+	target := resourceType
+	if resourceName != "" {
+		target = fmt.Sprintf("%s %q", resourceType, resourceName)
+	}
+	switch {
+	case errors.IsForbidden(err) || errors.IsUnauthorized(err):
+		_, _ = fmt.Fprintf(b.stderr, "Warning: cannot read %s: access denied (check your RBAC permissions).\n", target)
+		return true
+	case errors.IsNotFound(err):
+		// Stated as a finding, not silenced: a missing internal instance or disk is
+		// often the reason the VirtualMachine is unhealthy, so the operator sees it.
+		_, _ = fmt.Fprintf(b.stderr, "Warning: %s not found.\n", target)
 		return true
 	}
 	return false

--- a/src/cli/internal/cmd/collectdebuginfo/collectdebuginfo_test.go
+++ b/src/cli/internal/cmd/collectdebuginfo/collectdebuginfo_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 Flant JSC
+Copyright 2026 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/cli/internal/cmd/collectdebuginfo/collectdebuginfo_test.go
+++ b/src/cli/internal/cmd/collectdebuginfo/collectdebuginfo_test.go
@@ -1,0 +1,308 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectdebuginfo
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	virtualizationfake "github.com/deckhouse/virtualization/api/client/generated/clientset/versioned/fake"
+	virtualizationv1alpha2 "github.com/deckhouse/virtualization/api/client/generated/clientset/versioned/typed/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/client/kubeclient"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+)
+
+func TestCollectDebugInfo(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CollectDebugInfo Command Suite")
+}
+
+const testNamespace = "default"
+
+type fakeClient struct {
+	*k8sfake.Clientset
+	virtualizationv1alpha2.VirtualizationV1alpha2Interface
+}
+
+func newFakeClient(objects ...runtime.Object) kubeclient.Client {
+	return &fakeClient{
+		Clientset:                       k8sfake.NewSimpleClientset(),
+		VirtualizationV1alpha2Interface: virtualizationfake.NewSimpleClientset(objects...).VirtualizationV1alpha2(),
+	}
+}
+
+// newFakeClientFailingVMGet returns a client whose VirtualMachine Get fails with
+// the given error, used to exercise the target-VM error branches.
+func newFakeClientFailingVMGet(err error) kubeclient.Client {
+	virt := virtualizationfake.NewSimpleClientset()
+	virt.PrependReactor("get", "virtualmachines", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, err
+	})
+	return &fakeClient{
+		Clientset:                       k8sfake.NewSimpleClientset(),
+		VirtualizationV1alpha2Interface: virt.VirtualizationV1alpha2(),
+	}
+}
+
+func forbidden(resource, name string) error {
+	return apierrors.NewForbidden(schema.GroupResource{Group: "virtualization.deckhouse.io", Resource: resource}, name, errors.New("forbidden"))
+}
+
+// newDynamicFake returns a dynamic client that knows about the internal
+// virtualization resources but holds no objects, so Get returns NotFound and
+// List returns an empty list — matching a VM that has no KubeVirt VMI yet.
+func newDynamicFake(objects ...runtime.Object) *dynamicfake.FakeDynamicClient {
+	const group = "internal.virtualization.deckhouse.io"
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		{Group: group, Version: "v1", Resource: "internalvirtualizationvirtualmachines"}:                  "InternalVirtualizationVirtualMachineList",
+		{Group: group, Version: "v1", Resource: "internalvirtualizationvirtualmachineinstances"}:          "InternalVirtualizationVirtualMachineInstanceList",
+		{Group: group, Version: "v1", Resource: "internalvirtualizationvirtualmachineinstancemigrations"}: "InternalVirtualizationVirtualMachineInstanceMigrationList",
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind, objects...)
+}
+
+func newInternalResource(kind, name string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "internal.virtualization.deckhouse.io",
+		Version: "v1",
+		Kind:    kind,
+	})
+	obj.SetNamespace(testNamespace)
+	obj.SetName(name)
+	return obj
+}
+
+func newVM(name string, refs ...v1alpha2.BlockDeviceSpecRef) *v1alpha2.VirtualMachine {
+	return &v1alpha2.VirtualMachine{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "VirtualMachine",
+			APIVersion: "virtualization.deckhouse.io/v1alpha2",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+			UID:       types.UID("uid-" + name),
+		},
+		Spec: v1alpha2.VirtualMachineSpec{
+			BlockDeviceRefs: refs,
+		},
+	}
+}
+
+// runCollect drives collectResources with the given clients and returns the
+// files written into the tar.gz archive (keyed by name), the captured stderr,
+// and the returned error.
+func runCollect(client kubeclient.Client, dyn dynamic.Interface, vmName string) (map[string]string, string, error) {
+	var out, errBuf bytes.Buffer
+	b := &DebugBundle{
+		dynamicClient: dyn,
+		stdout:        &out,
+		stderr:        &errBuf,
+	}
+	b.gzipWriter = gzip.NewWriter(&out)
+	b.tarWriter = tar.NewWriter(b.gzipWriter)
+
+	err := b.collectResources(context.Background(), client, testNamespace, vmName)
+
+	_ = b.tarWriter.Close()
+	_ = b.gzipWriter.Close()
+
+	return readArchive(&out), errBuf.String(), err
+}
+
+func readArchive(buf *bytes.Buffer) map[string]string {
+	files := map[string]string{}
+	gz, err := gzip.NewReader(buf)
+	if err != nil {
+		return files
+	}
+	defer func() { _ = gz.Close() }()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			break
+		}
+		content, _ := io.ReadAll(tr)
+		files[hdr.Name] = string(content)
+	}
+	return files
+}
+
+var _ = Describe("collect-debug-info", func() {
+	It("collects a stopped VM even though it has no running VMI", func() {
+		client := newFakeClient(newVM("vm-stopped"))
+
+		files, stderr, err := runCollect(client, newDynamicFake(), "vm-stopped")
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(files).To(HaveKey("virtualmachine-vm-stopped.yaml"))
+		// Absent VMI: skipped (no error) but surfaced as a warning, not silenced.
+		Expect(stderr).To(ContainSubstring(`Warning: InternalVirtualizationVirtualMachineInstance "vm-stopped" not found.`))
+	})
+
+	It("skips a disk referenced in the spec that has not been created yet", func() {
+		client := newFakeClient(newVM("vm-pending", v1alpha2.BlockDeviceSpecRef{
+			Kind: v1alpha2.DiskDevice,
+			Name: "missing-disk",
+		}))
+
+		files, stderr, err := runCollect(client, newDynamicFake(), "vm-pending")
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(files).To(HaveKey("virtualmachine-vm-pending.yaml"))
+		Expect(files).NotTo(HaveKey("virtualdisk-missing-disk.yaml"))
+		Expect(stderr).To(ContainSubstring(`Warning: VirtualDisk "missing-disk" not found.`))
+	})
+
+	It("collects a disk referenced in the spec that exists", func() {
+		vm := newVM("vm-run", v1alpha2.BlockDeviceSpecRef{
+			Kind: v1alpha2.DiskDevice,
+			Name: "data-disk",
+		})
+		vd := &v1alpha2.VirtualDisk{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "VirtualDisk",
+				APIVersion: "virtualization.deckhouse.io/v1alpha2",
+			},
+			ObjectMeta: metav1.ObjectMeta{Name: "data-disk", Namespace: testNamespace},
+		}
+		client := newFakeClient(vm, vd)
+
+		files, _, err := runCollect(client, newDynamicFake(), "vm-run")
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(files).To(HaveKey("virtualdisk-data-disk.yaml"))
+	})
+
+	It("returns a clear error when the target VM does not exist", func() {
+		client := newFakeClient()
+
+		_, _, err := runCollect(client, newDynamicFake(), "ghost")
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(`VirtualMachine "ghost" not found in namespace "default"`))
+	})
+
+	It("returns an RBAC hint when reading the target VM is forbidden", func() {
+		client := newFakeClientFailingVMGet(forbidden("virtualmachines", "vm-x"))
+
+		_, _, err := runCollect(client, newDynamicFake(), "vm-x")
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("check your RBAC permissions"))
+	})
+
+	It("aborts with a wrapped error when reading the target VM fails unexpectedly", func() {
+		client := newFakeClientFailingVMGet(errors.New("connection refused"))
+
+		_, _, err := runCollect(client, newDynamicFake(), "vm-x")
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(`failed to read VirtualMachine "vm-x"`))
+		Expect(err.Error()).To(ContainSubstring("connection refused"))
+	})
+
+	It("skips a secondary resource the user is not allowed to read and keeps going", func() {
+		dyn := newDynamicFake()
+		dyn.PrependReactor("get", "internalvirtualizationvirtualmachines", func(k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, forbidden("internalvirtualizationvirtualmachines", "vm-x")
+		})
+		client := newFakeClient(newVM("vm-x"))
+
+		files, stderr, err := runCollect(client, dyn, "vm-x")
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(files).To(HaveKey("virtualmachine-vm-x.yaml"))
+		Expect(stderr).To(ContainSubstring(`Warning: cannot read InternalVirtualizationVirtualMachine "vm-x": access denied (check your RBAC permissions).`))
+	})
+
+	It("aborts collection on an unexpected error from a secondary resource", func() {
+		dyn := newDynamicFake()
+		dyn.PrependReactor("get", "internalvirtualizationvirtualmachines", func(k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("etcdserver: request timed out")
+		})
+		client := newFakeClient(newVM("vm-x"))
+
+		_, _, err := runCollect(client, dyn, "vm-x")
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to collect VirtualMachine resources"))
+	})
+
+	It("collects a disk attached through a VirtualMachineBlockDeviceAttachment", func() {
+		vm := newVM("vm-x")
+		vmbda := &v1alpha2.VirtualMachineBlockDeviceAttachment{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "VirtualMachineBlockDeviceAttachment",
+				APIVersion: "virtualization.deckhouse.io/v1alpha2",
+			},
+			ObjectMeta: metav1.ObjectMeta{Name: "attach-1", Namespace: testNamespace},
+			Spec: v1alpha2.VirtualMachineBlockDeviceAttachmentSpec{
+				VirtualMachineName: "vm-x",
+				BlockDeviceRef: v1alpha2.VMBDAObjectRef{
+					Kind: v1alpha2.VMBDAObjectRefKindVirtualDisk,
+					Name: "hot-disk",
+				},
+			},
+		}
+		vd := &v1alpha2.VirtualDisk{
+			TypeMeta:   metav1.TypeMeta{Kind: "VirtualDisk", APIVersion: "virtualization.deckhouse.io/v1alpha2"},
+			ObjectMeta: metav1.ObjectMeta{Name: "hot-disk", Namespace: testNamespace},
+		}
+		client := newFakeClient(vm, vmbda, vd)
+
+		files, _, err := runCollect(client, newDynamicFake(), "vm-x")
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(files).To(HaveKey("virtualmachineblockdeviceattachment-attach-1.yaml"))
+		Expect(files).To(HaveKey("virtualdisk-hot-disk.yaml"))
+	})
+
+	It("writes an existing internal resource into the bundle", func() {
+		client := newFakeClient(newVM("vm-run"))
+		dyn := newDynamicFake(newInternalResource("InternalVirtualizationVirtualMachineInstance", "vm-run"))
+
+		files, _, err := runCollect(client, dyn, "vm-run")
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(files).To(HaveKey("internalvirtualizationvirtualmachineinstance-vm-run.yaml"))
+	})
+})

--- a/src/cli/internal/cmd/collectdebuginfo/collectors.go
+++ b/src/cli/internal/cmd/collectdebuginfo/collectors.go
@@ -48,82 +48,68 @@ var coreKinds = map[string]bool{
 
 // Resource collection functions
 
-func (b *DebugBundle) collectVMResources(ctx context.Context, client kubeclient.Client, namespace, vmName string) error {
-	// Get VM
-	vm, err := client.VirtualMachines(namespace).Get(ctx, vmName, metav1.GetOptions{})
-	if err != nil {
-		if b.handleError("VirtualMachine", vmName, err) {
-			return nil
-		}
-		return err
-	}
-	if err := b.outputResource("VirtualMachine", vmName, namespace, vm); err != nil {
+func (b *DebugBundle) collectVMResources(ctx context.Context, client kubeclient.Client, vm *v1alpha2.VirtualMachine) error {
+	if err := b.outputResource("VirtualMachine", vm.Name, vm.Namespace, vm); err != nil {
 		return fmt.Errorf("failed to output VirtualMachine: %w", err)
 	}
 
 	// Get IVVM
-	ivvm, err := b.getInternalResource(ctx, "internalvirtualizationvirtualmachines", namespace, vmName)
+	ivvm, err := b.getInternalResource(ctx, "internalvirtualizationvirtualmachines", vm.Namespace, vm.Name)
 	if err == nil {
-		if err := b.outputResource("InternalVirtualizationVirtualMachine", vmName, namespace, ivvm); err != nil {
+		if err := b.outputResource("InternalVirtualizationVirtualMachine", vm.Name, vm.Namespace, ivvm); err != nil {
 			return fmt.Errorf("failed to output InternalVirtualizationVirtualMachine: %w", err)
 		}
-	} else if !b.handleError("InternalVirtualizationVirtualMachine", vmName, err) {
+	} else if !b.skipError("InternalVirtualizationVirtualMachine", vm.Name, err) {
 		return err
 	}
 
 	// Get IVVMI
-	ivvmi, err := b.getInternalResource(ctx, "internalvirtualizationvirtualmachineinstances", namespace, vmName)
+	ivvmi, err := b.getInternalResource(ctx, "internalvirtualizationvirtualmachineinstances", vm.Namespace, vm.Name)
 	if err == nil {
-		if err := b.outputResource("InternalVirtualizationVirtualMachineInstance", vmName, namespace, ivvmi); err != nil {
+		if err := b.outputResource("InternalVirtualizationVirtualMachineInstance", vm.Name, vm.Namespace, ivvmi); err != nil {
 			return fmt.Errorf("failed to output InternalVirtualizationVirtualMachineInstance: %w", err)
 		}
-	} else if !b.handleError("InternalVirtualizationVirtualMachineInstance", vmName, err) {
+	} else if !b.skipError("InternalVirtualizationVirtualMachineInstance", vm.Name, err) {
 		return err
 	}
 
 	// Get VM operations
-	vmUID := string(vm.UID)
-	vmops, err := client.VirtualMachineOperations(namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("virtualization.deckhouse.io/virtual-machine-uid=%s", vmUID),
+	vmops, err := client.VirtualMachineOperations(vm.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("virtualization.deckhouse.io/virtual-machine-uid=%s", vm.UID),
 	})
 	if err == nil {
 		for _, vmop := range vmops.Items {
-			if err := b.outputResource("VirtualMachineOperation", vmop.Name, namespace, &vmop); err != nil {
+			if err := b.outputResource("VirtualMachineOperation", vmop.Name, vm.Namespace, &vmop); err != nil {
 				return fmt.Errorf("failed to output VirtualMachineOperation: %w", err)
 			}
 		}
-	} else if !b.handleError("VirtualMachineOperation", "", err) {
+	} else if !b.skipError("VirtualMachineOperation", "", err) {
 		return err
 	}
 
 	// Get migrations
-	migrations, err := b.getInternalResourceList(ctx, "internalvirtualizationvirtualmachineinstancemigrations", namespace)
+	migrations, err := b.getInternalResourceList(ctx, "internalvirtualizationvirtualmachineinstancemigrations", vm.Namespace)
 	if err == nil {
 		for _, item := range migrations {
 			vmiName, found, _ := unstructured.NestedString(item.Object, "spec", "vmiName")
-			if found && vmiName == vmName {
+			if found && vmiName == vm.Name {
 				name, _, _ := unstructured.NestedString(item.Object, "metadata", "name")
-				if err := b.outputResource("InternalVirtualizationVirtualMachineInstanceMigration", name, namespace, item); err != nil {
+				if err := b.outputResource("InternalVirtualizationVirtualMachineInstanceMigration", name, vm.Namespace, item); err != nil {
 					return fmt.Errorf("failed to output InternalVirtualizationVirtualMachineInstanceMigration: %w", err)
 				}
 			}
 		}
-	} else if !b.handleError("InternalVirtualizationVirtualMachineInstanceMigration", "", err) {
+	} else if !b.skipError("InternalVirtualizationVirtualMachineInstanceMigration", "", err) {
 		return err
 	}
 
 	// Get events for VM
-	b.collectEvents(ctx, client, namespace, "VirtualMachine", vmName)
+	b.collectEvents(ctx, client, vm.Namespace, "VirtualMachine", vm.Name)
 
 	return nil
 }
 
-func (b *DebugBundle) collectBlockDevices(ctx context.Context, client kubeclient.Client, namespace, vmName string) error {
-	vm, err := client.VirtualMachines(namespace).Get(ctx, vmName, metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
-
+func (b *DebugBundle) collectBlockDevices(ctx context.Context, client kubeclient.Client, vm *v1alpha2.VirtualMachine) error {
 	// Track collected block devices to avoid duplicates
 	collectedBlockDevices := make(map[string]bool)
 
@@ -136,8 +122,8 @@ func (b *DebugBundle) collectBlockDevices(ctx context.Context, client kubeclient
 	for _, bdRef := range vm.Spec.BlockDeviceRefs {
 		key := bdKey(bdRef.Kind, bdRef.Name)
 		if !collectedBlockDevices[key] {
-			if err := b.collectBlockDevice(ctx, client, namespace, bdRef.Kind, bdRef.Name); err != nil {
-				if !b.handleError(string(bdRef.Kind), bdRef.Name, err) {
+			if err := b.collectBlockDevice(ctx, client, vm.Namespace, bdRef.Kind, bdRef.Name); err != nil {
+				if !b.skipError(string(bdRef.Kind), bdRef.Name, err) {
 					return err
 				}
 			} else {
@@ -147,14 +133,14 @@ func (b *DebugBundle) collectBlockDevices(ctx context.Context, client kubeclient
 	}
 
 	// Get all VMBDA that reference this VM
-	vmbdas, err := client.VirtualMachineBlockDeviceAttachments(namespace).List(ctx, metav1.ListOptions{})
+	vmbdas, err := client.VirtualMachineBlockDeviceAttachments(vm.Namespace).List(ctx, metav1.ListOptions{})
 	if err == nil {
 		for _, vmbda := range vmbdas.Items {
-			if vmbda.Spec.VirtualMachineName == vmName {
-				if err := b.outputResource("VirtualMachineBlockDeviceAttachment", vmbda.Name, namespace, &vmbda); err != nil {
+			if vmbda.Spec.VirtualMachineName == vm.Name {
+				if err := b.outputResource("VirtualMachineBlockDeviceAttachment", vmbda.Name, vm.Namespace, &vmbda); err != nil {
 					return fmt.Errorf("failed to output VirtualMachineBlockDeviceAttachment: %w", err)
 				}
-				b.collectEvents(ctx, client, namespace, "VirtualMachineBlockDeviceAttachment", vmbda.Name)
+				b.collectEvents(ctx, client, vm.Namespace, "VirtualMachineBlockDeviceAttachment", vmbda.Name)
 
 				// Get associated block device
 				if vmbda.Spec.BlockDeviceRef.Kind != "" && vmbda.Spec.BlockDeviceRef.Name != "" {
@@ -172,8 +158,8 @@ func (b *DebugBundle) collectBlockDevices(ctx context.Context, client kubeclient
 					}
 					key := bdKey(bdKind, vmbda.Spec.BlockDeviceRef.Name)
 					if !collectedBlockDevices[key] {
-						if err := b.collectBlockDevice(ctx, client, namespace, bdKind, vmbda.Spec.BlockDeviceRef.Name); err != nil {
-							if !b.handleError(string(bdKind), vmbda.Spec.BlockDeviceRef.Name, err) {
+						if err := b.collectBlockDevice(ctx, client, vm.Namespace, bdKind, vmbda.Spec.BlockDeviceRef.Name); err != nil {
+							if !b.skipError(string(bdKind), vmbda.Spec.BlockDeviceRef.Name, err) {
 								return err
 							}
 						} else {
@@ -183,7 +169,7 @@ func (b *DebugBundle) collectBlockDevices(ctx context.Context, client kubeclient
 				}
 			}
 		}
-	} else if !b.handleError("VirtualMachineBlockDeviceAttachment", "", err) {
+	} else if !b.skipError("VirtualMachineBlockDeviceAttachment", "", err) {
 		return err
 	}
 
@@ -218,11 +204,11 @@ func (b *DebugBundle) collectBlockDevice(ctx context.Context, client kubeclient.
 						if err := b.outputResource("PersistentVolume", pv.Name, "", pv); err != nil {
 							return fmt.Errorf("failed to output PersistentVolume: %w", err)
 						}
-					} else if !b.handleError("PersistentVolume", pvc.Spec.VolumeName, err) {
+					} else if !b.skipError("PersistentVolume", pvc.Spec.VolumeName, err) {
 						return err
 					}
 				}
-			} else if !b.handleError("PersistentVolumeClaim", vd.Status.Target.PersistentVolumeClaim, err) {
+			} else if !b.skipError("PersistentVolumeClaim", vd.Status.Target.PersistentVolumeClaim, err) {
 				return err
 			}
 		}
@@ -258,7 +244,7 @@ func (b *DebugBundle) collectPods(ctx context.Context, client kubeclient.Client,
 		LabelSelector: fmt.Sprintf("vm.kubevirt.internal.virtualization.deckhouse.io/name=%s", vmName),
 	})
 	if err != nil {
-		if b.handleError("Pod", "", err) {
+		if b.skipError("Pod", "", err) {
 			return nil
 		}
 		return err
@@ -284,7 +270,7 @@ func (b *DebugBundle) collectPods(ctx context.Context, client kubeclient.Client,
 		allPods, err := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			// If we can't list all pods, continue without dependent pods
-			if !b.handleError("Pod", namespace, err) {
+			if !b.skipError("Pod", "", err) {
 				return err
 			}
 		} else {
@@ -318,7 +304,7 @@ func (b *DebugBundle) collectEvents(ctx context.Context, client kubeclient.Clien
 		FieldSelector: fmt.Sprintf("involvedObject.name=%s", resourceName),
 	})
 	if err != nil {
-		if b.handleError("Event", resourceName, err) {
+		if b.skipError("Event", resourceName, err) {
 			return
 		}
 		return


### PR DESCRIPTION
## Description
`collect-debug-info` aborted with no archive at all when a secondary resource was missing — most often the KubeVirt VMI, which does not exist while a VM is stopped. Missing resources (and ones the caller has no access to) are now skipped with a warning and the rest of the bundle is still produced. A missing target VirtualMachine still fails, now with a clear message instead of a raw internal one.

## Why do we need it, and what problem does it solve?
Debug bundles are collected precisely when something is wrong — often on stopped or half-provisioned VMs. Aborting the whole command in that case left users with nothing to attach to a bug report.

## What is the expected result?
`d8v collect-debug-info <vm> -n <ns> > debug.tar.gz` on a stopped VM exits 0 and the archive contains the VM config, events and available block devices; skipped resources are reported as warnings on stderr. An unknown name returns `VirtualMachine "<vm>" not found in namespace "<ns>"`.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: cli
type: fix
summary: "collect-debug-info no longer fails to produce an archive when the VM is stopped or a referenced resource is missing."
```
