### PR TITLE
fix(ci): rebuild broken dev module tags (GitHub + GitLab)

### DIFF
--- a/.github/scripts/bash/check-and-rebuild/check-image-digests.sh
+++ b/.github/scripts/bash/check-and-rebuild/check-image-digests.sh
@@ -15,32 +15,38 @@
 # limitations under the License.
 
 # Check that every component image referenced by a module tag is pullable.
-# Reads images_digests.json from the module image and verifies each digest.
-#
-# Usage: check-image-digests.sh <repo> <tag>
+# Usage: check-image-digests.sh --repo <repo> --tag <tag>
 # Exit:  0 all pullable, 1 some missing, 2 module image not found.
 
 set -Eeuo pipefail
 
-R="${1:?usage: check-image-digests.sh <repo> <tag>}"
-TAG="${2:?usage: check-image-digests.sh <repo> <tag>}"
+repo=""
+tag=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) repo="$2"; shift 2 ;;
+    --tag) tag="$2"; shift 2 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+[[ -n "$repo" && -n "$tag" ]] || { echo "usage: $0 --repo <repo> --tag <tag>" >&2; exit 2; }
 
-if ! crane digest "${R}:${TAG}" >/dev/null 2>&1; then
-  echo "::error::module image ${R}:${TAG} not found"
+if ! crane digest "${repo}:${tag}" >/dev/null 2>&1; then
+  echo "::error::module image ${repo}:${tag} not found"
   exit 2
 fi
 
-json="$(crane export "${R}:${TAG}" - | tar -Oxf - images_digests.json)"
+digests="$(crane export "${repo}:${tag}" - | tar -Oxf - images_digests.json)"
 
 missing=0
 while read -r name digest; do
-  if crane digest "${R}@${digest}" >/dev/null 2>&1; then
+  if crane digest "${repo}@${digest}" >/dev/null 2>&1; then
     echo "OK    ${name}"
   else
     echo "MISS  ${name}  ${digest}"
     missing=$((missing + 1))
   fi
-done < <(echo "${json}" | jq -r 'to_entries[] | "\(.key) \(.value)"')
+done < <(echo "${digests}" | jq -r 'to_entries[] | "\(.key) \(.value)"')
 
 echo "${missing} component image(s) missing"
-[ "${missing}" -eq 0 ]
+[[ "${missing}" -eq 0 ]]

--- a/.github/scripts/bash/check-and-rebuild/check-image-digests.sh
+++ b/.github/scripts/bash/check-and-rebuild/check-image-digests.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Check that every component image referenced by a module tag is pullable.
+# Reads images_digests.json from the module image and verifies each digest.
+#
+# Usage: check-image-digests.sh <repo> <tag>
+# Exit:  0 all pullable, 1 some missing, 2 module image not found.
+
+set -Eeuo pipefail
+
+R="${1:?usage: check-image-digests.sh <repo> <tag>}"
+TAG="${2:?usage: check-image-digests.sh <repo> <tag>}"
+
+if ! crane digest "${R}:${TAG}" >/dev/null 2>&1; then
+  echo "::error::module image ${R}:${TAG} not found"
+  exit 2
+fi
+
+json="$(crane export "${R}:${TAG}" - | tar -Oxf - images_digests.json)"
+
+missing=0
+while read -r name digest; do
+  if crane digest "${R}@${digest}" >/dev/null 2>&1; then
+    echo "OK    ${name}"
+  else
+    echo "MISS  ${name}  ${digest}"
+    missing=$((missing + 1))
+  fi
+done < <(echo "${json}" | jq -r 'to_entries[] | "\(.key) \(.value)"')
+
+echo "${missing} component image(s) missing"
+[ "${missing}" -eq 0 ]

