### PR TITLE
fix(audit): gate log-shipper config on cert and warn on TLS handshake failures

### DIFF
--- a/images/virtualization-artifact/pkg/audit/server/server.go
+++ b/images/virtualization-artifact/pkg/audit/server/server.go
@@ -182,6 +182,18 @@ func loadServerTLSConfig(t *TLSPair) (*tls.Config, error) {
 func (s *tcpServer) handleConnection(ctx context.Context, conn net.Conn) {
 	defer conn.Close()
 
+	// A failing handshake here is typically a log-shipper agent whose vector hung on
+	// a topology reload after a CA rotation and keeps retrying with a stale CA. Do it
+	// explicitly (instead of letting the first read trigger it) so the operator gets an
+	// actionable warning instead of a debug-level "connection closed" buried in churn.
+	if tlsConn, ok := conn.(*tls.Conn); ok {
+		if err := tlsConn.HandshakeContext(ctx); err != nil {
+			log.Warn("TLS handshake with log-shipper failed; if it repeats after a CA rotation, restart the log-shipper agent pods to reload the new CA",
+				slog.String("remote", conn.RemoteAddr().String()), log.Err(err))
+			return
+		}
+	}
+
 	log.Debug("New connection", slog.String("remote", conn.RemoteAddr().String()))
 
 	scanner := bufio.NewScanner(conn)

--- a/templates/virtualization-audit/_helper.tpl
+++ b/templates/virtualization-audit/_helper.tpl
@@ -1,6 +1,9 @@
 {{- /* Helper to detect if the cluster and the module are configured to enable audit.
 - audit.enabled should be true in ModuleConfig
 - log-shipper and runtime-audit-engine modules should be enabled.
+- the audit TLS certificate must already be generated (the hook runs asynchronously),
+  otherwise dependent resources (ClusterLogDestination, cert secret, Deployment) would
+  render with empty CA/cert/key.
 
 Usage:
 
@@ -14,7 +17,9 @@ Usage:
 {{- if (dig "moduleConfig" "audit" "enabled" false .Values.virtualization.internal) -}}
 {{- if (.Values.global.enabledModules | has "log-shipper") -}}
 {{- if (.Values.global.enabledModules | has "runtime-audit-engine") -}}
+{{- if and (dig "audit" "cert" "ca" "" .Values.virtualization.internal) (dig "audit" "cert" "crt" "" .Values.virtualization.internal) (dig "audit" "cert" "key" "" .Values.virtualization.internal) -}}
 true
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description

Two robustness fixes for audit log delivery over the log-shipper.

1. Audit's log-shipper resources (`ClusterLogDestination` and the `ClusterLoggingConfig`s) are no longer rendered until the audit TLS certificate has actually been generated. The certificate is produced asynchronously by a hook, so on startup these resources could be created with an empty CA/cert/key.

2. When the audit receiver rejects a TLS connection, it now logs an actionable warning telling the operator to restart the log-shipper agent pods. Previously the handshake failure surfaced only at debug level, indistinguishable from normal connection churn.

## Why do we need it, and what problem does it solve?

Audit events are delivered from the log-shipper agent to the audit receiver over a mutually-authenticated TLS socket. Two situations left audit silently broken:

- On a fresh enablement, the log-shipper destination could be configured before the certificate existed, pointing it at an empty CA.
- After a CA rotation, a hung vector reload keeps the agent retrying with a stale CA. Audit stops being delivered, but the only trace was a debug log the operator would never see — so there was no signal about what to do.

Now the destination is only configured once its certificate is ready, and a persistent stream of warnings on the receiver points the operator straight at the fix (restart the log-shipper agents).

Task 67136162.

## What is the expected result?

- With audit enabled but the certificate not yet generated, no audit log-shipper resources are created; they appear once the certificate is ready.
- When the log-shipper connects with a mismatched CA, the audit receiver logs a warning naming the remedy instead of a silent debug line.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: audit
type: fix
summary: "Audit no longer configures its log-shipper destination before the TLS certificate is ready, and warns to restart the log-shipper agents when audit delivery fails on a TLS handshake."
impact_level: low
```