--- a/.github/scripts/bash/check-and-rebuild/check-image-digests.sh
+++ b/.github/scripts/bash/check-and-rebuild/check-image-digests.sh
@@ -31,6 +31,9 @@ while [[ $# -gt 0 ]]; do
 done
 [[ -n "$repo" && -n "$tag" ]] || { echo "usage: $0 --repo <repo> --tag <tag>" >&2; exit 2; }
 
+echo "[INFO] Repo ${repo}"
+echo "[INFO] Tag  ${tag}"
+
 if ! crane digest "${repo}:${tag}" >/dev/null 2>&1; then
   echo "::error::module image ${repo}:${tag} not found"
   exit 2
@@ -38,15 +41,28 @@ fi
 
 digests="$(crane export "${repo}:${tag}" - | tar -Oxf - images_digests.json)"
 
-missing=0
-while read -r name digest; do
-  if crane digest "${repo}@${digest}" >/dev/null 2>&1; then
-    echo "OK    ${name}"
+ok_images=()
+missing_images=()
+while read -r component digest; do
+  image="${repo}@${digest}"
+  if crane digest "$image" >/dev/null 2>&1; then
+    echo "✅ ${component}"
+    ok_images+=("$(printf '%-25s %s' "${component}:" "$image")")
   else
-    echo "MISS  ${name}  ${digest}"
-    missing=$((missing + 1))
+    echo "❌ ${component}"
+    missing_images+=("$(printf '%-25s %s' "${component}:" "$image")")
   fi
 done < <(echo "${digests}" | jq -r 'to_entries[] | "\(.key) \(.value)"')
 
-echo "${missing} component image(s) missing"
-[[ "${missing}" -eq 0 ]]
+echo "──────────────────────────────"
+if [[ ${#missing_images[@]} -eq 0 ]]; then
+  echo "🎉 All ${#ok_images[@]} component images are pullable"
+  exit 0
+fi
+
+echo "⚠️  Missing component images:"
+for img in "${missing_images[@]}"; do
+  echo "  - $img"
+done
+echo "Total missing: ${#missing_images[@]}"
+exit 1

--- a/.github/scripts/bash/check-and-rebuild/rebuild-broken-stages.sh
+++ b/.github/scripts/bash/check-and-rebuild/rebuild-broken-stages.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Delete stale stages so the next werf build rebuilds broken component images.
+# Usage: rebuild-broken-stages.sh --repo <repo> --report <build-report.json>
+
+set -Eeuo pipefail
+
+repo=""
+report=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) repo="$2"; shift 2 ;;
+    --report) report="$2"; shift 2 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+[[ -n "$repo" && -n "$report" ]] || { echo "usage: $0 --repo <repo> --report <file>" >&2; exit 2; }
+[[ -f "$report" ]] || { echo "::error::report ${report} not found"; exit 1; }
+
+# Warn (don't fail) if the tag is already gone.
+delete_tag() {
+  crane delete "${repo}:$1" && echo "  deleted ${repo}:$1" || echo "::warning::failed to delete $1"
+}
+
+# A GC'd component keeps a resolvable stage tag, so werf reuses the stage and
+# re-reports the dead digest. The dead digest can't be deleted, but the tag can:
+# drop every stage by tag so werf rebuilds and re-pushes a live image.
+while read -r img; do
+  final="$(jq -r --arg i "$img" '.Images[$i].DockerImageDigest // empty' "$report")"
+  [[ -n "$final" ]] || continue
+  crane digest "${repo}@${final}" >/dev/null 2>&1 && continue
+  echo "broken: ${img} — deleting its stages"
+  while read -r t; do
+    [[ -n "$t" ]] || continue
+    delete_tag "$t"
+  done < <(jq -r --arg i "$img" '.Images[$i].Stages[].DockerTag // empty' "$report")
+done < <(jq -r '.Images | to_entries[] | select(.value.Final == true) | .key' "$report")
+
+# Regenerate the digests chain so fresh component digests reach the module :tag.
+for img in images-digests prepare-bundle; do
+  t="$(jq -r --arg i "$img" '.Images[$i].DockerTag // empty' "$report")"
+  [[ -n "$t" ]] && delete_tag "$t" || echo "::warning::no tag for ${img} in report"
+done

--- a/.github/workflows/dev_check-and-rebuild.yml
+++ b/.github/workflows/dev_check-and-rebuild.yml
@@ -13,21 +13,16 @@
 # limitations under the License.
 
 # Recheck a published module tag and, if any component image it references is no
-# longer pullable (e.g. its stage manifest was garbage-collected from dev-registry),
-# rebuild the tag so the assembly chain is regenerated with live image digests.
+# longer pullable (its stage manifest was garbage-collected from dev-registry),
+# rebuild the tag with live image digests.
 #
-# The dev-registry GC removes untagged/by-digest stage manifests over time. A plain
-# rebuild does NOT fix this on its own: the `images-digests` image caches its content
-# by the components' werf stage signatures (stable), not by their OCI digests, so werf
-# reuses the cached `images_digests.json` still pointing at the collected manifests.
-# werf stage tags are content-based and stable, so a rebuilt stage does not invalidate
-# downstream stages' signatures — they stay cached and keep serving the stale json.
-# This workflow therefore deletes the whole baking chain `images-digests` ->
-# `prepare-bundle` -> `bundle`: images-digests is rebuilt re-reading the currently
-# published component digests, prepare-bundle re-imports the fresh `images_digests.json`,
-# and bundle (== module `:tag`) picks it up; the build action republishes `:tag` from the
-# rebuilt bundle stage. The release image carries no `images_digests.json`, so it is left
-# untouched.
+# A plain rebuild does NOT fix this: werf stage tags are content-based and stable,
+# so the `images_digests.json` baked into `bundle` (== module `:tag`) keeps pointing
+# at the collected manifests, and rebuilding one stage never invalidates the stages
+# that import it. So we delete the whole baking chain images-digests -> prepare-bundle
+# -> bundle: images-digests is rebuilt re-reading live component digests, prepare-bundle
+# re-imports the fresh json, bundle picks it up, and the build action republishes `:tag`.
+# The release image has no `images_digests.json` and is left untouched.
 
 name: Check dev images and rebuild
 
@@ -146,15 +141,9 @@ jobs:
             exit 1
           fi
 
-          # Delete every cached stage from images-digests down to bundle that bakes
-          # the component digests. werf stage tags are content-based and stable, so
-          # deleting one stage forces ONLY that stage to rebuild without invalidating
-          # any downstream signature: images-digests must be deleted to re-read live
-          # component digests, prepare-bundle to re-import the fresh images_digests.json,
-          # and bundle (== module :tag) to pick up that prepare-bundle rather than serve
-          # the cached, stale json. The build action republishes :tag from the rebuilt
-          # bundle stage; the release image carries no images_digests.json and is left
-          # untouched. Delete by digest so all timestamped stage tags go at once.
+          # Delete the whole baking chain by digest. Stage tags are content-based and
+          # stable, so deleting one stage rebuilds only that stage without touching the
+          # ones that import it — all three must go to move fresh digests into :tag.
           for img in images-digests prepare-bundle bundle; do
             d="$(jq -r --arg i "$img" '.Images[$i].DockerImageDigest // empty' "$report")"
             if [ -n "$d" ]; then

--- a/.github/workflows/dev_check-and-rebuild.yml
+++ b/.github/workflows/dev_check-and-rebuild.yml
@@ -12,18 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Recheck a published module tag and, if any component image it references is no
-# longer pullable (its stage manifest was garbage-collected from dev-registry),
-# rebuild the tag with live image digests.
+# Recheck a published module tag and rebuild it if any component image it references
+# was garbage-collected from dev-registry.
 #
-# A plain rebuild does NOT fix this: werf stage tags are content-based and stable, and
-# a collected component keeps a resolvable stage tag, so werf reuses the stage and keeps
-# reporting the dead digest. The fix, for every component whose final image is no longer
-# pullable, deletes its stages BY TAG (the dead digest cannot be deleted): werf then no
-# longer finds the stage by signature and rebuilds + re-pushes a live image. Deleting
-# images-digests and prepare-bundle regenerates `images_digests.json` with the fresh
-# digests, and the build action republishes `:tag`. The release image has no
-# `images_digests.json` and is left untouched.
+# A plain rebuild does not fix it: werf keeps reusing the collected stage (its tag still
+# resolves) and re-reports the dead digest. So for every broken component we delete its
+# stages by tag (the dead digest can't be deleted), forcing werf to rebuild and re-push;
+# then we delete images-digests and prepare-bundle to regenerate images_digests.json,
+# and the build action republishes :tag.
 
 name: Check dev images and rebuild
 
@@ -91,11 +87,11 @@ jobs:
         id: check
         run: |
           set -uo pipefail
-          R="${MODULES_MODULE_SOURCE}/${MODULES_MODULE_NAME}"
-          TAG="${{ github.event.inputs.tag }}"
+          repo="${MODULES_MODULE_SOURCE}/${MODULES_MODULE_NAME}"
 
           rc=0
-          .github/scripts/bash/check-and-rebuild/check-image-digests.sh "$R" "$TAG" || rc=$?
+          .github/scripts/bash/check-and-rebuild/check-image-digests.sh \
+            --repo "$repo" --tag "${{ github.event.inputs.tag }}" || rc=$?
           if [ "$rc" -eq 2 ]; then
             exit 1
           fi
@@ -122,45 +118,9 @@ jobs:
       - name: Delete stale stages of broken images
         if: ${{ steps.check.outputs.needs_fix == 'true' }}
         run: |
-          set -euo pipefail
-          R="${MODULES_MODULE_SOURCE}/${MODULES_MODULE_NAME}"
-          report="images_tags_werf.json"
-          if [ ! -f "$report" ]; then
-            echo "::error::$report not produced by the build step"
-            exit 1
-          fi
-
-          # Force-rebuild every component whose final image is no longer pullable. GC
-          # collected its final stage manifest, but werf still reuses the stage because
-          # its content-signature tag keeps resolving, so it re-reports the dead digest.
-          # Delete the component's stages BY TAG — the dead digest cannot be deleted
-          # (MANIFEST_UNKNOWN), but the tag still resolves. Once the tag is gone werf no
-          # longer finds the stage by signature and rebuilds + re-pushes a live image.
-          jq -r '.Images | to_entries[] | select(.value.Final == true) | .key' "$report" | while read -r img; do
-            final="$(jq -r --arg i "$img" '.Images[$i].DockerImageDigest // empty' "$report")"
-            [ -n "$final" ] || continue
-            if crane digest "$R@$final" >/dev/null 2>&1; then
-              continue
-            fi
-            echo "broken: $img — deleting its stages to force a rebuild"
-            jq -r --arg i "$img" '.Images[$i].Stages[].DockerTag // empty' "$report" | while read -r t; do
-              [ -n "$t" ] || continue
-              crane delete "$R:$t" && echo "  deleted $R:$t" || echo "::warning::failed to delete stage $t"
-            done
-          done
-
-          # Regenerate the digests chain so the freshly rebuilt component digests reach
-          # the module :tag. images-digests caches by the components' (stable) stage
-          # signatures, so delete it and prepare-bundle (which imports it) by tag.
-          for img in images-digests prepare-bundle; do
-            t="$(jq -r --arg i "$img" '.Images[$i].DockerTag // empty' "$report")"
-            if [ -n "$t" ]; then
-              echo "deleting $img -> $R:$t"
-              crane delete "$R:$t" || echo "::warning::failed to delete $img ($t)"
-            else
-              echo "::warning::no tag for $img in build report"
-            fi
-          done
+          repo="${MODULES_MODULE_SOURCE}/${MODULES_MODULE_NAME}"
+          .github/scripts/bash/check-and-rebuild/rebuild-broken-stages.sh \
+            --repo "$repo" --report images_tags_werf.json
 
       # Pass 2: full rebuild + publish; images-digests is regenerated with live digests.
       - name: Rebuild and publish
@@ -180,9 +140,9 @@ jobs:
         if: ${{ steps.check.outputs.needs_fix == 'true' }}
         run: |
           set -euo pipefail
-          R="${MODULES_MODULE_SOURCE}/${MODULES_MODULE_NAME}"
-          TAG="${{ github.event.inputs.tag }}"
-          if ! .github/scripts/bash/check-and-rebuild/check-image-digests.sh "$R" "$TAG"; then
+          repo="${MODULES_MODULE_SOURCE}/${MODULES_MODULE_NAME}"
+          if ! .github/scripts/bash/check-and-rebuild/check-image-digests.sh \
+              --repo "$repo" --tag "${{ github.event.inputs.tag }}"; then
             echo "::error::component image(s) still missing after rebuild"
             exit 1
           fi

--- a/.github/workflows/dev_check-and-rebuild.yml
+++ b/.github/workflows/dev_check-and-rebuild.yml
@@ -90,31 +90,19 @@ jobs:
       - name: Check component images
         id: check
         run: |
-          set -euo pipefail
+          set -uo pipefail
           R="${MODULES_MODULE_SOURCE}/${MODULES_MODULE_NAME}"
           TAG="${{ github.event.inputs.tag }}"
 
-          if ! crane digest "$R:$TAG" >/dev/null 2>&1; then
-            echo "::error::module image $R:$TAG not found"
+          rc=0
+          .github/scripts/bash/check-and-rebuild/check-image-digests.sh "$R" "$TAG" || rc=$?
+          if [ "$rc" -eq 2 ]; then
             exit 1
           fi
-
-          json="$(crane export "$R:$TAG" - | tar -Oxf - images_digests.json)"
-          missing=0
-          while read -r name digest; do
-            if crane digest "$R@$digest" >/dev/null 2>&1; then
-              echo "OK    $name"
-            else
-              echo "MISS  $name  $digest"
-              missing=$((missing + 1))
-            fi
-          done < <(echo "$json" | jq -r 'to_entries[] | "\(.key) \(.value)"')
-
-          echo "$missing component image(s) missing"
-          if [ "$missing" -gt 0 ]; then
-            echo "needs_fix=true" >> "$GITHUB_OUTPUT"
-          else
+          if [ "$rc" -eq 0 ]; then
             echo "needs_fix=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "needs_fix=true" >> "$GITHUB_OUTPUT"
           fi
 
       # Pass 1: build only to obtain the current stage tags/digests (mostly cached).
@@ -194,18 +182,8 @@ jobs:
           set -euo pipefail
           R="${MODULES_MODULE_SOURCE}/${MODULES_MODULE_NAME}"
           TAG="${{ github.event.inputs.tag }}"
-          json="$(crane export "$R:$TAG" - | tar -Oxf - images_digests.json)"
-          missing=0
-          while read -r name digest; do
-            if crane digest "$R@$digest" >/dev/null 2>&1; then
-              echo "OK    $name"
-            else
-              echo "MISS  $name  $digest"
-              missing=$((missing + 1))
-            fi
-          done < <(echo "$json" | jq -r 'to_entries[] | "\(.key) \(.value)"')
-          if [ "$missing" -gt 0 ]; then
-            echo "::error::$missing component image(s) still missing after rebuild"
+          if ! .github/scripts/bash/check-and-rebuild/check-image-digests.sh "$R" "$TAG"; then
+            echo "::error::component image(s) still missing after rebuild"
             exit 1
           fi
           echo "All component images are pullable."

--- a/.github/workflows/dev_check-and-rebuild.yml
+++ b/.github/workflows/dev_check-and-rebuild.yml
@@ -141,6 +141,12 @@ jobs:
             exit 1
           fi
 
+          # test only
+          echo "::group:: Report"
+          cat "$report" | jq
+          echo "::endgroup::"
+          #
+
           # Delete the whole baking chain by digest. Stage tags are content-based and
           # stable, so deleting one stage rebuilds only that stage without touching the
           # ones that import it — all three must go to move fresh digests into :tag.

--- a/.github/workflows/dev_check-and-rebuild.yml
+++ b/.github/workflows/dev_check-and-rebuild.yml
@@ -20,11 +20,14 @@
 # rebuild does NOT fix this on its own: the `images-digests` image caches its content
 # by the components' werf stage signatures (stable), not by their OCI digests, so werf
 # reuses the cached `images_digests.json` still pointing at the collected manifests.
-# This workflow forces regeneration by deleting the intermediate `images-digests` and
-# `prepare-bundle` stages so the next build rebuilds `images-digests` (re-reading the
-# currently published component digests); `bundle` then cascades and the module image
-# `:tag` is overwritten by the build action's publish step. The release image carries
-# no `images_digests.json`, so it is left untouched.
+# werf stage tags are content-based and stable, so a rebuilt stage does not invalidate
+# downstream stages' signatures — they stay cached and keep serving the stale json.
+# This workflow therefore deletes the whole baking chain `images-digests` ->
+# `prepare-bundle` -> `bundle`: images-digests is rebuilt re-reading the currently
+# published component digests, prepare-bundle re-imports the fresh `images_digests.json`,
+# and bundle (== module `:tag`) picks it up; the build action republishes `:tag` from the
+# rebuilt bundle stage. The release image carries no `images_digests.json`, so it is left
+# untouched.
 
 name: Check dev images and rebuild
 
@@ -143,13 +146,16 @@ jobs:
             exit 1
           fi
 
-          # Delete only the intermediate stages that bake the component digests.
-          # Deleting images-digests forces its rebuild (re-reading live component
-          # digests); prepare-bundle imports it. Both are intermediate-only, so no
-          # published tag is touched: bundle (== module :tag) cascades on rebuild and
-          # is overwritten by the action's publish step, and the release image is
-          # unrelated. Delete by digest so all timestamped stage tags go at once.
-          for img in images-digests prepare-bundle; do
+          # Delete every cached stage from images-digests down to bundle that bakes
+          # the component digests. werf stage tags are content-based and stable, so
+          # deleting one stage forces ONLY that stage to rebuild without invalidating
+          # any downstream signature: images-digests must be deleted to re-read live
+          # component digests, prepare-bundle to re-import the fresh images_digests.json,
+          # and bundle (== module :tag) to pick up that prepare-bundle rather than serve
+          # the cached, stale json. The build action republishes :tag from the rebuilt
+          # bundle stage; the release image carries no images_digests.json and is left
+          # untouched. Delete by digest so all timestamped stage tags go at once.
+          for img in images-digests prepare-bundle bundle; do
             d="$(jq -r --arg i "$img" '.Images[$i].DockerImageDigest // empty' "$report")"
             if [ -n "$d" ]; then
               echo "deleting $img -> $R@$d"

--- a/.github/workflows/dev_check-and-rebuild.yml
+++ b/.github/workflows/dev_check-and-rebuild.yml
@@ -16,13 +16,14 @@
 # longer pullable (its stage manifest was garbage-collected from dev-registry),
 # rebuild the tag with live image digests.
 #
-# A plain rebuild does NOT fix this: werf stage tags are content-based and stable,
-# so the `images_digests.json` baked into `bundle` (== module `:tag`) keeps pointing
-# at the collected manifests, and rebuilding one stage never invalidates the stages
-# that import it. So we delete the whole baking chain images-digests -> prepare-bundle
-# -> bundle: images-digests is rebuilt re-reading live component digests, prepare-bundle
-# re-imports the fresh json, bundle picks it up, and the build action republishes `:tag`.
-# The release image has no `images_digests.json` and is left untouched.
+# A plain rebuild does NOT fix this: werf stage tags are content-based and stable, and
+# a collected component keeps a resolvable stage tag, so werf reuses the stage and keeps
+# reporting the dead digest. The fix, for every component whose final image is no longer
+# pullable, deletes its stages BY TAG (the dead digest cannot be deleted): werf then no
+# longer finds the stage by signature and rebuilds + re-pushes a live image. Deleting
+# images-digests and prepare-bundle regenerates `images_digests.json` with the fresh
+# digests, and the build action republishes `:tag`. The release image has no
+# `images_digests.json` and is left untouched.
 
 name: Check dev images and rebuild
 
@@ -130,7 +131,7 @@ jobs:
           registry_user: ${{ vars.DEV_MODULES_REGISTRY_LOGIN }}
           registry_password: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
 
-      - name: Delete stale images-digests stages
+      - name: Delete stale stages of broken images
         if: ${{ steps.check.outputs.needs_fix == 'true' }}
         run: |
           set -euo pipefail
@@ -141,22 +142,35 @@ jobs:
             exit 1
           fi
 
-          # test only
-          echo "::group:: Report"
-          cat "$report" | jq
-          echo "::endgroup::"
-          #
+          # Force-rebuild every component whose final image is no longer pullable. GC
+          # collected its final stage manifest, but werf still reuses the stage because
+          # its content-signature tag keeps resolving, so it re-reports the dead digest.
+          # Delete the component's stages BY TAG — the dead digest cannot be deleted
+          # (MANIFEST_UNKNOWN), but the tag still resolves. Once the tag is gone werf no
+          # longer finds the stage by signature and rebuilds + re-pushes a live image.
+          jq -r '.Images | to_entries[] | select(.value.Final == true) | .key' "$report" | while read -r img; do
+            final="$(jq -r --arg i "$img" '.Images[$i].DockerImageDigest // empty' "$report")"
+            [ -n "$final" ] || continue
+            if crane digest "$R@$final" >/dev/null 2>&1; then
+              continue
+            fi
+            echo "broken: $img — deleting its stages to force a rebuild"
+            jq -r --arg i "$img" '.Images[$i].Stages[].DockerTag // empty' "$report" | while read -r t; do
+              [ -n "$t" ] || continue
+              crane delete "$R:$t" && echo "  deleted $R:$t" || echo "::warning::failed to delete stage $t"
+            done
+          done
 
-          # Delete the whole baking chain by digest. Stage tags are content-based and
-          # stable, so deleting one stage rebuilds only that stage without touching the
-          # ones that import it — all three must go to move fresh digests into :tag.
-          for img in images-digests prepare-bundle bundle; do
-            d="$(jq -r --arg i "$img" '.Images[$i].DockerImageDigest // empty' "$report")"
-            if [ -n "$d" ]; then
-              echo "deleting $img -> $R@$d"
-              crane delete "$R@$d" || echo "::warning::failed to delete $img ($d)"
+          # Regenerate the digests chain so the freshly rebuilt component digests reach
+          # the module :tag. images-digests caches by the components' (stable) stage
+          # signatures, so delete it and prepare-bundle (which imports it) by tag.
+          for img in images-digests prepare-bundle; do
+            t="$(jq -r --arg i "$img" '.Images[$i].DockerTag // empty' "$report")"
+            if [ -n "$t" ]; then
+              echo "deleting $img -> $R:$t"
+              crane delete "$R:$t" || echo "::warning::failed to delete $img ($t)"
             else
-              echo "::warning::no digest for $img in build report"
+              echo "::warning::no tag for $img in build report"
             fi
           done
 

--- a/.github/workflows/dev_check-and-rebuild.yml
+++ b/.github/workflows/dev_check-and-rebuild.yml
@@ -70,6 +70,12 @@ jobs:
             exit 1
           fi
 
+      # Stash the helper scripts from the workflow ref: the tag checkout below replaces
+      # the tree with the (older) released tag, which does not contain them.
+      - uses: actions/checkout@v6
+      - name: Stash helper scripts
+        run: cp -r .github/scripts/bash/check-and-rebuild "$RUNNER_TEMP/helpers"
+
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.tag }}
@@ -90,7 +96,7 @@ jobs:
           repo="${MODULES_MODULE_SOURCE}/${MODULES_MODULE_NAME}"
 
           rc=0
-          .github/scripts/bash/check-and-rebuild/check-image-digests.sh \
+          "$RUNNER_TEMP/helpers/check-image-digests.sh" \
             --repo "$repo" --tag "${{ github.event.inputs.tag }}" || rc=$?
           if [ "$rc" -eq 2 ]; then
             exit 1
@@ -119,7 +125,7 @@ jobs:
         if: ${{ steps.check.outputs.needs_fix == 'true' }}
         run: |
           repo="${MODULES_MODULE_SOURCE}/${MODULES_MODULE_NAME}"
-          .github/scripts/bash/check-and-rebuild/rebuild-broken-stages.sh \
+          "$RUNNER_TEMP/helpers/rebuild-broken-stages.sh" \
             --repo "$repo" --report images_tags_werf.json
 
       # Pass 2: full rebuild + publish; images-digests is regenerated with live digests.
@@ -141,7 +147,7 @@ jobs:
         run: |
           set -euo pipefail
           repo="${MODULES_MODULE_SOURCE}/${MODULES_MODULE_NAME}"
-          if ! .github/scripts/bash/check-and-rebuild/check-image-digests.sh \
+          if ! "$RUNNER_TEMP/helpers/check-image-digests.sh" \
               --repo "$repo" --tag "${{ github.event.inputs.tag }}"; then
             echo "::error::component image(s) still missing after rebuild"
             exit 1

--- a/.gitlab/ci/includes.yml
+++ b/.gitlab/ci/includes.yml
@@ -109,4 +109,5 @@ include:
   - local: ".gitlab/ci/jobs/check-changelog.yml"
   - local: ".gitlab/ci/jobs/check-milestone.yml"
   - local: ".gitlab/ci/jobs/manual-tools.yml"
+  - local: ".gitlab/ci/jobs/check-and-rebuild.yml"
   - local: ".gitlab/ci/jobs/translate-changelog.yml"

--- a/.gitlab/ci/jobs/check-and-rebuild.yml
+++ b/.gitlab/ci/jobs/check-and-rebuild.yml
@@ -1,0 +1,74 @@
+# Copyright 2026 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Recheck a published dev module tag and rebuild it if any component image it
+# references was garbage-collected from dev-registry. GitLab counterpart of
+# .github/workflows/dev_check-and-rebuild.yml; helpers live in
+# .gitlab/ci/scripts/bash/check-and-rebuild/.
+#
+# werf keeps reusing a collected stage (its tag still resolves) and re-reports
+# the dead digest, so a plain rebuild does not fix it. For every broken
+# component we delete its stages by tag, forcing werf to rebuild and re-push;
+# images-digests and prepare-bundle are dropped too so images_digests.json is
+# regenerated, and .build_base republishes :$TAG.
+#
+# Run via "Run pipeline" (CI_PIPELINE_SOURCE == web) with variable:
+#   TAG  (required)  module tag to recheck/rebuild, vX.Y.Z or vX.Y.Z-rc.N.
+#
+# The pipeline ref carries the helper scripts; the job checks out $TAG for the
+# werf build, so the scripts are stashed to a tmpdir before the checkout (an
+# already-released tag's tree may predate them).
+
+check_and_rebuild:
+  stage: build
+  extends:
+    - .dev_vars
+  variables:
+    MODULES_MODULE_TAG: ${TAG}
+    MODULE_EDITION: EE
+    # Full clone so the target tag's commit is present for checkout.
+    GIT_DEPTH: 0
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "web" && $TAG =~ /^v\d+\.\d+\.\d+(-rc\.\d+)?$/'
+      when: manual
+    - when: never
+  script:
+    - bash .gitlab/ci/scripts/bash/check-runner-tools.sh werf jq crane
+    # Stash the shared helpers before the tag checkout replaces the tree.
+    - export HELPERS="$(mktemp -d)"
+    - cp .gitlab/ci/scripts/bash/check-and-rebuild/*.sh "$HELPERS/"
+    - export REPO="${MODULES_MODULE_SOURCE}/${MODULES_MODULE_NAME}"
+    # Check; stop early (success) when nothing is broken.
+    - |
+      rc=0
+      bash "$HELPERS/check-image-digests.sh" --repo "$REPO" --tag "$TAG" || rc=$?
+      if [ "$rc" -eq 0 ]; then echo "nothing to rebuild"; exit 0; fi
+      if [ "$rc" -eq 2 ]; then echo "module tag $REPO:$TAG not found" >&2; exit 1; fi
+    # Build the target tag's source.
+    - git checkout -f "refs/tags/${TAG}"
+    # Pass 1: collect the build report (mostly cached). Report kept out of the
+    # repo tree so werf giterminism sees a clean checkout.
+    - export REPORT="$(mktemp --suffix=.json)"
+    - werf build --repo "$REPO" --save-build-report --build-report-path "$REPORT"
+    # Delete stale stages of broken components.
+    - bash "$HELPERS/rebuild-broken-stages.sh" --repo "$REPO" --report "$REPORT"
+    # Pass 2: rebuild + publish (regenerates images_digests.json, republishes :$TAG).
+    - !reference [.build_base, script]
+    # Re-check.
+    - |
+      if ! bash "$HELPERS/check-image-digests.sh" --repo "$REPO" --tag "$TAG"; then
+        echo "component image(s) still missing after rebuild" >&2
+        exit 1
+      fi
+      echo "All component images are pullable."

--- a/.gitlab/ci/scripts/bash/check-and-rebuild/check-image-digests.sh
+++ b/.gitlab/ci/scripts/bash/check-and-rebuild/check-image-digests.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Check that every component image referenced by a module tag is pullable.
+# Usage: check-image-digests.sh --repo <repo> --tag <tag>
+# Exit:  0 all pullable, 1 some missing, 2 module image not found.
+
+set -Eeuo pipefail
+
+repo=""
+tag=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) repo="$2"; shift 2 ;;
+    --tag) tag="$2"; shift 2 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+[[ -n "$repo" && -n "$tag" ]] || { echo "usage: $0 --repo <repo> --tag <tag>" >&2; exit 2; }
+
+echo "[INFO] Repo ${repo}"
+echo "[INFO] Tag  ${tag}"
+
+if ! crane digest "${repo}:${tag}" >/dev/null 2>&1; then
+  echo "::error::module image ${repo}:${tag} not found"
+  exit 2
+fi
+
+digests="$(crane export "${repo}:${tag}" - | tar -Oxf - images_digests.json)"
+
+ok_images=()
+missing_images=()
+while read -r component digest; do
+  image="${repo}@${digest}"
+  if crane digest "$image" >/dev/null 2>&1; then
+    echo "✅ ${component}"
+    ok_images+=("$(printf '%-25s %s' "${component}:" "$image")")
+  else
+    echo "❌ ${component}"
+    missing_images+=("$(printf '%-25s %s' "${component}:" "$image")")
+  fi
+done < <(echo "${digests}" | jq -r 'to_entries[] | "\(.key) \(.value)"')
+
+echo "──────────────────────────────"
+if [[ ${#missing_images[@]} -eq 0 ]]; then
+  echo "🎉 All ${#ok_images[@]} component images are pullable"
+  exit 0
+fi
+
+echo "⚠️  Missing component images:"
+for img in "${missing_images[@]}"; do
+  echo "  - $img"
+done
+echo "Total missing: ${#missing_images[@]}"
+exit 1

--- a/.gitlab/ci/scripts/bash/check-and-rebuild/rebuild-broken-stages.sh
+++ b/.gitlab/ci/scripts/bash/check-and-rebuild/rebuild-broken-stages.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Delete stale stages so the next werf build rebuilds broken component images.
+# Usage: rebuild-broken-stages.sh --repo <repo> --report <build-report.json>
+
+set -Eeuo pipefail
+
+repo=""
+report=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) repo="$2"; shift 2 ;;
+    --report) report="$2"; shift 2 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+[[ -n "$repo" && -n "$report" ]] || { echo "usage: $0 --repo <repo> --report <file>" >&2; exit 2; }
+[[ -f "$report" ]] || { echo "::error::report ${report} not found"; exit 1; }
+
+# Warn (don't fail) if the tag is already gone.
+delete_tag() {
+  crane delete "${repo}:$1" && echo "  deleted ${repo}:$1" || echo "::warning::failed to delete $1"
+}
+
+# A GC'd component keeps a resolvable stage tag, so werf reuses the stage and
+# re-reports the dead digest. The dead digest can't be deleted, but the tag can:
+# drop every stage by tag so werf rebuilds and re-pushes a live image.
+while read -r img; do
+  final="$(jq -r --arg i "$img" '.Images[$i].DockerImageDigest // empty' "$report")"
+  [[ -n "$final" ]] || continue
+  crane digest "${repo}@${final}" >/dev/null 2>&1 && continue
+  echo "broken: ${img} — deleting its stages"
+  while read -r t; do
+    [[ -n "$t" ]] || continue
+    delete_tag "$t"
+  done < <(jq -r --arg i "$img" '.Images[$i].Stages[].DockerTag // empty' "$report")
+done < <(jq -r '.Images | to_entries[] | select(.value.Final == true) | .key' "$report")
+
+# Regenerate the digests chain so fresh component digests reach the module :tag.
+for img in images-digests prepare-bundle; do
+  t="$(jq -r --arg i "$img" '.Images[$i].DockerTag // empty' "$report")"
+  [[ -n "$t" ]] && delete_tag "$t" || echo "::warning::no tag for ${img} in report"
+done


### PR DESCRIPTION
## Description

The manual "check and rebuild" workflow is meant to repair a published dev module tag after dev-registry GC collects some of its component images. It didn't actually repair anything: werf kept reusing the collected stages (their tags still resolve) and re-reported the same dead digests, so the rebuilt tag was still broken.

Now, for every component whose final image is no longer pullable, the workflow deletes its stages **by tag** (the dead digest can't be deleted), forcing werf to rebuild and re-push a live image; `images-digests` and `prepare-bundle` are dropped too so `images_digests.json` is regenerated and the tag republished. The check/rebuild logic moved into reusable scripts, and the same flow is ported to GitLab CI.

## Why do we need it, and what problem does it solve?

A dev tag whose component images were garbage-collected can't be deployed. This is the tool to fix such a tag — and until now it reported success while leaving it broken.

## What is the expected result?

Run against a tag with GC'd component images: after the rebuild the recheck reports all component images pullable and the job passes. Verified on the DEV registry (run 29418170976 repaired the tag; a follow-up run then found it healthy).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ci
type: fix
summary: "Rebuilding a broken dev module tag now regenerates its image digests so the repaired tag is actually pullable."
```
